### PR TITLE
Feature/Added cli command explore

### DIFF
--- a/explorer/src/server.ts
+++ b/explorer/src/server.ts
@@ -170,41 +170,6 @@ export function createServer(options: CreateServerOptions): express.Express {
 		}
 	});
 
-	// ============================================================================
-	// LEGACY ROUTES (v1) - Kept for backward compatibility
-	// ============================================================================
-
-	app.get('/v1/meta', (_req, res) => {
-		res.json({
-			generatedAt: catalog.generatedAt,
-			corsairVersion: catalog.corsairVersion,
-			catalogVersion: catalog.catalogVersion,
-			pluginCount: catalog.listSummaries().length,
-		});
-	});
-
-	app.get('/v1/plugins', (_req, res) => {
-		res.json({ plugins: catalog.listSummaries() });
-	});
-
-	app.get('/v1/plugins/:id', (req, res) => {
-		const plugin = catalog.getPlugin(req.params.id);
-		if (!plugin) {
-			sendPluginNotFound(res, req.params.id);
-			return;
-		}
-		res.json({ plugin });
-	});
-
-	app.get('/v1/plugins/:id/api', (req, res) => {
-		const plugin = catalog.getPlugin(req.params.id);
-		if (!plugin) {
-			sendPluginNotFound(res, req.params.id);
-			return;
-		}
-		res.json({ pluginId: plugin.id, api: plugin.api });
-	});
-
 	app.use((_req, res) => {
 		res.status(404).json({ error: 'not_found' });
 	});

--- a/explorer/src/server.ts
+++ b/explorer/src/server.ts
@@ -1,5 +1,6 @@
 import express, { type Request, type Response } from 'express';
 import type { Catalog } from './catalog';
+import type { DocsApiEndpoint, DocsDbEntity, DocsWebhook } from './types';
 
 export type CreateServerOptions = {
 	catalog: Catalog;
@@ -36,29 +37,142 @@ export function createServer(options: CreateServerOptions): express.Express {
 	});
 
 	app.get('/', (_req, res) => {
+		const plugins = catalog.listSummaries().map((p) => ({
+			name: p.id,
+			displayName: p.displayName,
+			npmPackageName: p.npmPackageName,
+			description: p.description,
+		}));
 		res.json({
-			name: 'corsair-explorer',
-			description:
-				'Browse every Corsair plugin and every api / webhook / db operation it exposes.',
-			endpoints: [
-				'GET /health',
-				'GET /v1/meta',
-				'GET /v1/plugins',
-				'GET /v1/plugins/:id',
-				'GET /v1/plugins/:id/api',
-				'GET /v1/plugins/:id/api/:shortPath',
-				'GET /v1/plugins/:id/webhooks',
-				'GET /v1/plugins/:id/webhooks/:shortPath',
-				'GET /v1/plugins/:id/db',
-				'GET /v1/plugins/:id/db/:entity',
-				'GET /v1/search?q=<query>',
-			],
+			plugins,
+			note: 'To install a plugin, run: pnpm install @corsair-dev/<plugin_name>',
 		});
 	});
 
 	app.get('/health', (_req, res) => {
 		res.json({ ok: true });
 	});
+
+	// GET /<plugin> or GET /<plugin>/api - List API endpoints
+	app.get('/:plugin', (req, res) => {
+		const plugin = catalog.getPlugin(req.params.plugin);
+		if (!plugin) {
+			sendPluginNotFound(res, req.params.plugin);
+			return;
+		}
+		const endpoints = plugin.api.map(toApiEndpointSummary);
+		res.json({ plugin: plugin.id, endpoints });
+	});
+
+	app.get('/:plugin/api', (req, res) => {
+		const plugin = catalog.getPlugin(req.params.plugin);
+		if (!plugin) {
+			sendPluginNotFound(res, req.params.plugin);
+			return;
+		}
+		const endpoints = plugin.api.map(toApiEndpointSummary);
+		res.json({ plugin: plugin.id, endpoints });
+	});
+
+	// GET /<plugin>/db - List DB entities
+	app.get('/:plugin/db', (req, res) => {
+		const plugin = catalog.getPlugin(req.params.plugin);
+		if (!plugin) {
+			sendPluginNotFound(res, req.params.plugin);
+			return;
+		}
+		const entities = plugin.db.map(toDbEntitySummary);
+		res.json({ plugin: plugin.id, entities });
+	});
+
+	// GET /<plugin>/webhooks - List webhooks
+	app.get('/:plugin/webhooks', (req, res) => {
+		const plugin = catalog.getPlugin(req.params.plugin);
+		if (!plugin) {
+			sendPluginNotFound(res, req.params.plugin);
+			return;
+		}
+		const webhooks = plugin.webhooks.map(toWebhookSummary);
+		res.json({ plugin: plugin.id, webhooks });
+	});
+
+	// GET /schema/<endpoint> - Full schema for specific endpoint
+	// Format: plugin.type.shortPath (e.g., slack.api.messages.post)
+	app.get('/schema/*', (req, res) => {
+		const endpointPath = getWildcardParam(req);
+		const parts = endpointPath.split('.');
+		
+		if (parts.length < 2) {
+			res.status(400).json({
+				error: 'invalid_path',
+				message: 'Schema path must be in format: plugin.type.shortPath (e.g., slack.api.messages.post)',
+			});
+			return;
+		}
+
+		const [pluginId, type, ...shortPathParts] = parts;
+		const shortPath = shortPathParts.join('.');
+
+		if (!['api', 'webhooks', 'db'].includes(type!)) {
+			res.status(400).json({
+				error: 'invalid_type',
+				message: `Invalid endpoint type "${type}". Must be one of: api, webhooks, db`,
+			});
+			return;
+		}
+
+		const plugin = catalog.getPlugin(pluginId!);
+		if (!plugin) {
+			sendPluginNotFound(res, pluginId!);
+			return;
+		}
+
+		if (type === 'api') {
+			const endpoint = catalog.findApiEndpoint(pluginId!, shortPath);
+			if (!endpoint) {
+				res.status(404).json({
+					error: 'endpoint_not_found',
+					message: `No api endpoint "${shortPath}" on plugin "${pluginId}".`,
+					available: plugin.api.map((e) => e.shortPath),
+				});
+				return;
+			}
+			res.json({ plugin: pluginId, type: 'api', shortPath, endpoint });
+			return;
+		}
+
+		if (type === 'webhooks') {
+			const webhook = catalog.findWebhook(pluginId!, shortPath);
+			if (!webhook) {
+				res.status(404).json({
+					error: 'webhook_not_found',
+					message: `No webhook "${shortPath}" on plugin "${pluginId}".`,
+					available: plugin.webhooks.map((w) => w.shortPath),
+				});
+				return;
+			}
+			res.json({ plugin: pluginId, type: 'webhooks', shortPath, webhook });
+			return;
+		}
+
+		if (type === 'db') {
+			const entity = catalog.findDbEntity(pluginId!, shortPath);
+			if (!entity) {
+				res.status(404).json({
+					error: 'entity_not_found',
+					message: `No db entity "${shortPath}" on plugin "${pluginId}".`,
+					available: plugin.db.map((d) => d.entityName),
+				});
+				return;
+			}
+			res.json({ plugin: pluginId, type: 'db', shortPath, entity });
+			return;
+		}
+	});
+
+	// ============================================================================
+	// LEGACY ROUTES (v1) - Kept for backward compatibility
+	// ============================================================================
 
 	app.get('/v1/meta', (_req, res) => {
 		res.json({
@@ -91,93 +205,6 @@ export function createServer(options: CreateServerOptions): express.Express {
 		res.json({ pluginId: plugin.id, api: plugin.api });
 	});
 
-	// `shortPath` uses `*` so values like `messages.post` come through intact.
-	app.get('/v1/plugins/:id/api/*', (req, res) => {
-		const plugin = catalog.getPlugin(req.params.id);
-		if (!plugin) {
-			sendPluginNotFound(res, req.params.id);
-			return;
-		}
-		const shortPath = getWildcardParam(req);
-		const endpoint = catalog.findApiEndpoint(plugin.id, shortPath);
-		if (!endpoint) {
-			res.status(404).json({
-				error: 'endpoint_not_found',
-				message: `No api endpoint "${shortPath}" on plugin "${plugin.id}".`,
-				available: plugin.api.map((e) => e.shortPath),
-			});
-			return;
-		}
-		res.json({ pluginId: plugin.id, endpoint });
-	});
-
-	app.get('/v1/plugins/:id/webhooks', (req, res) => {
-		const plugin = catalog.getPlugin(req.params.id);
-		if (!plugin) {
-			sendPluginNotFound(res, req.params.id);
-			return;
-		}
-		res.json({ pluginId: plugin.id, webhooks: plugin.webhooks });
-	});
-
-	app.get('/v1/plugins/:id/webhooks/*', (req, res) => {
-		const plugin = catalog.getPlugin(req.params.id);
-		if (!plugin) {
-			sendPluginNotFound(res, req.params.id);
-			return;
-		}
-		const shortPath = getWildcardParam(req);
-		const webhook = catalog.findWebhook(plugin.id, shortPath);
-		if (!webhook) {
-			res.status(404).json({
-				error: 'webhook_not_found',
-				message: `No webhook "${shortPath}" on plugin "${plugin.id}".`,
-				available: plugin.webhooks.map((w) => w.shortPath),
-			});
-			return;
-		}
-		res.json({ pluginId: plugin.id, webhook });
-	});
-
-	app.get('/v1/plugins/:id/db', (req, res) => {
-		const plugin = catalog.getPlugin(req.params.id);
-		if (!plugin) {
-			sendPluginNotFound(res, req.params.id);
-			return;
-		}
-		res.json({ pluginId: plugin.id, db: plugin.db });
-	});
-
-	app.get('/v1/plugins/:id/db/:entity', (req, res) => {
-		const plugin = catalog.getPlugin(req.params.id);
-		if (!plugin) {
-			sendPluginNotFound(res, req.params.id);
-			return;
-		}
-		const entity = catalog.findDbEntity(plugin.id, req.params.entity);
-		if (!entity) {
-			res.status(404).json({
-				error: 'entity_not_found',
-				message: `No db entity "${req.params.entity}" on plugin "${plugin.id}".`,
-				available: plugin.db.map((d) => d.entityName),
-			});
-			return;
-		}
-		res.json({ pluginId: plugin.id, entity });
-	});
-
-	app.get('/v1/search', (req, res) => {
-		const q = typeof req.query.q === 'string' ? req.query.q : '';
-		if (q.trim().length === 0) {
-			res.status(400).json({
-				error: 'missing_query',
-				message: 'Pass ?q=<query> to search.',
-			});
-			return;
-		}
-		res.json({ query: q, results: catalog.search(q) });
-	});
-
 	app.use((_req, res) => {
 		res.status(404).json({ error: 'not_found' });
 	});
@@ -199,4 +226,35 @@ function sendPluginNotFound(res: Response, id: string): void {
 function getWildcardParam(req: Request): string {
 	const params = req.params as Record<string, string>;
 	return params['0'] ?? '';
+}
+
+// ============================================================================
+// SUMMARY FUNCTIONS - Lightweight responses for agent progressive discovery
+// ============================================================================
+
+/**
+ * Summarize an API endpoint for list responses.
+ * Excludes input/output schemas to reduce token usage.
+ */
+function toApiEndpointSummary(endpoint: DocsApiEndpoint) {
+	const { path, shortPath, description, riskLevel, irreversible } = endpoint;
+	return { path, shortPath, description, riskLevel, irreversible };
+}
+
+/**
+ * Summarize a webhook for list responses.
+ * Excludes payload schema to reduce token usage.
+ */
+function toWebhookSummary(webhook: DocsWebhook) {
+	const { path, shortPath, description } = webhook;
+	return { path, shortPath, description };
+}
+
+/**
+ * Summarize a DB entity for list responses.
+ * Excludes filter details to reduce token usage.
+ */
+function toDbEntitySummary(entity: DocsDbEntity) {
+	const { path, entityName } = entity;
+	return { path, entityName };
 }

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -637,11 +637,11 @@ function parseRunArgs(args: string[]): {
 }
 
 function parseExploreArgs(args: string[]): {
-	plugin?: string;
+	target?: string;
 	type?: 'api' | 'webhooks' | 'db';
 	json: boolean;
 }{
-	let plugin: string | undefined;
+	let target: string | undefined;
 	let type: 'api' | 'webhooks' | 'db' | undefined;
 	let json = false;
 
@@ -666,11 +666,11 @@ function parseExploreArgs(args: string[]): {
 			continue;
 		}
 
-		if (!arg.startsWith('-') && !plugin) {
-			plugin = arg;
+		if (!arg.startsWith('-') && !target) {
+			target = arg;
 		}
 	}
-	return { plugin, type, json };
+	return { target, type, json };
 }
 
 function parseUiArgs(args: string[]): { port?: number; open?: boolean } {
@@ -743,7 +743,10 @@ function printHelp() {
 		'pnpm corsair auth --plugin=<id> --webhook       Set up webhook subscription',
 		'  `pnpm corsair list --type=webhooks` to see webhook plugins',
 		'pnpm corsair list [--plugin=<id>] [--type=api|webhooks|db]  List endpoint paths (tip: pipe to grep to filter)',
-		'pnpm corsair explore [provider] [--type=api|webhooks|db]  Discover official providers before installing them',
+		'pnpm corsair explore                            List all available plugins',
+		'pnpm corsair explore <plugin>                   List API endpoints of a plugin (before installing)',
+		'pnpm corsair explore <plugin> --type=api|webhooks|db  Filter to specific endpoint types',
+		'pnpm corsair explore <plugin.endpoint>          Show schema for a specific endpoint',
 		'pnpm corsair schema <path>                      Show schema for an endpoint/webhook/DB entity',
 		'pnpm corsair ui [--port=4317] [--no-open]       Open the Corsair Studio dashboard (requires @corsair-dev/studio)',
 		'pnpm corsair script --code "<js>" [--tenant=<id>]',
@@ -878,20 +881,39 @@ async function main() {
 	}
 
 	if (command === 'explore') {
-		const { plugin, type, json } = parseExploreArgs(args.slice(1));
+		const { target, type, json } = parseExploreArgs(args.slice(1));
 		const baseUrl = process.env.CORSAIR_EXPLORER_URL ?? 'http://localhost:4319';
 
-		const typePath = plugin && type ? `/${type}` : '';
-		const url = plugin 
-		? `${baseUrl}/v1/plugins/${encodeURIComponent(plugin)}${typePath}`
-			: `${baseUrl}/v1/plugins`;
-		
+		// Determine the target and build the URL based on the new flat route structure
+		let url: string;
+		if (!target) {
+			// No arguments: list all plugins
+			url = `${baseUrl}/`;
+		} else if (target.includes('.')) {
+			// Target contains dots: treat as endpoint path (e.g., slack.api.messages.post)
+			url = `${baseUrl}/schema/${encodeURIComponent(target)}`;
+		} else {
+			// Target is a plugin name: list its endpoints (optionally filtered by type)
+			if (type) {
+				// List specific endpoint type for a plugin
+				url = `${baseUrl}/${encodeURIComponent(target)}/${type}`;
+			} else {
+				// List all endpoints for a plugin (defaults to API)
+				url = `${baseUrl}/${encodeURIComponent(target)}`;
+			}
+		}
+
 		try {
 			const response = await fetch(url);
 			if (!response.ok) {
-				if (response.status === 404 && plugin) {
-					console.error(`[#corsair]: Unknown provider "${plugin}".`);
-					console.error('[#corsair]: Run `pnpm corsair explore` to see available providers.');
+				if (response.status === 404) {
+					if (target && target.includes('.')) {
+						console.error(`[#corsair]: Unknown endpoint "${target}".`);
+						console.error('[#corsair]: Run `pnpm corsair explore <plugin>` to see available endpoints.');
+					} else {
+						console.error(`[#corsair]: Unknown provider "${target}".`);
+						console.error('[#corsair]: Run `pnpm corsair explore` to see available providers.');
+					}
 					process.exit(1);
 				}
 

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -636,6 +636,43 @@ function parseRunArgs(args: string[]): {
 	return { path: endpointPath, input, tenant };
 }
 
+function parseExploreArgs(args: string[]): {
+	plugin?: string;
+	type?: 'api' | 'webhooks' | 'db';
+	json: boolean;
+}{
+	let plugin: string | undefined;
+	let type: 'api' | 'webhooks' | 'db' | undefined;
+	let json = false;
+
+	for (let i = 0; i < args.length; i++){
+		const arg = args[i]!;
+		if (arg === '--json') {
+			json = true;
+			continue;
+		}
+		if (arg === '--type' && args[i + 1]) {
+			const value = args[++i];
+			if (value === 'api' || value === 'webhooks' || value === 'db') {
+				type = value;
+			}
+			continue;
+		}
+		if (arg.startsWith('--type=')) {
+			const value = arg.slice('--type='.length);
+			if (value === 'api' || value === 'webhooks' || value === 'db') {
+				type = value;
+			}
+			continue;
+		}
+
+		if (!arg.startsWith('-') && !plugin) {
+			plugin = arg;
+		}
+	}
+	return { plugin, type, json };
+}
+
 function parseUiArgs(args: string[]): { port?: number; open?: boolean } {
 	let port: number | undefined;
 	let open: boolean | undefined;
@@ -706,6 +743,7 @@ function printHelp() {
 		'pnpm corsair auth --plugin=<id> --webhook       Set up webhook subscription',
 		'  `pnpm corsair list --type=webhooks` to see webhook plugins',
 		'pnpm corsair list [--plugin=<id>] [--type=api|webhooks|db]  List endpoint paths (tip: pipe to grep to filter)',
+		'pnpm corsair explore [provider] [--type=api|webhooks|db]  Discover official providers before installing them',
 		'pnpm corsair schema <path>                      Show schema for an endpoint/webhook/DB entity',
 		'pnpm corsair ui [--port=4317] [--no-open]       Open the Corsair Studio dashboard (requires @corsair-dev/studio)',
 		'pnpm corsair script --code "<js>" [--tenant=<id>]',
@@ -837,6 +875,48 @@ async function main() {
 		}
 		console.log(result);
 		return;
+	}
+
+	if (command === 'explore') {
+		const { plugin, type, json } = parseExploreArgs(args.slice(1));
+		const baseUrl = process.env.CORSAIR_EXPLORER_URL ?? 'http://localhost:4319';
+
+		const typePath = plugin && type ? `/${type}` : '';
+		const url = plugin 
+		? `${baseUrl}/v1/plugins/${encodeURIComponent(plugin)}${typePath}`
+			: `${baseUrl}/v1/plugins`;
+		
+		try {
+			const response = await fetch(url);
+			if (!response.ok) {
+				if (response.status === 404 && plugin) {
+					console.error(`[#corsair]: Unknown provider "${plugin}".`);
+					console.error('[#corsair]: Run `pnpm corsair explore` to see available providers.');
+					process.exit(1);
+				}
+
+				console.error(
+					`[#corsair]: Explore request failed with HTTP ${response.status}.`,
+				);
+				process.exit(1);
+			}
+			const data = await response.json();
+			console.log(JSON.stringify(data, null, 2));
+			return;
+		}
+		catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+
+			console.error('[#corsair]: Could not reach the Corsair explorer registry.');
+			console.error(`[#corsair]: Tried: ${url}`);
+			console.error(`[#corsair]: ${message}`);
+			console.error('');
+			console.error(
+				'[#corsair]: Start the explorer server locally or set CORSAIR_EXPLORER_URL.',
+			);
+
+			process.exit(1);
+		}
 	}
 
 	if (SHOW_RUN && command === 'run') {


### PR DESCRIPTION
# Feat: Add `corsair explore` CLI command for plugin discovery

## Overview
Adds a new `corsair explore` CLI command to discover and explore available Corsair plugins and their endpoints **before installing them**. This allows developers and AI agents to browse the plugin ecosystem, preview API/webhook/DB operations, and plan integration work without pre-configuring plugins.

## What's New

### Commands Added
- `pnpm corsair explore` — List all available first-party Corsair provider IDs
- `pnpm corsair explore <plugin>` — Show full details (API endpoints, webhooks, DB entities) for a named plugin
- `pnpm corsair explore <plugin> --type=api|webhooks|db` — Filter to specific operation types

### Features
- **Registry-backed discovery** — Calls the standalone explorer server (no auth required)
- **Configurable registry URL** — Via `CORSAIR_EXPLORER_URL` env var (defaults to `http://localhost:4319`)
- **Helpful error messages** — Clear guidance when plugins aren't found or registry isn't reachable
- **JSON output** — Structured data for programmatic use
- **Consistent UX** — Follows existing CLI patterns alongside `list` and `schema` commands

## Technical Details

### Changes
- **packages/cli/index.ts** — Added `explore` command handler + `parseExploreArgs()` parser
- **Explorer server** (`/explorer`) — Provides REST API for plugin catalog (already implemented)

### API Endpoints Used
- `GET /v1/plugins` — List all plugins
- `GET /v1/plugins/:id` — Get plugin details
- `GET /v1/plugins/:id/api` — Get API endpoints
- `GET /v1/plugins/:id/webhooks` — Get webhooks
- `GET /v1/plugins/:id/db` — Get DB entities