### PR TITLE
Fix TOC headings by trimming line endings

### DIFF
--- a/docs/lib/toc.ts
+++ b/docs/lib/toc.ts
@@ -253,7 +253,7 @@ export function extractTOC(mdxPath: string): TOCItem[] {
 	const slugCounts: Record<string, number> = {};
 
 	for (const line of lines) {
-		const trimmedLine = line.trim();
+		const trimmedLine = line.replace(/\r$/, '');
 		const match = trimmedLine.match(/^(#{2,6})\s+(.+)$/);
 		if (match) {
 			const depth = match[1].length;

--- a/docs/lib/toc.ts
+++ b/docs/lib/toc.ts
@@ -253,7 +253,8 @@ export function extractTOC(mdxPath: string): TOCItem[] {
 	const slugCounts: Record<string, number> = {};
 
 	for (const line of lines) {
-		const match = line.match(/^(#{2,6})\s+(.+)$/);
+		const trimmedLine = line.trim();
+		const match = trimmedLine.match(/^(#{2,6})\s+(.+)$/);
 		if (match) {
 			const depth = match[1].length;
 			const title = match[2].trim();


### PR DESCRIPTION
## Fix: TOC headings not displaying https://github.com/corsairdev/corsair/issues/140

### Problem
Table of contents headings were not showing in the sidebar (displaying "No Headings" instead).

### Root Cause
Windows line endings (`\r\n`) in MDX files prevented the heading regex from matching. The regex expected lines to end with `$`, but the carriage return `\r` was breaking the match.

### Solution
Added `.trim()` to remove whitespace and line ending characters before regex matching in the `extractTOC` function.

### Changes
- Modified `docs/lib/toc.ts`: Added `line.trim()` before regex matching

### Testing
- Tested on `/` (introduction) page: headings now display correctly
- Verified with multiple pages in the documentation