### PR TITLE
feat: add WhatsApp integration

### DIFF
--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -52,6 +52,7 @@ export const BaseProviders = [
 	'twitter',
 	'twitterapiio',
 	'typeform',
+	'whatsapp',
 	'zoom',
 ] as const;
 
@@ -95,6 +96,7 @@ export type AllProviders =
 	| 'twitter'
 	| 'twitterapiio'
 	| 'typeform'
+	| 'whatsapp'
 	| 'zoom'
 	| (string & {});
 

--- a/packages/corsair/db/kysely/orm.ts
+++ b/packages/corsair/db/kysely/orm.ts
@@ -13,10 +13,10 @@ import {
 	jsonbTimestampField,
 } from './postgres';
 
-type EntityQueryBuilder = SelectQueryBuilder<
+type EntityQueryBuilder<TResult = CorsairEntity> = SelectQueryBuilder<
 	CorsairKyselyDatabase,
 	'corsair_entities',
-	CorsairEntity
+	TResult
 >;
 
 function parseJsonLike(value: unknown): unknown {
@@ -73,11 +73,11 @@ function getDataFieldTypes(schema: ZodTypeAny): Record<string, DataFieldType> {
 	return fieldTypes;
 }
 
-function applyStringFilter(
-	q: EntityQueryBuilder,
+function applyStringFilter<TResult>(
+	q: EntityQueryBuilder<TResult>,
 	expr: ReturnType<typeof jsonbTextField>,
 	filterValue: unknown,
-) {
+): EntityQueryBuilder<TResult> {
 	if (typeof filterValue === 'string') {
 		return q.where(expr, '=', filterValue);
 	}
@@ -106,11 +106,11 @@ function applyStringFilter(
 	return q;
 }
 
-function applyNumberFilter(
-	q: EntityQueryBuilder,
+function applyNumberFilter<TResult>(
+	q: EntityQueryBuilder<TResult>,
 	expr: ReturnType<typeof jsonbNumberField>,
 	filterValue: unknown,
-) {
+): EntityQueryBuilder<TResult> {
 	if (typeof filterValue === 'number') {
 		return q.where(expr, '=', filterValue);
 	}
@@ -130,11 +130,11 @@ function applyNumberFilter(
 	return q;
 }
 
-function applyBooleanFilter(
-	q: EntityQueryBuilder,
+function applyBooleanFilter<TResult>(
+	q: EntityQueryBuilder<TResult>,
 	expr: ReturnType<typeof jsonbBooleanField>,
 	filterValue: unknown,
-) {
+): EntityQueryBuilder<TResult> {
 	if (typeof filterValue === 'boolean') {
 		return q.where(expr, '=', filterValue);
 	}
@@ -149,11 +149,11 @@ function applyBooleanFilter(
 	return q;
 }
 
-function applyDateFilter(
-	q: EntityQueryBuilder,
+function applyDateFilter<TResult>(
+	q: EntityQueryBuilder<TResult>,
 	expr: ReturnType<typeof jsonbTimestampField>,
 	filterValue: unknown,
-) {
+): EntityQueryBuilder<TResult> {
 	if (filterValue instanceof Date) {
 		return q.where(expr, '=', filterValue);
 	}
@@ -175,12 +175,12 @@ function applyDateFilter(
 	return q;
 }
 
-function applyDataFilter(
-	q: EntityQueryBuilder,
+function applyDataFilter<TResult>(
+	q: EntityQueryBuilder<TResult>,
 	key: string,
 	fieldType: DataFieldType,
 	filterValue: unknown,
-) {
+): EntityQueryBuilder<TResult> {
 	if (fieldType === 'number') {
 		return applyNumberFilter(q, jsonbNumberField(key), filterValue);
 	}
@@ -193,11 +193,11 @@ function applyDataFilter(
 	return applyStringFilter(q, jsonbTextField(key), filterValue);
 }
 
-function applyEntityFieldFilter(
-	q: EntityQueryBuilder,
+function applyEntityFieldFilter<TResult>(
+	q: EntityQueryBuilder<TResult>,
 	key: keyof CorsairEntity,
 	filterValue: unknown,
-) {
+): EntityQueryBuilder<TResult> {
 	if (
 		typeof filterValue === 'object' &&
 		filterValue !== null &&
@@ -390,14 +390,30 @@ export function createKyselyEntityClient<DataSchema extends ZodTypeAny>(
 			);
 		},
 
-		count: async () => {
+		count: async (options) => {
 			const accountId = await getAccountId();
-			const row = await db
+			let q = db
 				.selectFrom('corsair_entities')
 				.select((eb) => eb.fn.countAll().as('count'))
 				.where('account_id', '=', accountId)
-				.where('entity_type', '=', entityTypeName)
-				.executeTakeFirst();
+				.where('entity_type', '=', entityTypeName);
+
+			const reservedKeys = new Set(['data', 'limit', 'offset']);
+			for (const [key, filterValue] of Object.entries(options ?? {})) {
+				if (reservedKeys.has(key) || filterValue === undefined) continue;
+				q = applyEntityFieldFilter(q, key as keyof CorsairEntity, filterValue);
+			}
+
+			if (options?.data && typeof options.data === 'object') {
+				for (const [key, filterValue] of Object.entries(options.data)) {
+					if (filterValue === undefined) continue;
+					const fieldType = dataFieldTypes[key] ?? 'string';
+					q = applyDataFilter(q, key, fieldType, filterValue);
+				}
+			}
+
+			const row = await q.executeTakeFirst();
+			// Kysely count aggregation returns a driver-specific scalar shape.
 			return parseCountValue((row as { count?: unknown })?.count);
 		},
 	};

--- a/packages/corsair/db/orm.ts
+++ b/packages/corsair/db/orm.ts
@@ -987,8 +987,13 @@ type EntityFieldsFilter = {
  *   }
  * }
  */
+type SchemaDefinedKeys<DataSchema extends ZodTypeAny> =
+	DataSchema extends z.ZodObject<infer Shape, any, any, any, any>
+		? keyof Shape
+		: keyof z.infer<DataSchema>;
+
 export type DataSearchFilter<DataSchema extends ZodTypeAny> = {
-	[K in keyof z.infer<DataSchema>]?: z.infer<DataSchema>[K] extends
+	[K in SchemaDefinedKeys<DataSchema>]?: z.infer<DataSchema>[K] extends
 		| string
 		| number
 		| boolean
@@ -1201,8 +1206,13 @@ export type PluginEntityClient<DataSchema extends ZodTypeAny> = {
 	/** Delete by external entity ID. */
 	deleteByEntityId: (entityId: string) => Promise<boolean>;
 
-	/** Count entities for this entity type. */
-	count: () => Promise<number>;
+	/**
+	 * Count entities for this entity type.
+	 * Supports the same filters as `search`, excluding pagination fields.
+	 */
+	count: (
+		options?: Omit<EntitySearchOptions<DataSchema>, 'limit' | 'offset'>,
+	) => Promise<number>;
 };
 
 /**

--- a/packages/whatsapp/README.md
+++ b/packages/whatsapp/README.md
@@ -1,0 +1,85 @@
+# `@corsair-dev/whatsapp`
+
+The **WhatsApp** package adds a Corsair plugin for the **WhatsApp Cloud API**. It follows the same package structure used by the other first-party integrations and focuses on the core operational flow required by agent workflows: sending messages, receiving incoming webhook events, and listing persisted conversations and messages.
+
+## Features
+
+| Capability | Status | Notes |
+| --- | --- | --- |
+| Send outbound message | Implemented | Sends text messages through the WhatsApp Cloud API. |
+| Receive inbound message webhook | Implemented | Accepts and verifies WhatsApp webhook payloads for inbound messages. |
+| Receive delivery status webhook | Implemented | Persists delivery and conversation status updates from Meta webhook events. |
+| List stored messages | Implemented | Reads persisted message records from the plugin schema. |
+| List stored conversations | Implemented | Reads persisted conversation records derived from webhook status events. |
+
+## Authentication
+
+The plugin uses **API key style authentication** in Corsair, where the stored endpoint secret is the **WhatsApp access token** used for the Graph API.
+
+| Secret purpose | Expected value |
+| --- | --- |
+| Endpoint key | WhatsApp Cloud API access token |
+| Webhook signature secret | Meta app secret used for `X-Hub-Signature-256` verification |
+
+You can provide credentials either directly in plugin options or through the Corsair key manager.
+
+## Installation
+
+From the repository root, install dependencies and typecheck the package:
+
+```bash
+pnpm install
+pnpm exec tsc -p packages/whatsapp/tsconfig.json --noEmit
+```
+
+## Basic usage
+
+```ts
+import { whatsapp } from '@corsair-dev/whatsapp';
+
+const plugin = whatsapp({
+  key: process.env.WHATSAPP_ACCESS_TOKEN,
+  webhookSecret: process.env.WHATSAPP_APP_SECRET,
+});
+```
+
+## Available operations
+
+| Operation | Purpose |
+| --- | --- |
+| `messages.sendMessage` | Send a text message to a WhatsApp recipient. |
+| `messages.getMessages` | List persisted message records, optionally filtered by phone number. |
+| `messages.listConversations` | List persisted conversation records captured from status webhooks. |
+
+## Example: send a message
+
+```ts
+await plugin.endpoints.messages.sendMessage({
+  phoneNumberId: process.env.WHATSAPP_PHONE_NUMBER_ID!,
+  to: '15551234567',
+  text: 'Hello from Corsair',
+});
+```
+
+## Webhook behavior
+
+The plugin expects Meta webhook payloads for the **messages** field and supports two webhook event groups.
+
+| Webhook | Description |
+| --- | --- |
+| `message.message` | Triggered when an inbound user message is received. |
+| `status.status` | Triggered when Meta sends message delivery or conversation status updates. |
+
+The webhook matcher only accepts WhatsApp Business Account payloads and the verifier validates the `X-Hub-Signature-256` header when a webhook secret is configured.
+
+## Required environment details
+
+| Variable | Description |
+| --- | --- |
+| `WHATSAPP_ACCESS_TOKEN` | Access token for the WhatsApp Cloud API. |
+| `WHATSAPP_APP_SECRET` | Meta app secret for webhook signature validation. |
+| `WHATSAPP_PHONE_NUMBER_ID` | WhatsApp phone number ID used for outbound messages. |
+
+## Development notes
+
+This implementation intentionally keeps the surface area focused and production-safe. It persists webhook-backed message and conversation records into the package schema so agent-facing tooling can inspect prior activity without re-fetching raw webhook payloads.

--- a/packages/whatsapp/client.ts
+++ b/packages/whatsapp/client.ts
@@ -55,17 +55,24 @@ export async function makeWhatsAppRequest<T>(
 			typeof error === 'object' &&
 			'body' in error &&
 			error.body &&
-			typeof error.body === 'object'
+			typeof error.body === 'object' &&
+			'error' in error.body &&
+			error.body.error &&
+			typeof error.body.error === 'object'
 		) {
-			const body = error.body as {
-				error?: { message?: string; code?: string | number; type?: string };
-			};
-			if (body.error) {
-				throw new WhatsAppAPIError(
-					body.error.message ?? 'WhatsApp API request failed',
-					body.error.code ? String(body.error.code) : body.error.type,
-				);
-			}
+			const apiError = error.body.error;
+			const message =
+				'message' in apiError && typeof apiError.message === 'string'
+					? apiError.message
+					: 'WhatsApp API request failed';
+			const code =
+				'code' in apiError &&
+				(typeof apiError.code === 'string' || typeof apiError.code === 'number')
+					? String(apiError.code)
+					: 'type' in apiError && typeof apiError.type === 'string'
+						? apiError.type
+						: undefined;
+			throw new WhatsAppAPIError(message, code);
 		}
 
 		if (error instanceof Error) {

--- a/packages/whatsapp/client.ts
+++ b/packages/whatsapp/client.ts
@@ -1,0 +1,76 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { request } from 'corsair/http';
+
+export class WhatsAppAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly code?: string,
+	) {
+		super(message);
+		this.name = 'WhatsAppAPIError';
+	}
+}
+
+const WHATSAPP_API_BASE = 'https://graph.facebook.com/v23.0';
+
+export async function makeWhatsAppRequest<T>(
+	endpoint: string,
+	accessToken: string,
+	options: {
+		method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+		body?: Record<string, unknown>;
+		query?: Record<string, string | number | boolean | undefined>;
+	} = {},
+): Promise<T> {
+	const { method = 'GET', body, query } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: WHATSAPP_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: accessToken,
+		HEADERS: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${accessToken}`,
+		},
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint,
+		body:
+			method === 'POST' || method === 'PUT' || method === 'PATCH'
+				? body
+				: undefined,
+		mediaType: 'application/json; charset=utf-8',
+		query,
+	};
+
+	try {
+		return await request<T>(config, requestOptions);
+	} catch (error) {
+		if (
+			error &&
+			typeof error === 'object' &&
+			'body' in error &&
+			error.body &&
+			typeof error.body === 'object'
+		) {
+			const body = error.body as {
+				error?: { message?: string; code?: string | number; type?: string };
+			};
+			if (body.error) {
+				throw new WhatsAppAPIError(
+					body.error.message ?? 'WhatsApp API request failed',
+					body.error.code ? String(body.error.code) : body.error.type,
+				);
+			}
+		}
+
+		if (error instanceof Error) {
+			throw new WhatsAppAPIError(error.message);
+		}
+		throw new WhatsAppAPIError('Unknown error');
+	}
+}

--- a/packages/whatsapp/endpoints/index.ts
+++ b/packages/whatsapp/endpoints/index.ts
@@ -1,0 +1,13 @@
+import {
+	getMessages,
+	listConversations,
+	sendMessage,
+} from './messages';
+
+export const Messages = {
+	sendMessage,
+	getMessages,
+	listConversations,
+};
+
+export * from './types';

--- a/packages/whatsapp/endpoints/messages.ts
+++ b/packages/whatsapp/endpoints/messages.ts
@@ -74,35 +74,41 @@ export const getMessages: WhatsAppEndpoints['getMessages'] = async (ctx, input) 
 		return empty;
 	}
 
-	const persisted = await ctx.db.messages.list({
+	const searchOptions: Parameters<typeof ctx.db.messages.search>[0] = {
 		limit: input.limit,
 		offset: input.offset,
-	});
+	};
+	const countOptions: Parameters<typeof ctx.db.messages.count>[0] = {};
 
-	const messages = persisted
-		.map((entity) => entity.data)
-		.filter((message) => {
-			if (input.phoneNumberId && message.phone_number_id !== input.phoneNumberId) {
-				return false;
-			}
-			if (input.contactWaId) {
-				const waId = message.wa_id ?? message.from ?? message.recipient_id;
-				if (waId !== input.contactWaId) {
-					return false;
-				}
-			}
-			if (input.direction && message.direction !== input.direction) {
-				return false;
-			}
-			if (input.status && message.status !== input.status) {
-				return false;
-			}
-			return true;
-		});
+	if (input.phoneNumberId || input.contactWaId || input.direction || input.status) {
+		searchOptions.data = {};
+		countOptions.data = {};
+		if (input.phoneNumberId) {
+			searchOptions.data.phone_number_id = input.phoneNumberId;
+			countOptions.data.phone_number_id = input.phoneNumberId;
+		}
+		if (input.contactWaId) {
+			searchOptions.data.wa_id = input.contactWaId;
+			countOptions.data.wa_id = input.contactWaId;
+		}
+		if (input.direction) {
+			searchOptions.data.direction = input.direction;
+			countOptions.data.direction = input.direction;
+		}
+		if (input.status) {
+			searchOptions.data.status = input.status;
+			countOptions.data.status = input.status;
+		}
+	}
+
+	const [persisted, count] = await Promise.all([
+		ctx.db.messages.search(searchOptions),
+		ctx.db.messages.count(countOptions),
+	]);
 
 	const response: GetMessagesResponse = {
-		messages,
-		count: messages.length,
+		messages: persisted.map((entity) => entity.data),
+		count,
 	};
 
 	await logEventFromContext(
@@ -127,23 +133,25 @@ export const listConversations: WhatsAppEndpoints['listConversations'] = async (
 		return empty;
 	}
 
-	const persisted = await ctx.db.conversations.list({
+	const searchOptions: Parameters<typeof ctx.db.conversations.search>[0] = {
 		limit: input.limit,
 		offset: input.offset,
-	});
+	};
+	const countOptions: Parameters<typeof ctx.db.conversations.count>[0] = {};
 
-	const conversations = persisted
-		.map((entity) => entity.data)
-		.filter((conversation) => {
-			if (input.category && conversation.category !== input.category) {
-				return false;
-			}
-			return true;
-		});
+	if (input.category) {
+		searchOptions.data = { category: input.category };
+		countOptions.data = { category: input.category };
+	}
+
+	const [persisted, count] = await Promise.all([
+		ctx.db.conversations.search(searchOptions),
+		ctx.db.conversations.count(countOptions),
+	]);
 
 	const response: ListConversationsResponse = {
-		conversations,
-		count: conversations.length,
+		conversations: persisted.map((entity) => entity.data),
+		count,
 	};
 
 	await logEventFromContext(

--- a/packages/whatsapp/endpoints/messages.ts
+++ b/packages/whatsapp/endpoints/messages.ts
@@ -1,0 +1,157 @@
+import { logEventFromContext } from 'corsair/core';
+import type { WhatsAppEndpoints } from '..';
+import { makeWhatsAppRequest } from '../client';
+import type {
+	GetMessagesResponse,
+	ListConversationsResponse,
+	WhatsAppEndpointOutputs,
+} from './types';
+
+export const sendMessage: WhatsAppEndpoints['sendMessage'] = async (ctx, input) => {
+	const result = await makeWhatsAppRequest<WhatsAppEndpointOutputs['sendMessage']>(
+		`/${input.phoneNumberId}/messages`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: {
+				messaging_product: 'whatsapp',
+				recipient_type: input.recipient_type ?? 'individual',
+				to: input.to,
+				type: 'text',
+				text: {
+					body: input.text,
+					preview_url: input.preview_url,
+				},
+			},
+		},
+	);
+
+	const messageId = result.messages?.[0]?.id;
+	const waId = result.contacts?.[0]?.wa_id;
+
+	if (messageId && ctx.db.messages) {
+		try {
+			await ctx.db.messages.upsertByEntityId(messageId, {
+				id: messageId,
+				messaging_product: result.messaging_product ?? 'whatsapp',
+				to: input.to,
+				wa_id: waId,
+				type: 'text',
+				text: {
+					body: input.text,
+					preview_url: input.preview_url,
+				},
+				phone_number_id: input.phoneNumberId,
+				direction: 'outbound',
+				createdAt: new Date(),
+				raw: result,
+			});
+		} catch (error) {
+			console.warn('Failed to save WhatsApp message to database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'whatsapp.messages.sendMessage',
+		{
+			phoneNumberId: input.phoneNumberId,
+			to: input.to,
+			recipient_type: input.recipient_type,
+		},
+		'completed',
+	);
+
+	return result;
+};
+
+export const getMessages: WhatsAppEndpoints['getMessages'] = async (ctx, input) => {
+	if (!ctx.db.messages) {
+		const empty: GetMessagesResponse = {
+			messages: [],
+			count: 0,
+		};
+		return empty;
+	}
+
+	const persisted = await ctx.db.messages.list({
+		limit: input.limit,
+		offset: input.offset,
+	});
+
+	const messages = persisted
+		.map((entity) => entity.data)
+		.filter((message) => {
+			if (input.phoneNumberId && message.phone_number_id !== input.phoneNumberId) {
+				return false;
+			}
+			if (input.contactWaId) {
+				const waId = message.wa_id ?? message.from ?? message.recipient_id;
+				if (waId !== input.contactWaId) {
+					return false;
+				}
+			}
+			if (input.direction && message.direction !== input.direction) {
+				return false;
+			}
+			if (input.status && message.status !== input.status) {
+				return false;
+			}
+			return true;
+		});
+
+	const response: GetMessagesResponse = {
+		messages,
+		count: messages.length,
+	};
+
+	await logEventFromContext(
+		ctx,
+		'whatsapp.messages.getMessages',
+		{ ...input },
+		'completed',
+	);
+
+	return response;
+};
+
+export const listConversations: WhatsAppEndpoints['listConversations'] = async (
+	ctx,
+	input,
+) => {
+	if (!ctx.db.conversations) {
+		const empty: ListConversationsResponse = {
+			conversations: [],
+			count: 0,
+		};
+		return empty;
+	}
+
+	const persisted = await ctx.db.conversations.list({
+		limit: input.limit,
+		offset: input.offset,
+	});
+
+	const conversations = persisted
+		.map((entity) => entity.data)
+		.filter((conversation) => {
+			if (input.category && conversation.category !== input.category) {
+				return false;
+			}
+			return true;
+		});
+
+	const response: ListConversationsResponse = {
+		conversations,
+		count: conversations.length,
+	};
+
+	await logEventFromContext(
+		ctx,
+		'whatsapp.messages.listConversations',
+		{ ...input },
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/whatsapp/endpoints/types.ts
+++ b/packages/whatsapp/endpoints/types.ts
@@ -1,0 +1,95 @@
+import { z } from 'zod';
+import {
+	WhatsAppConversation as WhatsAppConversationEntitySchema,
+	WhatsAppMessage as WhatsAppMessageEntitySchema,
+} from '../schema/database';
+
+const SendMessageInputSchema = z.object({
+	phoneNumberId: z.string(),
+	to: z.string(),
+	text: z.string().min(1),
+	recipient_type: z.enum(['individual', 'group']).optional(),
+	preview_url: z.boolean().optional(),
+});
+
+const SendMessageResponseSchema = z
+	.object({
+		messaging_product: z.string().optional(),
+		contacts: z
+			.array(
+				z
+					.object({
+						input: z.string().optional(),
+						wa_id: z.string().optional(),
+					})
+					.passthrough(),
+			)
+			.optional(),
+		messages: z
+			.array(
+				z
+					.object({
+						id: z.string(),
+						message_status: z.string().optional(),
+					})
+					.passthrough(),
+			)
+			.optional(),
+	})
+	.passthrough();
+
+const GetMessagesInputSchema = z.object({
+	limit: z.number().int().positive().max(100).optional(),
+	offset: z.number().int().min(0).optional(),
+	phoneNumberId: z.string().optional(),
+	contactWaId: z.string().optional(),
+	direction: z.enum(['inbound', 'outbound']).optional(),
+	status: z.string().optional(),
+});
+
+const GetMessagesResponseSchema = z.object({
+	messages: z.array(WhatsAppMessageEntitySchema),
+	count: z.number().int().min(0),
+});
+
+const ListConversationsInputSchema = z.object({
+	limit: z.number().int().positive().max(100).optional(),
+	offset: z.number().int().min(0).optional(),
+	category: z.string().optional(),
+});
+
+const ListConversationsResponseSchema = z.object({
+	conversations: z.array(WhatsAppConversationEntitySchema),
+	count: z.number().int().min(0),
+});
+
+export type SendMessageInput = z.infer<typeof SendMessageInputSchema>;
+export type SendMessageResponse = z.infer<typeof SendMessageResponseSchema>;
+export type GetMessagesInput = z.infer<typeof GetMessagesInputSchema>;
+export type GetMessagesResponse = z.infer<typeof GetMessagesResponseSchema>;
+export type ListConversationsInput = z.infer<typeof ListConversationsInputSchema>;
+export type ListConversationsResponse = z.infer<typeof ListConversationsResponseSchema>;
+
+export type WhatsAppEndpointInputs = {
+	sendMessage: SendMessageInput;
+	getMessages: GetMessagesInput;
+	listConversations: ListConversationsInput;
+};
+
+export type WhatsAppEndpointOutputs = {
+	sendMessage: SendMessageResponse;
+	getMessages: GetMessagesResponse;
+	listConversations: ListConversationsResponse;
+};
+
+export const WhatsAppEndpointInputSchemas = {
+	sendMessage: SendMessageInputSchema,
+	getMessages: GetMessagesInputSchema,
+	listConversations: ListConversationsInputSchema,
+} as const;
+
+export const WhatsAppEndpointOutputSchemas = {
+	sendMessage: SendMessageResponseSchema,
+	getMessages: GetMessagesResponseSchema,
+	listConversations: ListConversationsResponseSchema,
+} as const;

--- a/packages/whatsapp/error-handlers.ts
+++ b/packages/whatsapp/error-handlers.ts
@@ -1,0 +1,31 @@
+import { ApiError } from 'corsair/http';
+import type { CorsairErrorHandler } from 'corsair/core';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('429');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('unauthorized') || msg.includes('invalid_auth');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/whatsapp/index.ts
+++ b/packages/whatsapp/index.ts
@@ -1,4 +1,5 @@
 import type {
+	AuthTypes,
 	BindEndpoints,
 	BindWebhooks,
 	CorsairEndpoint,
@@ -14,12 +15,14 @@ import type {
 	RequiredPluginEndpointSchemas,
 	RequiredPluginWebhookSchemas,
 } from 'corsair/core';
-import type { AuthTypes } from 'corsair/core';
 import type { WhatsAppEndpointInputs, WhatsAppEndpointOutputs } from './endpoints/types';
 import {
 	WhatsAppEndpointInputSchemas,
 	WhatsAppEndpointOutputSchemas,
 } from './endpoints/types';
+import { Messages } from './endpoints';
+import { errorHandlers } from './error-handlers';
+import { WhatsAppSchema } from './schema';
 import type {
 	MessageEvent,
 	StatusEvent,
@@ -28,11 +31,26 @@ import type {
 import {
 	WhatsAppMessageEventSchema,
 	WhatsAppStatusEventSchema,
+	WhatsAppWebhookPayloadSchema,
 } from './webhooks/types';
-import { Messages } from './endpoints';
-import { WhatsAppSchema } from './schema';
 import { MessageWebhooks, StatusWebhooks } from './webhooks';
-import { errorHandlers } from './error-handlers';
+
+const whatsAppEndpointsNested = {
+	messages: {
+		sendMessage: Messages.sendMessage,
+		getMessages: Messages.getMessages,
+		listConversations: Messages.listConversations,
+	},
+} as const;
+
+const whatsAppWebhooksNested = {
+	message: {
+		message: MessageWebhooks.message,
+	},
+	status: {
+		status: StatusWebhooks.status,
+	},
+} as const;
 
 export type WhatsAppPluginOptions = {
 	authType?: PickAuth<'api_key'>;
@@ -50,8 +68,18 @@ export type WhatsAppContext = CorsairPluginContext<
 >;
 
 export type WhatsAppKeyBuilderContext = KeyBuilderContext<WhatsAppPluginOptions>;
-
 export type WhatsAppBoundEndpoints = BindEndpoints<typeof whatsAppEndpointsNested>;
+
+export type BaseWhatsAppPlugin<T extends WhatsAppPluginOptions> = CorsairPlugin<
+	'whatsapp',
+	typeof WhatsAppSchema,
+	typeof whatsAppEndpointsNested,
+	typeof whatsAppWebhooksNested,
+	T,
+	typeof defaultAuthType
+>;
+
+export type InternalWhatsAppPlugin = BaseWhatsAppPlugin<WhatsAppPluginOptions>;
 
 type WhatsAppEndpoint<K extends keyof WhatsAppEndpointOutputs> = CorsairEndpoint<
 	WhatsAppContext,
@@ -76,23 +104,6 @@ export type WhatsAppWebhooks = {
 };
 
 export type WhatsAppBoundWebhooks = BindWebhooks<WhatsAppWebhooks>;
-
-const whatsAppEndpointsNested = {
-	messages: {
-		sendMessage: Messages.sendMessage,
-		getMessages: Messages.getMessages,
-		listConversations: Messages.listConversations,
-	},
-} as const;
-
-const whatsAppWebhooksNested = {
-	message: {
-		message: MessageWebhooks.message,
-	},
-	status: {
-		status: StatusWebhooks.status,
-	},
-} as const;
 
 export const whatsAppEndpointSchemas = {
 	'messages.sendMessage': {
@@ -124,7 +135,7 @@ export const whatsAppWebhookSchemas: RequiredPluginWebhookSchemas<
 	},
 };
 
-const defaultAuthType: AuthTypes = 'api_key' as const;
+const defaultAuthType = 'api_key' as const;
 
 const whatsAppEndpointMeta = {
 	'messages.sendMessage': {
@@ -147,26 +158,12 @@ export const whatsAppAuthConfig = {
 	},
 } as const satisfies PluginAuthConfig;
 
-export type BaseWhatsAppPlugin<T extends WhatsAppPluginOptions> = CorsairPlugin<
-	'whatsapp',
-	typeof WhatsAppSchema,
-	typeof whatsAppEndpointsNested,
-	typeof whatsAppWebhooksNested,
-	T,
-	typeof defaultAuthType
->;
-
-export type InternalWhatsAppPlugin = BaseWhatsAppPlugin<WhatsAppPluginOptions>;
-
-export type ExternalWhatsAppPlugin<T extends WhatsAppPluginOptions> =
-	BaseWhatsAppPlugin<T>;
-
-export function whatsapp<const T extends WhatsAppPluginOptions>(
-	incomingOptions: WhatsAppPluginOptions & T = {} as WhatsAppPluginOptions & T,
-): ExternalWhatsAppPlugin<T> {
+export function whatsapp(
+	incomingOptions?: WhatsAppPluginOptions,
+): InternalWhatsAppPlugin {
 	const options = {
-		...incomingOptions,
-		authType: incomingOptions.authType ?? defaultAuthType,
+		...(incomingOptions ?? {}),
+		authType: incomingOptions?.authType ?? defaultAuthType,
 	};
 
 	return {
@@ -182,24 +179,17 @@ export function whatsapp<const T extends WhatsAppPluginOptions>(
 		webhookSchemas: whatsAppWebhookSchemas,
 		pluginWebhookMatcher: (request) => {
 			try {
-				const body = typeof request.body === 'string'
-					? JSON.parse(request.body)
-					: request.body;
-
-				if (!body || typeof body !== 'object' || !('object' in body)) {
+				const body: unknown =
+					typeof request.body === 'string'
+						? JSON.parse(request.body)
+						: request.body;
+				const parsed = WhatsAppWebhookPayloadSchema.safeParse(body);
+				if (!parsed.success) {
 					return false;
 				}
 
-				if (body.object !== 'whatsapp_business_account') {
-					return false;
-				}
-
-				if (!Array.isArray((body as { entry?: unknown[] }).entry)) {
-					return false;
-				}
-
-				return (body as { entry: Array<{ changes?: Array<{ field?: string }> }> }).entry.some(
-					(entry) => entry.changes?.some((change) => change.field === 'messages'),
+				return parsed.data.entry.some((entry) =>
+					entry.changes.some((change) => change.field === 'messages'),
 				);
 			} catch {
 				return false;
@@ -235,15 +225,6 @@ export function whatsapp<const T extends WhatsAppPluginOptions>(
 }
 
 export type {
-	MessageEvent,
-	StatusEvent,
-	WhatsAppIncomingMessage,
-	WhatsAppStatus,
-	WhatsAppWebhookOutputs,
-	WhatsAppWebhookPayload,
-} from './webhooks/types';
-
-export type {
 	GetMessagesInput,
 	GetMessagesResponse,
 	ListConversationsInput,
@@ -253,3 +234,12 @@ export type {
 	WhatsAppEndpointInputs,
 	WhatsAppEndpointOutputs,
 } from './endpoints/types';
+
+export type {
+	MessageEvent,
+	StatusEvent,
+	WhatsAppIncomingMessage,
+	WhatsAppStatus,
+	WhatsAppWebhookOutputs,
+	WhatsAppWebhookPayload,
+} from './webhooks/types';

--- a/packages/whatsapp/index.ts
+++ b/packages/whatsapp/index.ts
@@ -1,0 +1,255 @@
+import type {
+	BindEndpoints,
+	BindWebhooks,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	CorsairWebhook,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+	RequiredPluginWebhookSchemas,
+} from 'corsair/core';
+import type { AuthTypes } from 'corsair/core';
+import type { WhatsAppEndpointInputs, WhatsAppEndpointOutputs } from './endpoints/types';
+import {
+	WhatsAppEndpointInputSchemas,
+	WhatsAppEndpointOutputSchemas,
+} from './endpoints/types';
+import type {
+	MessageEvent,
+	StatusEvent,
+	WhatsAppWebhookOutputs,
+} from './webhooks/types';
+import {
+	WhatsAppMessageEventSchema,
+	WhatsAppStatusEventSchema,
+} from './webhooks/types';
+import { Messages } from './endpoints';
+import { WhatsAppSchema } from './schema';
+import { MessageWebhooks, StatusWebhooks } from './webhooks';
+import { errorHandlers } from './error-handlers';
+
+export type WhatsAppPluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	webhookSecret?: string;
+	hooks?: InternalWhatsAppPlugin['hooks'];
+	webhookHooks?: InternalWhatsAppPlugin['webhookHooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof whatsAppEndpointsNested>;
+};
+
+export type WhatsAppContext = CorsairPluginContext<
+	typeof WhatsAppSchema,
+	WhatsAppPluginOptions
+>;
+
+export type WhatsAppKeyBuilderContext = KeyBuilderContext<WhatsAppPluginOptions>;
+
+export type WhatsAppBoundEndpoints = BindEndpoints<typeof whatsAppEndpointsNested>;
+
+type WhatsAppEndpoint<K extends keyof WhatsAppEndpointOutputs> = CorsairEndpoint<
+	WhatsAppContext,
+	WhatsAppEndpointInputs[K],
+	WhatsAppEndpointOutputs[K]
+>;
+
+export type WhatsAppEndpoints = {
+	sendMessage: WhatsAppEndpoint<'sendMessage'>;
+	getMessages: WhatsAppEndpoint<'getMessages'>;
+	listConversations: WhatsAppEndpoint<'listConversations'>;
+};
+
+type WhatsAppWebhook<
+	K extends keyof WhatsAppWebhookOutputs,
+	TEvent,
+> = CorsairWebhook<WhatsAppContext, TEvent, WhatsAppWebhookOutputs[K]>;
+
+export type WhatsAppWebhooks = {
+	message: WhatsAppWebhook<'message', MessageEvent>;
+	status: WhatsAppWebhook<'status', StatusEvent>;
+};
+
+export type WhatsAppBoundWebhooks = BindWebhooks<WhatsAppWebhooks>;
+
+const whatsAppEndpointsNested = {
+	messages: {
+		sendMessage: Messages.sendMessage,
+		getMessages: Messages.getMessages,
+		listConversations: Messages.listConversations,
+	},
+} as const;
+
+const whatsAppWebhooksNested = {
+	message: {
+		message: MessageWebhooks.message,
+	},
+	status: {
+		status: StatusWebhooks.status,
+	},
+} as const;
+
+export const whatsAppEndpointSchemas = {
+	'messages.sendMessage': {
+		input: WhatsAppEndpointInputSchemas.sendMessage,
+		output: WhatsAppEndpointOutputSchemas.sendMessage,
+	},
+	'messages.getMessages': {
+		input: WhatsAppEndpointInputSchemas.getMessages,
+		output: WhatsAppEndpointOutputSchemas.getMessages,
+	},
+	'messages.listConversations': {
+		input: WhatsAppEndpointInputSchemas.listConversations,
+		output: WhatsAppEndpointOutputSchemas.listConversations,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<typeof whatsAppEndpointsNested>;
+
+export const whatsAppWebhookSchemas: RequiredPluginWebhookSchemas<
+	typeof whatsAppWebhooksNested
+> = {
+	'message.message': {
+		description: 'Fires when an inbound WhatsApp message is received from a user.',
+		payload: WhatsAppMessageEventSchema,
+		response: WhatsAppMessageEventSchema,
+	},
+	'status.status': {
+		description: 'Fires when Meta sends a WhatsApp outbound message status update.',
+		payload: WhatsAppStatusEventSchema,
+		response: WhatsAppStatusEventSchema,
+	},
+};
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const whatsAppEndpointMeta = {
+	'messages.sendMessage': {
+		riskLevel: 'write',
+		description: 'Send a WhatsApp text message through the WhatsApp Cloud API.',
+	},
+	'messages.getMessages': {
+		riskLevel: 'read',
+		description: 'List WhatsApp messages previously persisted by API calls or webhooks.',
+	},
+	'messages.listConversations': {
+		riskLevel: 'read',
+		description: 'List WhatsApp conversations previously persisted from status webhooks.',
+	},
+} as const satisfies RequiredPluginEndpointMeta<typeof whatsAppEndpointsNested>;
+
+export const whatsAppAuthConfig = {
+	api_key: {
+		account: ['one'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type BaseWhatsAppPlugin<T extends WhatsAppPluginOptions> = CorsairPlugin<
+	'whatsapp',
+	typeof WhatsAppSchema,
+	typeof whatsAppEndpointsNested,
+	typeof whatsAppWebhooksNested,
+	T,
+	typeof defaultAuthType
+>;
+
+export type InternalWhatsAppPlugin = BaseWhatsAppPlugin<WhatsAppPluginOptions>;
+
+export type ExternalWhatsAppPlugin<T extends WhatsAppPluginOptions> =
+	BaseWhatsAppPlugin<T>;
+
+export function whatsapp<const T extends WhatsAppPluginOptions>(
+	incomingOptions: WhatsAppPluginOptions & T = {} as WhatsAppPluginOptions & T,
+): ExternalWhatsAppPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+
+	return {
+		id: 'whatsapp',
+		schema: WhatsAppSchema,
+		options,
+		hooks: options.hooks,
+		webhookHooks: options.webhookHooks,
+		endpoints: whatsAppEndpointsNested,
+		webhooks: whatsAppWebhooksNested,
+		endpointMeta: whatsAppEndpointMeta,
+		endpointSchemas: whatsAppEndpointSchemas,
+		webhookSchemas: whatsAppWebhookSchemas,
+		pluginWebhookMatcher: (request) => {
+			try {
+				const body = typeof request.body === 'string'
+					? JSON.parse(request.body)
+					: request.body;
+
+				if (!body || typeof body !== 'object' || !('object' in body)) {
+					return false;
+				}
+
+				if (body.object !== 'whatsapp_business_account') {
+					return false;
+				}
+
+				if (!Array.isArray((body as { entry?: unknown[] }).entry)) {
+					return false;
+				}
+
+				return (body as { entry: Array<{ changes?: Array<{ field?: string }> }> }).entry.some(
+					(entry) => entry.changes?.some((change) => change.field === 'messages'),
+				);
+			} catch {
+				return false;
+			}
+		},
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		authConfig: whatsAppAuthConfig,
+		keyBuilder: async (ctx: WhatsAppKeyBuilderContext, source) => {
+			if (source === 'webhook' && options.webhookSecret) {
+				return options.webhookSecret;
+			}
+
+			if (source === 'webhook') {
+				const res = await ctx.keys.get_webhook_signature();
+				return res ?? '';
+			}
+
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys.get_api_key();
+				return res ?? '';
+			}
+
+			return '';
+		},
+	} satisfies InternalWhatsAppPlugin;
+}
+
+export type {
+	MessageEvent,
+	StatusEvent,
+	WhatsAppIncomingMessage,
+	WhatsAppStatus,
+	WhatsAppWebhookOutputs,
+	WhatsAppWebhookPayload,
+} from './webhooks/types';
+
+export type {
+	GetMessagesInput,
+	GetMessagesResponse,
+	ListConversationsInput,
+	ListConversationsResponse,
+	SendMessageInput,
+	SendMessageResponse,
+	WhatsAppEndpointInputs,
+	WhatsAppEndpointOutputs,
+} from './endpoints/types';

--- a/packages/whatsapp/package.json
+++ b/packages/whatsapp/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@corsair-dev/whatsapp",
+  "version": "0.1.0",
+  "description": "WhatsApp plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^3.0.0"
+  },
+  "devDependencies": {
+    "corsair": "workspace:*",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^3.25.76"
+  },
+  "keywords": [
+    "corsair",
+    "whatsapp",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/whatsapp/schema/database.ts
+++ b/packages/whatsapp/schema/database.ts
@@ -23,8 +23,8 @@ export const WhatsAppConversation = z
 			})
 			.passthrough()
 			.optional(),
-			category: z.string().optional(),
-			createdAt: z.coerce.date().nullable().optional(),
+		category: z.string().optional(),
+		createdAt: z.coerce.date().nullable().optional(),
 	})
 	.passthrough();
 
@@ -74,6 +74,7 @@ export const WhatsAppMessage = z
 		direction: z.enum(['inbound', 'outbound']).optional(),
 		authorId: z.string().optional(),
 		createdAt: z.coerce.date().nullable().optional(),
+		// raw stores the original webhook or API payload because Meta message shapes vary by event type and API version.
 		raw: z.unknown().optional(),
 	})
 	.passthrough();

--- a/packages/whatsapp/schema/database.ts
+++ b/packages/whatsapp/schema/database.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod';
+
+export const WhatsAppContactProfile = z
+	.object({
+		name: z.string().optional(),
+	})
+	.passthrough();
+
+export const WhatsAppContact = z
+	.object({
+		profile: WhatsAppContactProfile.optional(),
+		wa_id: z.string().optional(),
+	})
+	.passthrough();
+
+export const WhatsAppConversation = z
+	.object({
+		id: z.string(),
+		expiration_timestamp: z.string().optional(),
+		origin: z
+			.object({
+				type: z.string().optional(),
+			})
+			.passthrough()
+			.optional(),
+			category: z.string().optional(),
+			createdAt: z.coerce.date().nullable().optional(),
+	})
+	.passthrough();
+
+export const WhatsAppMessage = z
+	.object({
+		id: z.string(),
+		messaging_product: z.string().optional(),
+		from: z.string().optional(),
+		to: z.string().optional(),
+		wa_id: z.string().optional(),
+		recipient_id: z.string().optional(),
+		status: z.string().optional(),
+		type: z.string().optional(),
+		text: z
+			.object({
+				body: z.string().optional(),
+				preview_url: z.boolean().optional(),
+			})
+			.passthrough()
+			.optional(),
+		timestamp: z.string().optional(),
+		phone_number_id: z.string().optional(),
+		display_phone_number: z.string().optional(),
+		conversation: z
+			.object({
+				id: z.string().optional(),
+				expiration_timestamp: z.string().optional(),
+				origin: z
+					.object({
+						type: z.string().optional(),
+					})
+					.passthrough()
+					.optional(),
+			})
+			.passthrough()
+			.optional(),
+		pricing: z
+			.object({
+				billable: z.boolean().optional(),
+				category: z.string().optional(),
+				pricing_model: z.string().optional(),
+			})
+			.passthrough()
+			.optional(),
+		profile: WhatsAppContactProfile.optional(),
+		contacts: z.array(WhatsAppContact).optional(),
+		direction: z.enum(['inbound', 'outbound']).optional(),
+		authorId: z.string().optional(),
+		createdAt: z.coerce.date().nullable().optional(),
+		raw: z.unknown().optional(),
+	})
+	.passthrough();
+
+export type WhatsAppContactProfile = z.infer<typeof WhatsAppContactProfile>;
+export type WhatsAppContact = z.infer<typeof WhatsAppContact>;
+export type WhatsAppConversation = z.infer<typeof WhatsAppConversation>;
+export type WhatsAppMessage = z.infer<typeof WhatsAppMessage>;

--- a/packages/whatsapp/schema/index.ts
+++ b/packages/whatsapp/schema/index.ts
@@ -1,0 +1,9 @@
+import { WhatsAppConversation, WhatsAppMessage } from './database';
+
+export const WhatsAppSchema = {
+	version: '1.0.0',
+	entities: {
+		messages: WhatsAppMessage,
+		conversations: WhatsAppConversation,
+	},
+} as const;

--- a/packages/whatsapp/tsconfig.json
+++ b/packages/whatsapp/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": [
+      "esnext"
+    ],
+    "types": [
+      "node"
+    ],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "./**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ],
+  "references": []
+}

--- a/packages/whatsapp/tsup.config.ts
+++ b/packages/whatsapp/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/whatsapp/webhooks/index.ts
+++ b/packages/whatsapp/webhooks/index.ts
@@ -1,0 +1,12 @@
+import { message } from './message';
+import { status } from './status';
+
+export const MessageWebhooks = {
+	message,
+};
+
+export const StatusWebhooks = {
+	status,
+};
+
+export * from './types';

--- a/packages/whatsapp/webhooks/message.ts
+++ b/packages/whatsapp/webhooks/message.ts
@@ -31,10 +31,7 @@ export const message: WhatsAppWebhooks['message'] = {
 						id: incomingMessage.id,
 						messaging_product: change.value.messaging_product,
 						from: incomingMessage.from,
-						wa_id:
-							change.value.contacts?.find(
-								(contact) => contact.wa_id === incomingMessage.from,
-							)?.wa_id ?? incomingMessage.from,
+						wa_id: incomingMessage.from,
 						phone_number_id: change.value.metadata?.phone_number_id,
 						display_phone_number: change.value.metadata?.display_phone_number,
 						contacts: change.value.contacts,
@@ -44,6 +41,7 @@ export const message: WhatsAppWebhooks['message'] = {
 						createdAt: incomingMessage.timestamp
 							? new Date(Number(incomingMessage.timestamp) * 1000)
 							: new Date(),
+						// raw preserves the original inbound message payload because interactive and media message variants differ across WhatsApp webhook events.
 						raw: incomingMessage,
 					};
 

--- a/packages/whatsapp/webhooks/message.ts
+++ b/packages/whatsapp/webhooks/message.ts
@@ -1,0 +1,80 @@
+import { logEventFromContext } from 'corsair/core';
+import type { WhatsAppWebhooks } from '..';
+import { createWhatsAppMatch, verifyWhatsAppWebhookSignature } from './types';
+
+export const message: WhatsAppWebhooks['message'] = {
+	match: createWhatsAppMatch('message'),
+
+	handler: async (ctx, request) => {
+		const verification = verifyWhatsAppWebhookSignature(request, ctx.key);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
+
+		const payload = request.payload;
+		let corsairEntityId = '';
+		const persistedMessages: Array<Record<string, unknown>> = [];
+
+		for (const entry of payload.entry) {
+			for (const change of entry.changes) {
+				if (change.field !== 'messages' || !change.value.messages?.length) {
+					continue;
+				}
+
+				for (const incomingMessage of change.value.messages) {
+					const normalizedMessage = {
+						...incomingMessage,
+						id: incomingMessage.id,
+						messaging_product: change.value.messaging_product,
+						from: incomingMessage.from,
+						wa_id:
+							change.value.contacts?.find(
+								(contact) => contact.wa_id === incomingMessage.from,
+							)?.wa_id ?? incomingMessage.from,
+						phone_number_id: change.value.metadata?.phone_number_id,
+						display_phone_number: change.value.metadata?.display_phone_number,
+						contacts: change.value.contacts,
+						profile: change.value.contacts?.[0]?.profile,
+						direction: 'inbound' as const,
+						authorId: incomingMessage.from,
+						createdAt: incomingMessage.timestamp
+							? new Date(Number(incomingMessage.timestamp) * 1000)
+							: new Date(),
+						raw: incomingMessage,
+					};
+
+					persistedMessages.push(normalizedMessage);
+
+					if (ctx.db.messages) {
+						try {
+							const entity = await ctx.db.messages.upsertByEntityId(
+								incomingMessage.id,
+								normalizedMessage,
+							);
+							corsairEntityId = entity?.id || corsairEntityId;
+						} catch (error) {
+							console.warn('Failed to save WhatsApp webhook message:', error);
+						}
+					}
+				}
+			}
+		}
+
+		await logEventFromContext(
+			ctx,
+			'whatsapp.webhook.message',
+			{ object: payload.object, messages: persistedMessages },
+			'completed',
+		);
+
+		return {
+			success: true,
+			corsairEntityId,
+			data: payload,
+		};
+	},
+};

--- a/packages/whatsapp/webhooks/status.ts
+++ b/packages/whatsapp/webhooks/status.ts
@@ -1,0 +1,94 @@
+import { logEventFromContext } from 'corsair/core';
+import type { WhatsAppWebhooks } from '..';
+import { createWhatsAppMatch, verifyWhatsAppWebhookSignature } from './types';
+
+export const status: WhatsAppWebhooks['status'] = {
+	match: createWhatsAppMatch('status'),
+
+	handler: async (ctx, request) => {
+		const verification = verifyWhatsAppWebhookSignature(request, ctx.key);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
+
+		const payload = request.payload;
+		let corsairEntityId = '';
+		const persistedStatuses: Array<Record<string, unknown>> = [];
+
+		for (const entry of payload.entry) {
+			for (const change of entry.changes) {
+				if (change.field !== 'messages' || !change.value.statuses?.length) {
+					continue;
+				}
+
+				for (const statusEvent of change.value.statuses) {
+					const normalizedStatus = {
+						...statusEvent,
+						id: statusEvent.id,
+						messaging_product: change.value.messaging_product,
+						recipient_id: statusEvent.recipient_id,
+						wa_id: statusEvent.recipient_id,
+						phone_number_id: change.value.metadata?.phone_number_id,
+						display_phone_number: change.value.metadata?.display_phone_number,
+						direction: 'outbound' as const,
+						status: statusEvent.status,
+						conversation: statusEvent.conversation,
+						pricing: statusEvent.pricing,
+						createdAt: statusEvent.timestamp
+							? new Date(Number(statusEvent.timestamp) * 1000)
+							: new Date(),
+						raw: statusEvent,
+					};
+
+					persistedStatuses.push(normalizedStatus);
+
+					if (ctx.db.messages) {
+						try {
+							const existing = await ctx.db.messages.findByEntityId(statusEvent.id);
+							const entity = await ctx.db.messages.upsertByEntityId(statusEvent.id, {
+								...(existing?.data ?? {}),
+								...normalizedStatus,
+							});
+							corsairEntityId = entity?.id || corsairEntityId;
+						} catch (error) {
+							console.warn('Failed to save WhatsApp status update:', error);
+						}
+					}
+
+					if (statusEvent.conversation?.id && ctx.db.conversations) {
+						try {
+							await ctx.db.conversations.upsertByEntityId(statusEvent.conversation.id, {
+								id: statusEvent.conversation.id,
+								expiration_timestamp: statusEvent.conversation.expiration_timestamp,
+								origin: statusEvent.conversation.origin,
+								category: statusEvent.pricing?.category,
+								createdAt: statusEvent.timestamp
+									? new Date(Number(statusEvent.timestamp) * 1000)
+									: new Date(),
+							});
+						} catch (error) {
+							console.warn('Failed to save WhatsApp conversation:', error);
+						}
+					}
+				}
+			}
+		}
+
+		await logEventFromContext(
+			ctx,
+			'whatsapp.webhook.status',
+			{ object: payload.object, statuses: persistedStatuses },
+			'completed',
+		);
+
+		return {
+			success: true,
+			corsairEntityId,
+			data: payload,
+		};
+	},
+};

--- a/packages/whatsapp/webhooks/types.ts
+++ b/packages/whatsapp/webhooks/types.ts
@@ -79,6 +79,7 @@ const WhatsAppChangeValueSchema = z
 		contacts: z.array(WhatsAppContactSchema).optional(),
 		messages: z.array(WhatsAppIncomingMessageSchema).optional(),
 		statuses: z.array(WhatsAppStatusSchema).optional(),
+		// Meta error objects vary across message types and delivery contexts, so the original payload is preserved without narrowing.
 		errors: z.array(z.unknown()).optional(),
 	})
 	.passthrough();
@@ -105,106 +106,97 @@ export const WhatsAppWebhookPayloadSchema = z
 	.passthrough();
 
 export type WhatsAppWebhookPayload = z.infer<typeof WhatsAppWebhookPayloadSchema>;
+export type WhatsAppIncomingMessage = z.infer<typeof WhatsAppIncomingMessageSchema>;
+export type WhatsAppStatus = z.infer<typeof WhatsAppStatusSchema>;
 export type MessageEvent = WhatsAppWebhookPayload;
 export type StatusEvent = WhatsAppWebhookPayload;
 
-export const WhatsAppMessageEventSchema: z.ZodType<MessageEvent> =
-	WhatsAppWebhookPayloadSchema.refine(
-		(payload) =>
-			payload.entry.some((entry) =>
-				entry.changes.some(
-					(change) =>
-						change.field === 'messages' &&
-						Array.isArray(change.value.messages) &&
-						change.value.messages.length > 0,
-				),
-			),
-		{
-			message: 'Payload does not contain incoming WhatsApp messages',
-		},
+function hasExclusiveMessageChanges(payload: WhatsAppWebhookPayload): boolean {
+	return payload.entry.some((entry) =>
+		entry.changes.some((change) => {
+			if (change.field !== 'messages') {
+				return false;
+			}
+
+			const hasMessages = Boolean(change.value.messages?.length);
+			const hasStatuses = Boolean(change.value.statuses?.length);
+			return hasMessages && !hasStatuses;
+		}),
 	);
+}
+
+function hasExclusiveStatusChanges(payload: WhatsAppWebhookPayload): boolean {
+	return payload.entry.some((entry) =>
+		entry.changes.some((change) => {
+			if (change.field !== 'messages') {
+				return false;
+			}
+
+			const hasMessages = Boolean(change.value.messages?.length);
+			const hasStatuses = Boolean(change.value.statuses?.length);
+			return hasStatuses && !hasMessages;
+		}),
+	);
+}
+
+export const WhatsAppMessageEventSchema: z.ZodType<MessageEvent> =
+	WhatsAppWebhookPayloadSchema.refine(hasExclusiveMessageChanges, {
+		message: 'Payload does not contain exclusive incoming WhatsApp messages',
+	});
 
 export const WhatsAppStatusEventSchema: z.ZodType<StatusEvent> =
-	WhatsAppWebhookPayloadSchema.refine(
-		(payload) =>
-			payload.entry.some((entry) =>
-				entry.changes.some(
-					(change) =>
-						change.field === 'messages' &&
-						Array.isArray(change.value.statuses) &&
-						change.value.statuses.length > 0,
-				),
-			),
-		{
-			message: 'Payload does not contain WhatsApp status updates',
-		},
-	);
-export type WhatsAppIncomingMessage = z.infer<typeof WhatsAppIncomingMessageSchema>;
-export type WhatsAppStatus = z.infer<typeof WhatsAppStatusSchema>;
+	WhatsAppWebhookPayloadSchema.refine(hasExclusiveStatusChanges, {
+		message: 'Payload does not contain exclusive WhatsApp status updates',
+	});
 
 export type WhatsAppWebhookOutputs = {
 	message: MessageEvent;
 	status: StatusEvent;
 };
 
-function parseBody(body: unknown): Record<string, unknown> {
-	if (typeof body === 'string') {
-		return JSON.parse(body) as Record<string, unknown>;
-	}
-	return (body ?? {}) as Record<string, unknown>;
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
-function hasMessagesPayload(body: Record<string, unknown>): boolean {
-	if (body.object !== 'whatsapp_business_account' || !Array.isArray(body.entry)) {
-		return false;
+function parseBody(body: unknown): Record<string, unknown> {
+	if (typeof body === 'string') {
+		const parsed: unknown = JSON.parse(body);
+		return isRecord(parsed) ? parsed : {};
 	}
 
-	return body.entry.some((entry: unknown) => {
-		if (!entry || typeof entry !== 'object' || !('changes' in entry)) {
-			return false;
-		}
+	return isRecord(body) ? body : {};
+}
 
-		const changes = (entry as { changes?: unknown }).changes;
-		if (!Array.isArray(changes)) {
-			return false;
-		}
+function extractMessageChanges(body: Record<string, unknown>) {
+	const parsed = WhatsAppWebhookPayloadSchema.safeParse(body);
+	if (!parsed.success) {
+		return [];
+	}
 
-		return changes.some((change: unknown) => {
-			if (!change || typeof change !== 'object' || !('field' in change)) {
-				return false;
-			}
-
-			if ((change as { field?: unknown }).field !== 'messages') {
-				return false;
-			}
-
-			const value = (change as { value?: unknown }).value;
-			return !!value && typeof value === 'object';
-		});
-	});
+	return parsed.data.entry.flatMap((entry) =>
+		entry.changes.filter((change) => change.field === 'messages'),
+	);
 }
 
 export function createWhatsAppMatch(
 	eventType: keyof WhatsAppWebhookOutputs,
 ): CorsairWebhookMatcher {
 	return (request: RawWebhookRequest) => {
-		const parsedBody = parseBody(request.body);
-		if (!hasMessagesPayload(parsedBody)) {
+		const changes = extractMessageChanges(parseBody(request.body));
+		if (changes.length === 0) {
 			return false;
 		}
 
-		const body = parsedBody as WhatsAppWebhookPayload;
-		return body.entry.some((entry) =>
-			entry.changes.some((change) => {
-				if (change.field !== 'messages') {
-					return false;
-				}
-				if (eventType === 'message') {
-					return !!change.value.messages?.length;
-				}
-				return !!change.value.statuses?.length;
-			}),
-		);
+		return changes.some((change) => {
+			const hasMessages = Boolean(change.value.messages?.length);
+			const hasStatuses = Boolean(change.value.statuses?.length);
+
+			if (eventType === 'message') {
+				return hasMessages && !hasStatuses;
+			}
+
+			return hasStatuses && !hasMessages;
+		});
 	};
 }
 

--- a/packages/whatsapp/webhooks/types.ts
+++ b/packages/whatsapp/webhooks/types.ts
@@ -1,0 +1,258 @@
+import crypto from 'node:crypto';
+import type {
+	CorsairWebhookMatcher,
+	RawWebhookRequest,
+	WebhookRequest,
+} from 'corsair/core';
+import { z } from 'zod';
+
+const WhatsAppMetadataSchema = z
+	.object({
+		display_phone_number: z.string().optional(),
+		phone_number_id: z.string().optional(),
+	})
+	.passthrough();
+
+const WhatsAppContactProfileSchema = z
+	.object({
+		name: z.string().optional(),
+	})
+	.passthrough();
+
+const WhatsAppContactSchema = z
+	.object({
+		profile: WhatsAppContactProfileSchema.optional(),
+		wa_id: z.string().optional(),
+	})
+	.passthrough();
+
+export const WhatsAppIncomingMessageSchema = z
+	.object({
+		from: z.string(),
+		id: z.string(),
+		timestamp: z.string(),
+		type: z.string(),
+		text: z
+			.object({
+				body: z.string().optional(),
+				preview_url: z.boolean().optional(),
+			})
+			.passthrough()
+			.optional(),
+	})
+	.passthrough();
+
+export const WhatsAppStatusSchema = z
+	.object({
+		id: z.string(),
+		status: z.string(),
+		timestamp: z.string(),
+		recipient_id: z.string(),
+		conversation: z
+			.object({
+				id: z.string().optional(),
+				expiration_timestamp: z.string().optional(),
+				origin: z
+					.object({
+						type: z.string().optional(),
+					})
+					.passthrough()
+					.optional(),
+			})
+			.passthrough()
+			.optional(),
+		pricing: z
+			.object({
+				billable: z.boolean().optional(),
+				pricing_model: z.string().optional(),
+				category: z.string().optional(),
+			})
+			.passthrough()
+			.optional(),
+	})
+	.passthrough();
+
+const WhatsAppChangeValueSchema = z
+	.object({
+		messaging_product: z.string().optional(),
+		metadata: WhatsAppMetadataSchema.optional(),
+		contacts: z.array(WhatsAppContactSchema).optional(),
+		messages: z.array(WhatsAppIncomingMessageSchema).optional(),
+		statuses: z.array(WhatsAppStatusSchema).optional(),
+		errors: z.array(z.unknown()).optional(),
+	})
+	.passthrough();
+
+const WhatsAppChangeSchema = z
+	.object({
+		field: z.string(),
+		value: WhatsAppChangeValueSchema,
+	})
+	.passthrough();
+
+const WhatsAppEntrySchema = z
+	.object({
+		id: z.string().optional(),
+		changes: z.array(WhatsAppChangeSchema),
+	})
+	.passthrough();
+
+export const WhatsAppWebhookPayloadSchema = z
+	.object({
+		object: z.literal('whatsapp_business_account'),
+		entry: z.array(WhatsAppEntrySchema),
+	})
+	.passthrough();
+
+export type WhatsAppWebhookPayload = z.infer<typeof WhatsAppWebhookPayloadSchema>;
+export type MessageEvent = WhatsAppWebhookPayload;
+export type StatusEvent = WhatsAppWebhookPayload;
+
+export const WhatsAppMessageEventSchema: z.ZodType<MessageEvent> =
+	WhatsAppWebhookPayloadSchema.refine(
+		(payload) =>
+			payload.entry.some((entry) =>
+				entry.changes.some(
+					(change) =>
+						change.field === 'messages' &&
+						Array.isArray(change.value.messages) &&
+						change.value.messages.length > 0,
+				),
+			),
+		{
+			message: 'Payload does not contain incoming WhatsApp messages',
+		},
+	);
+
+export const WhatsAppStatusEventSchema: z.ZodType<StatusEvent> =
+	WhatsAppWebhookPayloadSchema.refine(
+		(payload) =>
+			payload.entry.some((entry) =>
+				entry.changes.some(
+					(change) =>
+						change.field === 'messages' &&
+						Array.isArray(change.value.statuses) &&
+						change.value.statuses.length > 0,
+				),
+			),
+		{
+			message: 'Payload does not contain WhatsApp status updates',
+		},
+	);
+export type WhatsAppIncomingMessage = z.infer<typeof WhatsAppIncomingMessageSchema>;
+export type WhatsAppStatus = z.infer<typeof WhatsAppStatusSchema>;
+
+export type WhatsAppWebhookOutputs = {
+	message: MessageEvent;
+	status: StatusEvent;
+};
+
+function parseBody(body: unknown): Record<string, unknown> {
+	if (typeof body === 'string') {
+		return JSON.parse(body) as Record<string, unknown>;
+	}
+	return (body ?? {}) as Record<string, unknown>;
+}
+
+function hasMessagesPayload(body: Record<string, unknown>): boolean {
+	if (body.object !== 'whatsapp_business_account' || !Array.isArray(body.entry)) {
+		return false;
+	}
+
+	return body.entry.some((entry: unknown) => {
+		if (!entry || typeof entry !== 'object' || !('changes' in entry)) {
+			return false;
+		}
+
+		const changes = (entry as { changes?: unknown }).changes;
+		if (!Array.isArray(changes)) {
+			return false;
+		}
+
+		return changes.some((change: unknown) => {
+			if (!change || typeof change !== 'object' || !('field' in change)) {
+				return false;
+			}
+
+			if ((change as { field?: unknown }).field !== 'messages') {
+				return false;
+			}
+
+			const value = (change as { value?: unknown }).value;
+			return !!value && typeof value === 'object';
+		});
+	});
+}
+
+export function createWhatsAppMatch(
+	eventType: keyof WhatsAppWebhookOutputs,
+): CorsairWebhookMatcher {
+	return (request: RawWebhookRequest) => {
+		const parsedBody = parseBody(request.body);
+		if (!hasMessagesPayload(parsedBody)) {
+			return false;
+		}
+
+		const body = parsedBody as WhatsAppWebhookPayload;
+		return body.entry.some((entry) =>
+			entry.changes.some((change) => {
+				if (change.field !== 'messages') {
+					return false;
+				}
+				if (eventType === 'message') {
+					return !!change.value.messages?.length;
+				}
+				return !!change.value.statuses?.length;
+			}),
+		);
+	};
+}
+
+export function verifyWhatsAppWebhookSignature(
+	request: WebhookRequest<WhatsAppWebhookPayload>,
+	secret?: string,
+): { valid: boolean; error?: string } {
+	if (!secret) {
+		return { valid: false, error: 'Missing webhook secret' };
+	}
+
+	const rawBody = request.rawBody;
+	if (!rawBody) {
+		return {
+			valid: false,
+			error: 'Missing raw body for signature verification',
+		};
+	}
+
+	const headers = request.headers;
+	const signature = Array.isArray(headers['x-hub-signature-256'])
+		? headers['x-hub-signature-256'][0]
+		: headers['x-hub-signature-256'];
+
+	if (!signature) {
+		return {
+			valid: false,
+			error: 'Missing x-hub-signature-256 header',
+		};
+	}
+
+	try {
+		const expectedSignature = `sha256=${crypto
+			.createHmac('sha256', secret)
+			.update(rawBody)
+			.digest('hex')}`;
+
+		const isValid = crypto.timingSafeEqual(
+			Buffer.from(signature),
+			Buffer.from(expectedSignature),
+		);
+
+		if (!isValid) {
+			return { valid: false, error: 'Invalid signature' };
+		}
+
+		return { valid: true };
+	} catch {
+		return { valid: false, error: 'Invalid signature' };
+	}
+}


### PR DESCRIPTION
## Summary

This pull request adds a new **WhatsApp** integration package for Corsair following the repository's existing plugin conventions.

## What changed

- Added a new `@corsair-dev/whatsapp` package
- - Implemented outbound `messages.sendMessage`
- - Implemented persisted `messages.getMessages` and `messages.listConversations`
- - Added webhook handlers for inbound messages and delivery status updates
- - Added WhatsApp schema models for persisted messages and conversations
- - Wired endpoint metadata, endpoint schemas, webhook schemas, auth configuration, and webhook matching into the plugin entry point
- - Registered `whatsapp` as a provider in the shared provider constants
- - Added package-level README documentation with setup and usage examples
## Validation

- [x] `pnpm exec tsc -p packages/whatsapp/tsconfig.json --noEmit`
## Checklist

- [x] Follows existing package structure and naming conventions
- [ ] - [x] Keeps changes focused on the WhatsApp integration
- [ ] - [x] Includes setup and usage documentation