### PR TITLE
feat(mcp): add universal OpenAI-compatible OllamaProvider

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -51,6 +51,9 @@
     },
     "@openai/agents": {
       "optional": true
+    },
+    "openai": {
+      "optional": true
     }
   },
   "devDependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -33,7 +33,8 @@
     "@anthropic-ai/claude-agent-sdk": ">=0.2.0",
     "@anthropic-ai/sdk": ">=0.78.0",
     "@mastra/core": ">=1.0.0",
-    "@openai/agents": ">=0.5.0"
+    "@openai/agents": ">=0.5.0",
+    "openai": ">=4.0.0"
   },
   "peerDependenciesMeta": {
     "@ai-sdk/mcp": {

--- a/packages/mcp/src/adapters/ollama.ts
+++ b/packages/mcp/src/adapters/ollama.ts
@@ -29,6 +29,18 @@ export class OllamaProvider extends BaseProvider<CorsairOllamaTool> {
             type: 'function',
             function: {
                 name: def.name,
+                description: def.description,
+                parameters: schema as Record<string, unknown>,
+            },
+            /**
+             * The `execute` helper provides a simplified execution interface for runners.
+             * It handles:
+             * 1. Parsing arguments (handles both object and JSON string inputs).
+             * 2. Validation against the tool's Zod schema.
+             * 3. Execution of the underlying Corsair tool handler.
+             * 4. Extraction and concatenation of text results into a single string.
+             * 5. Graceful error handling for robust integration.
+             */
             execute: async (args) => {
                 try {
                     const raw = (
@@ -42,9 +54,6 @@ export class OllamaProvider extends BaseProvider<CorsairOllamaTool> {
                         .join('\n');
                 } catch (err) {
                     const message = err instanceof Error ? err.message : String(err);
-                    return `Error: ${message}`;
-                }
-            },
                     return `Error: ${message}`;
                 }
             },

--- a/packages/mcp/src/adapters/ollama.ts
+++ b/packages/mcp/src/adapters/ollama.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import { BaseProvider } from '../core/provider.js';
+import type { CorsairToolDef } from '../core/tools.js';
+
+
+
+export type CorsairOllamaTool = {
+    type: 'function';
+    function: {
+        name: string;
+        description: string;
+        parameters: Record<string, unknown>;
+    };
+    execute: (args: Record<string, unknown>) => Promise<string>;
+};
+
+
+// Represents a tool compatible with Ollama's OpenAI-style API.
+// Includes an `execute` method to simplify runner implementations.
+
+export class OllamaProvider extends BaseProvider<CorsairOllamaTool> {
+    readonly name = 'ollama';
+
+    wrapTool(def: CorsairToolDef): CorsairOllamaTool {
+        const schema = zodToJsonSchema(z.object(def.shape));
+
+        return {
+            type: 'function',
+            function: {
+                name: def.name,
+                description: def.description,
+                parameters: schema as Record<string, unknown>,
+            },
+            execute: async (args) => {
+                try {
+                    const result = await def.handler(args);
+                    return result.content
+                        .filter((c) => c.type === 'text')
+                        .map((c) => ('text' in c ? c.text : ''))
+                        .join('\n');
+                } catch (err) {
+                    const message = err instanceof Error ? err.message : String(err);
+                    return `Error: ${message}`;
+                }
+            },
+        };
+    }
+}

--- a/packages/mcp/src/adapters/ollama.ts
+++ b/packages/mcp/src/adapters/ollama.ts
@@ -29,18 +29,22 @@ export class OllamaProvider extends BaseProvider<CorsairOllamaTool> {
             type: 'function',
             function: {
                 name: def.name,
-                description: def.description,
-                parameters: schema as Record<string, unknown>,
-            },
             execute: async (args) => {
                 try {
-                    const result = await def.handler(args);
+                    const raw = (
+                        typeof args === 'string' ? JSON.parse(args) : args
+                    ) as Record<string, unknown>;
+                    const validated = z.object(def.shape).parse(raw);
+                    const result = await def.handler(validated);
                     return result.content
                         .filter((c) => c.type === 'text')
                         .map((c) => ('text' in c ? c.text : ''))
                         .join('\n');
                 } catch (err) {
                     const message = err instanceof Error ? err.message : String(err);
+                    return `Error: ${message}`;
+                }
+            },
                     return `Error: ${message}`;
                 }
             },

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -13,3 +13,4 @@ export { createMcpRouter } from './core/http.js';
 export { BaseProvider } from './core/provider.js';
 export { runStdioMcpServer } from './core/stdio.js';
 export type { CorsairToolDef } from './core/tools.js';
+export { OllamaProvider } from './adapters/ollama.js'


### PR DESCRIPTION
This PR introduces the Corsair MCP adapter (OllamaProvider), enabling seamless integration between the Corsair plugin ecosystem and any OpenAI-compatible LLM (Ollama, vLLM, NVIDIA NIM, etc.).

- Universal OpenAI Bridge: Converts Corsair tools (Zod schemas + handlers) into standard OpenAI function format.
- Local + Hosted Support: Works with both local models (Ollama) and hosted APIs (e.g., NVIDIA NIM).
- Native SDK Compatibility: Enables direct usage with the official openai npm package.
- Plug-and-Play Tooling: Automatically exposes Corsair plugins (GitHub, Hacker News, etc.) as callable tools

Unlike standard SDKs that only handle transport, this adapter provides translation, allowing LLMs to understand and execute Corsair tools without custom integration.

What’s Included
- MCP adapter setup (OllamaProvider)
- Example agents:
- Local Ollama agent
- NVIDIA NIM agent
- Hacker News agent with multi-step tool execution
- Best practices for system prompts and tool usage

Use tool-calling capable models for best results.
Smaller models may require stricter system prompts to enforce tool usage.