### PR TITLE
Feature/script tenant selector

### DIFF
--- a/packages/studio/src/web/pages/ScriptPage.tsx
+++ b/packages/studio/src/web/pages/ScriptPage.tsx
@@ -21,7 +21,6 @@ export function ScriptPage({ tenant }: { tenant: string }) {
 	const [running, setRunning] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [tenants, setTenants] = useState<string[]>([]);
-	const [scope, setScope] = useState<'main' | 'tenant'>('main');
 	const [activeTenant, setActiveTenant] = useState('');
 	const [multiTenancy, setMultiTenancy] = useState(false);
 
@@ -55,7 +54,7 @@ export function ScriptPage({ tenant }: { tenant: string }) {
 	}, [tenants]);
 
 	const run = async () => {
-		if (scope === 'tenant' && !activeTenant) {
+		if (multiTenancy && !activeTenant) {
 			setError('Please select a tenant before running the script.');
 			return;
 		}
@@ -64,7 +63,7 @@ export function ScriptPage({ tenant }: { tenant: string }) {
 		try {
 			const r = await api.runScript({
 				code,
-				tenant: scope === 'tenant' ? activeTenant : undefined
+				tenant: multiTenancy ? activeTenant : undefined
 			});
 			setResult(r);
 		} catch (e) {
@@ -77,36 +76,20 @@ export function ScriptPage({ tenant }: { tenant: string }) {
 	return (
 		<div className="flex flex-col gap-4">
 			{multiTenancy && (
-				<Section title="Tenant Scope">
+				<Section title="Tenant">
 					<Card className="p-3 flex items-center gap-2">
 						<select
-							value={scope}
-							onChange={(e) =>
-								setScope(
-									e.target.value === 'main' ? 'main' : 'tenant'
-								)
-							}
+							value={activeTenant}
+							onChange={(e) => setActiveTenant(e.target.value)}
 							className="h-8 px-2 rounded-md text-xs bg-[var(--color-bg)] border border-[var(--color-border)] focus:outline-none focus:border-[var(--color-accent-dim)]"
 						>
-							<option value="main">Main (integration keys)</option>
-							<option value="tenant">Tenant (account keys)</option>
-						</select>
-						{scope === 'tenant' ? (
-							<select
-								value={activeTenant}
-								onChange={(e) => setActiveTenant(e.target.value)}
-								className="h-8 px-2 rounded-md text-xs bg-[var(--color-bg)] border border-[var(--color-border)] focus:outline-none focus:border-[var(--color-accent-dim)]"
-							>
-								<option value="">
-									Select tenant
+							<option value="">Select tenant</option>
+							{tenants.map((tenantId) => (
+								<option key={tenantId} value={tenantId}>
+									{tenantId}
 								</option>
-								{tenants.map((tenantId) => (
-									<option key={tenantId} value={tenantId}>
-										{tenantId}
-									</option>
-								))}
-							</select>
-						) : null}
+							))}
+						</select>
 					</Card>
 				</Section>
 			)}
@@ -116,7 +99,7 @@ export function ScriptPage({ tenant }: { tenant: string }) {
 					<Button
 						variant="primary"
 						onClick={run}
-						disabled={running || (scope === 'tenant' && !activeTenant)}
+						disabled={running || (multiTenancy && !activeTenant)}
 					>
 						{running ? 'Running…' : '▶ Run'}
 					</Button>

--- a/packages/studio/src/web/pages/ScriptPage.tsx
+++ b/packages/studio/src/web/pages/ScriptPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState,useEffect } from 'react';
 import type { OperationResult } from '../api';
 import { api } from '../api';
 import {
@@ -20,12 +20,52 @@ export function ScriptPage({ tenant }: { tenant: string }) {
 	const [result, setResult] = useState<OperationResult | null>(null);
 	const [running, setRunning] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [tenants, setTenants] = useState<string[]>([]);
+	const [scope, setScope] = useState<'main' | 'tenant'>('main');
+	const [activeTenant, setActiveTenant] = useState('');
+	const [multiTenancy, setMultiTenancy] = useState(false);
+
+	const refreshTenants = () => {
+		api
+			.listTenants()
+			.then((res) => setTenants(res.tenants))
+			.catch((e) => setError(e.message));
+	};
+
+	useEffect(() => {
+		const fetchStatus = async () => {
+			try {
+				const status = await api.status();
+				setMultiTenancy(status.multiTenancy);
+				if (status.multiTenancy) {
+					refreshTenants();
+				}
+			} catch (e) {
+				// Silently fail
+			}
+		};
+		fetchStatus();
+	}, []);
+
+	useEffect(() => {
+		if (tenants.length === 0) return;
+		if (activeTenant && !tenants.includes(activeTenant)) {
+			setActiveTenant('');
+		}
+	}, [tenants]);
 
 	const run = async () => {
+		if (scope === 'tenant' && !activeTenant) {
+			setError('Please select a tenant before running the script.');
+			return;
+		}
 		setError(null);
 		setRunning(true);
 		try {
-			const r = await api.runScript({ code, tenant });
+			const r = await api.runScript({
+				code,
+				tenant: scope === 'tenant' ? activeTenant : undefined
+			});
 			setResult(r);
 		} catch (e) {
 			setError((e as Error).message);
@@ -36,10 +76,45 @@ export function ScriptPage({ tenant }: { tenant: string }) {
 
 	return (
 		<div className="flex flex-col gap-4">
+			{multiTenancy && (
+				<Section title="Tenant Scope">
+					<Card className="p-3 flex items-center gap-2">
+						<select
+							value={scope}
+							onChange={(e) =>
+								setScope(
+									e.target.value === 'main' ? 'main' : 'tenant'
+								)
+							}
+							className="h-8 px-2 rounded-md text-xs bg-[var(--color-bg)] border border-[var(--color-border)] focus:outline-none focus:border-[var(--color-accent-dim)]"
+						>
+							<option value="main">Main (integration keys)</option>
+							<option value="tenant">Tenant (account keys)</option>
+						</select>
+						{scope === 'tenant' ? (
+							<select
+								value={activeTenant}
+								onChange={(e) => setActiveTenant(e.target.value)}
+								className="h-8 px-2 rounded-md text-xs bg-[var(--color-bg)] border border-[var(--color-border)] focus:outline-none focus:border-[var(--color-accent-dim)]"
+							>
+								{tenants.map((tenantId) => (
+									<option key={tenantId} value={tenantId}>
+										{tenantId}
+									</option>
+								))}
+							</select>
+						) : null}
+					</Card>
+				</Section>
+			)}
 			<Section
 				title="Script"
 				action={
-					<Button variant="primary" onClick={run} disabled={running}>
+					<Button
+						variant="primary"
+						onClick={run}
+						disabled={running || (scope === 'tenant' && !activeTenant)}
+					>
 						{running ? 'Running…' : '▶ Run'}
 					</Button>
 				}

--- a/packages/studio/src/web/pages/ScriptPage.tsx
+++ b/packages/studio/src/web/pages/ScriptPage.tsx
@@ -41,7 +41,7 @@ export function ScriptPage({ tenant }: { tenant: string }) {
 					refreshTenants();
 				}
 			} catch (e) {
-				// Silently fail
+				console.error(e)
 			}
 		};
 		fetchStatus();
@@ -97,6 +97,9 @@ export function ScriptPage({ tenant }: { tenant: string }) {
 								onChange={(e) => setActiveTenant(e.target.value)}
 								className="h-8 px-2 rounded-md text-xs bg-[var(--color-bg)] border border-[var(--color-border)] focus:outline-none focus:border-[var(--color-accent-dim)]"
 							>
+								<option value="">
+									Select tenant
+								</option>
 								{tenants.map((tenantId) => (
 									<option key={tenantId} value={tenantId}>
 										{tenantId}


### PR DESCRIPTION
## Summary

Adds explicit tenant selection to the Script page in Corsair Studio so users must intentionally choose the execution scope before running scripts.

Previously, the Script page relied on the app-level `tenant` state and passed it directly into `runScript`, which made tenant context implicit and could lead to running scripts against the wrong tenant.

This change aligns Script behavior with the existing Plugins page by introducing:

- Main vs Tenant scope selection
- Tenant dropdown for tenant-scoped execution
- Explicit tenant selection before running scripts
- Session-only selection (no persistence across page visits)

This improves safety for multi-tenant environments where running a script against the wrong tenant could have serious consequences.

---

## Changes Made

### Added tenant scope controls to `ScriptPage.tsx`

Introduced:

- `scope` state (`main | tenant`)
- `activeTenant` state for selected tenant
- `tenants` state loaded from `api.listTenants()`
- `multiTenancy` check using `api.status()`

This mirrors the tenant selection pattern used in `PluginsPage.tsx`.

---

### Updated script execution behavior

Changed:

```ts
api.runScript({ code, tenant })