### PR TITLE
feat: add production OAuth

### DIFF
--- a/demo/minimal/oauth.ts
+++ b/demo/minimal/oauth.ts
@@ -1,0 +1,106 @@
+import {
+	generateOAuthUrl,
+	processOAuthCallback,
+} from 'corsair/oauth';
+import express from 'express';
+import { corsair } from './corsair';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helper — escape user-controlled values before inserting into HTML
+// ─────────────────────────────────────────────────────────────────────────────
+
+function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#x27;');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Express app
+// ─────────────────────────────────────────────────────────────────────────────
+
+const app = express();
+
+const REDIRECT_URI = `${process.env.APP_URL ?? 'http://localhost:3000'}/api/auth`;
+
+/**
+ * GET /connect/:plugin
+ *
+ * Initiates OAuth for a tenant. In a real app, tenantId would come from
+ * your session/auth middleware.
+ *
+ * Example: GET /connect/slack?tenantId=acme
+ */
+app.get('/connect/:plugin', async (req, res) => {
+	const pluginId = req.params.plugin;
+	const tenantId = (req.query.tenantId as string | undefined) ?? 'default';
+
+	try {
+		const { url, state } = await generateOAuthUrl(corsair, pluginId, {
+			tenantId,
+			redirectUri: REDIRECT_URI,
+		});
+
+		// In production: persist `state` in a session or signed cookie
+		// so you can verify it in the callback below.
+		// Here we pass it via the provider's redirect (it comes back as ?state=).
+		res.redirect(url);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		res.status(400).send(`<p>${escapeHtml(message)}</p>`);
+	}
+});
+
+/**
+ * GET /api/auth
+ *
+ * OAuth callback — the provider redirects here with ?code= and ?state=.
+ * Exchanges the code for tokens and stores them for the tenant.
+ */
+app.get('/api/auth', async (req, res) => {
+	const code = req.query.code as string | undefined;
+	const state = req.query.state as string | undefined;
+	const error = req.query.error as string | undefined;
+
+	if (error) {
+		res.status(400).send(
+			`<html><body><h2>Authorization failed</h2><p>${escapeHtml(error)}</p></body></html>`,
+		);
+		return;
+	}
+
+	if (!code || !state) {
+		res.status(400).send('<p>Missing code or state parameter.</p>');
+		return;
+	}
+
+	try {
+		const result = await processOAuthCallback(corsair, {
+			code,
+			state,
+			redirectUri: REDIRECT_URI,
+		});
+
+		res.send(
+			`<html><body><h2>Connected!</h2>` +
+				`<p>Plugin <strong>${escapeHtml(result.plugin)}</strong> ` +
+				`authorized for tenant <strong>${escapeHtml(result.tenantId)}</strong>.</p>` +
+				`<p>You can close this tab.</p></body></html>`,
+		);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		res.status(500).send(
+			`<html><body><h2>OAuth error</h2><p>${escapeHtml(message)}</p></body></html>`,
+		);
+	}
+});
+
+app.listen(3000, () => {
+	console.log('OAuth demo listening on http://localhost:3000');
+	console.log(
+		'Connect a plugin: http://localhost:3000/connect/<pluginId>?tenantId=<id>',
+	);
+});

--- a/demo/minimal/oauth.ts
+++ b/demo/minimal/oauth.ts
@@ -3,6 +3,12 @@ import {
 	processOAuthCallback,
 } from 'corsair/oauth';
 import express from 'express';
+
+/**
+ * Import your own corsair instance here.
+ * The plugin you connect must have oauthConfig defined
+ * (e.g. googlecalendar, gmail, notion, spotify — NOT slack or linear).
+ */
 import { corsair } from './corsair';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -26,13 +32,17 @@ const app = express();
 
 const REDIRECT_URI = `${process.env.APP_URL ?? 'http://localhost:3000'}/api/auth`;
 
+// Pending OAuth states — prevents CSRF by ensuring the callback state
+// was issued by this server. Use Redis or sessions in production.
+const pendingStates = new Set<string>();
+
 /**
- * GET /connect/:plugin
+ * GET /connect/:plugin?tenantId=<id>
  *
- * Initiates OAuth for a tenant. In a real app, tenantId would come from
+ * Initiates OAuth for a tenant. In a real app, tenantId comes from
  * your session/auth middleware.
  *
- * Example: GET /connect/slack?tenantId=acme
+ * Example: GET /connect/googlecalendar?tenantId=acme
  */
 app.get('/connect/:plugin', async (req, res) => {
 	const pluginId = req.params.plugin;
@@ -44,9 +54,7 @@ app.get('/connect/:plugin', async (req, res) => {
 			redirectUri: REDIRECT_URI,
 		});
 
-		// In production: persist `state` in a session or signed cookie
-		// so you can verify it in the callback below.
-		// Here we pass it via the provider's redirect (it comes back as ?state=).
+		pendingStates.add(state);
 		res.redirect(url);
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
@@ -58,7 +66,7 @@ app.get('/connect/:plugin', async (req, res) => {
  * GET /api/auth
  *
  * OAuth callback — the provider redirects here with ?code= and ?state=.
- * Exchanges the code for tokens and stores them for the tenant.
+ * Verifies state, exchanges the code for tokens, stores them for the tenant.
  */
 app.get('/api/auth', async (req, res) => {
 	const code = req.query.code as string | undefined;
@@ -76,6 +84,12 @@ app.get('/api/auth', async (req, res) => {
 		res.status(400).send('<p>Missing code or state parameter.</p>');
 		return;
 	}
+
+	if (!pendingStates.has(state)) {
+		res.status(400).send('<p>Invalid state. Possible CSRF attempt.</p>');
+		return;
+	}
+	pendingStates.delete(state);
 
 	try {
 		const result = await processOAuthCallback(corsair, {

--- a/demo/testing/src/app/api/auth/route.ts
+++ b/demo/testing/src/app/api/auth/route.ts
@@ -1,0 +1,69 @@
+import { processOAuthCallback } from 'corsair/oauth';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { corsair } from '@/server/corsair';
+
+const REDIRECT_URI = `${process.env.APP_URL ?? 'http://localhost:3001'}/api/auth`;
+
+function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#x27;');
+}
+
+export async function GET(request: NextRequest) {
+	const { searchParams } = new URL(request.url);
+	const code = searchParams.get('code');
+	const state = searchParams.get('state');
+	const error = searchParams.get('error');
+
+	if (error) {
+		return new NextResponse(
+			`<html><body><h2>Authorization failed</h2><p>${escapeHtml(error)}</p></body></html>`,
+			{ status: 400, headers: { 'Content-Type': 'text/html' } },
+		);
+	}
+
+	if (!code || !state) {
+		return new NextResponse('<p>Missing code or state.</p>', {
+			status: 400,
+			headers: { 'Content-Type': 'text/html' },
+		});
+	}
+
+	const storedState = request.cookies.get('oauth_state')?.value;
+	if (!storedState || storedState !== state) {
+		return new NextResponse('<p>Invalid state. Possible CSRF attempt.</p>', {
+			status: 400,
+			headers: { 'Content-Type': 'text/html' },
+		});
+	}
+
+	try {
+		const result = await processOAuthCallback(corsair, {
+			code,
+			state,
+			redirectUri: REDIRECT_URI,
+		});
+
+		const response = new NextResponse(
+			`<html><body>
+				<h2>Connected!</h2>
+				<p><strong>${escapeHtml(result.plugin)}</strong> authorized for tenant <strong>${escapeHtml(result.tenantId)}</strong>.</p>
+				<p><a href="/">Back to home</a></p>
+			</body></html>`,
+			{ status: 200, headers: { 'Content-Type': 'text/html' } },
+		);
+		response.cookies.delete('oauth_state');
+		return response;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return new NextResponse(
+			`<html><body><h2>OAuth error</h2><p>${escapeHtml(message)}</p></body></html>`,
+			{ status: 500, headers: { 'Content-Type': 'text/html' } },
+		);
+	}
+}

--- a/demo/testing/src/app/api/auth/route.ts
+++ b/demo/testing/src/app/api/auth/route.ts
@@ -61,9 +61,11 @@ export async function GET(request: NextRequest) {
 		return response;
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		return new NextResponse(
+		const response = new NextResponse(
 			`<html><body><h2>OAuth error</h2><p>${escapeHtml(message)}</p></body></html>`,
 			{ status: 500, headers: { 'Content-Type': 'text/html' } },
 		);
+		response.cookies.delete('oauth_state');
+		return response;
 	}
 }

--- a/demo/testing/src/app/api/connect/route.ts
+++ b/demo/testing/src/app/api/connect/route.ts
@@ -21,7 +21,12 @@ export async function GET(request: NextRequest) {
 		});
 		const response = NextResponse.redirect(url);
 		// Store state in httpOnly cookie for CSRF verification in /api/auth
-		response.cookies.set('oauth_state', state, { httpOnly: true, sameSite: 'lax' });
+		response.cookies.set('oauth_state', state, {
+			httpOnly: true,
+			sameSite: 'lax',
+			secure: process.env.NODE_ENV === 'production',
+			maxAge: 60 * 10, // 10 minutes
+		});
 		return response;
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);

--- a/demo/testing/src/app/api/connect/route.ts
+++ b/demo/testing/src/app/api/connect/route.ts
@@ -1,0 +1,30 @@
+import { generateOAuthUrl } from 'corsair/oauth';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { corsair } from '@/server/corsair';
+
+const REDIRECT_URI = `${process.env.APP_URL ?? 'http://localhost:3001'}/api/auth`;
+
+export async function GET(request: NextRequest) {
+	const { searchParams } = new URL(request.url);
+	const plugin = searchParams.get('plugin');
+	const tenantId = searchParams.get('tenantId') ?? 'demo-user';
+
+	if (!plugin) {
+		return NextResponse.json({ error: 'Missing plugin param' }, { status: 400 });
+	}
+
+	try {
+		const { url, state } = await generateOAuthUrl(corsair, plugin, {
+			tenantId,
+			redirectUri: REDIRECT_URI,
+		});
+		const response = NextResponse.redirect(url);
+		// Store state in httpOnly cookie for CSRF verification in /api/auth
+		response.cookies.set('oauth_state', state, { httpOnly: true, sameSite: 'lax' });
+		return response;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return NextResponse.json({ error: message }, { status: 500 });
+	}
+}

--- a/demo/testing/src/app/page.tsx
+++ b/demo/testing/src/app/page.tsx
@@ -155,6 +155,34 @@ export default function Home() {
 				)}
 			</div>
 
+			<div
+				style={{
+					marginTop: '2rem',
+					padding: '1.5rem',
+					border: '1px solid #e0e0e0',
+					borderRadius: '8px',
+				}}
+			>
+				<h2>Connect Integrations</h2>
+				<p style={{ color: '#666', marginBottom: '1rem' }}>
+					Authorize a plugin using OAuth
+				</p>
+				<a
+					href="/api/connect?plugin=googlecalendar&tenantId=demo-user"
+					style={{
+						display: 'inline-block',
+						padding: '0.75rem 1.5rem',
+						backgroundColor: '#4285F4',
+						color: 'white',
+						borderRadius: '4px',
+						textDecoration: 'none',
+						fontSize: '1rem',
+					}}
+				>
+					Connect Google Calendar
+				</a>
+			</div>
+
 			<div style={{ marginTop: '2rem' }}>
 				<h2>API Endpoints</h2>
 				<ul>

--- a/packages/cli/auth.ts
+++ b/packages/cli/auth.ts
@@ -14,12 +14,14 @@ import type {
 	CorsairPlugin,
 	OAuthConfig,
 	PluginAuthConfig,
+	TokenResponse,
 } from 'corsair/core';
 import {
 	CORSAIR_INTERNAL,
 	createAccountKeyManager,
 	createIntegrationKeyManager,
 	encryptDEK,
+	exchangeCodeForTokens,
 	generateDEK,
 } from 'corsair/core';
 import type { CorsairDatabase } from 'corsair/db';
@@ -210,71 +212,6 @@ function waitForOAuthCode(port: number): Promise<string> {
 	});
 }
 
-function exchangeCodeForTokens(
-	code: string,
-	clientId: string,
-	clientSecret: string,
-	oauthConfig: OAuthConfig,
-	redirectUri: string | null,
-): Promise<{
-	access_token?: string;
-	refresh_token?: string;
-	expires_in?: number;
-	token_type?: string;
-}> {
-	const tokenUrl = new URL(oauthConfig.tokenUrl);
-	const useBasicAuth = oauthConfig.tokenAuthMethod === 'basic';
-
-	return new Promise((resolve, reject) => {
-		const postDataParams: Record<string, string | null> = {
-			code: code.trim(),
-			redirect_uri: redirectUri,
-			grant_type: 'authorization_code',
-		};
-
-		if (!useBasicAuth) {
-			postDataParams.client_id = clientId;
-			postDataParams.client_secret = clientSecret;
-		}
-
-		const postData = querystring.stringify(postDataParams);
-		const headers: Record<string, string> = {
-			'Content-Type': 'application/x-www-form-urlencoded',
-			'Content-Length': Buffer.byteLength(postData).toString(),
-		};
-
-		if (useBasicAuth) {
-			headers.Authorization = `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`;
-		}
-
-		const req = https.request(
-			{
-				hostname: tokenUrl.hostname,
-				path: tokenUrl.pathname,
-				method: 'POST',
-				headers,
-			},
-			(res) => {
-				let data = '';
-				res.on('data', (chunk) => {
-					data += chunk;
-				});
-				res.on('end', () => {
-					if (res.statusCode !== 200) {
-						reject(new Error(`Token exchange failed: ${data}`));
-						return;
-					}
-					resolve(JSON.parse(data));
-				});
-			},
-		);
-		req.on('error', (error) =>
-			reject(new Error(`Request failed: ${error.message}`)),
-		);
-		req.write(postData);
-		req.end();
-	});
-}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Internal config loader
@@ -356,11 +293,7 @@ async function oauthExchangeCode(
 	clientSecret: string,
 	oauthCfg: OAuthConfig,
 ): Promise<boolean> {
-	let tokens: {
-		access_token?: string;
-		refresh_token?: string;
-		expires_in?: number;
-	};
+	let tokens: TokenResponse;
 	try {
 		tokens = await exchangeCodeForTokens(
 			code,

--- a/packages/corsair/core/auth/exchange.ts
+++ b/packages/corsair/core/auth/exchange.ts
@@ -48,6 +48,7 @@ export function exchangeCodeForTokens(
 		const req = https.request(
 			{
 				hostname: tokenUrl.hostname,
+				...(tokenUrl.port ? { port: Number(tokenUrl.port) } : {}),
 				path: tokenUrl.pathname + tokenUrl.search,
 				method: 'POST',
 				headers,
@@ -62,7 +63,11 @@ export function exchangeCodeForTokens(
 						reject(new Error(`Token exchange failed (${res.statusCode}): ${data}`));
 						return;
 					}
-					resolve(JSON.parse(data) as TokenResponse);
+					try {
+						resolve(JSON.parse(data) as TokenResponse);
+					} catch {
+						reject(new Error(`Token endpoint returned non-JSON response: ${data}`));
+					}
 				});
 			},
 		);

--- a/packages/corsair/core/auth/exchange.ts
+++ b/packages/corsair/core/auth/exchange.ts
@@ -1,0 +1,75 @@
+import * as https from 'node:https';
+import * as querystring from 'node:querystring';
+import type { OAuthConfig } from '../plugins';
+
+export type TokenResponse = {
+	access_token?: string;
+	refresh_token?: string;
+	expires_in?: number;
+	token_type?: string;
+};
+
+/**
+ * Exchanges an OAuth authorization code for access/refresh tokens.
+ * Supports both 'body' (default) and 'basic' token auth methods.
+ */
+export function exchangeCodeForTokens(
+	code: string,
+	clientId: string,
+	clientSecret: string,
+	oauthConfig: OAuthConfig,
+	redirectUri: string,
+): Promise<TokenResponse> {
+	const tokenUrl = new URL(oauthConfig.tokenUrl);
+	const useBasicAuth = oauthConfig.tokenAuthMethod === 'basic';
+
+	return new Promise((resolve, reject) => {
+		const postDataParams: Record<string, string> = {
+			code: code.trim(),
+			redirect_uri: redirectUri,
+			grant_type: 'authorization_code',
+		};
+
+		if (!useBasicAuth) {
+			postDataParams.client_id = clientId;
+			postDataParams.client_secret = clientSecret;
+		}
+
+		const postData = querystring.stringify(postDataParams);
+		const headers: Record<string, string> = {
+			'Content-Type': 'application/x-www-form-urlencoded',
+			'Content-Length': Buffer.byteLength(postData).toString(),
+		};
+
+		if (useBasicAuth) {
+			headers.Authorization = `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`;
+		}
+
+		const req = https.request(
+			{
+				hostname: tokenUrl.hostname,
+				path: tokenUrl.pathname + tokenUrl.search,
+				method: 'POST',
+				headers,
+			},
+			(res) => {
+				let data = '';
+				res.on('data', (chunk) => {
+					data += chunk;
+				});
+				res.on('end', () => {
+					if (res.statusCode !== 200) {
+						reject(new Error(`Token exchange failed (${res.statusCode}): ${data}`));
+						return;
+					}
+					resolve(JSON.parse(data) as TokenResponse);
+				});
+			},
+		);
+		req.on('error', (error) =>
+			reject(new Error(`Request failed: ${error.message}`)),
+		);
+		req.write(postData);
+		req.end();
+	});
+}

--- a/packages/corsair/core/auth/index.ts
+++ b/packages/corsair/core/auth/index.ts
@@ -39,3 +39,7 @@ export type {
 } from './types';
 
 export { BASE_AUTH_FIELDS } from './types';
+
+// Token exchange utility
+export { exchangeCodeForTokens } from './exchange';
+export type { TokenResponse } from './exchange';

--- a/packages/corsair/core/index.ts
+++ b/packages/corsair/core/index.ts
@@ -156,11 +156,13 @@ export {
 	encryptConfig,
 	encryptDEK,
 	encryptWithDEK,
+	exchangeCodeForTokens,
 	generateDEK,
 	initializeAccountDEK,
 	initializeIntegrationDEK,
 	reEncryptConfig,
 } from './auth';
+export type { TokenResponse } from './auth';
 // Core types
 export type {
 	CorsairClient,

--- a/packages/corsair/oauth.ts
+++ b/packages/corsair/oauth.ts
@@ -1,0 +1,12 @@
+export {
+	decodeOAuthState,
+	encodeOAuthState,
+	generateOAuthUrl,
+	processOAuthCallback,
+} from './oauth/index';
+export type {
+	GenerateOAuthUrlOptions,
+	GenerateOAuthUrlResult,
+	ProcessOAuthCallbackOptions,
+	ProcessOAuthCallbackResult,
+} from './oauth/index';

--- a/packages/corsair/oauth/index.ts
+++ b/packages/corsair/oauth/index.ts
@@ -150,8 +150,11 @@ export type GenerateOAuthUrlResult = {
  * Builds an OAuth authorization URL for the given plugin and tenant.
  *
  * Embed the returned `url` in a button or link for the customer to click.
- * Persist `state` server-side (e.g. in a session cookie) so you can verify
- * it matches when processOAuthCallback is called.
+ * The returned `state` is HMAC-signed — pass it to processOAuthCallback as-is.
+ *
+ * Requires the plugin to have an oauthConfig (e.g. googlecalendar, gmail,
+ * notion, spotify). Plugins like slack and linear use API keys, not OAuth.
+ * The plugin's client_id and client_secret must be set via `corsair setup`.
  *
  * Works for both multi-tenant and single-tenant corsair instances.
  */

--- a/packages/corsair/oauth/index.ts
+++ b/packages/corsair/oauth/index.ts
@@ -68,7 +68,9 @@ function verifyAndDecodeState(
 		.createHmac('sha256', kek)
 		.update(payload)
 		.digest('base64url');
-	if (!crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) {
+	const sigBuf = Buffer.from(sig, 'base64url');
+	const expectedBuf = Buffer.from(expected, 'base64url');
+	if (sigBuf.length !== expectedBuf.length || !crypto.timingSafeEqual(sigBuf, expectedBuf)) {
 		return null;
 	}
 	return decodeOAuthState(payload);
@@ -188,12 +190,12 @@ export async function generateOAuthUrl(
 	const state = signState(encodeOAuthState(pluginId, tenantId), internal.kek);
 
 	const params: Record<string, string> = {
+		...oauthCfg.authParams,
 		client_id: clientId,
 		redirect_uri: redirectUri,
 		response_type: 'code',
 		scope: oauthCfg.scopes.join(' '),
 		state,
-		...oauthCfg.authParams,
 	};
 
 	return {

--- a/packages/corsair/oauth/index.ts
+++ b/packages/corsair/oauth/index.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'node:crypto';
 import * as querystring from 'node:querystring';
 import {
 	CORSAIR_INTERNAL,
@@ -15,7 +16,7 @@ import type {
 import { createCorsairOrm } from '../db/orm';
 
 // ─────────────────────────────────────────────────────────────────────────────
-// State encoding
+// State encoding — HMAC-signed to prevent forged callbacks
 // ─────────────────────────────────────────────────────────────────────────────
 
 type OAuthState = { plugin: string; tenantId: string };
@@ -26,8 +27,10 @@ export function encodeOAuthState(plugin: string, tenantId: string): string {
 
 export function decodeOAuthState(state: string): OAuthState | null {
 	try {
+		// Accepts both raw payload (for tests/utilities) and signed `payload.sig` format
+		const payload = state.includes('.') ? state.split('.')[0] : state;
 		const decoded = JSON.parse(
-			Buffer.from(state, 'base64url').toString('utf-8'),
+			Buffer.from(payload!, 'base64url').toString('utf-8'),
 		) as unknown;
 		if (
 			decoded !== null &&
@@ -43,6 +46,32 @@ export function decodeOAuthState(state: string): OAuthState | null {
 	} catch {
 		return null;
 	}
+}
+
+function signState(payload: string, kek: string): string {
+	const sig = crypto
+		.createHmac('sha256', kek)
+		.update(payload)
+		.digest('base64url');
+	return `${payload}.${sig}`;
+}
+
+function verifyAndDecodeState(
+	signed: string,
+	kek: string,
+): OAuthState | null {
+	const dotIdx = signed.lastIndexOf('.');
+	if (dotIdx === -1) return null;
+	const payload = signed.slice(0, dotIdx);
+	const sig = signed.slice(dotIdx + 1);
+	const expected = crypto
+		.createHmac('sha256', kek)
+		.update(payload)
+		.digest('base64url');
+	if (!crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) {
+		return null;
+	}
+	return decodeOAuthState(payload);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -153,7 +182,7 @@ export async function generateOAuthUrl(
 		throw new Error(`client_id not configured for '${pluginId}'`);
 	}
 
-	const state = encodeOAuthState(pluginId, tenantId);
+	const state = signState(encodeOAuthState(pluginId, tenantId), internal.kek);
 
 	const params: Record<string, string> = {
 		client_id: clientId,
@@ -197,11 +226,12 @@ export async function processOAuthCallback(
 ): Promise<ProcessOAuthCallbackResult> {
 	const { code, state, redirectUri } = options;
 
-	const decoded = decodeOAuthState(state);
-	if (!decoded) throw new Error('Invalid or malformed state parameter');
+	const internal = getInternal(corsair);
+
+	const decoded = verifyAndDecodeState(state, internal.kek);
+	if (!decoded) throw new Error('Invalid or tampered state parameter');
 
 	const { plugin: pluginId, tenantId } = decoded;
-	const internal = getInternal(corsair);
 
 	if (!internal.database) {
 		throw new Error('No database configured on corsair instance');

--- a/packages/corsair/oauth/index.ts
+++ b/packages/corsair/oauth/index.ts
@@ -1,0 +1,260 @@
+import * as querystring from 'node:querystring';
+import {
+	CORSAIR_INTERNAL,
+	createAccountKeyManager,
+	createIntegrationKeyManager,
+	encryptDEK,
+	exchangeCodeForTokens,
+	generateDEK,
+} from '../core';
+import type {
+	CorsairInternalConfig,
+	CorsairPlugin,
+	OAuthConfig,
+} from '../core';
+import { createCorsairOrm } from '../db/orm';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// State encoding
+// ─────────────────────────────────────────────────────────────────────────────
+
+type OAuthState = { plugin: string; tenantId: string };
+
+export function encodeOAuthState(plugin: string, tenantId: string): string {
+	return Buffer.from(JSON.stringify({ plugin, tenantId })).toString('base64url');
+}
+
+export function decodeOAuthState(state: string): OAuthState | null {
+	try {
+		const decoded = JSON.parse(
+			Buffer.from(state, 'base64url').toString('utf-8'),
+		) as unknown;
+		if (
+			decoded !== null &&
+			typeof decoded === 'object' &&
+			'plugin' in decoded &&
+			'tenantId' in decoded &&
+			typeof (decoded as OAuthState).plugin === 'string' &&
+			typeof (decoded as OAuthState).tenantId === 'string'
+		) {
+			return decoded as OAuthState;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function getInternal(corsair: unknown): CorsairInternalConfig {
+	const internal = (corsair as Record<symbol, unknown>)[
+		CORSAIR_INTERNAL
+	] as CorsairInternalConfig | undefined;
+	if (!internal) throw new Error('Invalid corsair instance');
+	return internal;
+}
+
+function findPlugin(
+	internal: CorsairInternalConfig,
+	pluginId: string,
+): CorsairPlugin {
+	const plugin = internal.plugins.find((p) => p.id === pluginId);
+	if (!plugin) throw new Error(`Plugin '${pluginId}' not found`);
+	return plugin;
+}
+
+function getOAuthConfig(plugin: CorsairPlugin): OAuthConfig {
+	const cfg = (plugin as { oauthConfig?: OAuthConfig }).oauthConfig;
+	if (!cfg) throw new Error(`Plugin '${plugin.id}' has no oauthConfig`);
+	return cfg;
+}
+
+async function ensureAccount(
+	database: NonNullable<CorsairInternalConfig['database']>,
+	pluginId: string,
+	tenantId: string,
+	kek: string,
+): Promise<void> {
+	const orm = createCorsairOrm(database);
+
+	const integration = await orm.integrations.findByName(pluginId);
+	if (!integration) {
+		throw new Error(
+			`Integration '${pluginId}' not found. Run setupCorsair first.`,
+		);
+	}
+
+	const existing = await orm.accounts.findOne({
+		tenant_id: tenantId,
+		integration_id: integration.id,
+	});
+	if (existing) return;
+
+	const dek = generateDEK();
+	const encryptedDek = await encryptDEK(dek, kek);
+	await orm.accounts.create({
+		tenant_id: tenantId,
+		integration_id: integration.id,
+		config: {},
+		dek: encryptedDek,
+	});
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type GenerateOAuthUrlOptions = {
+	tenantId: string;
+	redirectUri: string;
+};
+
+export type GenerateOAuthUrlResult = {
+	url: string;
+	state: string;
+};
+
+/**
+ * Builds an OAuth authorization URL for the given plugin and tenant.
+ *
+ * Embed the returned `url` in a button or link for the customer to click.
+ * Persist `state` server-side (e.g. in a session cookie) so you can verify
+ * it matches when processOAuthCallback is called.
+ *
+ * Works for both multi-tenant and single-tenant corsair instances.
+ */
+export async function generateOAuthUrl(
+	corsair: unknown,
+	pluginId: string,
+	options: GenerateOAuthUrlOptions,
+): Promise<GenerateOAuthUrlResult> {
+	const { tenantId, redirectUri } = options;
+	const internal = getInternal(corsair);
+
+	if (!internal.database) {
+		throw new Error('No database configured on corsair instance');
+	}
+
+	const plugin = findPlugin(internal, pluginId);
+	const oauthCfg = getOAuthConfig(plugin);
+
+	const integrationKm = createIntegrationKeyManager({
+		authType: 'oauth_2',
+		integrationName: pluginId,
+		kek: internal.kek,
+		database: internal.database,
+	});
+
+	const clientId = await integrationKm.get_client_id();
+	if (!clientId) {
+		throw new Error(`client_id not configured for '${pluginId}'`);
+	}
+
+	const state = encodeOAuthState(pluginId, tenantId);
+
+	const params: Record<string, string> = {
+		client_id: clientId,
+		redirect_uri: redirectUri,
+		response_type: 'code',
+		scope: oauthCfg.scopes.join(' '),
+		state,
+		...oauthCfg.authParams,
+	};
+
+	return {
+		url: `${oauthCfg.authUrl}?${querystring.stringify(params)}`,
+		state,
+	};
+}
+
+export type ProcessOAuthCallbackOptions = {
+	code: string;
+	state: string;
+	/** Must exactly match the redirectUri passed to generateOAuthUrl. */
+	redirectUri: string;
+};
+
+export type ProcessOAuthCallbackResult = {
+	plugin: string;
+	tenantId: string;
+};
+
+/**
+ * Completes the OAuth flow by exchanging the authorization code for tokens
+ * and storing them encrypted in the database for the tenant.
+ *
+ * Call this inside your /api/auth route after receiving `code` and `state`
+ * from the provider redirect.
+ *
+ * @throws if state is invalid, credentials are missing, or token exchange fails
+ */
+export async function processOAuthCallback(
+	corsair: unknown,
+	options: ProcessOAuthCallbackOptions,
+): Promise<ProcessOAuthCallbackResult> {
+	const { code, state, redirectUri } = options;
+
+	const decoded = decodeOAuthState(state);
+	if (!decoded) throw new Error('Invalid or malformed state parameter');
+
+	const { plugin: pluginId, tenantId } = decoded;
+	const internal = getInternal(corsair);
+
+	if (!internal.database) {
+		throw new Error('No database configured on corsair instance');
+	}
+
+	const plugin = findPlugin(internal, pluginId);
+	const oauthCfg = getOAuthConfig(plugin);
+
+	const integrationKm = createIntegrationKeyManager({
+		authType: 'oauth_2',
+		integrationName: pluginId,
+		kek: internal.kek,
+		database: internal.database,
+	});
+
+	const clientId = await integrationKm.get_client_id();
+	const clientSecret = await integrationKm.get_client_secret();
+	if (!clientId || !clientSecret) {
+		throw new Error(`Credentials not configured for '${pluginId}'`);
+	}
+
+	// Ensure tenant account row exists before writing tokens
+	await ensureAccount(internal.database, pluginId, tenantId, internal.kek);
+
+	const tokens = await exchangeCodeForTokens(
+		code,
+		clientId,
+		clientSecret,
+		oauthCfg,
+		redirectUri,
+	);
+
+	if (!tokens.access_token) {
+		throw new Error(`No access_token returned from ${oauthCfg.providerName}`);
+	}
+
+	const accountKm = createAccountKeyManager({
+		authType: 'oauth_2',
+		integrationName: pluginId,
+		tenantId,
+		kek: internal.kek,
+		database: internal.database,
+	});
+
+	await accountKm.set_access_token(tokens.access_token);
+	if (tokens.refresh_token) {
+		await accountKm.set_refresh_token(tokens.refresh_token);
+	}
+	if (tokens.expires_in) {
+		await accountKm.set_expires_at(
+			String(Math.floor(Date.now() / 1000) + tokens.expires_in),
+		);
+	}
+
+	return { plugin: pluginId, tenantId };
+}

--- a/packages/corsair/package.json
+++ b/packages/corsair/package.json
@@ -37,6 +37,11 @@
       "types": "./dist/http.d.ts",
       "default": "./dist/http.js"
     },
+    "./oauth": {
+      "dev-source": "./oauth.ts",
+      "types": "./dist/oauth.d.ts",
+      "default": "./dist/oauth.js"
+    },
     "./tests": {
       "dev-source": "./tests.ts",
       "types": "./dist/tests.d.ts",

--- a/packages/corsair/tsup.config.ts
+++ b/packages/corsair/tsup.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
 		'core.ts',
 		'db.ts',
 		'mcp.ts',
+		'oauth.ts',
 		'orm.ts',
 		'setup.ts',
 		'http.ts',


### PR DESCRIPTION
Closes #172

  ## What

  Adds OAuth support to the `corsair` package via a new `corsair/oauth` subpath export.

  Previously, OAuth only worked through the CLI's localhost listener (`pnpm corsair auth --plugin=...`) — unusable for real customers in production.

  ## API

  ```ts
  import { generateOAuthUrl, processOAuthCallback } from 'corsair/oauth';

  // 1. Generate a link for your customer
  const { url, state } = await generateOAuthUrl(corsair, 'googlecalendar', {
    tenantId: req.user.id,
    redirectUri: 'https://yourapp.com/api/auth',
  });

  // 2. Handle the callback
  const result = await processOAuthCallback(corsair, {
    code: req.query.code,
    state: req.query.state,
    redirectUri: 'https://yourapp.com/api/auth',
  });
  // tokens stored, tenant connected

  Works for both multi-tenant and single-tenant instances.
```

## E2E OAuth flow with Google Calendar on the Next.js demo

https://github.com/user-attachments/assets/d16dab24-56e6-4b66-9f09-91bb7708a494

