### PR TITLE
#171 add chat page to Studio wired to Corsair MCP tools

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -13,4 +13,5 @@ export { createBaseMcpServer } from './core/base.js';
 export { createMcpRouter } from './core/http.js';
 export { BaseProvider } from './core/provider.js';
 export { runStdioMcpServer } from './core/stdio.js';
+export { buildCorsairToolDefs } from './core/tools.js';
 export type { CorsairToolDef } from './core/tools.js';

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -27,11 +27,13 @@
     "@corsair-dev/cli": "workspace:*",
     "@corsair-dev/mcp": "workspace:*",
     "ai": "^4.0.0",
+    "better-sqlite3": "^12.0.0",
     "corsair": "workspace:*",
     "typescript": "^5.9.3",
     "zod": "^3.25.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.0",
     "@tailwindcss/vite": "^4.0.0",
     "@types/node": "^24.10.1",
     "@types/react": "^19.0.0",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -20,9 +20,16 @@
     "build:watch": "tsup --watch"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^1.0.0",
+    "@ai-sdk/google": "^1.0.0",
+    "@ai-sdk/groq": "^1.0.0",
+    "@ai-sdk/openai": "^1.0.0",
     "@corsair-dev/cli": "workspace:*",
+    "@corsair-dev/mcp": "workspace:*",
+    "ai": "^4.0.0",
     "corsair": "workspace:*",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "zod": "^3.25.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -29,12 +29,13 @@
     "ai": "^4.0.0",
     "better-sqlite3": "^12.0.0",
     "corsair": "workspace:*",
+    "kysely": "^0.28.9",
     "typescript": "^5.9.3",
     "zod": "^3.25.0"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.0",
     "@tailwindcss/vite": "^4.0.0",
+    "@types/better-sqlite3": "^7.6.0",
     "@types/node": "^24.10.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/packages/studio/src/server/chat-store.ts
+++ b/packages/studio/src/server/chat-store.ts
@@ -1,4 +1,5 @@
 import Database from 'better-sqlite3';
+import { Kysely, SqliteDialect } from 'kysely';
 
 export type StoredChat = {
 	id: string;
@@ -18,101 +19,154 @@ export type StoredMessage = {
 	error: string | null;
 };
 
-const db = new Database(':memory:');
+type ChatTable = {
+	id: string;
+	title: string;
+	created_at: number;
+};
 
-db.exec(`
-  CREATE TABLE chats (
-    id TEXT PRIMARY KEY,
-    title TEXT NOT NULL,
-    created_at INTEGER NOT NULL
-  );
-  CREATE TABLE chat_messages (
-    id TEXT PRIMARY KEY,
-    chat_id TEXT NOT NULL,
-    role TEXT NOT NULL,
-    blocks TEXT NOT NULL,
-    error TEXT,
-    seq INTEGER NOT NULL
-  );
-`);
+type ChatMessageTable = {
+	id: string;
+	chat_id: string;
+	role: 'user' | 'assistant';
+	blocks: string;
+	error: string | null;
+	seq: number;
+};
+
+type ChatStoreDb = {
+	chats: ChatTable;
+	chat_messages: ChatMessageTable;
+};
+
+const sqlite = new Database(':memory:');
+const db = new Kysely<ChatStoreDb>({
+	dialect: new SqliteDialect({ database: sqlite }),
+});
+const schemaReady = initSchema();
+
+async function initSchema() {
+	await db.schema
+		.createTable('chats')
+		.ifNotExists()
+		.addColumn('id', 'text', (col) => col.primaryKey())
+		.addColumn('title', 'text', (col) => col.notNull())
+		.addColumn('created_at', 'integer', (col) => col.notNull())
+		.execute();
+
+	await db.schema
+		.createTable('chat_messages')
+		.ifNotExists()
+		.addColumn('id', 'text', (col) => col.primaryKey())
+		.addColumn('chat_id', 'text', (col) => col.notNull())
+		.addColumn('role', 'text', (col) => col.notNull())
+		.addColumn('blocks', 'text', (col) => col.notNull())
+		.addColumn('error', 'text')
+		.addColumn('seq', 'integer', (col) => col.notNull())
+		.execute();
+}
 
 let _seq = 0;
 
-export function createChat(): StoredChat {
+function getTextFromBlocks(blocks: StoredMsgBlock[]) {
+	return blocks
+		.filter((block): block is Extract<StoredMsgBlock, { type: 'text' }> =>
+			block.type === 'text',
+		)
+		.map((block) => block.content)
+		.join('');
+}
+
+export async function createChat() {
+	await schemaReady;
+
 	const chat: StoredChat = {
 		id: crypto.randomUUID(),
 		title: 'New chat',
 		created_at: Date.now(),
 	};
-	db.prepare('INSERT INTO chats (id, title, created_at) VALUES (?, ?, ?)').run(
-		chat.id,
-		chat.title,
-		chat.created_at,
-	);
+
+	await db.insertInto('chats').values(chat).execute();
 	return chat;
 }
 
-export function listChats(): StoredChat[] {
+export async function listChats() {
+	await schemaReady;
+
 	return db
-		.prepare(
-			'SELECT id, title, created_at FROM chats ORDER BY created_at DESC',
-		)
-		.all() as StoredChat[];
+		.selectFrom('chats')
+		.select(['id', 'title', 'created_at'])
+		.orderBy('created_at', 'desc')
+		.execute();
 }
 
-export function chatExists(chatId: string): boolean {
-	return !!db.prepare('SELECT 1 FROM chats WHERE id = ?').get(chatId);
+export async function chatExists(chatId: string) {
+	await schemaReady;
+
+	const row = await db
+		.selectFrom('chats')
+		.select('id')
+		.where('id', '=', chatId)
+		.executeTakeFirst();
+	return !!row;
 }
 
-export function getMessages(chatId: string): StoredMessage[] {
-	const rows = db
-		.prepare(
-			'SELECT id, chat_id, role, blocks, error FROM chat_messages WHERE chat_id = ? ORDER BY seq ASC',
-		)
-		.all(chatId) as Array<{
-		id: string;
-		chat_id: string;
-		role: string;
-		blocks: string;
-		error: string | null;
-	}>;
+export async function getMessages(chatId: string) {
+	await schemaReady;
+
+	const rows = await db
+		.selectFrom('chat_messages')
+		.select(['id', 'chat_id', 'role', 'blocks', 'error'])
+		.where('chat_id', '=', chatId)
+		.orderBy('seq', 'asc')
+		.execute();
+
 	return rows.map((row) => ({
 		id: row.id,
 		chat_id: row.chat_id,
-		role: row.role as 'user' | 'assistant',
+		role: row.role,
 		blocks: JSON.parse(row.blocks) as StoredMsgBlock[],
 		error: row.error,
 	}));
 }
 
-export function appendMessage(
+export async function appendMessage(
 	chatId: string,
 	id: string,
 	role: 'user' | 'assistant',
 	blocks: StoredMsgBlock[],
 	error?: string,
-): void {
-	db.prepare(
-		'INSERT INTO chat_messages (id, chat_id, role, blocks, error, seq) VALUES (?, ?, ?, ?, ?, ?)',
-	).run(id, chatId, role, JSON.stringify(blocks), error ?? null, ++_seq);
+) {
+	await schemaReady;
+
+	await db
+		.insertInto('chat_messages')
+		.values({
+			id,
+			chat_id: chatId,
+			role,
+			blocks: JSON.stringify(blocks),
+			error: error ?? null,
+			seq: ++_seq,
+		})
+		.execute();
 
 	if (role === 'user') {
-		const row = db
-			.prepare('SELECT title FROM chats WHERE id = ?')
-			.get(chatId) as { title: string } | undefined;
+		const row = await db
+			.selectFrom('chats')
+			.select('title')
+			.where('id', '=', chatId)
+			.executeTakeFirst();
+
 		if (row?.title === 'New chat') {
-			const text = blocks
-				.filter(
-					(b): b is { type: 'text'; content: string } => b.type === 'text',
-				)
-				.map((b) => b.content)
-				.join('');
+			const text = getTextFromBlocks(blocks);
 			const newTitle = text.slice(0, 60).trim();
 			if (newTitle) {
-				db.prepare('UPDATE chats SET title = ? WHERE id = ?').run(
-					newTitle,
-					chatId,
-				);
+				await db
+					.updateTable('chats')
+					.set({ title: newTitle })
+					.where('id', '=', chatId)
+					.execute();
 			}
 		}
 	}

--- a/packages/studio/src/server/chat-store.ts
+++ b/packages/studio/src/server/chat-store.ts
@@ -1,0 +1,119 @@
+import Database from 'better-sqlite3';
+
+export type StoredChat = {
+	id: string;
+	title: string;
+	created_at: number;
+};
+
+export type StoredMsgBlock =
+	| { type: 'text'; content: string }
+	| { type: 'tool'; name: string; args: unknown; result?: unknown };
+
+export type StoredMessage = {
+	id: string;
+	chat_id: string;
+	role: 'user' | 'assistant';
+	blocks: StoredMsgBlock[];
+	error: string | null;
+};
+
+const db = new Database(':memory:');
+
+db.exec(`
+  CREATE TABLE chats (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+  );
+  CREATE TABLE chat_messages (
+    id TEXT PRIMARY KEY,
+    chat_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    blocks TEXT NOT NULL,
+    error TEXT,
+    seq INTEGER NOT NULL
+  );
+`);
+
+let _seq = 0;
+
+export function createChat(): StoredChat {
+	const chat: StoredChat = {
+		id: crypto.randomUUID(),
+		title: 'New chat',
+		created_at: Date.now(),
+	};
+	db.prepare('INSERT INTO chats (id, title, created_at) VALUES (?, ?, ?)').run(
+		chat.id,
+		chat.title,
+		chat.created_at,
+	);
+	return chat;
+}
+
+export function listChats(): StoredChat[] {
+	return db
+		.prepare(
+			'SELECT id, title, created_at FROM chats ORDER BY created_at DESC',
+		)
+		.all() as StoredChat[];
+}
+
+export function chatExists(chatId: string): boolean {
+	return !!db.prepare('SELECT 1 FROM chats WHERE id = ?').get(chatId);
+}
+
+export function getMessages(chatId: string): StoredMessage[] {
+	const rows = db
+		.prepare(
+			'SELECT id, chat_id, role, blocks, error FROM chat_messages WHERE chat_id = ? ORDER BY seq ASC',
+		)
+		.all(chatId) as Array<{
+		id: string;
+		chat_id: string;
+		role: string;
+		blocks: string;
+		error: string | null;
+	}>;
+	return rows.map((row) => ({
+		id: row.id,
+		chat_id: row.chat_id,
+		role: row.role as 'user' | 'assistant',
+		blocks: JSON.parse(row.blocks) as StoredMsgBlock[],
+		error: row.error,
+	}));
+}
+
+export function appendMessage(
+	chatId: string,
+	id: string,
+	role: 'user' | 'assistant',
+	blocks: StoredMsgBlock[],
+	error?: string,
+): void {
+	db.prepare(
+		'INSERT INTO chat_messages (id, chat_id, role, blocks, error, seq) VALUES (?, ?, ?, ?, ?, ?)',
+	).run(id, chatId, role, JSON.stringify(blocks), error ?? null, ++_seq);
+
+	if (role === 'user') {
+		const row = db
+			.prepare('SELECT title FROM chats WHERE id = ?')
+			.get(chatId) as { title: string } | undefined;
+		if (row?.title === 'New chat') {
+			const text = blocks
+				.filter(
+					(b): b is { type: 'text'; content: string } => b.type === 'text',
+				)
+				.map((b) => b.content)
+				.join('');
+			const newTitle = text.slice(0, 60).trim();
+			if (newTitle) {
+				db.prepare('UPDATE chats SET title = ? WHERE id = ?').run(
+					newTitle,
+					chatId,
+				);
+			}
+		}
+	}
+}

--- a/packages/studio/src/server/handlers/chat.ts
+++ b/packages/studio/src/server/handlers/chat.ts
@@ -1,0 +1,128 @@
+import { buildCorsairToolDefs } from '@corsair-dev/mcp';
+import type { CoreMessage, LanguageModel, ToolSet } from 'ai';
+import { streamText, tool } from 'ai';
+import { z } from 'zod';
+import { readJsonBody } from '../router.js';
+import type { HandlerFn } from '../types.js';
+
+function buildAiTools(corsairClient: Record<string, unknown>): ToolSet {
+	const defs = buildCorsairToolDefs({ corsair: corsairClient, setup: false });
+	const tools: ToolSet = {};
+	for (const def of defs) {
+		tools[def.name] = tool({
+			description: def.description,
+			parameters: z.object(def.shape),
+			execute: async (args) => {
+				const result = await def.handler(
+					args as unknown as Record<string, unknown>,
+				);
+				const texts = result.content.filter(
+					(c): c is { type: 'text'; text: string } => c.type === 'text',
+				);
+				if (result.isError) {
+					throw new Error(texts.map((c) => c.text).join('\n'));
+				}
+				const text = texts[0]?.text ?? '';
+				try {
+					return JSON.parse(text);
+				} catch {
+					return text;
+				}
+			},
+		});
+	}
+	return tools;
+}
+
+async function resolveModel(): Promise<LanguageModel> {
+	const model = process.env.CORSAIR_CHAT_MODEL;
+
+	if (process.env.OPENAI_API_KEY) {
+		const { openai } = await import('@ai-sdk/openai');
+		return openai(model ?? 'gpt-4o-mini');
+	}
+
+	if (process.env.ANTHROPIC_API_KEY) {
+		const { anthropic } = await import('@ai-sdk/anthropic');
+		return anthropic(model ?? 'claude-3-5-sonnet-20241022');
+	}
+
+	if (process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
+		const { google } = await import('@ai-sdk/google');
+		return google(model ?? 'gemini-2.0-flash');
+	}
+
+	if (process.env.GROQ_API_KEY) {
+		const { createGroq } = await import('@ai-sdk/groq');
+		return createGroq()(model ?? 'llama-3.3-70b-versatile');
+	}
+
+	throw new Error(
+		'No AI provider configured. Set one of: OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY, or GROQ_API_KEY.',
+	);
+}
+
+type StreamPart = {
+	type: string;
+	textDelta?: string;
+	toolName?: string;
+	args?: unknown;
+	result?: unknown;
+};
+
+export const chatHandler: HandlerFn = async (ctx) => {
+	const body = await readJsonBody(ctx.req);
+	const messages = (body.messages ?? []) as CoreMessage[];
+	const tenant = body.tenant ? String(body.tenant) : undefined;
+
+	let model: LanguageModel;
+	try {
+		model = await resolveModel();
+	} catch (err) {
+		ctx.res.writeHead(400, { 'content-type': 'application/json' });
+		ctx.res.end(JSON.stringify({ error: (err as Error).message }));
+		return;
+	}
+
+	const handle = await ctx.getCorsair();
+	const client = handle.resolveClient(tenant);
+	const tools = buildAiTools(client);
+
+	ctx.res.writeHead(200, {
+		'content-type': 'text/event-stream',
+		'cache-control': 'no-cache',
+		connection: 'keep-alive',
+	});
+
+	const send = (data: unknown) => {
+		ctx.res.write(`data: ${JSON.stringify(data)}\n\n`);
+	};
+
+	try {
+		const result = streamText({
+			model,
+			system:
+				"You are a helpful assistant with access to Corsair tools. Use the tools to answer questions about the user's integrations and data.",
+			messages,
+			tools,
+			maxSteps: 10,
+		});
+
+		for await (const raw of result.fullStream) {
+			const part = raw as StreamPart;
+			if (part.type === 'text-delta') {
+				send({ type: 'text', text: part.textDelta });
+			} else if (part.type === 'tool-call') {
+				send({ type: 'tool-start', name: part.toolName, args: part.args });
+			} else if (part.type === 'tool-result') {
+				send({ type: 'tool-end', name: part.toolName, result: part.result });
+			} else if (part.type === 'finish') {
+				send({ type: 'done' });
+			}
+		}
+	} catch (err) {
+		send({ type: 'error', message: (err as Error).message });
+	} finally {
+		ctx.res.end();
+	}
+};

--- a/packages/studio/src/server/handlers/chat.ts
+++ b/packages/studio/src/server/handlers/chat.ts
@@ -201,6 +201,31 @@ type StreamPart = {
 	result?: unknown;
 };
 
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+function parseStreamPart(raw: unknown): StreamPart | null {
+	if (!isObject(raw) || typeof raw.type !== 'string') {
+		return null;
+	}
+
+	const textDelta =
+		typeof raw.textDelta === 'string' ? raw.textDelta : undefined;
+	const toolName = typeof raw.toolName === 'string' ? raw.toolName : undefined;
+	return {
+		type: raw.type,
+		textDelta,
+		toolName,
+		args: raw.args,
+		result: raw.result,
+	};
+}
+
 export const chatHandler: HandlerFn = async (ctx) => {
 	console.log('[corsair:chat] request received');
 	const body = await readJsonBody(ctx.req);
@@ -209,7 +234,8 @@ export const chatHandler: HandlerFn = async (ctx) => {
 	const newUserText = body.message ? String(body.message) : undefined;
 
 	// Load history from the store — don't trust the client to serialize tool calls
-	const storedHistory = chatId && chatExists(chatId) ? getMessages(chatId) : [];
+	const storedHistory =
+		chatId && (await chatExists(chatId)) ? await getMessages(chatId) : [];
 	const messages: CoreMessage[] = toAiMessages(storedHistory);
 	if (newUserText) {
 		messages.push({ role: 'user', content: newUserText });
@@ -230,12 +256,10 @@ export const chatHandler: HandlerFn = async (ctx) => {
 	try {
 		model = await resolveModel();
 	} catch (err) {
-		console.error(
-			'[corsair:chat] model resolution failed:',
-			(err as Error).message,
-		);
+		const message = errorMessage(err);
+		console.error('[corsair:chat] model resolution failed:', message);
 		ctx.res.writeHead(400, { 'content-type': 'application/json' });
-		ctx.res.end(JSON.stringify({ error: (err as Error).message }));
+		ctx.res.end(JSON.stringify({ error: message }));
 		return;
 	}
 
@@ -244,9 +268,9 @@ export const chatHandler: HandlerFn = async (ctx) => {
 	const tools = buildAiTools(client);
 
 	const userMsgId = crypto.randomUUID();
-	if (chatId && chatExists(chatId) && newUserText) {
+	if (chatId && (await chatExists(chatId)) && newUserText) {
 		try {
-			appendMessage(chatId, userMsgId, 'user', [
+			await appendMessage(chatId, userMsgId, 'user', [
 				{ type: 'text', content: newUserText },
 			]);
 		} catch (err) {
@@ -278,7 +302,11 @@ export const chatHandler: HandlerFn = async (ctx) => {
 		});
 
 		for await (const raw of result.fullStream) {
-			const part = raw as StreamPart;
+			const part = parseStreamPart(raw);
+			if (!part) {
+				continue;
+			}
+
 			if (part.type === 'text-delta') {
 				send({ type: 'text', text: part.textDelta });
 				const last = assistantBlocks[assistantBlocks.length - 1];
@@ -306,13 +334,14 @@ export const chatHandler: HandlerFn = async (ctx) => {
 			}
 		}
 	} catch (err) {
-		console.error('[corsair:chat] stream error:', (err as Error).message);
-		send({ type: 'error', message: (err as Error).message });
+		const message = errorMessage(err);
+		console.error('[corsair:chat] stream error:', message);
+		send({ type: 'error', message });
 	} finally {
 		// Persist the assistant response
-		if (chatId && chatExists(chatId) && assistantBlocks.length > 0) {
+		if (chatId && (await chatExists(chatId)) && assistantBlocks.length > 0) {
 			try {
-				appendMessage(
+				await appendMessage(
 					chatId,
 					crypto.randomUUID(),
 					'assistant',

--- a/packages/studio/src/server/handlers/chat.ts
+++ b/packages/studio/src/server/handlers/chat.ts
@@ -7,54 +7,122 @@ import type { StoredMessage, StoredMsgBlock } from '../chat-store.js';
 import { readJsonBody } from '../router.js';
 import type { HandlerFn } from '../types.js';
 
+type TextBlock = Extract<StoredMsgBlock, { type: 'text' }>;
+type ToolBlock = Extract<StoredMsgBlock, { type: 'tool' }>;
+type CompletedToolBlock = ToolBlock & { result: unknown };
+type AssistantContentPart =
+	| { type: 'text'; text: string }
+	| {
+			type: 'tool-call';
+			toolCallId: string;
+			toolName: string;
+			args: Record<string, unknown>;
+	  };
+type ToolContentPart = {
+	type: 'tool-result';
+	toolCallId: string;
+	toolName: string;
+	result: unknown;
+};
+
+function isTextBlock(block: StoredMsgBlock): block is TextBlock {
+	return block.type === 'text';
+}
+
+function isCompletedToolBlock(
+	block: StoredMsgBlock,
+): block is CompletedToolBlock {
+	return block.type === 'tool' && block.result !== undefined;
+}
+
+function isPendingToolBlock(block: StoredMsgBlock): block is ToolBlock {
+	return block.type === 'tool' && block.result === undefined;
+}
+
+function joinTextBlocks(blocks: TextBlock[]): string {
+	return blocks.map((block) => block.content).join('');
+}
+
+function toToolArgs(args: unknown): Record<string, unknown> {
+	if (args && typeof args === 'object') {
+		const toolArgs: Record<string, unknown> = {};
+		for (const [key, value] of Object.entries(args)) {
+			toolArgs[key] = value;
+		}
+		return toolArgs;
+	}
+	return {};
+}
+
+function makeTextPart(block: TextBlock): AssistantContentPart {
+	return { type: 'text', text: block.content };
+}
+
+function makeToolCallPart(
+	toolCallId: string,
+	block: CompletedToolBlock,
+): AssistantContentPart {
+	return {
+		type: 'tool-call',
+		toolCallId,
+		toolName: block.name,
+		args: toToolArgs(block.args),
+	};
+}
+
+function makeToolResultPart(
+	toolCallId: string,
+	block: CompletedToolBlock,
+): ToolContentPart {
+	return {
+		type: 'tool-result',
+		toolCallId,
+		toolName: block.name,
+		result: block.result,
+	};
+}
+
+function findPendingToolBlockIndex(
+	blocks: StoredMsgBlock[],
+	toolName: string | undefined,
+): number {
+	return blocks.findLastIndex(
+		(block) => isPendingToolBlock(block) && block.name === toolName,
+	);
+}
+
 function toAiMessages(stored: StoredMessage[]): CoreMessage[] {
 	const result: CoreMessage[] = [];
 	for (const msg of stored) {
-		if (msg.role === 'user') {
-			const text = msg.blocks
-				.filter((b): b is { type: 'text'; content: string } => b.type === 'text')
-				.map((b) => b.content)
-				.join('');
-			result.push({ role: 'user', content: text });
-		} else {
-			const textBlocks = msg.blocks.filter(
-				(b): b is { type: 'text'; content: string } => b.type === 'text',
-			);
-			const toolBlocks = msg.blocks.filter(
-				(b): b is { type: 'tool'; name: string; args: unknown; result: unknown } =>
-					b.type === 'tool' && (b as { result?: unknown }).result !== undefined,
-			);
+		const textBlocks = msg.blocks.filter(isTextBlock);
+		const text = joinTextBlocks(textBlocks);
 
-			if (toolBlocks.length === 0) {
-				result.push({
-					role: 'assistant',
-					content: textBlocks.map((b) => b.content).join(''),
-				});
-			} else {
-				const ids = toolBlocks.map(() => crypto.randomUUID());
-				result.push({
-					role: 'assistant',
-					content: [
-						...textBlocks.map((b) => ({ type: 'text' as const, text: b.content })),
-						...toolBlocks.map((b, i) => ({
-							type: 'tool-call' as const,
-							toolCallId: ids[i]!,
-							toolName: b.name,
-							args: b.args as Record<string, unknown>,
-						})),
-					],
-				});
-				result.push({
-					role: 'tool',
-					content: toolBlocks.map((b, i) => ({
-						type: 'tool-result' as const,
-						toolCallId: ids[i]!,
-						toolName: b.name,
-						result: b.result,
-					})),
-				});
-			}
+		if (msg.role === 'user') {
+			result.push({ role: 'user', content: text });
+			continue;
 		}
+
+		const toolBlocks = msg.blocks.filter(isCompletedToolBlock);
+		if (toolBlocks.length === 0) {
+			result.push({ role: 'assistant', content: text });
+			continue;
+		}
+
+		const toolCallIds = toolBlocks.map(() => crypto.randomUUID());
+		const assistantParts: AssistantContentPart[] = textBlocks.map(makeTextPart);
+		const toolParts: ToolContentPart[] = [];
+
+		for (const [index, block] of toolBlocks.entries()) {
+			const toolCallId = toolCallIds[index];
+			if (!toolCallId) {
+				continue;
+			}
+			assistantParts.push(makeToolCallPart(toolCallId, block));
+			toolParts.push(makeToolResultPart(toolCallId, block));
+		}
+
+		result.push({ role: 'assistant', content: assistantParts });
+		result.push({ role: 'tool', content: toolParts });
 	}
 	return result;
 }
@@ -67,12 +135,8 @@ function buildAiTools(corsairClient: Record<string, unknown>): ToolSet {
 			description: def.description,
 			parameters: z.object(def.shape),
 			execute: async (args) => {
-				const result = await def.handler(
-					args as unknown as Record<string, unknown>,
-				);
-				const texts = result.content.filter(
-					(c): c is { type: 'text'; text: string } => c.type === 'text',
-				);
+				const result = await def.handler(args);
+				const texts = result.content.filter((c) => c.type === 'text');
 				if (result.isError) {
 					throw new Error(texts.map((c) => c.text).join('\n'));
 				}
@@ -182,7 +246,9 @@ export const chatHandler: HandlerFn = async (ctx) => {
 	const userMsgId = crypto.randomUUID();
 	if (chatId && chatExists(chatId) && newUserText) {
 		try {
-			appendMessage(chatId, userMsgId, 'user', [{ type: 'text', content: newUserText }]);
+			appendMessage(chatId, userMsgId, 'user', [
+				{ type: 'text', content: newUserText },
+			]);
 		} catch (err) {
 			console.error('[corsair:chat] failed to save user message:', err);
 		}
@@ -230,18 +296,10 @@ export const chatHandler: HandlerFn = async (ctx) => {
 				});
 			} else if (part.type === 'tool-result') {
 				send({ type: 'tool-end', name: part.toolName, result: part.result });
-				const idx = assistantBlocks.findLastIndex(
-					(b): b is Extract<StoredMsgBlock, { type: 'tool' }> =>
-						b.type === 'tool' &&
-						(b as Extract<StoredMsgBlock, { type: 'tool' }>).name ===
-							part.toolName &&
-						(b as Extract<StoredMsgBlock, { type: 'tool' }>).result ===
-							undefined,
-				);
-				if (idx >= 0) {
-					(
-						assistantBlocks[idx] as Extract<StoredMsgBlock, { type: 'tool' }>
-					).result = part.result;
+				const idx = findPendingToolBlockIndex(assistantBlocks, part.toolName);
+				const block = idx >= 0 ? assistantBlocks[idx] : undefined;
+				if (block && isPendingToolBlock(block)) {
+					block.result = part.result;
 				}
 			} else if (part.type === 'finish') {
 				send({ type: 'done' });

--- a/packages/studio/src/server/handlers/chat.ts
+++ b/packages/studio/src/server/handlers/chat.ts
@@ -2,8 +2,62 @@ import { buildCorsairToolDefs } from '@corsair-dev/mcp';
 import type { CoreMessage, LanguageModel, ToolSet } from 'ai';
 import { streamText, tool } from 'ai';
 import { z } from 'zod';
+import { appendMessage, chatExists, getMessages } from '../chat-store.js';
+import type { StoredMessage, StoredMsgBlock } from '../chat-store.js';
 import { readJsonBody } from '../router.js';
 import type { HandlerFn } from '../types.js';
+
+function toAiMessages(stored: StoredMessage[]): CoreMessage[] {
+	const result: CoreMessage[] = [];
+	for (const msg of stored) {
+		if (msg.role === 'user') {
+			const text = msg.blocks
+				.filter((b): b is { type: 'text'; content: string } => b.type === 'text')
+				.map((b) => b.content)
+				.join('');
+			result.push({ role: 'user', content: text });
+		} else {
+			const textBlocks = msg.blocks.filter(
+				(b): b is { type: 'text'; content: string } => b.type === 'text',
+			);
+			const toolBlocks = msg.blocks.filter(
+				(b): b is { type: 'tool'; name: string; args: unknown; result: unknown } =>
+					b.type === 'tool' && (b as { result?: unknown }).result !== undefined,
+			);
+
+			if (toolBlocks.length === 0) {
+				result.push({
+					role: 'assistant',
+					content: textBlocks.map((b) => b.content).join(''),
+				});
+			} else {
+				const ids = toolBlocks.map(() => crypto.randomUUID());
+				result.push({
+					role: 'assistant',
+					content: [
+						...textBlocks.map((b) => ({ type: 'text' as const, text: b.content })),
+						...toolBlocks.map((b, i) => ({
+							type: 'tool-call' as const,
+							toolCallId: ids[i]!,
+							toolName: b.name,
+							args: b.args as Record<string, unknown>,
+						})),
+					],
+				});
+				result.push({
+					role: 'tool',
+					content: toolBlocks.map((b, i) => ({
+						type: 'tool-result' as const,
+						toolCallId: ids[i]!,
+						toolName: b.name,
+						result: b.result,
+					})),
+				});
+			}
+		}
+	}
+	return result;
+}
 
 function buildAiTools(corsairClient: Record<string, unknown>): ToolSet {
 	const defs = buildCorsairToolDefs({ corsair: corsairClient, setup: false });
@@ -36,15 +90,28 @@ function buildAiTools(corsairClient: Record<string, unknown>): ToolSet {
 
 async function resolveModel(): Promise<LanguageModel> {
 	const model = process.env.CORSAIR_CHAT_MODEL;
+	console.log(
+		'[corsair:chat] resolving model — OPENAI_API_KEY:',
+		!!process.env.OPENAI_API_KEY,
+		'| ANTHROPIC_API_KEY:',
+		!!process.env.ANTHROPIC_API_KEY,
+		'| CORSAIR_CHAT_MODEL:',
+		model ?? '(default)',
+	);
 
 	if (process.env.OPENAI_API_KEY) {
 		const { openai } = await import('@ai-sdk/openai');
+		console.log('[corsair:chat] using openai:', model ?? 'gpt-4o-mini');
 		return openai(model ?? 'gpt-4o-mini');
 	}
 
 	if (process.env.ANTHROPIC_API_KEY) {
 		const { anthropic } = await import('@ai-sdk/anthropic');
-		return anthropic(model ?? 'claude-3-5-sonnet-20241022');
+		console.log(
+			'[corsair:chat] using anthropic:',
+			model ?? 'claude-sonnet-4-6',
+		);
+		return anthropic(model ?? 'claude-sonnet-4-6');
 	}
 
 	if (process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
@@ -71,14 +138,38 @@ type StreamPart = {
 };
 
 export const chatHandler: HandlerFn = async (ctx) => {
+	console.log('[corsair:chat] request received');
 	const body = await readJsonBody(ctx.req);
-	const messages = (body.messages ?? []) as CoreMessage[];
 	const tenant = body.tenant ? String(body.tenant) : undefined;
+	const chatId = body.chatId ? String(body.chatId) : undefined;
+	const newUserText = body.message ? String(body.message) : undefined;
+
+	// Load history from the store — don't trust the client to serialize tool calls
+	const storedHistory = chatId && chatExists(chatId) ? getMessages(chatId) : [];
+	const messages: CoreMessage[] = toAiMessages(storedHistory);
+	if (newUserText) {
+		messages.push({ role: 'user', content: newUserText });
+	}
+
+	console.log(
+		'[corsair:chat] history:',
+		storedHistory.length,
+		'stored msgs →',
+		messages.length,
+		'AI msgs | tenant:',
+		tenant ?? '(none)',
+		'| chatId:',
+		chatId ?? '(none)',
+	);
 
 	let model: LanguageModel;
 	try {
 		model = await resolveModel();
 	} catch (err) {
+		console.error(
+			'[corsair:chat] model resolution failed:',
+			(err as Error).message,
+		);
 		ctx.res.writeHead(400, { 'content-type': 'application/json' });
 		ctx.res.end(JSON.stringify({ error: (err as Error).message }));
 		return;
@@ -87,6 +178,15 @@ export const chatHandler: HandlerFn = async (ctx) => {
 	const handle = await ctx.getCorsair();
 	const client = handle.resolveClient(tenant);
 	const tools = buildAiTools(client);
+
+	const userMsgId = crypto.randomUUID();
+	if (chatId && chatExists(chatId) && newUserText) {
+		try {
+			appendMessage(chatId, userMsgId, 'user', [{ type: 'text', content: newUserText }]);
+		} catch (err) {
+			console.error('[corsair:chat] failed to save user message:', err);
+		}
+	}
 
 	ctx.res.writeHead(200, {
 		'content-type': 'text/event-stream',
@@ -98,11 +198,14 @@ export const chatHandler: HandlerFn = async (ctx) => {
 		ctx.res.write(`data: ${JSON.stringify(data)}\n\n`);
 	};
 
+	const assistantBlocks: StoredMsgBlock[] = [];
+
+	console.log('[corsair:chat] starting stream');
 	try {
 		const result = streamText({
 			model,
 			system:
-				"You are a helpful assistant with access to Corsair tools. Use the tools to answer questions about the user's integrations and data.",
+				"You are a helpful assistant with access to Corsair tools. Use the tools to answer questions about the user's integrations and data. Use list_operations to get the exact endpoint names.",
 			messages,
 			tools,
 			maxSteps: 10,
@@ -112,17 +215,56 @@ export const chatHandler: HandlerFn = async (ctx) => {
 			const part = raw as StreamPart;
 			if (part.type === 'text-delta') {
 				send({ type: 'text', text: part.textDelta });
+				const last = assistantBlocks[assistantBlocks.length - 1];
+				if (last?.type === 'text') {
+					last.content += part.textDelta ?? '';
+				} else {
+					assistantBlocks.push({ type: 'text', content: part.textDelta ?? '' });
+				}
 			} else if (part.type === 'tool-call') {
 				send({ type: 'tool-start', name: part.toolName, args: part.args });
+				assistantBlocks.push({
+					type: 'tool',
+					name: part.toolName ?? '',
+					args: part.args,
+				});
 			} else if (part.type === 'tool-result') {
 				send({ type: 'tool-end', name: part.toolName, result: part.result });
+				const idx = assistantBlocks.findLastIndex(
+					(b): b is Extract<StoredMsgBlock, { type: 'tool' }> =>
+						b.type === 'tool' &&
+						(b as Extract<StoredMsgBlock, { type: 'tool' }>).name ===
+							part.toolName &&
+						(b as Extract<StoredMsgBlock, { type: 'tool' }>).result ===
+							undefined,
+				);
+				if (idx >= 0) {
+					(
+						assistantBlocks[idx] as Extract<StoredMsgBlock, { type: 'tool' }>
+					).result = part.result;
+				}
 			} else if (part.type === 'finish') {
 				send({ type: 'done' });
 			}
 		}
 	} catch (err) {
+		console.error('[corsair:chat] stream error:', (err as Error).message);
 		send({ type: 'error', message: (err as Error).message });
 	} finally {
+		// Persist the assistant response
+		if (chatId && chatExists(chatId) && assistantBlocks.length > 0) {
+			try {
+				appendMessage(
+					chatId,
+					crypto.randomUUID(),
+					'assistant',
+					assistantBlocks,
+				);
+			} catch (err) {
+				console.error('[corsair:chat] failed to save assistant message:', err);
+			}
+		}
+		console.log('[corsair:chat] done');
 		ctx.res.end();
 	}
 };

--- a/packages/studio/src/server/handlers/chats.ts
+++ b/packages/studio/src/server/handlers/chats.ts
@@ -6,15 +6,15 @@ import {
 import type { HandlerFn } from '../types.js';
 
 export const listChatsHandler: HandlerFn = async () => {
-	return { chats: listChats() };
+	return { chats: await listChats() };
 };
 
 export const createChatHandler: HandlerFn = async () => {
-	return { chat: createChat() };
+	return { chat: await createChat() };
 };
 
 export const getChatMessagesHandler: HandlerFn = async (ctx) => {
 	const chatId = ctx.url.searchParams.get('chatId');
 	if (!chatId) throw new Error('chatId is required');
-	return { messages: getMessages(chatId) };
+	return { messages: await getMessages(chatId) };
 };

--- a/packages/studio/src/server/handlers/chats.ts
+++ b/packages/studio/src/server/handlers/chats.ts
@@ -1,0 +1,20 @@
+import {
+	createChat,
+	getMessages,
+	listChats,
+} from '../chat-store.js';
+import type { HandlerFn } from '../types.js';
+
+export const listChatsHandler: HandlerFn = async () => {
+	return { chats: listChats() };
+};
+
+export const createChatHandler: HandlerFn = async () => {
+	return { chat: createChat() };
+};
+
+export const getChatMessagesHandler: HandlerFn = async (ctx) => {
+	const chatId = ctx.url.searchParams.get('chatId');
+	if (!chatId) throw new Error('chatId is required');
+	return { messages: getMessages(chatId) };
+};

--- a/packages/studio/src/server/router.ts
+++ b/packages/studio/src/server/router.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { exchangeOAuth, startOAuth } from './handlers/auth';
+import { chatHandler } from './handlers/chat';
 import { getCredentials, setCredentials } from './handlers/credentials';
 import {
 	listDbRows,
@@ -51,6 +52,8 @@ const routes: Route[] = [
 	{ method: 'POST', path: '/api/db/rows', handler: listDbRows },
 	{ method: 'POST', path: '/api/db/entities/query', handler: queryEntityData },
 	{ method: 'GET', path: '/api/db/permissions', handler: listPermissions },
+
+	{ method: 'POST', path: '/api/chat', handler: chatHandler },
 ];
 
 export async function handleApi(

--- a/packages/studio/src/server/router.ts
+++ b/packages/studio/src/server/router.ts
@@ -1,6 +1,11 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { exchangeOAuth, startOAuth } from './handlers/auth';
 import { chatHandler } from './handlers/chat';
+import {
+	createChatHandler,
+	getChatMessagesHandler,
+	listChatsHandler,
+} from './handlers/chats';
 import { getCredentials, setCredentials } from './handlers/credentials';
 import {
 	listDbRows,
@@ -52,6 +57,10 @@ const routes: Route[] = [
 	{ method: 'POST', path: '/api/db/rows', handler: listDbRows },
 	{ method: 'POST', path: '/api/db/entities/query', handler: queryEntityData },
 	{ method: 'GET', path: '/api/db/permissions', handler: listPermissions },
+
+	{ method: 'GET', path: '/api/chats', handler: listChatsHandler },
+	{ method: 'POST', path: '/api/chats', handler: createChatHandler },
+	{ method: 'GET', path: '/api/chats/messages', handler: getChatMessagesHandler },
 
 	{ method: 'POST', path: '/api/chat', handler: chatHandler },
 ];

--- a/packages/studio/src/web/App.tsx
+++ b/packages/studio/src/web/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import type { StatusResp } from './api';
 import { api } from './api';
 import { Sidebar } from './components/Sidebar';
+import { ChatPage } from './pages/ChatPage';
 import { DatabasePage } from './pages/DatabasePage';
 import { OperationsPage } from './pages/OperationsPage';
 import { PermissionsPage } from './pages/PermissionsPage';
@@ -13,7 +14,8 @@ export type Route =
 	| 'operations'
 	| 'database'
 	| 'permissions'
-	| 'script';
+	| 'script'
+	| 'chat';
 
 const TITLES: Record<Route, string> = {
 	plugins: 'Plugins',
@@ -21,6 +23,7 @@ const TITLES: Record<Route, string> = {
 	database: 'Data',
 	permissions: 'Permissions',
 	script: 'Script',
+	chat: 'Chat',
 };
 
 type AppLocation = {
@@ -34,6 +37,7 @@ const ROUTES = new Set<Route>([
 	'database',
 	'permissions',
 	'script',
+	'chat',
 ]);
 
 function parseLocation(pathname: string): AppLocation {
@@ -156,7 +160,9 @@ export function App() {
 					) : null}
 				</header>
 
-				<div className="flex-1 min-h-0 overflow-auto p-6">
+				<div
+					className={`flex-1 min-h-0 ${route === 'chat' ? 'overflow-hidden' : 'overflow-auto p-6'}`}
+				>
 					{route === 'plugins' ? (
 						<PluginsPage
 							tenant={tenant}
@@ -171,6 +177,7 @@ export function App() {
 					{route === 'database' ? <DatabasePage /> : null}
 					{route === 'permissions' ? <PermissionsPage /> : null}
 					{route === 'script' ? <ScriptPage tenant={tenant} /> : null}
+					{route === 'chat' ? <ChatPage tenant={tenant} /> : null}
 				</div>
 			</main>
 		</div>

--- a/packages/studio/src/web/components/Sidebar.tsx
+++ b/packages/studio/src/web/components/Sidebar.tsx
@@ -6,6 +6,7 @@ const items: Array<{ id: Route; label: string; icon: string }> = [
 	{ id: 'database', label: 'Data', icon: '▤' },
 	{ id: 'permissions', label: 'Permissions', icon: '⚑' },
 	{ id: 'script', label: 'Script', icon: '›_' },
+	{ id: 'chat', label: 'Chat', icon: '✦' },
 ];
 
 export function Sidebar({

--- a/packages/studio/src/web/pages/ChatPage.tsx
+++ b/packages/studio/src/web/pages/ChatPage.tsx
@@ -1,0 +1,304 @@
+import { useEffect, useRef, useState } from 'react';
+import { Button, EmptyState, Textarea } from '../components/Primitives';
+
+type ToolEvent = {
+	name: string;
+	args: unknown;
+	result?: unknown;
+};
+
+type Msg = {
+	id: string;
+	role: 'user' | 'assistant';
+	text: string;
+	tools: ToolEvent[];
+	error?: string;
+};
+
+type SseEvent =
+	| { type: 'text'; text: string }
+	| { type: 'tool-start'; name: string; args: unknown }
+	| { type: 'tool-end'; name: string; result: unknown }
+	| { type: 'done' }
+	| { type: 'error'; message: string };
+
+function ToolCallRow({ tc }: { tc: ToolEvent }) {
+	const [open, setOpen] = useState(false);
+	const done = tc.result !== undefined;
+	return (
+		<div className="text-[11px] border border-[var(--color-border)] rounded-md overflow-hidden">
+			<button
+				type="button"
+				onClick={() => setOpen((v) => !v)}
+				className="w-full flex items-center gap-2 px-2 py-1 bg-[var(--color-bg-elevated)] text-left hover:bg-[var(--color-bg-hover)] transition-colors"
+			>
+				<span
+					className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${done ? 'bg-[var(--color-ok)]' : 'bg-[var(--color-warn)] animate-pulse'}`}
+				/>
+				<span className="font-mono text-[var(--color-text-muted)]">
+					{tc.name}
+				</span>
+				<span className="ml-auto text-[var(--color-text-subtle)]">
+					{open ? '▴' : '▾'}
+				</span>
+			</button>
+			{open ? (
+				<div className="border-t border-[var(--color-border)] divide-y divide-[var(--color-border)]">
+					<div className="px-2 py-1.5">
+						<div className="text-[10px] uppercase tracking-wide text-[var(--color-text-subtle)] mb-1">
+							args
+						</div>
+						<pre className="font-mono text-[var(--color-text-muted)] whitespace-pre-wrap break-all">
+							{JSON.stringify(tc.args, null, 2)}
+						</pre>
+					</div>
+					{tc.result !== undefined ? (
+						<div className="px-2 py-1.5">
+							<div className="text-[10px] uppercase tracking-wide text-[var(--color-text-subtle)] mb-1">
+								result
+							</div>
+							<pre className="font-mono text-[var(--color-text-muted)] whitespace-pre-wrap break-all max-h-48 overflow-auto">
+								{typeof tc.result === 'string'
+									? tc.result
+									: JSON.stringify(tc.result, null, 2)}
+							</pre>
+						</div>
+					) : null}
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+function MessageBubble({ msg }: { msg: Msg }) {
+	const isUser = msg.role === 'user';
+
+	if (isUser) {
+		return (
+			<div className="flex justify-end">
+				<div className="max-w-[75%] px-3 py-2 rounded-xl rounded-br-sm bg-[var(--color-accent)] text-black text-xs leading-relaxed whitespace-pre-wrap break-words">
+					{msg.text}
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-2 max-w-[85%]">
+			{msg.tools.length > 0 ? (
+				<div className="flex flex-col gap-1">
+					{msg.tools.map((tc, i) => (
+						<ToolCallRow key={`${tc.name}-${i}`} tc={tc} />
+					))}
+				</div>
+			) : null}
+
+			{msg.text ? (
+				<div className="px-3 py-2 rounded-xl rounded-bl-sm bg-[var(--color-bg-elevated)] border border-[var(--color-border)] text-xs leading-relaxed whitespace-pre-wrap break-words text-[var(--color-text)]">
+					{msg.text}
+					{!msg.error && msg.text.endsWith('…') ? null : null}
+				</div>
+			) : null}
+
+			{msg.error ? (
+				<div className="px-3 py-2 rounded-xl border border-[var(--color-err)]/40 bg-[var(--color-err)]/5 text-xs text-[var(--color-err)]">
+					{msg.error}
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+export function ChatPage({ tenant }: { tenant: string }) {
+	const [messages, setMessages] = useState<Msg[]>([]);
+	const [input, setInput] = useState('');
+	const [streaming, setStreaming] = useState(false);
+	const bottomRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+	}, [messages]);
+
+	const send = async () => {
+		const text = input.trim();
+		if (!text || streaming) return;
+		setInput('');
+
+		const userMsg: Msg = {
+			id: crypto.randomUUID(),
+			role: 'user',
+			text,
+			tools: [],
+		};
+		const asstId = crypto.randomUUID();
+		const asstMsg: Msg = {
+			id: asstId,
+			role: 'assistant',
+			text: '',
+			tools: [],
+		};
+
+		setMessages((prev) => [...prev, userMsg, asstMsg]);
+		setStreaming(true);
+
+		const apiMessages = [...messages, userMsg].map((m) => ({
+			role: m.role,
+			content: m.text,
+		}));
+
+		try {
+			const response = await fetch('/api/chat', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ messages: apiMessages, tenant }),
+			});
+
+			if (!response.ok) {
+				const err = (await response.json()) as { error?: string };
+				setMessages((prev) =>
+					prev.map((m) =>
+						m.id === asstId
+							? { ...m, error: err.error ?? 'Request failed' }
+							: m,
+					),
+				);
+				return;
+			}
+
+			const reader = response.body!.getReader();
+			const decoder = new TextDecoder();
+			let buffer = '';
+
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				buffer += decoder.decode(value, { stream: true });
+
+				const lines = buffer.split('\n');
+				buffer = lines.pop() ?? '';
+
+				for (const line of lines) {
+					if (!line.startsWith('data: ')) continue;
+					let event: SseEvent;
+					try {
+						event = JSON.parse(line.slice(6)) as SseEvent;
+					} catch {
+						continue;
+					}
+
+					if (event.type === 'text') {
+						setMessages((prev) =>
+							prev.map((m) =>
+								m.id === asstId ? { ...m, text: m.text + event.text } : m,
+							),
+						);
+					} else if (event.type === 'tool-start') {
+						setMessages((prev) =>
+							prev.map((m) =>
+								m.id === asstId
+									? {
+											...m,
+											tools: [
+												...m.tools,
+												{ name: event.name, args: event.args },
+											],
+										}
+									: m,
+							),
+						);
+					} else if (event.type === 'tool-end') {
+						setMessages((prev) =>
+							prev.map((m) => {
+								if (m.id !== asstId) return m;
+								const tools = [...m.tools];
+								const idx = tools.findLastIndex(
+									(t) => t.name === event.name && t.result === undefined,
+								);
+								const existing = idx >= 0 ? tools[idx] : undefined;
+								if (existing) {
+									tools[idx] = {
+										name: existing.name,
+										args: existing.args,
+										result: event.result,
+									};
+								}
+								return { ...m, tools };
+							}),
+						);
+					} else if (event.type === 'error') {
+						setMessages((prev) =>
+							prev.map((m) =>
+								m.id === asstId ? { ...m, error: event.message } : m,
+							),
+						);
+					}
+				}
+			}
+		} catch (err) {
+			setMessages((prev) =>
+				prev.map((m) =>
+					m.id === asstId
+						? { ...m, error: (err as Error).message }
+						: m,
+				),
+			);
+		} finally {
+			setStreaming(false);
+		}
+	};
+
+	const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+		if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+			e.preventDefault();
+			void send();
+		}
+	};
+
+	return (
+		<div className="h-full flex flex-col">
+			<div className="flex-1 overflow-auto p-4 flex flex-col gap-3 min-h-0">
+				{messages.length === 0 ? (
+					<EmptyState
+						title="Chat with your Corsair instance"
+						hint="Ask about your plugins, operations, or data. The assistant has access to Corsair MCP tools."
+					/>
+				) : (
+					messages.map((msg) => <MessageBubble key={msg.id} msg={msg} />)
+				)}
+				{streaming && messages.at(-1)?.role === 'assistant' && !messages.at(-1)?.text && !messages.at(-1)?.tools.length ? (
+					<div className="flex items-center gap-1.5 text-[11px] text-[var(--color-text-subtle)]">
+						<span className="w-1 h-1 rounded-full bg-current animate-bounce [animation-delay:-0.3s]" />
+						<span className="w-1 h-1 rounded-full bg-current animate-bounce [animation-delay:-0.15s]" />
+						<span className="w-1 h-1 rounded-full bg-current animate-bounce" />
+					</div>
+				) : null}
+				<div ref={bottomRef} />
+			</div>
+
+			<div className="flex-shrink-0 border-t border-[var(--color-border)] p-4">
+				<div className="flex gap-2 items-end">
+					<Textarea
+						className="flex-1 resize-none"
+						rows={3}
+						value={input}
+						onChange={(e) => setInput(e.target.value)}
+						onKeyDown={onKeyDown}
+						placeholder="Ask about your integrations… (Ctrl+Enter to send)"
+						disabled={streaming}
+					/>
+					<Button
+						variant="primary"
+						onClick={() => void send()}
+						disabled={!input.trim() || streaming}
+						className="h-auto py-2 self-stretch"
+					>
+						{streaming ? '…' : '↑'}
+					</Button>
+				</div>
+				<div className="mt-1.5 text-[10px] text-[var(--color-text-subtle)]">
+					Ctrl+Enter to send · Powered by Corsair MCP tools
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/studio/src/web/pages/ChatPage.tsx
+++ b/packages/studio/src/web/pages/ChatPage.tsx
@@ -1,18 +1,38 @@
 import { useEffect, useRef, useState } from 'react';
 import { Button, EmptyState, Textarea } from '../components/Primitives';
 
-type ToolEvent = {
+type ToolBlock = {
+	type: 'tool';
 	name: string;
 	args: unknown;
 	result?: unknown;
 };
 
+type TextBlock = {
+	type: 'text';
+	content: string;
+};
+
+type MsgBlock = TextBlock | ToolBlock;
+
 type Msg = {
 	id: string;
 	role: 'user' | 'assistant';
-	text: string;
-	tools: ToolEvent[];
+	blocks: MsgBlock[];
 	error?: string;
+};
+
+type ApiChat = {
+	id: string;
+	title: string;
+	created_at: number;
+};
+
+type ApiMessage = {
+	id: string;
+	role: 'user' | 'assistant';
+	blocks: MsgBlock[];
+	error: string | null;
 };
 
 type SseEvent =
@@ -22,7 +42,7 @@ type SseEvent =
 	| { type: 'done' }
 	| { type: 'error'; message: string };
 
-function ToolCallRow({ tc }: { tc: ToolEvent }) {
+function ToolCallRow({ tc }: { tc: ToolBlock }) {
 	const [open, setOpen] = useState(false);
 	const done = tc.result !== undefined;
 	return (
@@ -74,10 +94,13 @@ function MessageBubble({ msg }: { msg: Msg }) {
 	const isUser = msg.role === 'user';
 
 	if (isUser) {
+		const text = msg.blocks
+			.map((b) => (b.type === 'text' ? b.content : ''))
+			.join('');
 		return (
 			<div className="flex justify-end">
 				<div className="max-w-[75%] px-3 py-2 rounded-xl rounded-br-sm bg-[var(--color-accent)] text-black text-xs leading-relaxed whitespace-pre-wrap break-words">
-					{msg.text}
+					{text}
 				</div>
 			</div>
 		);
@@ -85,20 +108,18 @@ function MessageBubble({ msg }: { msg: Msg }) {
 
 	return (
 		<div className="flex flex-col gap-2 max-w-[85%]">
-			{msg.tools.length > 0 ? (
-				<div className="flex flex-col gap-1">
-					{msg.tools.map((tc, i) => (
-						<ToolCallRow key={`${tc.name}-${i}`} tc={tc} />
-					))}
-				</div>
-			) : null}
-
-			{msg.text ? (
-				<div className="px-3 py-2 rounded-xl rounded-bl-sm bg-[var(--color-bg-elevated)] border border-[var(--color-border)] text-xs leading-relaxed whitespace-pre-wrap break-words text-[var(--color-text)]">
-					{msg.text}
-					{!msg.error && msg.text.endsWith('…') ? null : null}
-				</div>
-			) : null}
+			{msg.blocks.map((block, i) =>
+				block.type === 'tool' ? (
+					<ToolCallRow key={`${block.name}-${i}`} tc={block} />
+				) : block.content ? (
+					<div
+						key={i}
+						className="px-3 py-2 rounded-xl rounded-bl-sm bg-[var(--color-bg-elevated)] border border-[var(--color-border)] text-xs leading-relaxed whitespace-pre-wrap break-words text-[var(--color-text)]"
+					>
+						{block.content}
+					</div>
+				) : null,
+			)}
 
 			{msg.error ? (
 				<div className="px-3 py-2 rounded-xl border border-[var(--color-err)]/40 bg-[var(--color-err)]/5 text-xs text-[var(--color-err)]">
@@ -109,48 +130,108 @@ function MessageBubble({ msg }: { msg: Msg }) {
 	);
 }
 
+function toMsg(m: ApiMessage): Msg {
+	return {
+		id: m.id,
+		role: m.role,
+		blocks: m.blocks,
+		error: m.error ?? undefined,
+	};
+}
+
 export function ChatPage({ tenant }: { tenant: string }) {
+	const [chats, setChats] = useState<ApiChat[]>([]);
+	const [activeChatId, setActiveChatId] = useState<string | null>(null);
 	const [messages, setMessages] = useState<Msg[]>([]);
 	const [input, setInput] = useState('');
 	const [streaming, setStreaming] = useState(false);
+	const [chatLoading, setChatLoading] = useState(true);
 	const bottomRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
 	}, [messages]);
 
+	const loadMessages = async (chatId: string) => {
+		const res = await fetch(`/api/chats/messages?chatId=${chatId}`);
+		const data = (await res.json()) as { messages: ApiMessage[] };
+		setMessages(data.messages.map(toMsg));
+	};
+
+	const newChat = async () => {
+		const res = await fetch('/api/chats', { method: 'POST' });
+		const data = (await res.json()) as { chat: ApiChat };
+		setChats((prev) => [data.chat, ...prev]);
+		setActiveChatId(data.chat.id);
+		setMessages([]);
+	};
+
+	const switchChat = async (chatId: string) => {
+		if (chatId === activeChatId) return;
+		setActiveChatId(chatId);
+		setChatLoading(true);
+		try {
+			await loadMessages(chatId);
+		} finally {
+			setChatLoading(false);
+		}
+	};
+
+	useEffect(() => {
+		const init = async () => {
+			setChatLoading(true);
+			try {
+				const res = await fetch('/api/chats');
+				const data = (await res.json()) as { chats: ApiChat[] };
+				const first = data.chats[0];
+				if (first) {
+					setChats(data.chats);
+					setActiveChatId(first.id);
+					await loadMessages(first.id);
+				} else {
+					const createRes = await fetch('/api/chats', { method: 'POST' });
+					const createData = (await createRes.json()) as { chat: ApiChat };
+					setChats([createData.chat]);
+					setActiveChatId(createData.chat.id);
+					setMessages([]);
+				}
+			} finally {
+				setChatLoading(false);
+			}
+		};
+		void init();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
 	const send = async () => {
 		const text = input.trim();
-		if (!text || streaming) return;
+		if (!text || streaming || !activeChatId) return;
 		setInput('');
 
 		const userMsg: Msg = {
 			id: crypto.randomUUID(),
 			role: 'user',
-			text,
-			tools: [],
+			blocks: [{ type: 'text', content: text }],
 		};
 		const asstId = crypto.randomUUID();
 		const asstMsg: Msg = {
 			id: asstId,
 			role: 'assistant',
-			text: '',
-			tools: [],
+			blocks: [],
 		};
 
 		setMessages((prev) => [...prev, userMsg, asstMsg]);
 		setStreaming(true);
 
-		const apiMessages = [...messages, userMsg].map((m) => ({
-			role: m.role,
-			content: m.text,
-		}));
-
 		try {
 			const response = await fetch('/api/chat', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ messages: apiMessages, tenant }),
+				body: JSON.stringify({
+					message: text,
+					tenant,
+					chatId: activeChatId,
+				}),
 			});
 
 			if (!response.ok) {
@@ -188,9 +269,20 @@ export function ChatPage({ tenant }: { tenant: string }) {
 
 					if (event.type === 'text') {
 						setMessages((prev) =>
-							prev.map((m) =>
-								m.id === asstId ? { ...m, text: m.text + event.text } : m,
-							),
+							prev.map((m) => {
+								if (m.id !== asstId) return m;
+								const blocks = [...m.blocks];
+								const last = blocks[blocks.length - 1];
+								if (last?.type === 'text') {
+									blocks[blocks.length - 1] = {
+										...last,
+										content: last.content + event.text,
+									};
+								} else {
+									blocks.push({ type: 'text', content: event.text });
+								}
+								return { ...m, blocks };
+							}),
 						);
 					} else if (event.type === 'tool-start') {
 						setMessages((prev) =>
@@ -198,9 +290,9 @@ export function ChatPage({ tenant }: { tenant: string }) {
 								m.id === asstId
 									? {
 											...m,
-											tools: [
-												...m.tools,
-												{ name: event.name, args: event.args },
+											blocks: [
+												...m.blocks,
+												{ type: 'tool', name: event.name, args: event.args },
 											],
 										}
 									: m,
@@ -210,19 +302,18 @@ export function ChatPage({ tenant }: { tenant: string }) {
 						setMessages((prev) =>
 							prev.map((m) => {
 								if (m.id !== asstId) return m;
-								const tools = [...m.tools];
-								const idx = tools.findLastIndex(
-									(t) => t.name === event.name && t.result === undefined,
+								const blocks = [...m.blocks];
+								const idx = blocks.findLastIndex(
+									(b): b is ToolBlock =>
+										b.type === 'tool' &&
+										b.name === event.name &&
+										b.result === undefined,
 								);
-								const existing = idx >= 0 ? tools[idx] : undefined;
-								if (existing) {
-									tools[idx] = {
-										name: existing.name,
-										args: existing.args,
-										result: event.result,
-									};
+								if (idx >= 0) {
+									const existing = blocks[idx] as ToolBlock;
+									blocks[idx] = { ...existing, result: event.result };
 								}
-								return { ...m, tools };
+								return { ...m, blocks };
 							}),
 						);
 					} else if (event.type === 'error') {
@@ -237,13 +328,16 @@ export function ChatPage({ tenant }: { tenant: string }) {
 		} catch (err) {
 			setMessages((prev) =>
 				prev.map((m) =>
-					m.id === asstId
-						? { ...m, error: (err as Error).message }
-						: m,
+					m.id === asstId ? { ...m, error: (err as Error).message } : m,
 				),
 			);
 		} finally {
 			setStreaming(false);
+			// Refresh chat list so title updates (first message sets title)
+			fetch('/api/chats')
+				.then((r) => r.json())
+				.then((data) => setChats((data as { chats: ApiChat[] }).chats))
+				.catch(() => undefined);
 		}
 	};
 
@@ -256,8 +350,39 @@ export function ChatPage({ tenant }: { tenant: string }) {
 
 	return (
 		<div className="h-full flex flex-col">
+			{/* Chat selector */}
+			<div className="flex-shrink-0 border-b border-[var(--color-border)] px-4 py-2 flex items-center gap-2">
+				<select
+					value={activeChatId ?? ''}
+					onChange={(e) => void switchChat(e.target.value)}
+					disabled={chatLoading || streaming}
+					className="flex-1 text-xs bg-[var(--color-bg)] border border-[var(--color-border)] rounded-md px-2 h-7 text-[var(--color-text)] focus:outline-none focus:border-[var(--color-accent-dim)] disabled:opacity-40"
+				>
+					{chats.map((c) => (
+						<option key={c.id} value={c.id}>
+							{c.title}
+						</option>
+					))}
+				</select>
+				<Button
+					variant="default"
+					onClick={() => void newChat()}
+					disabled={chatLoading || streaming}
+					className="h-7 px-2 flex-shrink-0"
+				>
+					+ New
+				</Button>
+			</div>
+
+			{/* Messages */}
 			<div className="flex-1 overflow-auto p-4 flex flex-col gap-3 min-h-0">
-				{messages.length === 0 ? (
+				{chatLoading ? (
+					<div className="flex items-center gap-1.5 text-[11px] text-[var(--color-text-subtle)]">
+						<span className="w-1 h-1 rounded-full bg-current animate-bounce [animation-delay:-0.3s]" />
+						<span className="w-1 h-1 rounded-full bg-current animate-bounce [animation-delay:-0.15s]" />
+						<span className="w-1 h-1 rounded-full bg-current animate-bounce" />
+					</div>
+				) : messages.length === 0 ? (
 					<EmptyState
 						title="Chat with your Corsair instance"
 						hint="Ask about your plugins, operations, or data. The assistant has access to Corsair MCP tools."
@@ -265,7 +390,9 @@ export function ChatPage({ tenant }: { tenant: string }) {
 				) : (
 					messages.map((msg) => <MessageBubble key={msg.id} msg={msg} />)
 				)}
-				{streaming && messages.at(-1)?.role === 'assistant' && !messages.at(-1)?.text && !messages.at(-1)?.tools.length ? (
+				{streaming &&
+				messages.at(-1)?.role === 'assistant' &&
+				!messages.at(-1)?.blocks.length ? (
 					<div className="flex items-center gap-1.5 text-[11px] text-[var(--color-text-subtle)]">
 						<span className="w-1 h-1 rounded-full bg-current animate-bounce [animation-delay:-0.3s]" />
 						<span className="w-1 h-1 rounded-full bg-current animate-bounce [animation-delay:-0.15s]" />
@@ -275,6 +402,7 @@ export function ChatPage({ tenant }: { tenant: string }) {
 				<div ref={bottomRef} />
 			</div>
 
+			{/* Input */}
 			<div className="flex-shrink-0 border-t border-[var(--color-border)] p-4">
 				<div className="flex gap-2 items-end">
 					<Textarea
@@ -284,12 +412,12 @@ export function ChatPage({ tenant }: { tenant: string }) {
 						onChange={(e) => setInput(e.target.value)}
 						onKeyDown={onKeyDown}
 						placeholder="Ask about your integrations… (Ctrl+Enter to send)"
-						disabled={streaming}
+						disabled={streaming || chatLoading}
 					/>
 					<Button
 						variant="primary"
 						onClick={() => void send()}
-						disabled={!input.trim() || streaming}
+						disabled={!input.trim() || streaming || chatLoading}
 						className="h-auto py-2 self-stretch"
 					>
 						{streaming ? '…' : '↑'}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,7 +252,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -277,7 +277,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -302,7 +302,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -327,7 +327,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -352,7 +352,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -377,7 +377,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -429,7 +429,7 @@ importers:
         version: 2.6.1
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@24.10.1)(typescript@5.9.3)
@@ -487,7 +487,7 @@ importers:
         version: 3.4.7
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@24.10.1)(typescript@5.9.3)
@@ -511,7 +511,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -536,7 +536,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -576,7 +576,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -601,7 +601,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -626,7 +626,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -651,7 +651,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -676,7 +676,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -701,7 +701,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -726,7 +726,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -751,7 +751,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -776,7 +776,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -801,7 +801,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -826,7 +826,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -851,7 +851,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -876,7 +876,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -901,7 +901,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -926,7 +926,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -951,7 +951,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1025,7 +1025,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1050,7 +1050,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1075,7 +1075,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1100,7 +1100,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1125,7 +1125,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1150,7 +1150,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1175,7 +1175,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1203,7 +1203,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1242,7 +1242,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.6
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1267,7 +1267,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1292,7 +1292,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1317,7 +1317,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1342,7 +1342,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1367,7 +1367,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1391,7 +1391,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1416,7 +1416,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1456,6 +1456,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      kysely:
+        specifier: ^0.28.9
+        version: 0.28.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1513,7 +1516,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1538,7 +1541,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1563,7 +1566,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1588,7 +1591,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1613,7 +1616,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1638,7 +1641,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1663,7 +1666,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1688,7 +1691,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1744,7 +1747,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1769,7 +1772,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -5164,6 +5167,7 @@ packages:
   inngest@3.49.3:
     resolution: {integrity: sha512-JH4VBcxmBh7J0QIk28yYNSlBs1q2wnlds20Sj4a1m8RXRSfDh+z6+Lq+WVpaHH0XolsPYwkRwUA9Gf540AcBmg==}
     engines: {node: '>=20'}
+    deprecated: 'CRITICAL SECURITY: upgrade to >=3.54.0'
     peerDependencies:
       '@sveltejs/kit': '>=1.27.3'
       '@vercel/node': '>=2.15.9'
@@ -12325,7 +12329,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -12343,7 +12347,6 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.28.6)
-      esbuild: 0.27.0
       jest-util: 29.7.0
 
   ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1450,6 +1450,9 @@ importers:
       ai:
         specifier: ^4.0.0
         version: 4.3.19(react@19.2.5)(zod@3.25.76)
+      better-sqlite3:
+        specifier: ^12.0.0
+        version: 12.5.0
       corsair:
         specifier: workspace:*
         version: link:../corsair
@@ -1463,6 +1466,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.0.0
         version: 4.2.4(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.1))
+      '@types/better-sqlite3':
+        specifier: ^7.6.0
+        version: 7.6.13
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1429,15 +1429,36 @@ importers:
 
   packages/studio:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^1.0.0
+        version: 1.2.12(zod@3.25.76)
+      '@ai-sdk/google':
+        specifier: ^1.0.0
+        version: 1.2.22(zod@3.25.76)
+      '@ai-sdk/groq':
+        specifier: ^1.0.0
+        version: 1.2.9(zod@3.25.76)
+      '@ai-sdk/openai':
+        specifier: ^1.0.0
+        version: 1.3.24(zod@3.25.76)
       '@corsair-dev/cli':
         specifier: workspace:*
         version: link:../cli
+      '@corsair-dev/mcp':
+        specifier: workspace:*
+        version: link:../mcp
+      ai:
+        specifier: ^4.0.0
+        version: 4.3.19(react@19.2.5)(zod@3.25.76)
       corsair:
         specifier: workspace:*
         version: link:../corsair
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.0.0
@@ -1759,11 +1780,35 @@ packages:
     resolution: {integrity: sha512-VTDuRS5V0ATbJ/LkaQlisMnTAeYKXAK6scMguVBstf+KIBQ7HIuKhiXLv+G/hvejkV+THoXzoNifInAkU81P1g==}
     engines: {node: '>=18'}
 
+  '@ai-sdk/anthropic@1.2.12':
+    resolution: {integrity: sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
+  '@ai-sdk/google@1.2.22':
+    resolution: {integrity: sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
+  '@ai-sdk/groq@1.2.9':
+    resolution: {integrity: sha512-7MoDaxm8yWtiRbD1LipYZG0kBl+Xe0sv/EeyxnHnGPZappXdlgtdOgTZVjjXkT3nWP30jjZi9A45zoVrBMb3Xg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
   '@ai-sdk/mcp@1.0.25':
     resolution: {integrity: sha512-vMlXUPGHGDE2vzLcPR8sw7Dhz2OBjtPU5lB+lIuC1hNQo4REuUC08P0e96/hzBKf4oQYJ8Zo6uP8AG2qThyFbg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@1.3.24':
+    resolution: {integrity: sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
 
   '@ai-sdk/provider-utils@2.2.8':
     resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
@@ -1808,6 +1853,16 @@ packages:
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/react@1.2.12':
+    resolution: {integrity: sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@ai-sdk/ui-utils@1.2.11':
     resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
@@ -3914,6 +3969,9 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/diff-match-patch@1.0.36':
+    resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -4061,6 +4119,16 @@ packages:
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
+
+  ai@4.3.19:
+    resolution: {integrity: sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -4291,6 +4359,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
@@ -4488,6 +4560,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -4506,6 +4582,9 @@ packages:
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
+
+  diff-match-patch@1.0.5:
+    resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -5399,6 +5478,11 @@ packages:
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jsondiffpatch@0.6.0:
+    resolution: {integrity: sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -6453,6 +6537,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swr@2.4.1:
+    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   tailwindcss@4.2.4:
     resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
 
@@ -6488,6 +6577,10 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
@@ -6691,6 +6784,11 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -6910,11 +7008,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@ai-sdk/anthropic@1.2.12(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/google@1.2.22(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/groq@1.2.9(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      zod: 3.25.76
+
   '@ai-sdk/mcp@1.0.25(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
       pkce-challenge: 5.0.1
+      zod: 3.25.76
+
+  '@ai-sdk/openai@1.3.24(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
       zod: 3.25.76
 
   '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
@@ -6964,6 +7086,16 @@ snapshots:
   '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
+
+  '@ai-sdk/react@1.2.12(react@19.2.5)(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
+      react: 19.2.5
+      swr: 2.4.1(react@19.2.5)
+      throttleit: 2.1.0
+    optionalDependencies:
+      zod: 3.25.76
 
   '@ai-sdk/ui-utils@1.2.11(zod@3.25.76)':
     dependencies:
@@ -9170,6 +9302,8 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/diff-match-patch@1.0.36': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/express-serve-static-core@4.19.8':
@@ -9346,6 +9480,18 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
     optional: true
+
+  ai@4.3.19(react@19.2.5)(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/react': 1.2.12(react@19.2.5)(zod@3.25.76)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      jsondiffpatch: 0.6.0
+      zod: 3.25.76
+    optionalDependencies:
+      react: 19.2.5
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -9668,6 +9814,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
   char-regex@1.0.2: {}
 
   chokidar@4.0.3:
@@ -9828,6 +9976,8 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   destr@2.0.5: {}
 
   destroy@1.2.0: {}
@@ -9838,6 +9988,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-newline@3.1.0: {}
+
+  diff-match-patch@1.0.5: {}
 
   diff-sequences@29.6.3: {}
 
@@ -10989,6 +11141,12 @@ snapshots:
 
   jsonc-parser@3.3.1: {}
 
+  jsondiffpatch@0.6.0:
+    dependencies:
+      '@types/diff-match-patch': 1.0.36
+      chalk: 5.6.2
+      diff-match-patch: 1.0.5
+
   kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
@@ -12079,6 +12237,12 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swr@2.4.1(react@19.2.5):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)
+
   tailwindcss@4.2.4: {}
 
   tapable@2.3.3: {}
@@ -12127,6 +12291,8 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  throttleit@2.1.0: {}
 
   tinyexec@0.3.2: {}
 
@@ -12309,6 +12475,10 @@ snapshots:
       browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  use-sync-external-store@1.6.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
Closes #171                                                                                             
                  
  Adds a first-party chat experience to Corsair Studio that uses the same tools as the stdio MCP server —
  so a new user can open Studio, go to Chat, and talk to their integrations without any extra setup.

  ## What changed

  - New `/chat` route wired into `App.tsx` routing and `Sidebar.tsx` nav
  - `ChatPage` — streaming chat UI: message bubbles, collapsible tool-call rows showing args + result,
  typing indicator
  - `POST /api/chat` — SSE handler using Vercel AI SDK `streamText` with `maxSteps: 10` for multi-step
  tool use
  - Tool source: `buildCorsairToolDefs` from `@corsair-dev/mcp` — same tools the stdio MCP server exposes
  (`list_operations`, `get_schema`, `run_script`), imported directly per maintainer guidance
  - Provider-agnostic: checks `OPENAI_API_KEY` → `ANTHROPIC_API_KEY` → `GOOGLE_GENERATIVE_AI_API_KEY` →
  `GROQ_API_KEY` in order; override model with `CORSAIR_CHAT_MODEL`

  ## Test plan

  - Set one of: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, or `GROQ_API_KEY`
  in `.env` next to your `corsair.ts`
  - Run `pnpm --filter @corsair-dev/studio run dev:server` and `dev:web`
  - Open `http://localhost:4318` → click **Chat** in sidebar
  - Ask "list all operations" — should call `list_operations` tool and return results
  - Verify tool-call row expands to show args and result
  - Verify other Studio pages (Plugins, Operations, Script) still work