### PR TITLE
Added openweathermap agent plugin into ecosystem

### DIFF
--- a/demo/testing/package.json
+++ b/demo/testing/package.json
@@ -32,6 +32,7 @@
     "@corsair-dev/mcp": "workspace:*",
     "@corsair-dev/notion": "workspace:*",
     "@corsair-dev/onedrive": "workspace:*",
+    "@corsair-dev/openweathermap": "workspace:*",
     "@corsair-dev/outlook": "workspace:*",
     "@corsair-dev/sharepoint": "workspace:*",
     "@corsair-dev/slack": "workspace:*",

--- a/demo/testing/src/scripts/test-script.ts
+++ b/demo/testing/src/scripts/test-script.ts
@@ -2,9 +2,76 @@ import { corsair } from '@/server/corsair';
 import 'dotenv/config';
 
 const main = async () => {
-	// write any test scripts here
-	// const res = await corsair -> fill in the rest
-	const res = await corsair.googlesheets.api.spreadsheets.list({});
+	// ── OpenWeatherMap Plugin Tests ──────────────────────────────────────────
+
+	console.log('=== OpenWeatherMap Plugin Tests ===\n');
+
+	// Test 1: list_operations — verify the plugin is registered and endpoints are discoverable
+	console.log('1. list_operations({ plugin: "openweathermap" })');
+	const ops = corsair.list_operations({ plugin: 'openweathermap' });
+	console.log(ops);
+	console.log();
+
+	// Test 2: get_schema — verify schema introspection works for each endpoint
+	console.log('2. get_schema("openweathermap.api.weather.oneCall")');
+	const oneCallSchema = corsair.get_schema('openweathermap.api.weather.oneCall');
+	console.log(oneCallSchema);
+	console.log();
+
+	console.log('3. get_schema("openweathermap.api.history.timeMachine")');
+	const timeMachineSchema = corsair.get_schema(
+		'openweathermap.api.history.timeMachine',
+	);
+	console.log(timeMachineSchema);
+	console.log();
+
+	console.log('4. get_schema("openweathermap.api.summary.daySummary")');
+	const daySummarySchema = corsair.get_schema(
+		'openweathermap.api.summary.daySummary',
+	);
+	console.log(daySummarySchema);
+	console.log();
+
+	console.log('5. get_schema("openweathermap.api.summary.overview")');
+	const overviewSchema = corsair.get_schema(
+		'openweathermap.api.summary.overview',
+	);
+	console.log(overviewSchema);
+	console.log();
+
+	// Test 3: Live API call — requires OPENWEATHERMAP_API_KEY in .env
+	// Uncomment the following to test with a real API key:
+	//
+	// console.log('6. Live API call: weather.oneCall (New York City)');
+	// try {
+	// 	const weather = await corsair.openweathermap.api.weather.oneCall({
+	// 		lat: 40.7128,
+	// 		lon: -74.006,
+	// 		units: 'metric',
+	// 		exclude: ['minutely'],
+	// 	});
+	// 	console.log('Current temp:', weather.current?.temp, '°C');
+	// 	console.log('Weather:', weather.current?.weather[0]?.description);
+	// 	console.log('Daily forecast entries:', weather.daily?.length);
+	// 	console.log('Hourly forecast entries:', weather.hourly?.length);
+	// } catch (error) {
+	// 	console.error('API call failed:', error);
+	// }
+	// console.log();
+	//
+	// console.log('7. Live API call: summary.overview (London)');
+	// try {
+	// 	const overview = await corsair.openweathermap.api.summary.overview({
+	// 		lat: 51.5074,
+	// 		lon: -0.1278,
+	// 		units: 'metric',
+	// 	});
+	// 	console.log('Overview:', overview.weather_overview);
+	// } catch (error) {
+	// 	console.error('API call failed:', error);
+	// }
+
+	console.log('=== All schema tests passed ===');
 };
 
 main();

--- a/demo/testing/src/server/corsair.ts
+++ b/demo/testing/src/server/corsair.ts
@@ -9,6 +9,7 @@ import { sharepoint } from '@corsair-dev/sharepoint';
 import { outlook } from '@corsair-dev/outlook';
 import { slack } from '@corsair-dev/slack';
 import { onedrive } from '@corsair-dev/onedrive'
+import { openweathermap } from '@corsair-dev/openweathermap'
 import { teams } from '@corsair-dev/teams'
 import { createCorsair } from 'corsair';
 import { sqlite } from '../db';
@@ -21,5 +22,5 @@ export const corsair = createCorsair({
 		timeout: '10m',
 		onTimeout: 'deny',
 	},
-	plugins: [github(), slack(), googlesheets(), googlecalendar(), gmail(), linear(), sharepoint(), onedrive()],
+	plugins: [github(), slack(), googlesheets(), googlecalendar(), gmail(), linear(), sharepoint(), onedrive(), openweathermap()],
 });

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -38,6 +38,7 @@ export const BaseProviders = [
 	'monday',
 	'notion',
 	'onedrive',
+	'openweathermap',
 	'oura',
 	'outlook',
 	'pagerduty',
@@ -57,8 +58,8 @@ export const BaseProviders = [
 	'trello',
 	'twitter',
 	'twitterapiio',
-	'youtube',
 	'typeform',
+	'youtube',
 	'zoom',
 ] as const;
 
@@ -88,6 +89,7 @@ export type AllProviders =
 	| 'monday'
 	| 'notion'
 	| 'onedrive'
+	| 'openweathermap'
 	| 'oura'
 	| 'outlook'
 	| 'pagerduty'
@@ -107,8 +109,8 @@ export type AllProviders =
 	| 'trello'
 	| 'twitter'
 	| 'twitterapiio'
-	| 'youtube'
 	| 'typeform'
+	| 'youtube'
 	| 'zoom'
 	| (string & {});
 

--- a/packages/openweathermap/client.ts
+++ b/packages/openweathermap/client.ts
@@ -1,0 +1,63 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { request } from 'corsair/http';
+
+export class OpenWeatherMapAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly code?: number,
+	) {
+		super(message);
+		this.name = 'OpenWeatherMapAPIError';
+	}
+}
+
+const OPENWEATHERMAP_API_BASE = 'https://api.openweathermap.org/data/3.0';
+
+/**
+ * Performs a request to the OpenWeatherMap One Call API 3.0.
+ *
+ * Auth: API key passed as the `appid` query parameter (the only supported method).
+ * All endpoints are GET-only.
+ */
+export async function makeOpenWeatherMapRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	options: {
+		query?: Record<string, string | number | boolean | undefined>;
+	} = {},
+): Promise<T> {
+	const { query = {} } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: OPENWEATHERMAP_API_BASE,
+		VERSION: '3.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: undefined,
+		HEADERS: {
+			'Content-Type': 'application/json',
+		},
+	};
+
+	// OpenWeatherMap authenticates via the `appid` query parameter
+	const queryWithAuth: Record<string, string | number | boolean | undefined> = {
+		...query,
+		appid: apiKey,
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method: 'GET',
+		url: endpoint,
+		query: queryWithAuth,
+	};
+
+	try {
+		const response = await request<T>(config, requestOptions);
+		return response;
+	} catch (error) {
+		if (error instanceof Error) {
+			throw new OpenWeatherMapAPIError(error.message);
+		}
+		throw new OpenWeatherMapAPIError('Unknown error');
+	}
+}

--- a/packages/openweathermap/endpoints/history.ts
+++ b/packages/openweathermap/endpoints/history.ts
@@ -1,0 +1,37 @@
+import { logEventFromContext } from 'corsair/core';
+import type { OpenWeatherMapEndpoints } from '..';
+import { makeOpenWeatherMapRequest } from '../client';
+import type { OpenWeatherMapEndpointOutputs } from './types';
+
+/**
+ * Get historical weather data for a specific timestamp.
+ * Data is available from January 1st, 1979.
+ *
+ * API: GET /onecall/timemachine
+ * Docs: https://openweathermap.org/api/one-call-3#history
+ */
+export const timeMachine: OpenWeatherMapEndpoints['timeMachine'] = async (
+	ctx,
+	input,
+) => {
+	const query: Record<string, string | number | boolean | undefined> = {
+		lat: input.lat,
+		lon: input.lon,
+		dt: input.dt,
+		units: input.units,
+		lang: input.lang,
+	};
+
+	const response = await makeOpenWeatherMapRequest<
+		OpenWeatherMapEndpointOutputs['timeMachine']
+	>('onecall/timemachine', ctx.key, { query });
+
+	await logEventFromContext(
+		ctx,
+		'openweathermap.history.timeMachine',
+		{ lat: input.lat, lon: input.lon, dt: input.dt },
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/openweathermap/endpoints/index.ts
+++ b/packages/openweathermap/endpoints/index.ts
@@ -1,0 +1,18 @@
+import { oneCall } from './weather';
+import { timeMachine } from './history';
+import { daySummary, overview } from './summary';
+
+export const Weather = {
+	oneCall,
+};
+
+export const History = {
+	timeMachine,
+};
+
+export const Summary = {
+	daySummary,
+	overview,
+};
+
+export * from './types';

--- a/packages/openweathermap/endpoints/summary.ts
+++ b/packages/openweathermap/endpoints/summary.ts
@@ -1,0 +1,70 @@
+import { logEventFromContext } from 'corsair/core';
+import type { OpenWeatherMapEndpoints } from '..';
+import { makeOpenWeatherMapRequest } from '../client';
+import type { OpenWeatherMapEndpointOutputs } from './types';
+
+/**
+ * Get aggregated weather data for a specific date.
+ * Data is available from January 2nd, 1979 to 1.5 years ahead of the current date.
+ *
+ * API: GET /onecall/day_summary
+ * Docs: https://openweathermap.org/api/one-call-3#day_summary
+ */
+export const daySummary: OpenWeatherMapEndpoints['daySummary'] = async (
+	ctx,
+	input,
+) => {
+	const query: Record<string, string | number | boolean | undefined> = {
+		lat: input.lat,
+		lon: input.lon,
+		date: input.date,
+		units: input.units,
+		lang: input.lang,
+		tz: input.tz,
+	};
+
+	const response = await makeOpenWeatherMapRequest<
+		OpenWeatherMapEndpointOutputs['daySummary']
+	>('onecall/day_summary', ctx.key, { query });
+
+	await logEventFromContext(
+		ctx,
+		'openweathermap.summary.daySummary',
+		{ lat: input.lat, lon: input.lon, date: input.date },
+		'completed',
+	);
+
+	return response;
+};
+
+/**
+ * Get a human-readable weather overview for a location.
+ * Returns a text summary of the weather conditions.
+ *
+ * API: GET /onecall/overview
+ * Docs: https://openweathermap.org/api/one-call-3#overview
+ */
+export const overview: OpenWeatherMapEndpoints['overview'] = async (
+	ctx,
+	input,
+) => {
+	const query: Record<string, string | number | boolean | undefined> = {
+		lat: input.lat,
+		lon: input.lon,
+		date: input.date,
+		units: input.units,
+	};
+
+	const response = await makeOpenWeatherMapRequest<
+		OpenWeatherMapEndpointOutputs['overview']
+	>('onecall/overview', ctx.key, { query });
+
+	await logEventFromContext(
+		ctx,
+		'openweathermap.summary.overview',
+		{ lat: input.lat, lon: input.lon, date: input.date },
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/openweathermap/endpoints/types.ts
+++ b/packages/openweathermap/endpoints/types.ts
@@ -1,0 +1,402 @@
+import { z } from 'zod';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared / Common Schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const OPENWEATHERMAP_UNITS = ['standard', 'metric', 'imperial'] as const;
+export type OpenWeatherMapUnits = (typeof OPENWEATHERMAP_UNITS)[number];
+
+export const OPENWEATHERMAP_EXCLUDE = [
+	'current',
+	'minutely',
+	'hourly',
+	'daily',
+	'alerts',
+] as const;
+export type OpenWeatherMapExclude = (typeof OPENWEATHERMAP_EXCLUDE)[number];
+
+/** Weather condition object returned in most responses. */
+const WeatherConditionSchema = z.object({
+	/** Weather condition ID */
+	id: z.number(),
+	/** Group of weather parameters (Rain, Snow, Clouds, etc.) */
+	main: z.string(),
+	/** Weather condition within the group */
+	description: z.string(),
+	/** Weather icon ID */
+	icon: z.string(),
+});
+
+export type WeatherCondition = z.infer<typeof WeatherConditionSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Current & Forecast — GET /onecall
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const OneCallInputSchema = z.object({
+	/** Latitude (-90 to 90) */
+	lat: z.number().min(-90).max(90).describe('Latitude of the location'),
+	/** Longitude (-180 to 180) */
+	lon: z.number().min(-180).max(180).describe('Longitude of the location'),
+	/** Exclude parts of the response. Comma-separated list. */
+	exclude: z
+		.array(z.enum(OPENWEATHERMAP_EXCLUDE))
+		.optional()
+		.describe(
+			'Parts to exclude from the response: current, minutely, hourly, daily, alerts',
+		),
+	/** Units of measurement: standard, metric, or imperial */
+	units: z
+		.enum(OPENWEATHERMAP_UNITS)
+		.optional()
+		.describe('Units: standard (Kelvin), metric (Celsius), imperial (Fahrenheit)'),
+	/** Language code for descriptions (e.g. "en", "fr", "de") */
+	lang: z.string().optional().describe('Language code for weather descriptions'),
+});
+
+export type OneCallInput = z.infer<typeof OneCallInputSchema>;
+
+const CurrentWeatherSchema = z.object({
+	/** Current time, Unix, UTC */
+	dt: z.number(),
+	/** Sunrise time, Unix, UTC */
+	sunrise: z.number().optional(),
+	/** Sunset time, Unix, UTC */
+	sunset: z.number().optional(),
+	/** Temperature */
+	temp: z.number(),
+	/** Human perception of temperature */
+	feels_like: z.number(),
+	/** Atmospheric pressure on sea level, hPa */
+	pressure: z.number(),
+	/** Humidity, % */
+	humidity: z.number(),
+	/** Atmospheric temperature below which water droplets begin to condense */
+	dew_point: z.number(),
+	/** UV index */
+	uvi: z.number(),
+	/** Cloudiness, % */
+	clouds: z.number(),
+	/** Average visibility, metres (max 10km) */
+	visibility: z.number().optional(),
+	/** Wind speed */
+	wind_speed: z.number(),
+	/** Wind direction, degrees (meteorological) */
+	wind_deg: z.number(),
+	/** Wind gust */
+	wind_gust: z.number().optional(),
+	/** Weather conditions */
+	weather: z.array(WeatherConditionSchema),
+	/** Rain volume for last 1 hour, mm */
+	rain: z.object({ '1h': z.number() }).optional(),
+	/** Snow volume for last 1 hour, mm */
+	snow: z.object({ '1h': z.number() }).optional(),
+});
+
+export type CurrentWeather = z.infer<typeof CurrentWeatherSchema>;
+
+const MinutelyForecastSchema = z.object({
+	/** Time of the forecasted data, Unix, UTC */
+	dt: z.number(),
+	/** Precipitation volume, mm/h */
+	precipitation: z.number(),
+});
+
+export type MinutelyForecast = z.infer<typeof MinutelyForecastSchema>;
+
+const HourlyForecastSchema = z.object({
+	dt: z.number(),
+	temp: z.number(),
+	feels_like: z.number(),
+	pressure: z.number(),
+	humidity: z.number(),
+	dew_point: z.number(),
+	uvi: z.number(),
+	clouds: z.number(),
+	visibility: z.number().optional(),
+	wind_speed: z.number(),
+	wind_deg: z.number(),
+	wind_gust: z.number().optional(),
+	weather: z.array(WeatherConditionSchema),
+	/** Probability of precipitation (0–1) */
+	pop: z.number(),
+	rain: z.object({ '1h': z.number() }).optional(),
+	snow: z.object({ '1h': z.number() }).optional(),
+});
+
+export type HourlyForecast = z.infer<typeof HourlyForecastSchema>;
+
+const DailyTemperatureSchema = z.object({
+	day: z.number(),
+	min: z.number(),
+	max: z.number(),
+	night: z.number(),
+	eve: z.number(),
+	morn: z.number(),
+});
+
+const DailyFeelsLikeSchema = z.object({
+	day: z.number(),
+	night: z.number(),
+	eve: z.number(),
+	morn: z.number(),
+});
+
+const DailyForecastSchema = z.object({
+	dt: z.number(),
+	sunrise: z.number(),
+	sunset: z.number(),
+	moonrise: z.number(),
+	moonset: z.number(),
+	/** Moon phase (0 = new moon, 0.25 = first quarter, 0.5 = full moon, 0.75 = last quarter) */
+	moon_phase: z.number(),
+	summary: z.string().optional(),
+	temp: DailyTemperatureSchema,
+	feels_like: DailyFeelsLikeSchema,
+	pressure: z.number(),
+	humidity: z.number(),
+	dew_point: z.number(),
+	wind_speed: z.number(),
+	wind_deg: z.number(),
+	wind_gust: z.number().optional(),
+	weather: z.array(WeatherConditionSchema),
+	clouds: z.number(),
+	/** Probability of precipitation (0–1) */
+	pop: z.number(),
+	/** Precipitation volume, mm */
+	rain: z.number().optional(),
+	/** Snow volume, mm */
+	snow: z.number().optional(),
+	uvi: z.number(),
+});
+
+export type DailyForecast = z.infer<typeof DailyForecastSchema>;
+
+const WeatherAlertSchema = z.object({
+	/** Name of the alert source */
+	sender_name: z.string(),
+	/** Alert event name */
+	event: z.string(),
+	/** Start of the alert, Unix, UTC */
+	start: z.number(),
+	/** End of the alert, Unix, UTC */
+	end: z.number(),
+	/** Description of the alert */
+	description: z.string(),
+	/** Tags associated with the alert */
+	tags: z.array(z.string()),
+});
+
+export type WeatherAlert = z.infer<typeof WeatherAlertSchema>;
+
+export const OneCallResponseSchema = z.object({
+	/** Latitude of the location */
+	lat: z.number(),
+	/** Longitude of the location */
+	lon: z.number(),
+	/** Timezone name (e.g. "America/Chicago") */
+	timezone: z.string(),
+	/** Shift in seconds from UTC */
+	timezone_offset: z.number(),
+	/** Current weather data */
+	current: CurrentWeatherSchema.optional(),
+	/** Minute-by-minute forecast for 1 hour */
+	minutely: z.array(MinutelyForecastSchema).optional(),
+	/** Hourly forecast for 48 hours */
+	hourly: z.array(HourlyForecastSchema).optional(),
+	/** Daily forecast for 8 days */
+	daily: z.array(DailyForecastSchema).optional(),
+	/** Government weather alerts */
+	alerts: z.array(WeatherAlertSchema).optional(),
+});
+
+export type OneCallResponse = z.infer<typeof OneCallResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Historical Weather — GET /onecall/timemachine
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const TimeMachineInputSchema = z.object({
+	/** Latitude (-90 to 90) */
+	lat: z.number().min(-90).max(90).describe('Latitude of the location'),
+	/** Longitude (-180 to 180) */
+	lon: z.number().min(-180).max(180).describe('Longitude of the location'),
+	/** Timestamp (Unix time, UTC) for the requested date. Data is available from 1979-01-01. */
+	dt: z.number().describe('Unix timestamp (UTC) for the requested historical date'),
+	/** Units of measurement: standard, metric, or imperial */
+	units: z
+		.enum(OPENWEATHERMAP_UNITS)
+		.optional()
+		.describe('Units: standard (Kelvin), metric (Celsius), imperial (Fahrenheit)'),
+	/** Language code for descriptions */
+	lang: z.string().optional().describe('Language code for weather descriptions'),
+});
+
+export type TimeMachineInput = z.infer<typeof TimeMachineInputSchema>;
+
+const HistoricalWeatherDataSchema = z.object({
+	dt: z.number(),
+	sunrise: z.number(),
+	sunset: z.number(),
+	temp: z.number(),
+	feels_like: z.number(),
+	pressure: z.number(),
+	humidity: z.number(),
+	dew_point: z.number(),
+	uvi: z.number(),
+	clouds: z.number(),
+	visibility: z.number().optional(),
+	wind_speed: z.number(),
+	wind_deg: z.number(),
+	wind_gust: z.number().optional(),
+	weather: z.array(WeatherConditionSchema),
+	rain: z.object({ '1h': z.number() }).optional(),
+	snow: z.object({ '1h': z.number() }).optional(),
+});
+
+export type HistoricalWeatherData = z.infer<typeof HistoricalWeatherDataSchema>;
+
+export const TimeMachineResponseSchema = z.object({
+	lat: z.number(),
+	lon: z.number(),
+	timezone: z.string(),
+	timezone_offset: z.number(),
+	data: z.array(HistoricalWeatherDataSchema),
+});
+
+export type TimeMachineResponse = z.infer<typeof TimeMachineResponseSchema>;
+
+// ────────────────────────────────────────────────────────────────────────────��
+// Day Summary — GET /onecall/day_summary
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const DaySummaryInputSchema = z.object({
+	/** Latitude (-90 to 90) */
+	lat: z.number().min(-90).max(90).describe('Latitude of the location'),
+	/** Longitude (-180 to 180) */
+	lon: z.number().min(-180).max(180).describe('Longitude of the location'),
+	/** Date in YYYY-MM-DD format. Data is available from 1979-01-02 to 1.5 years ahead. */
+	date: z
+		.string()
+		.regex(/^\d{4}-\d{2}-\d{2}$/)
+		.describe('Date in YYYY-MM-DD format'),
+	/** Units of measurement: standard, metric, or imperial */
+	units: z
+		.enum(OPENWEATHERMAP_UNITS)
+		.optional()
+		.describe('Units: standard (Kelvin), metric (Celsius), imperial (Fahrenheit)'),
+	/** Language code for descriptions */
+	lang: z.string().optional().describe('Language code for weather descriptions'),
+	/** Timezone in ±XX:XX format for date interpretation */
+	tz: z
+		.string()
+		.optional()
+		.describe('Timezone offset in ±XX:XX format (e.g. +05:30)'),
+});
+
+export type DaySummaryInput = z.infer<typeof DaySummaryInputSchema>;
+
+const DaySummaryTemperatureSchema = z.object({
+	min: z.number(),
+	max: z.number(),
+	afternoon: z.number(),
+	night: z.number(),
+	evening: z.number(),
+	morning: z.number(),
+});
+
+const DaySummaryWindSchema = z.object({
+	max: z.object({
+		speed: z.number(),
+		direction: z.number(),
+	}),
+});
+
+const DaySummaryPrecipitationSchema = z.object({
+	total: z.number(),
+});
+
+export const DaySummaryResponseSchema = z.object({
+	lat: z.number(),
+	lon: z.number(),
+	tz: z.string(),
+	date: z.string(),
+	units: z.string(),
+	cloud_cover: z.object({ afternoon: z.number() }),
+	humidity: z.object({ afternoon: z.number() }),
+	precipitation: DaySummaryPrecipitationSchema,
+	temperature: DaySummaryTemperatureSchema,
+	pressure: z.object({ afternoon: z.number() }),
+	wind: DaySummaryWindSchema,
+});
+
+export type DaySummaryResponse = z.infer<typeof DaySummaryResponseSchema>;
+
+// ───────────────────────────────��─────────────────────────────────────────────
+// Weather Overview — GET /onecall/overview
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const OverviewInputSchema = z.object({
+	/** Latitude (-90 to 90) */
+	lat: z.number().min(-90).max(90).describe('Latitude of the location'),
+	/** Longitude (-180 to 180) */
+	lon: z.number().min(-180).max(180).describe('Longitude of the location'),
+	/** Date in YYYY-MM-DD format. If omitted, returns today's overview. */
+	date: z
+		.string()
+		.regex(/^\d{4}-\d{2}-\d{2}$/)
+		.optional()
+		.describe('Date in YYYY-MM-DD format (defaults to today)'),
+	/** Units of measurement: standard, metric, or imperial */
+	units: z
+		.enum(OPENWEATHERMAP_UNITS)
+		.optional()
+		.describe('Units: standard (Kelvin), metric (Celsius), imperial (Fahrenheit)'),
+});
+
+export type OverviewInput = z.infer<typeof OverviewInputSchema>;
+
+export const OverviewResponseSchema = z.object({
+	lat: z.number(),
+	lon: z.number(),
+	tz: z.string(),
+	date: z.string(),
+	units: z.string(),
+	/** Human-readable weather overview text */
+	weather_overview: z.string(),
+});
+
+export type OverviewResponse = z.infer<typeof OverviewResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin Endpoint Input / Output Maps
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type OpenWeatherMapEndpointInputs = {
+	oneCall: OneCallInput;
+	timeMachine: TimeMachineInput;
+	daySummary: DaySummaryInput;
+	overview: OverviewInput;
+};
+
+export type OpenWeatherMapEndpointOutputs = {
+	oneCall: OneCallResponse;
+	timeMachine: TimeMachineResponse;
+	daySummary: DaySummaryResponse;
+	overview: OverviewResponse;
+};
+
+export const OpenWeatherMapEndpointInputSchemas = {
+	oneCall: OneCallInputSchema,
+	timeMachine: TimeMachineInputSchema,
+	daySummary: DaySummaryInputSchema,
+	overview: OverviewInputSchema,
+} as const;
+
+export const OpenWeatherMapEndpointOutputSchemas = {
+	oneCall: OneCallResponseSchema,
+	timeMachine: TimeMachineResponseSchema,
+	daySummary: DaySummaryResponseSchema,
+	overview: OverviewResponseSchema,
+} as const;

--- a/packages/openweathermap/endpoints/weather.ts
+++ b/packages/openweathermap/endpoints/weather.ts
@@ -1,0 +1,40 @@
+import { logEventFromContext } from 'corsair/core';
+import type { OpenWeatherMapEndpoints } from '..';
+import { makeOpenWeatherMapRequest } from '../client';
+import type { OpenWeatherMapEndpointOutputs } from './types';
+
+/**
+ * Get current weather, minute-by-minute forecast for 1 hour, hourly forecast for 48 hours,
+ * daily forecast for 8 days, and government weather alerts.
+ *
+ * API: GET /onecall
+ * Docs: https://openweathermap.org/api/one-call-3#current
+ */
+export const oneCall: OpenWeatherMapEndpoints['oneCall'] = async (
+	ctx,
+	input,
+) => {
+	const query: Record<string, string | number | boolean | undefined> = {
+		lat: input.lat,
+		lon: input.lon,
+		units: input.units,
+		lang: input.lang,
+	};
+
+	if (input.exclude && input.exclude.length > 0) {
+		query.exclude = input.exclude.join(',');
+	}
+
+	const response = await makeOpenWeatherMapRequest<
+		OpenWeatherMapEndpointOutputs['oneCall']
+	>('onecall', ctx.key, { query });
+
+	await logEventFromContext(
+		ctx,
+		'openweathermap.weather.oneCall',
+		{ lat: input.lat, lon: input.lon },
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/openweathermap/error-handlers.ts
+++ b/packages/openweathermap/error-handlers.ts
@@ -1,0 +1,81 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+
+/**
+ * Error handlers for the OpenWeatherMap plugin.
+ *
+ * OpenWeatherMap error codes:
+ * - 401: Invalid API key or API key not activated (new keys take up to 2 hours)
+ * - 404: Data not available for the requested location/time
+ * - 429: Rate limit exceeded (free tier: 60 calls/min, 1,000 calls/day)
+ * - 5xx: Internal server error
+ */
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('429') || msg.includes('rate limit');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return {
+				maxRetries: 3,
+				retryStrategy: 'exponential_backoff' as const,
+				headersRetryAfterMs: retryAfterMs,
+			};
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('invalid api key') ||
+				msg.includes('unauthorized') ||
+				msg.includes('401')
+			);
+		},
+		handler: async (error: Error) => {
+			console.log(
+				'[OPENWEATHERMAP] Authentication failed — check your API key. ' +
+					'Note: new API keys can take up to 2 hours to activate.',
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	NOT_FOUND_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 404) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('404') || msg.includes('not found');
+		},
+		handler: async (error: Error) => {
+			console.warn(
+				'[OPENWEATHERMAP] Data not found — the requested location or time range may not have data available.',
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	SERVER_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status >= 500) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('500') || msg.includes('internal server error');
+		},
+		handler: async () => ({
+			maxRetries: 2,
+			retryStrategy: 'exponential_backoff' as const,
+		}),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async (error: Error) => {
+			console.error(`[OPENWEATHERMAP] Unhandled error: ${error.message}`);
+			return { maxRetries: 0 };
+		},
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/openweathermap/index.ts
+++ b/packages/openweathermap/index.ts
@@ -1,0 +1,266 @@
+import type {
+	BindEndpoints,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+} from 'corsair/core';
+import type { AuthTypes } from 'corsair/core';
+import { Weather, History, Summary } from './endpoints';
+import type {
+	OpenWeatherMapEndpointInputs,
+	OpenWeatherMapEndpointOutputs,
+} from './endpoints/types';
+import {
+	OpenWeatherMapEndpointInputSchemas,
+	OpenWeatherMapEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { OpenWeatherMapSchema } from './schema';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin Options
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type OpenWeatherMapPluginOptions = {
+	/** Authentication method. Only api_key is supported. */
+	authType?: PickAuth<'api_key'>;
+	/** Optional: pass the API key directly (bypasses key manager) */
+	key?: string;
+	/** Optional: lifecycle hooks for endpoints */
+	hooks?: InternalOpenWeatherMapPlugin['hooks'];
+	/** Optional: custom error handlers (merged with defaults) */
+	errorHandlers?: CorsairErrorHandler;
+	/**
+	 * Permission configuration for the OpenWeatherMap plugin.
+	 * All endpoints are read-only, so the default mode is effectively 'open'.
+	 */
+	permissions?: PluginPermissionsConfig<typeof openWeatherMapEndpointsNested>;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Context & Type Helpers
+// ───────────────────────────────────────────────────���─────────────────────────
+
+export type OpenWeatherMapContext = CorsairPluginContext<
+	typeof OpenWeatherMapSchema,
+	OpenWeatherMapPluginOptions
+>;
+
+export type OpenWeatherMapKeyBuilderContext =
+	KeyBuilderContext<OpenWeatherMapPluginOptions>;
+
+export type OpenWeatherMapBoundEndpoints = BindEndpoints<
+	typeof openWeatherMapEndpointsNested
+>;
+
+type OpenWeatherMapEndpoint<K extends keyof OpenWeatherMapEndpointOutputs> =
+	CorsairEndpoint<
+		OpenWeatherMapContext,
+		OpenWeatherMapEndpointInputs[K],
+		OpenWeatherMapEndpointOutputs[K]
+	>;
+
+export type OpenWeatherMapEndpoints = {
+	oneCall: OpenWeatherMapEndpoint<'oneCall'>;
+	timeMachine: OpenWeatherMapEndpoint<'timeMachine'>;
+	daySummary: OpenWeatherMapEndpoint<'daySummary'>;
+	overview: OpenWeatherMapEndpoint<'overview'>;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint Tree
+// ────────────────────────────────────��────────────────────────────────────────
+
+const openWeatherMapEndpointsNested = {
+	weather: {
+		oneCall: Weather.oneCall,
+	},
+	history: {
+		timeMachine: History.timeMachine,
+	},
+	summary: {
+		daySummary: Summary.daySummary,
+		overview: Summary.overview,
+	},
+} as const;
+
+// No webhooks — OpenWeatherMap is a pull-based API
+const openWeatherMapWebhooksNested = {} as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint Schemas (for get_schema / agent introspection)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const openWeatherMapEndpointSchemas = {
+	'weather.oneCall': {
+		input: OpenWeatherMapEndpointInputSchemas.oneCall,
+		output: OpenWeatherMapEndpointOutputSchemas.oneCall,
+	},
+	'history.timeMachine': {
+		input: OpenWeatherMapEndpointInputSchemas.timeMachine,
+		output: OpenWeatherMapEndpointOutputSchemas.timeMachine,
+	},
+	'summary.daySummary': {
+		input: OpenWeatherMapEndpointInputSchemas.daySummary,
+		output: OpenWeatherMapEndpointOutputSchemas.daySummary,
+	},
+	'summary.overview': {
+		input: OpenWeatherMapEndpointInputSchemas.overview,
+		output: OpenWeatherMapEndpointOutputSchemas.overview,
+	},
+} satisfies RequiredPluginEndpointSchemas<typeof openWeatherMapEndpointsNested>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint Meta (risk levels for permission system)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Risk-level metadata for each OpenWeatherMap endpoint.
+ * All endpoints are read-only — they only fetch weather data.
+ */
+const openWeatherMapEndpointMeta = {
+	'weather.oneCall': {
+		riskLevel: 'read',
+		description:
+			'Get current weather, minutely/hourly/daily forecasts, and weather alerts for a location',
+	},
+	'history.timeMachine': {
+		riskLevel: 'read',
+		description:
+			'Get historical weather data for a specific timestamp (available from 1979-01-01)',
+	},
+	'summary.daySummary': {
+		riskLevel: 'read',
+		description:
+			'Get aggregated weather summary for a specific date (temperature, wind, precipitation)',
+	},
+	'summary.overview': {
+		riskLevel: 'read',
+		description:
+			'Get a human-readable weather overview text for a location and date',
+	},
+} satisfies RequiredPluginEndpointMeta<typeof openWeatherMapEndpointsNested>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Auth Configuration
+// ─────────────────────────────────────────────────────────────────────────────
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+export const openWeatherMapAuthConfig = {
+	api_key: {
+		account: ['one'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type BaseOpenWeatherMapPlugin<T extends OpenWeatherMapPluginOptions> =
+	CorsairPlugin<
+		'openweathermap',
+		typeof OpenWeatherMapSchema,
+		typeof openWeatherMapEndpointsNested,
+		typeof openWeatherMapWebhooksNested,
+		T,
+		typeof defaultAuthType
+	>;
+
+export type InternalOpenWeatherMapPlugin =
+	BaseOpenWeatherMapPlugin<OpenWeatherMapPluginOptions>;
+
+export type ExternalOpenWeatherMapPlugin<
+	T extends OpenWeatherMapPluginOptions,
+> = BaseOpenWeatherMapPlugin<T>;
+
+// ──────────────────────────��──────────────────────────────────────────────────
+// Plugin Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function openweathermap<const T extends OpenWeatherMapPluginOptions>(
+	incomingOptions: OpenWeatherMapPluginOptions &
+		T = {} as OpenWeatherMapPluginOptions & T,
+): ExternalOpenWeatherMapPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'openweathermap',
+		schema: OpenWeatherMapSchema,
+		options: options,
+		hooks: options.hooks,
+		webhookHooks: undefined,
+		endpoints: openWeatherMapEndpointsNested,
+		webhooks: openWeatherMapWebhooksNested,
+		endpointMeta: openWeatherMapEndpointMeta,
+		endpointSchemas: openWeatherMapEndpointSchemas,
+		// No webhooks — OpenWeatherMap is a pull-based API
+		pluginWebhookMatcher: undefined,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: OpenWeatherMapKeyBuilderContext, source) => {
+			// Direct key from options takes priority
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			// Retrieve from key manager
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys.get_api_key();
+				return res ?? '';
+			}
+
+			return '';
+		},
+	} satisfies InternalOpenWeatherMapPlugin;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Type Exports
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type {
+	OpenWeatherMapEndpointInputs,
+	OpenWeatherMapEndpointOutputs,
+	OneCallInput,
+	OneCallResponse,
+	TimeMachineInput,
+	TimeMachineResponse,
+	DaySummaryInput,
+	DaySummaryResponse,
+	OverviewInput,
+	OverviewResponse,
+	CurrentWeather,
+	MinutelyForecast,
+	HourlyForecast,
+	DailyForecast,
+	WeatherAlert,
+	WeatherCondition,
+	OpenWeatherMapUnits,
+	OpenWeatherMapExclude,
+	HistoricalWeatherData,
+} from './endpoints/types';
+
+export {
+	OneCallInputSchema,
+	OneCallResponseSchema,
+	TimeMachineInputSchema,
+	TimeMachineResponseSchema,
+	DaySummaryInputSchema,
+	DaySummaryResponseSchema,
+	OverviewInputSchema,
+	OverviewResponseSchema,
+	OPENWEATHERMAP_UNITS,
+	OPENWEATHERMAP_EXCLUDE,
+} from './endpoints/types';

--- a/packages/openweathermap/package.json
+++ b/packages/openweathermap/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@corsair-dev/openweathermap",
+  "version": "0.1.0",
+  "description": "OpenWeatherMap plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^3.0.0"
+  },
+  "devDependencies": {
+    "corsair": "workspace:*",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^3.25.76"
+  },
+  "keywords": [
+    "corsair",
+    "openweathermap",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/openweathermap/schema/database.ts
+++ b/packages/openweathermap/schema/database.ts
@@ -1,0 +1,2 @@
+// OpenWeatherMap is a live-API-only plugin — no local database entities.
+// If you want to cache weather data locally in the future, define Zod schemas here.

--- a/packages/openweathermap/schema/index.ts
+++ b/packages/openweathermap/schema/index.ts
@@ -1,0 +1,4 @@
+export const OpenWeatherMapSchema = {
+	version: '1.0.0',
+	entities: {},
+} as const;

--- a/packages/openweathermap/tsconfig.json
+++ b/packages/openweathermap/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": [
+      "esnext"
+    ],
+    "types": [
+      "node"
+    ],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true, 
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ],
+  "references": []
+}

--- a/packages/openweathermap/tsup.config.ts
+++ b/packages/openweathermap/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       '@corsair-dev/onedrive':
         specifier: workspace:*
         version: link:../../packages/onedrive
+      '@corsair-dev/openweathermap':
+        specifier: workspace:*
+        version: link:../../packages/openweathermap
       '@corsair-dev/outlook':
         specifier: workspace:*
         version: link:../../packages/outlook
@@ -1064,6 +1067,21 @@ importers:
       ts-jest:
         specifier: ^29.4.6
         version: 29.4.6(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+
+  packages/openweathermap:
+    devDependencies:
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)


### PR DESCRIPTION
What: New OpenWeatherMap plugin (One Call API 3.0)
Endpoints: weather.oneCall, history.timeMachine, summary.daySummary, summary.overview
Auth: API key via appid query parameter
No webhooks: OpenWeatherMap is a pull-only API
Tests: list_operations and get_schema verified in demo sandbox