### PR TITLE
feat: implement cloudflare plugin

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -190,6 +190,15 @@
                 ]
               },
               {
+                "group": "Cloudflare",
+                "pages": [
+                  "plugins/cloudflare/overview",
+                  "plugins/cloudflare/get-credentials",
+                  "plugins/cloudflare/api",
+                  "plugins/cloudflare/database"
+                ]
+              },
+              {
                 "group": "Cursor",
                 "pages": [
                   "plugins/cursor/overview",

--- a/docs/plugins/cloudflare/api.mdx
+++ b/docs/plugins/cloudflare/api.mdx
@@ -674,7 +674,7 @@ await corsair.cloudflare.api.workers.scripts.delete({});
 
 `workers.scripts.get`
 
-Retrieve a Workers script by name
+Download Workers script source code by name
 
 **Risk:** `read`
 
@@ -691,14 +691,7 @@ await corsair.cloudflare.api.workers.scripts.get({});
 
 
 
-**Output**
-
-| Name | Type | Required | Description |
-|------|------|----------|-------------|
-| `id` | `string` | No | — |
-| `created_on` | `string` | No | — |
-| `modified_on` | `string` | No | — |
-
+**Output:** `string`
 
 
 ---

--- a/docs/plugins/cloudflare/api.mdx
+++ b/docs/plugins/cloudflare/api.mdx
@@ -33,6 +33,7 @@ await corsair.cloudflare.api.dns.create({});
 | `content` | `string` | Yes | — |
 | `ttl` | `number` | No | — |
 | `proxied` | `boolean` | No | — |
+| `priority` | `number` | No | — |
 
 
 
@@ -111,6 +112,7 @@ await corsair.cloudflare.api.dns.edit({});
 | `content` | `string` | No | — |
 | `ttl` | `number` | No | — |
 | `proxied` | `boolean` | No | — |
+| `priority` | `number` | No | — |
 
 
 
@@ -314,7 +316,7 @@ await corsair.cloudflare.api.rulesets.delete({});
 
 
 
-**Output:** _empty object_
+**Output:** `null`
 
 
 ---
@@ -665,7 +667,7 @@ await corsair.cloudflare.api.workers.scripts.delete({});
 
 
 
-**Output:** _empty object_
+**Output:** `null`
 
 
 ---
@@ -838,6 +840,7 @@ await corsair.cloudflare.api.zones.create({});
 
 ```ts
 {
+  id: string
 }
 ```
 </Accordion>
@@ -934,6 +937,7 @@ await corsair.cloudflare.api.zones.edit({});
 
 ```ts
 {
+  id: string
 }
 ```
 </Accordion>
@@ -986,6 +990,7 @@ await corsair.cloudflare.api.zones.get({});
 
 ```ts
 {
+  id: string
 }
 ```
 </Accordion>
@@ -1031,6 +1036,7 @@ await corsair.cloudflare.api.zones.list({});
   paused?: boolean,
   type?: string,
   account?: {
+    id: string
   },
   name_servers?: string[],
   original_name_servers?: string[],

--- a/docs/plugins/cloudflare/api.mdx
+++ b/docs/plugins/cloudflare/api.mdx
@@ -1,0 +1,1056 @@
+---
+title: API
+description: "API reference for Cloudflare: every `cloudflare.api.*` operation with input and output types."
+---
+
+Every `cloudflare.api.*` operation is listed below with parameter shapes and return types from the plugin Zod schemas.
+
+<Info>
+**New to Corsair?** See [API access](/concepts/api), [authentication](/concepts/auth), and [error handling](/concepts/error-handling).
+</Info>
+
+## Dns
+
+### create
+
+`dns.create`
+
+Create a DNS record in a zone
+
+**Risk:** `write`
+
+```ts
+await corsair.cloudflare.api.dns.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `zone_id` | `string` | Yes | — |
+| `type` | `string` | Yes | — |
+| `name` | `string` | Yes | — |
+| `content` | `string` | Yes | — |
+| `ttl` | `number` | No | — |
+| `proxied` | `boolean` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `zone_id` | `string` | No | — |
+| `zone_name` | `string` | No | — |
+| `type` | `string` | Yes | — |
+| `name` | `string` | Yes | — |
+| `content` | `string` | Yes | — |
+| `proxiable` | `boolean` | No | — |
+| `proxied` | `boolean` | No | — |
+| `ttl` | `number` | No | — |
+| `locked` | `boolean` | No | — |
+| `created_on` | `string` | No | — |
+| `modified_on` | `string` | No | — |
+
+
+
+---
+
+### delete
+
+`dns.delete`
+
+Delete a DNS record [DESTRUCTIVE]
+
+**Risk:** `destructive`
+
+```ts
+await corsair.cloudflare.api.dns.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `zone_id` | `string` | Yes | — |
+| `dns_record_id` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+
+
+
+---
+
+### edit
+
+`dns.edit`
+
+Update a DNS record
+
+**Risk:** `write`
+
+```ts
+await corsair.cloudflare.api.dns.edit({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `zone_id` | `string` | Yes | — |
+| `dns_record_id` | `string` | Yes | — |
+| `type` | `string` | No | — |
+| `name` | `string` | No | — |
+| `content` | `string` | No | — |
+| `ttl` | `number` | No | — |
+| `proxied` | `boolean` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `zone_id` | `string` | No | — |
+| `zone_name` | `string` | No | — |
+| `type` | `string` | Yes | — |
+| `name` | `string` | Yes | — |
+| `content` | `string` | Yes | — |
+| `proxiable` | `boolean` | No | — |
+| `proxied` | `boolean` | No | — |
+| `ttl` | `number` | No | — |
+| `locked` | `boolean` | No | — |
+| `created_on` | `string` | No | — |
+| `modified_on` | `string` | No | — |
+
+
+
+---
+
+### get
+
+`dns.get`
+
+Retrieve a DNS record by ID
+
+**Risk:** `read`
+
+```ts
+await corsair.cloudflare.api.dns.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `zone_id` | `string` | Yes | — |
+| `dns_record_id` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `zone_id` | `string` | No | — |
+| `zone_name` | `string` | No | — |
+| `type` | `string` | Yes | — |
+| `name` | `string` | Yes | — |
+| `content` | `string` | Yes | — |
+| `proxiable` | `boolean` | No | — |
+| `proxied` | `boolean` | No | — |
+| `ttl` | `number` | No | — |
+| `locked` | `boolean` | No | — |
+| `created_on` | `string` | No | — |
+| `modified_on` | `string` | No | — |
+
+
+
+---
+
+### list
+
+`dns.list`
+
+List DNS records for a zone
+
+**Risk:** `read`
+
+```ts
+await corsair.cloudflare.api.dns.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `page` | `number` | No | — |
+| `per_page` | `number` | No | — |
+| `zone_id` | `string` | Yes | — |
+| `type` | `string` | No | — |
+| `name` | `string` | No | — |
+| `content` | `string` | No | — |
+
+
+
+**Output:** `object[]`
+
+<AccordionGroup>
+<Accordion title="Output full type">
+
+```ts
+{
+  id: string,
+  zone_id?: string,
+  zone_name?: string,
+  type: string,
+  name: string,
+  content: string,
+  proxiable?: boolean,
+  proxied?: boolean,
+  ttl?: number,
+  locked?: boolean,
+  created_on?: string,
+  modified_on?: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+---
+
+## Rulesets
+
+### create
+
+`rulesets.create`
+
+Create a ruleset in a zone
+
+**Risk:** `write`
+
+```ts
+await corsair.cloudflare.api.rulesets.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `zone_id` | `string` | Yes | — |
+| `name` | `string` | Yes | — |
+| `kind` | `string` | Yes | — |
+| `phase` | `string` | Yes | — |
+| `rules` | `object[]` | No | — |
+| `description` | `string` | No | — |
+
+<AccordionGroup>
+<Accordion title="rules full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `name` | `string` | Yes | — |
+| `description` | `string` | No | — |
+| `kind` | `string` | Yes | — |
+| `version` | `string` | No | — |
+| `last_updated` | `string` | No | — |
+| `phase` | `string` | Yes | — |
+| `rules` | `object[]` | No | — |
+
+<AccordionGroup>
+<Accordion title="rules full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### delete
+
+`rulesets.delete`
+
+Delete a ruleset [DESTRUCTIVE]
+
+**Risk:** `destructive`
+
+```ts
+await corsair.cloudflare.api.rulesets.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `zone_id` | `string` | Yes | — |
+| `ruleset_id` | `string` | Yes | — |
+
+
+
+**Output:** _empty object_
+
+
+---
+
+### get
+
+`rulesets.get`
+
+Retrieve a ruleset by ID
+
+**Risk:** `read`
+
+```ts
+await corsair.cloudflare.api.rulesets.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `zone_id` | `string` | Yes | — |
+| `ruleset_id` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `name` | `string` | Yes | — |
+| `description` | `string` | No | — |
+| `kind` | `string` | Yes | — |
+| `version` | `string` | No | — |
+| `last_updated` | `string` | No | — |
+| `phase` | `string` | Yes | — |
+| `rules` | `object[]` | No | — |
+
+<AccordionGroup>
+<Accordion title="rules full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### list
+
+`rulesets.list`
+
+List rulesets for a zone
+
+**Risk:** `read`
+
+```ts
+await corsair.cloudflare.api.rulesets.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `zone_id` | `string` | Yes | — |
+
+
+
+**Output:** `object[]`
+
+<AccordionGroup>
+<Accordion title="Output full type">
+
+```ts
+{
+  id: string,
+  name: string,
+  description?: string,
+  kind: string,
+  version?: string,
+  last_updated?: string,
+  phase: string,
+  rules?: {
+  }[]
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+---
+
+### update
+
+`rulesets.update`
+
+Update a ruleset
+
+**Risk:** `write`
+
+```ts
+await corsair.cloudflare.api.rulesets.update({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `zone_id` | `string` | Yes | — |
+| `ruleset_id` | `string` | Yes | — |
+| `rules` | `object[]` | Yes | — |
+| `description` | `string` | No | — |
+
+<AccordionGroup>
+<Accordion title="rules full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `name` | `string` | Yes | — |
+| `description` | `string` | No | — |
+| `kind` | `string` | Yes | — |
+| `version` | `string` | No | — |
+| `last_updated` | `string` | No | — |
+| `phase` | `string` | Yes | — |
+| `rules` | `object[]` | No | — |
+
+<AccordionGroup>
+<Accordion title="rules full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Workers
+
+### routes.create
+
+`workers.routes.create`
+
+Create a Workers route
+
+**Risk:** `write`
+
+```ts
+await corsair.cloudflare.api.workers.routes.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `zone_id` | `string` | Yes | — |
+| `pattern` | `string` | Yes | — |
+| `script` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `pattern` | `string` | Yes | — |
+| `script` | `string` | No | — |
+
+
+
+---
+
+### routes.delete
+
+`workers.routes.delete`
+
+Delete a Workers route [DESTRUCTIVE]
+
+**Risk:** `destructive`
+
+```ts
+await corsair.cloudflare.api.workers.routes.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `zone_id` | `string` | Yes | — |
+| `route_id` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+
+
+
+---
+
+### routes.edit
+
+`workers.routes.edit`
+
+Update a Workers route
+
+**Risk:** `write`
+
+```ts
+await corsair.cloudflare.api.workers.routes.edit({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `zone_id` | `string` | Yes | — |
+| `route_id` | `string` | Yes | — |
+| `pattern` | `string` | No | — |
+| `script` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `pattern` | `string` | Yes | — |
+| `script` | `string` | No | — |
+
+
+
+---
+
+### routes.get
+
+`workers.routes.get`
+
+Retrieve a Workers route by ID
+
+**Risk:** `read`
+
+```ts
+await corsair.cloudflare.api.workers.routes.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `zone_id` | `string` | Yes | — |
+| `route_id` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `pattern` | `string` | Yes | — |
+| `script` | `string` | No | — |
+
+
+
+---
+
+### routes.list
+
+`workers.routes.list`
+
+List Workers routes for a zone
+
+**Risk:** `read`
+
+```ts
+await corsair.cloudflare.api.workers.routes.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `zone_id` | `string` | Yes | — |
+
+
+
+**Output:** `object[]`
+
+<AccordionGroup>
+<Accordion title="Output full type">
+
+```ts
+{
+  id: string,
+  pattern: string,
+  script?: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+---
+
+### scripts.delete
+
+`workers.scripts.delete`
+
+Delete a Workers script [DESTRUCTIVE]
+
+**Risk:** `destructive`
+
+```ts
+await corsair.cloudflare.api.workers.scripts.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `account_id` | `string` | Yes | — |
+| `script_name` | `string` | Yes | — |
+
+
+
+**Output:** _empty object_
+
+
+---
+
+### scripts.get
+
+`workers.scripts.get`
+
+Retrieve a Workers script by name
+
+**Risk:** `read`
+
+```ts
+await corsair.cloudflare.api.workers.scripts.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `account_id` | `string` | Yes | — |
+| `script_name` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | No | — |
+| `created_on` | `string` | No | — |
+| `modified_on` | `string` | No | — |
+
+
+
+---
+
+### scripts.list
+
+`workers.scripts.list`
+
+List Workers scripts for an account
+
+**Risk:** `read`
+
+```ts
+await corsair.cloudflare.api.workers.scripts.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `account_id` | `string` | Yes | — |
+
+
+
+**Output:** `object[]`
+
+<AccordionGroup>
+<Accordion title="Output full type">
+
+```ts
+{
+  id?: string,
+  created_on?: string,
+  modified_on?: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+---
+
+### scripts.upload
+
+`workers.scripts.upload`
+
+Upload or overwrite a Workers script
+
+**Risk:** `write`
+
+```ts
+await corsair.cloudflare.api.workers.scripts.upload({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `account_id` | `string` | Yes | — |
+| `script_name` | `string` | Yes | — |
+| `script_content` | `string` | Yes | — |
+| `bindings` | `object[]` | No | — |
+| `compatibility_date` | `string` | No | — |
+
+<AccordionGroup>
+<Accordion title="bindings full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | No | — |
+| `created_on` | `string` | No | — |
+| `modified_on` | `string` | No | — |
+
+
+
+---
+
+## Zones
+
+### create
+
+`zones.create`
+
+Create a new Cloudflare zone
+
+**Risk:** `write`
+
+```ts
+await corsair.cloudflare.api.zones.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | `string` | Yes | — |
+| `account` | `object` | Yes | — |
+| `jump_start` | `boolean` | No | — |
+
+<AccordionGroup>
+<Accordion title="account full type">
+
+```ts
+{
+  id: string
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `name` | `string` | Yes | — |
+| `status` | `string` | No | — |
+| `paused` | `boolean` | No | — |
+| `type` | `string` | No | — |
+| `account` | `object` | No | — |
+| `name_servers` | `string[]` | No | — |
+| `original_name_servers` | `string[]` | No | — |
+| `original_registrar` | `string` | No | — |
+| `original_dnshost` | `string` | No | — |
+| `created_on` | `string` | No | — |
+| `modified_on` | `string` | No | — |
+| `activated_on` | `string` | No | — |
+
+<AccordionGroup>
+<Accordion title="account full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### delete
+
+`zones.delete`
+
+Delete a Cloudflare zone [DESTRUCTIVE]
+
+**Risk:** `destructive`
+
+```ts
+await corsair.cloudflare.api.zones.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `zone_id` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+
+
+
+---
+
+### edit
+
+`zones.edit`
+
+Update a Cloudflare zone
+
+**Risk:** `write`
+
+```ts
+await corsair.cloudflare.api.zones.edit({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `zone_id` | `string` | Yes | — |
+| `paused` | `boolean` | No | — |
+| `plan` | `object` | No | — |
+| `vanity_name_servers` | `string[]` | No | — |
+
+<AccordionGroup>
+<Accordion title="plan full type">
+
+```ts
+{
+  id: string
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `name` | `string` | Yes | — |
+| `status` | `string` | No | — |
+| `paused` | `boolean` | No | — |
+| `type` | `string` | No | — |
+| `account` | `object` | No | — |
+| `name_servers` | `string[]` | No | — |
+| `original_name_servers` | `string[]` | No | — |
+| `original_registrar` | `string` | No | — |
+| `original_dnshost` | `string` | No | — |
+| `created_on` | `string` | No | — |
+| `modified_on` | `string` | No | — |
+| `activated_on` | `string` | No | — |
+
+<AccordionGroup>
+<Accordion title="account full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### get
+
+`zones.get`
+
+Retrieve a Cloudflare zone by ID
+
+**Risk:** `read`
+
+```ts
+await corsair.cloudflare.api.zones.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `zone_id` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `name` | `string` | Yes | — |
+| `status` | `string` | No | — |
+| `paused` | `boolean` | No | — |
+| `type` | `string` | No | — |
+| `account` | `object` | No | — |
+| `name_servers` | `string[]` | No | — |
+| `original_name_servers` | `string[]` | No | — |
+| `original_registrar` | `string` | No | — |
+| `original_dnshost` | `string` | No | — |
+| `created_on` | `string` | No | — |
+| `modified_on` | `string` | No | — |
+| `activated_on` | `string` | No | — |
+
+<AccordionGroup>
+<Accordion title="account full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### list
+
+`zones.list`
+
+List Cloudflare zones
+
+**Risk:** `read`
+
+```ts
+await corsair.cloudflare.api.zones.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `page` | `number` | No | — |
+| `per_page` | `number` | No | — |
+| `name` | `string` | No | — |
+| `status` | `string` | No | — |
+
+
+
+**Output:** `object[]`
+
+<AccordionGroup>
+<Accordion title="Output full type">
+
+```ts
+{
+  id: string,
+  name: string,
+  status?: string,
+  paused?: boolean,
+  type?: string,
+  account?: {
+  },
+  name_servers?: string[],
+  original_name_servers?: string[],
+  original_registrar?: string,
+  original_dnshost?: string,
+  created_on?: string,
+  modified_on?: string,
+  activated_on?: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+---
+

--- a/docs/plugins/cloudflare/database.mdx
+++ b/docs/plugins/cloudflare/database.mdx
@@ -1,0 +1,10 @@
+---
+title: Database
+description: "Cloudflare plugin local database entities."
+---
+
+This plugin does not define local database entities. Use the [API](/plugins/cloudflare/api) (`corsair.cloudflare.api.*`) to read and manage zones, DNS, Workers, and rulesets.
+
+<Info>
+**New to Corsair?** See [database operations](/concepts/database) for how local sync works on plugins that define entities.
+</Info>

--- a/docs/plugins/cloudflare/database.mdx
+++ b/docs/plugins/cloudflare/database.mdx
@@ -1,10 +1,158 @@
 ---
 title: Database
-description: "Cloudflare plugin local database entities."
+description: "Cloudflare local sync: searchable entities, `.search()` filters, and operators."
 ---
 
-This plugin does not define local database entities. Use the [API](/plugins/cloudflare/api) (`corsair.cloudflare.api.*`) to read and manage zones, DNS, Workers, and rulesets.
+The Cloudflare plugin syncs data locally. Use `corsair.cloudflare.db.<entity>.search({ data, limit?, offset? })` with the filters listed per entity.
 
 <Info>
-**New to Corsair?** See [database operations](/concepts/database) for how local sync works on plugins that define entities.
+**New to Corsair?** See [database operations](/concepts/database), [data synchronization](/concepts/integrations), and [multi-tenancy](/concepts/multi-tenancy).
 </Info>
+
+## Dns Records
+
+Path: `cloudflare.db.dnsRecords.search`
+
+```ts
+const rows = await corsair.cloudflare.db.dnsRecords.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `id` | `string` | equals, contains, startsWith, endsWith, in |
+| `zone_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `zone_name` | `string` | equals, contains, startsWith, endsWith, in |
+| `type` | `string` | equals, contains, startsWith, endsWith, in |
+| `name` | `string` | equals, contains, startsWith, endsWith, in |
+| `content` | `string` | equals, contains, startsWith, endsWith, in |
+| `proxiable` | `boolean` | equals |
+| `proxied` | `boolean` | equals |
+| `ttl` | `number` | equals, gt, gte, lt, lte, in |
+| `priority` | `number` | equals, gt, gte, lt, lte, in |
+| `locked` | `boolean` | equals |
+| `created_on` | `date` | equals, before, after, between |
+| `modified_on` | `date` | equals, before, after, between |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+
+## Rulesets
+
+Path: `cloudflare.db.rulesets.search`
+
+```ts
+const rows = await corsair.cloudflare.db.rulesets.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `id` | `string` | equals, contains, startsWith, endsWith, in |
+| `zone_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `name` | `string` | equals, contains, startsWith, endsWith, in |
+| `description` | `string` | equals, contains, startsWith, endsWith, in |
+| `kind` | `string` | equals, contains, startsWith, endsWith, in |
+| `version` | `string` | equals, contains, startsWith, endsWith, in |
+| `last_updated` | `date` | equals, before, after, between |
+| `phase` | `string` | equals, contains, startsWith, endsWith, in |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+
+## Worker Routes
+
+Path: `cloudflare.db.workerRoutes.search`
+
+```ts
+const rows = await corsair.cloudflare.db.workerRoutes.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `id` | `string` | equals, contains, startsWith, endsWith, in |
+| `zone_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `pattern` | `string` | equals, contains, startsWith, endsWith, in |
+| `script` | `string` | equals, contains, startsWith, endsWith, in |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+
+## Worker Scripts
+
+Path: `cloudflare.db.workerScripts.search`
+
+```ts
+const rows = await corsair.cloudflare.db.workerScripts.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `id` | `string` | equals, contains, startsWith, endsWith, in |
+| `account_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `created_on` | `date` | equals, before, after, between |
+| `modified_on` | `date` | equals, before, after, between |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+
+## Zones
+
+Path: `cloudflare.db.zones.search`
+
+```ts
+const rows = await corsair.cloudflare.db.zones.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `id` | `string` | equals, contains, startsWith, endsWith, in |
+| `name` | `string` | equals, contains, startsWith, endsWith, in |
+| `status` | `string` | equals, contains, startsWith, endsWith, in |
+| `paused` | `boolean` | equals |
+| `type` | `string` | equals, contains, startsWith, endsWith, in |
+| `created_on` | `date` | equals, before, after, between |
+| `modified_on` | `date` | equals, before, after, between |
+| `activated_on` | `date` | equals, before, after, between |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+

--- a/docs/plugins/cloudflare/get-credentials.mdx
+++ b/docs/plugins/cloudflare/get-credentials.mdx
@@ -1,0 +1,49 @@
+---
+title: Get Credentials
+description: Step-by-step instructions for obtaining a Cloudflare API token for the Corsair Cloudflare plugin.
+---
+
+This guide walks you through obtaining credentials for the Cloudflare plugin.
+
+## Authentication Method
+
+The Cloudflare plugin uses API key authentication (Cloudflare **API tokens** sent as `Authorization: Bearer`).
+
+- **[`api_key`](/concepts/api-key)** (default) — Cloudflare API token
+
+## API Token
+
+### Step 1: Create a token
+
+1. Sign in to the [Cloudflare dashboard](https://dash.cloudflare.com).
+2. Go to **My Profile** → **API Tokens** → **Create Token**.
+3. Use a template or **Create Custom Token** with permissions for what you need (for example **Zone Read**, **DNS Read**, **Workers Scripts Read** on your account/zones).
+4. Copy the token immediately — it is shown only once.
+
+**Storing credentials:**
+
+```bash
+pnpm corsair setup --plugin=cloudflare api_key=your-cloudflare-api-token
+```
+
+Or pass the token in plugin options:
+
+```ts corsair.ts
+cloudflare({
+	key: process.env.CLOUDFLARE_API_TOKEN,
+})
+```
+
+Verify:
+
+```bash
+pnpm corsair auth --plugin=cloudflare --credentials
+```
+
+## Required Credentials Summary
+
+| Credential | Required for | Where to find |
+|------------|----------------|---------------|
+| API token | [`api_key`](/concepts/api-key) auth | Dashboard → My Profile → API Tokens |
+
+For general information about how Corsair handles authentication, see [Authentication](/concepts/auth).

--- a/docs/plugins/cloudflare/overview.mdx
+++ b/docs/plugins/cloudflare/overview.mdx
@@ -3,11 +3,12 @@ title: Overview
 description: "Cloudflare plugin for Corsair"
 ---
 
-Use **Cloudflare** through Corsair: one client and typed API calls against Cloudflare API v4.
+Use **Cloudflare** through Corsair: one client, typed API calls against Cloudflare API v4, and optional local DB sync for zones, DNS, Workers, and rulesets.
 
 **What you get:**
 
 - 24 typed API operations
+- Local search via `corsair.cloudflare.db.*` (synced on API calls when a database is configured)
 
 ## Setup
 

--- a/docs/plugins/cloudflare/overview.mdx
+++ b/docs/plugins/cloudflare/overview.mdx
@@ -1,0 +1,143 @@
+---
+title: Overview
+description: "Cloudflare plugin for Corsair"
+---
+
+Use **Cloudflare** through Corsair: one client and typed API calls against Cloudflare API v4.
+
+**What you get:**
+
+- 24 typed API operations
+
+## Setup
+
+<Steps>
+
+<Step title="Install">
+```bash
+pnpm install @corsair-dev/cloudflare
+```
+
+</Step>
+
+<Step title="Add the plugin">
+<Tabs>
+<Tab title="Solo">
+```ts corsair.ts
+import { createCorsair } from 'corsair';
+import { cloudflare } from '@corsair-dev/cloudflare';
+
+export const corsair = createCorsair({
+	// ... other config options,
+	multiTenancy: false,
+    plugins: [cloudflare()],
+});
+```
+</Tab>
+<Tab title="Multi-Tenant">
+```ts corsair.ts
+import { createCorsair } from 'corsair';
+import { cloudflare } from '@corsair-dev/cloudflare';
+
+export const corsair = createCorsair({
+	// ... other config options,
+    multiTenancy: true,
+    plugins: [cloudflare()],
+});
+```
+
+See [Multi-tenancy](/concepts/multi-tenancy) for account isolation.
+
+</Tab>
+</Tabs>
+
+</Step>
+
+<Step title="Get credentials">
+Follow [Get Credentials](/plugins/cloudflare/get-credentials) if you need help getting keys.
+
+</Step>
+
+<Step title="Store credentials">
+<Tabs>
+<Tab title="Solo">
+```bash
+pnpm corsair setup --plugin=cloudflare
+```
+
+Use the key names documented in [Get Credentials](/plugins/cloudflare/get-credentials) (for example `api_key=`).
+</Tab>
+<Tab title="Multi-Tenant">
+```bash
+pnpm corsair setup --plugin=cloudflare --tenant=<tenantId>
+```
+
+Store per-tenant secrets after you create the tenant record. See [Multi-tenancy](/concepts/multi-tenancy).
+</Tab>
+</Tabs>
+
+</Step>
+
+</Steps>
+
+## Authentication
+
+Each tab shows how to register the plugin for that authentication method. The default `authType` from the plugin does not need to appear in the factory call.
+
+<Tabs>
+<Tab title="API Key (Default)">
+
+```ts corsair.ts
+cloudflare()
+```
+
+Store credentials with `pnpm corsair setup --plugin=cloudflare` (see [Get Credentials](/plugins/cloudflare/get-credentials) for field names).
+
+More: [API Key](/concepts/api-key)
+
+</Tab>
+</Tabs>
+
+
+
+## Example API calls
+
+**Read-style (read):** `dns.get`
+
+```ts
+await corsair.cloudflare.api.dns.get({
+	zone_id: 'your-zone-id',
+	dns_record_id: 'your-record-id',
+});
+```
+
+
+**Write-style (write):** `dns.create`
+
+```ts
+await corsair.cloudflare.api.dns.create({
+	zone_id: 'your-zone-id',
+	type: 'A',
+	name: 'www.example.com',
+	content: '192.0.2.1',
+});
+```
+
+
+See the full list on the [API](/plugins/cloudflare/api) page. Use `pnpm corsair list --plugin=cloudflare` and `pnpm corsair schema <path>` locally to inspect schemas.
+
+---
+
+## Hooks
+
+Use `hooks` on API calls to add logging, approvals, or side effects. See [Hooks](/concepts/hooks).
+
+---
+
+## Reference
+
+| Topic | Link |
+|-------|------|
+| API | [API](/plugins/cloudflare/api) |
+| Credentials | [Get credentials](/plugins/cloudflare/get-credentials) |
+

--- a/packages/cloudflare/api-error.ts
+++ b/packages/cloudflare/api-error.ts
@@ -1,0 +1,9 @@
+export class CloudflareAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly code?: number,
+	) {
+		super(message);
+		this.name = 'CloudflareAPIError';
+	}
+}

--- a/packages/cloudflare/api.test.ts
+++ b/packages/cloudflare/api.test.ts
@@ -17,6 +17,7 @@ import { CloudflareEndpointOutputSchemas } from './endpoints/types';
 const TEST_API_TOKEN = process.env.CLOUDFLARE_API_TOKEN;
 const ZONE_ID_OVERRIDE = process.env.CLOUDFLARE_ZONE_ID;
 const ACCOUNT_ID_OVERRIDE = process.env.CLOUDFLARE_ACCOUNT_ID;
+const SCRIPT_NAME_OVERRIDE = process.env.CLOUDFLARE_SCRIPT_NAME;
 
 function requireToken(): string {
 	if (!TEST_API_TOKEN?.trim()) {
@@ -167,7 +168,7 @@ describe('Cloudflare API Type Tests', () => {
 			CloudflareEndpointOutputSchemas.workersList.parse(result);
 		});
 
-		it('workersGet returns correct type', async () => {
+		it('workersGet returns script source as string', async () => {
 			const token = requireToken();
 			if (!accountId) {
 				console.warn('No account_id — skipping workersGet');
@@ -179,9 +180,11 @@ describe('Cloudflare API Type Tests', () => {
 				token,
 				{ method: 'GET' },
 			);
-			const scriptName = list[0]?.id;
+			const scriptName = SCRIPT_NAME_OVERRIDE ?? list[0]?.id;
 			if (!scriptName) {
-				console.warn('No Workers scripts — skipping workersGet');
+				console.warn(
+					'No Workers scripts — set CLOUDFLARE_SCRIPT_NAME or upload a script to test workersGet',
+				);
 				return;
 			}
 
@@ -191,6 +194,7 @@ describe('Cloudflare API Type Tests', () => {
 				{ method: 'GET' },
 			);
 
+			expect(typeof result).toBe('string');
 			CloudflareEndpointOutputSchemas.workersGet.parse(result);
 		});
 	});

--- a/packages/cloudflare/api.test.ts
+++ b/packages/cloudflare/api.test.ts
@@ -1,0 +1,287 @@
+import 'dotenv/config';
+import { makeCloudflareRequest } from './client';
+import type {
+	DnsGetResponse,
+	DnsListResponse,
+	RulesetsGetResponse,
+	RulesetsListResponse,
+	WorkerRoutesGetResponse,
+	WorkerRoutesListResponse,
+	WorkersGetResponse,
+	WorkersListResponse,
+	ZonesGetResponse,
+	ZonesListResponse,
+} from './endpoints/types';
+import { CloudflareEndpointOutputSchemas } from './endpoints/types';
+
+const TEST_API_TOKEN = process.env.CLOUDFLARE_API_TOKEN;
+const ZONE_ID_OVERRIDE = process.env.CLOUDFLARE_ZONE_ID;
+const ACCOUNT_ID_OVERRIDE = process.env.CLOUDFLARE_ACCOUNT_ID;
+
+function requireToken(): string {
+	if (!TEST_API_TOKEN?.trim()) {
+		throw new Error(
+			'Set CLOUDFLARE_API_TOKEN in packages/cloudflare/.env (see .env.example)',
+		);
+	}
+	return TEST_API_TOKEN;
+}
+
+function accountIdFromZone(
+	zone: ZonesListResponse[number],
+): string | undefined {
+	const account = zone.account;
+	if (account && typeof account === 'object' && 'id' in account) {
+		return String(account.id);
+	}
+	return undefined;
+}
+
+/** When the account has no zones, resolve account id via Account Settings Read. */
+async function resolveAccountId(token: string): Promise<string | undefined> {
+	const accounts = await makeCloudflareRequest<Array<{ id: string }>>(
+		'/accounts',
+		token,
+		{
+			method: 'GET',
+			query: { per_page: 1 },
+		},
+	);
+	return accounts[0]?.id;
+}
+
+describe('Cloudflare API Type Tests', () => {
+	let zoneId: string | undefined = ZONE_ID_OVERRIDE;
+	let accountId: string | undefined = ACCOUNT_ID_OVERRIDE;
+
+	describe('zones', () => {
+		it('zonesList returns correct type', async () => {
+			const token = requireToken();
+			const result = await makeCloudflareRequest<ZonesListResponse>(
+				'/zones',
+				token,
+				{
+					method: 'GET',
+					query: { per_page: 5 },
+				},
+			);
+
+			if (result.length > 0) {
+				zoneId ??= result[0]?.id;
+				accountId ??= result[0] ? accountIdFromZone(result[0]) : undefined;
+			} else {
+				accountId ??= await resolveAccountId(token);
+			}
+
+			CloudflareEndpointOutputSchemas.zonesList.parse(result);
+		});
+
+		it('zonesGet returns correct type', async () => {
+			const token = requireToken();
+			if (!zoneId) {
+				const list = await makeCloudflareRequest<ZonesListResponse>(
+					'/zones',
+					token,
+					{
+						method: 'GET',
+						query: { per_page: 1 },
+					},
+				);
+				zoneId = list[0]?.id;
+			}
+			if (!zoneId) {
+				console.warn('No zones on account — skipping zonesGet');
+				return;
+			}
+
+			const result = await makeCloudflareRequest<ZonesGetResponse>(
+				`/zones/${zoneId}`,
+				token,
+				{ method: 'GET' },
+			);
+
+			accountId ??= accountIdFromZone(result);
+			CloudflareEndpointOutputSchemas.zonesGet.parse(result);
+		});
+	});
+
+	describe('dns', () => {
+		it('dnsList returns correct type', async () => {
+			const token = requireToken();
+			if (!zoneId) {
+				console.warn('No zone_id — skipping dnsList');
+				return;
+			}
+
+			const result = await makeCloudflareRequest<DnsListResponse>(
+				`/zones/${zoneId}/dns_records`,
+				token,
+				{ method: 'GET', query: { per_page: 5 } },
+			);
+
+			CloudflareEndpointOutputSchemas.dnsList.parse(result);
+		});
+
+		it('dnsGet returns correct type', async () => {
+			const token = requireToken();
+			if (!zoneId) {
+				console.warn('No zone_id — skipping dnsGet');
+				return;
+			}
+
+			const list = await makeCloudflareRequest<DnsListResponse>(
+				`/zones/${zoneId}/dns_records`,
+				token,
+				{ method: 'GET', query: { per_page: 1 } },
+			);
+			const recordId = list[0]?.id;
+			if (!recordId) {
+				console.warn('No DNS records in zone — skipping dnsGet');
+				return;
+			}
+
+			const result = await makeCloudflareRequest<DnsGetResponse>(
+				`/zones/${zoneId}/dns_records/${recordId}`,
+				token,
+				{ method: 'GET' },
+			);
+
+			CloudflareEndpointOutputSchemas.dnsGet.parse(result);
+		});
+	});
+
+	describe('workers.scripts', () => {
+		it('workersList returns correct type', async () => {
+			const token = requireToken();
+			if (!accountId) {
+				console.warn('No account_id — skipping workersList');
+				return;
+			}
+
+			const result = await makeCloudflareRequest<WorkersListResponse>(
+				`/accounts/${accountId}/workers/scripts`,
+				token,
+				{ method: 'GET' },
+			);
+
+			CloudflareEndpointOutputSchemas.workersList.parse(result);
+		});
+
+		it('workersGet returns correct type', async () => {
+			const token = requireToken();
+			if (!accountId) {
+				console.warn('No account_id — skipping workersGet');
+				return;
+			}
+
+			const list = await makeCloudflareRequest<WorkersListResponse>(
+				`/accounts/${accountId}/workers/scripts`,
+				token,
+				{ method: 'GET' },
+			);
+			const scriptName = list[0]?.id;
+			if (!scriptName) {
+				console.warn('No Workers scripts — skipping workersGet');
+				return;
+			}
+
+			const result = await makeCloudflareRequest<WorkersGetResponse>(
+				`/accounts/${accountId}/workers/scripts/${scriptName}`,
+				token,
+				{ method: 'GET' },
+			);
+
+			CloudflareEndpointOutputSchemas.workersGet.parse(result);
+		});
+	});
+
+	describe('workers.routes', () => {
+		it('workerRoutesList returns correct type', async () => {
+			const token = requireToken();
+			if (!zoneId) {
+				console.warn('No zone_id — skipping workerRoutesList');
+				return;
+			}
+
+			const result = await makeCloudflareRequest<WorkerRoutesListResponse>(
+				`/zones/${zoneId}/workers/routes`,
+				token,
+				{ method: 'GET' },
+			);
+
+			CloudflareEndpointOutputSchemas.workerRoutesList.parse(result);
+		});
+
+		it('workerRoutesGet returns correct type', async () => {
+			const token = requireToken();
+			if (!zoneId) {
+				console.warn('No zone_id — skipping workerRoutesGet');
+				return;
+			}
+
+			const list = await makeCloudflareRequest<WorkerRoutesListResponse>(
+				`/zones/${zoneId}/workers/routes`,
+				token,
+				{ method: 'GET' },
+			);
+			const routeId = list[0]?.id;
+			if (!routeId) {
+				console.warn('No Workers routes — skipping workerRoutesGet');
+				return;
+			}
+
+			const result = await makeCloudflareRequest<WorkerRoutesGetResponse>(
+				`/zones/${zoneId}/workers/routes/${routeId}`,
+				token,
+				{ method: 'GET' },
+			);
+
+			CloudflareEndpointOutputSchemas.workerRoutesGet.parse(result);
+		});
+	});
+
+	describe('rulesets', () => {
+		it('rulesetsList returns correct type', async () => {
+			const token = requireToken();
+			if (!zoneId) {
+				console.warn('No zone_id — skipping rulesetsList');
+				return;
+			}
+
+			const result = await makeCloudflareRequest<RulesetsListResponse>(
+				`/zones/${zoneId}/rulesets`,
+				token,
+				{ method: 'GET' },
+			);
+
+			CloudflareEndpointOutputSchemas.rulesetsList.parse(result);
+		});
+
+		it('rulesetsGet returns correct type', async () => {
+			const token = requireToken();
+			if (!zoneId) {
+				console.warn('No zone_id — skipping rulesetsGet');
+				return;
+			}
+
+			const list = await makeCloudflareRequest<RulesetsListResponse>(
+				`/zones/${zoneId}/rulesets`,
+				token,
+				{ method: 'GET' },
+			);
+			const rulesetId = list[0]?.id;
+			if (!rulesetId) {
+				console.warn('No rulesets in zone — skipping rulesetsGet');
+				return;
+			}
+
+			const result = await makeCloudflareRequest<RulesetsGetResponse>(
+				`/zones/${zoneId}/rulesets/${rulesetId}`,
+				token,
+				{ method: 'GET' },
+			);
+
+			CloudflareEndpointOutputSchemas.rulesetsGet.parse(result);
+		});
+	});
+});

--- a/packages/cloudflare/client.ts
+++ b/packages/cloudflare/client.ts
@@ -1,50 +1,22 @@
 import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
 import { ApiError, request } from 'corsair/http';
+import { CloudflareAPIError } from './api-error';
+import {
+	cloudflareErrorFromApiErrorBody,
+	unwrapCloudflareResponse,
+	type CloudflareApiResponse,
+} from './response';
 
-export class CloudflareAPIError extends Error {
-	constructor(
-		message: string,
-		public readonly code?: number,
-	) {
-		super(message);
-		this.name = 'CloudflareAPIError';
-	}
-}
+export { CloudflareAPIError } from './api-error';
 
 const CLOUDFLARE_API_BASE = 'https://api.cloudflare.com/client/v4';
-
-type CloudflareApiResponse<T> = {
-	result: T;
-	success: boolean;
-	errors: Array<{ code: number; message: string }>;
-	messages: unknown[];
-};
-
-function unwrapCloudflareResponse<T>(response: unknown): T {
-	if (
-		response &&
-		typeof response === 'object' &&
-		'success' in response &&
-		'result' in response
-	) {
-		const wrapped = response as CloudflareApiResponse<T>;
-		if (!wrapped.success) {
-			const message =
-				wrapped.errors?.map((e) => e.message).join('; ') ||
-				'Cloudflare API request failed';
-			const code = wrapped.errors?.[0]?.code;
-			throw new CloudflareAPIError(message, code);
-		}
-		return wrapped.result;
-	}
-	return response as T;
-}
 
 export async function makeCloudflareRequest<T>(
 	path: string,
 	token: string,
 	options: {
 		method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+		// JSON bodies use loose records because each endpoint accepts different fields.
 		body?: Record<string, unknown>;
 		query?: Record<string, string | number | boolean | undefined>;
 		formData?: Record<string, unknown>;
@@ -75,21 +47,24 @@ export async function makeCloudflareRequest<T>(
 		? {
 				method,
 				url: path,
+				query,
+				// Multipart fields are strings or Blobs; corsair/http accepts a loose record.
 				formData: formData as Record<string, unknown>,
 			}
 		: rawBody != null
 			? {
 					method,
 					url: path,
+					query,
 					body: rawBody,
 					mediaType: mediaType ?? 'application/javascript',
 				}
 			: {
 					method,
 					url: path,
+					query,
 					body: isWriteMethod ? body : undefined,
 					mediaType: 'application/json',
-					query: method === 'GET' ? query : undefined,
 				};
 
 	try {
@@ -103,24 +78,11 @@ export async function makeCloudflareRequest<T>(
 			throw error;
 		}
 		if (error instanceof ApiError) {
-			const apiError = error;
-			const errorBody = apiError.body as
-				| CloudflareApiResponse<unknown>
-				| undefined;
-			if (
-				errorBody &&
-				typeof errorBody === 'object' &&
-				'errors' in errorBody &&
-				Array.isArray(errorBody.errors) &&
-				errorBody.errors.length > 0
-			) {
-				const message = errorBody.errors.map((e) => e.message).join('; ');
-				throw new CloudflareAPIError(
-					message,
-					errorBody.errors[0]?.code ?? apiError.status,
-				);
+			const mapped = cloudflareErrorFromApiErrorBody(error.body);
+			if (mapped) {
+				throw mapped;
 			}
-			throw new CloudflareAPIError(apiError.message, apiError.status);
+			throw new CloudflareAPIError(error.message, error.status);
 		}
 		if (error instanceof Error) {
 			throw new CloudflareAPIError(error.message);

--- a/packages/cloudflare/client.ts
+++ b/packages/cloudflare/client.ts
@@ -1,0 +1,130 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+
+export class CloudflareAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly code?: number,
+	) {
+		super(message);
+		this.name = 'CloudflareAPIError';
+	}
+}
+
+const CLOUDFLARE_API_BASE = 'https://api.cloudflare.com/client/v4';
+
+type CloudflareApiResponse<T> = {
+	result: T;
+	success: boolean;
+	errors: Array<{ code: number; message: string }>;
+	messages: unknown[];
+};
+
+function unwrapCloudflareResponse<T>(response: unknown): T {
+	if (
+		response &&
+		typeof response === 'object' &&
+		'success' in response &&
+		'result' in response
+	) {
+		const wrapped = response as CloudflareApiResponse<T>;
+		if (!wrapped.success) {
+			const message =
+				wrapped.errors?.map((e) => e.message).join('; ') ||
+				'Cloudflare API request failed';
+			const code = wrapped.errors?.[0]?.code;
+			throw new CloudflareAPIError(message, code);
+		}
+		return wrapped.result;
+	}
+	return response as T;
+}
+
+export async function makeCloudflareRequest<T>(
+	path: string,
+	token: string,
+	options: {
+		method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+		body?: Record<string, unknown>;
+		query?: Record<string, string | number | boolean | undefined>;
+		formData?: Record<string, unknown>;
+		rawBody?: string;
+		mediaType?: string;
+	} = {},
+): Promise<T> {
+	const { method = 'GET', body, query, formData, rawBody, mediaType } = options;
+
+	const isWriteMethod =
+		method === 'POST' || method === 'PUT' || method === 'PATCH';
+	const isMultipart = formData != null;
+
+	const config: OpenAPIConfig = {
+		BASE: CLOUDFLARE_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		HEADERS: {
+			Authorization: `Bearer ${token}`,
+			...(isMultipart || rawBody != null
+				? {}
+				: { 'Content-Type': 'application/json' }),
+		},
+	};
+
+	const requestOptions: ApiRequestOptions = isMultipart
+		? {
+				method,
+				url: path,
+				formData: formData as Record<string, unknown>,
+			}
+		: rawBody != null
+			? {
+					method,
+					url: path,
+					body: rawBody,
+					mediaType: mediaType ?? 'application/javascript',
+				}
+			: {
+					method,
+					url: path,
+					body: isWriteMethod ? body : undefined,
+					mediaType: 'application/json',
+					query: method === 'GET' ? query : undefined,
+				};
+
+	try {
+		const response = await request<CloudflareApiResponse<T> | T>(
+			config,
+			requestOptions,
+		);
+		return unwrapCloudflareResponse<T>(response);
+	} catch (error) {
+		if (error instanceof CloudflareAPIError) {
+			throw error;
+		}
+		if (error instanceof ApiError) {
+			const apiError = error;
+			const errorBody = apiError.body as
+				| CloudflareApiResponse<unknown>
+				| undefined;
+			if (
+				errorBody &&
+				typeof errorBody === 'object' &&
+				'errors' in errorBody &&
+				Array.isArray(errorBody.errors) &&
+				errorBody.errors.length > 0
+			) {
+				const message = errorBody.errors.map((e) => e.message).join('; ');
+				throw new CloudflareAPIError(
+					message,
+					errorBody.errors[0]?.code ?? apiError.status,
+				);
+			}
+			throw new CloudflareAPIError(apiError.message, apiError.status);
+		}
+		if (error instanceof Error) {
+			throw new CloudflareAPIError(error.message);
+		}
+		throw new CloudflareAPIError('Unknown error');
+	}
+}

--- a/packages/cloudflare/endpoints/dns.ts
+++ b/packages/cloudflare/endpoints/dns.ts
@@ -1,0 +1,84 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeCloudflareRequest } from '../client';
+import type { CloudflareEndpoints } from '../index';
+import type { CloudflareEndpointOutputs } from './types';
+
+export const list: CloudflareEndpoints['dnsList'] = async (ctx, input) => {
+	const { zone_id, ...query } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['dnsList']
+	>(`/zones/${zone_id}/dns_records`, ctx.key, { method: 'GET', query });
+	await logEventFromContext(
+		ctx,
+		'cloudflare.dns.list',
+		{ zone_id, ...query },
+		'completed',
+	);
+	return result;
+};
+
+export const get: CloudflareEndpoints['dnsGet'] = async (ctx, input) => {
+	const { zone_id, dns_record_id } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['dnsGet']
+	>(`/zones/${zone_id}/dns_records/${dns_record_id}`, ctx.key, {
+		method: 'GET',
+	});
+	await logEventFromContext(
+		ctx,
+		'cloudflare.dns.get',
+		{ zone_id, dns_record_id },
+		'completed',
+	);
+	return result;
+};
+
+export const create: CloudflareEndpoints['dnsCreate'] = async (ctx, input) => {
+	const { zone_id, ...body } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['dnsCreate']
+	>(`/zones/${zone_id}/dns_records`, ctx.key, { method: 'POST', body });
+	await logEventFromContext(
+		ctx,
+		'cloudflare.dns.create',
+		{ zone_id },
+		'completed',
+	);
+	return result;
+};
+
+export const edit: CloudflareEndpoints['dnsEdit'] = async (ctx, input) => {
+	const { zone_id, dns_record_id, ...body } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['dnsEdit']
+	>(`/zones/${zone_id}/dns_records/${dns_record_id}`, ctx.key, {
+		method: 'PATCH',
+		body,
+	});
+	await logEventFromContext(
+		ctx,
+		'cloudflare.dns.edit',
+		{ zone_id, dns_record_id },
+		'completed',
+	);
+	return result;
+};
+
+export const deleteDns: CloudflareEndpoints['dnsDelete'] = async (
+	ctx,
+	input,
+) => {
+	const { zone_id, dns_record_id } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['dnsDelete']
+	>(`/zones/${zone_id}/dns_records/${dns_record_id}`, ctx.key, {
+		method: 'DELETE',
+	});
+	await logEventFromContext(
+		ctx,
+		'cloudflare.dns.delete',
+		{ zone_id, dns_record_id },
+		'completed',
+	);
+	return result;
+};

--- a/packages/cloudflare/endpoints/dns.ts
+++ b/packages/cloudflare/endpoints/dns.ts
@@ -1,6 +1,7 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeCloudflareRequest } from '../client';
 import type { CloudflareEndpoints } from '../index';
+import { deleteDnsRecord, persistDnsRecord } from '../persist';
 import type { CloudflareEndpointOutputs } from './types';
 
 export const list: CloudflareEndpoints['dnsList'] = async (ctx, input) => {
@@ -8,6 +9,13 @@ export const list: CloudflareEndpoints['dnsList'] = async (ctx, input) => {
 	const result = await makeCloudflareRequest<
 		CloudflareEndpointOutputs['dnsList']
 	>(`/zones/${zone_id}/dns_records`, ctx.key, { method: 'GET', query });
+
+	if (ctx.db.dnsRecords) {
+		for (const record of result) {
+			await persistDnsRecord(record, zone_id, ctx.db);
+		}
+	}
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.dns.list',
@@ -24,6 +32,9 @@ export const get: CloudflareEndpoints['dnsGet'] = async (ctx, input) => {
 	>(`/zones/${zone_id}/dns_records/${dns_record_id}`, ctx.key, {
 		method: 'GET',
 	});
+
+	await persistDnsRecord(result, zone_id, ctx.db);
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.dns.get',
@@ -38,6 +49,9 @@ export const create: CloudflareEndpoints['dnsCreate'] = async (ctx, input) => {
 	const result = await makeCloudflareRequest<
 		CloudflareEndpointOutputs['dnsCreate']
 	>(`/zones/${zone_id}/dns_records`, ctx.key, { method: 'POST', body });
+
+	await persistDnsRecord(result, zone_id, ctx.db);
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.dns.create',
@@ -55,6 +69,9 @@ export const edit: CloudflareEndpoints['dnsEdit'] = async (ctx, input) => {
 		method: 'PATCH',
 		body,
 	});
+
+	await persistDnsRecord(result, zone_id, ctx.db);
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.dns.edit',
@@ -74,6 +91,9 @@ export const deleteDns: CloudflareEndpoints['dnsDelete'] = async (
 	>(`/zones/${zone_id}/dns_records/${dns_record_id}`, ctx.key, {
 		method: 'DELETE',
 	});
+
+	await deleteDnsRecord(dns_record_id, ctx.db);
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.dns.delete',

--- a/packages/cloudflare/endpoints/index.ts
+++ b/packages/cloudflare/endpoints/index.ts
@@ -1,0 +1,45 @@
+import * as Dns from './dns';
+import * as Rulesets from './rulesets';
+import * as Workers from './workers';
+import * as Zones from './zones';
+
+export const ZonesEndpoints = {
+	list: Zones.list,
+	get: Zones.get,
+	create: Zones.create,
+	edit: Zones.edit,
+	delete: Zones.deleteZone,
+};
+
+export const DNSEndpoints = {
+	list: Dns.list,
+	get: Dns.get,
+	create: Dns.create,
+	edit: Dns.edit,
+	delete: Dns.deleteDns,
+};
+
+export const WorkersEndpoints = {
+	list: Workers.list,
+	get: Workers.get,
+	upload: Workers.upload,
+	delete: Workers.deleteWorker,
+};
+
+export const WorkerRoutesEndpoints = {
+	list: Workers.routesList,
+	get: Workers.routesGet,
+	create: Workers.routesCreate,
+	edit: Workers.routesEdit,
+	delete: Workers.routesDelete,
+};
+
+export const RulesetsEndpoints = {
+	list: Rulesets.list,
+	get: Rulesets.get,
+	create: Rulesets.create,
+	update: Rulesets.update,
+	delete: Rulesets.deleteRuleset,
+};
+
+export * from './types';

--- a/packages/cloudflare/endpoints/rulesets.ts
+++ b/packages/cloudflare/endpoints/rulesets.ts
@@ -1,6 +1,7 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeCloudflareRequest } from '../client';
 import type { CloudflareEndpoints } from '../index';
+import { deleteRuleset as removeRulesetFromDb, persistRuleset } from '../persist';
 import type { CloudflareEndpointOutputs } from './types';
 
 export const list: CloudflareEndpoints['rulesetsList'] = async (ctx, input) => {
@@ -8,6 +9,13 @@ export const list: CloudflareEndpoints['rulesetsList'] = async (ctx, input) => {
 	const result = await makeCloudflareRequest<
 		CloudflareEndpointOutputs['rulesetsList']
 	>(`/zones/${zone_id}/rulesets`, ctx.key, { method: 'GET' });
+
+	if (ctx.db.rulesets) {
+		for (const ruleset of result) {
+			await persistRuleset(ruleset, zone_id, ctx.db);
+		}
+	}
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.rulesets.list',
@@ -22,6 +30,9 @@ export const get: CloudflareEndpoints['rulesetsGet'] = async (ctx, input) => {
 	const result = await makeCloudflareRequest<
 		CloudflareEndpointOutputs['rulesetsGet']
 	>(`/zones/${zone_id}/rulesets/${ruleset_id}`, ctx.key, { method: 'GET' });
+
+	await persistRuleset(result, zone_id, ctx.db);
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.rulesets.get',
@@ -39,6 +50,9 @@ export const create: CloudflareEndpoints['rulesetsCreate'] = async (
 	const result = await makeCloudflareRequest<
 		CloudflareEndpointOutputs['rulesetsCreate']
 	>(`/zones/${zone_id}/rulesets`, ctx.key, { method: 'POST', body });
+
+	await persistRuleset(result, zone_id, ctx.db);
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.rulesets.create',
@@ -59,6 +73,9 @@ export const update: CloudflareEndpoints['rulesetsUpdate'] = async (
 		method: 'PUT',
 		body,
 	});
+
+	await persistRuleset(result, zone_id, ctx.db);
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.rulesets.update',
@@ -76,6 +93,9 @@ export const deleteRuleset: CloudflareEndpoints['rulesetsDelete'] = async (
 	const result = await makeCloudflareRequest<
 		CloudflareEndpointOutputs['rulesetsDelete']
 	>(`/zones/${zone_id}/rulesets/${ruleset_id}`, ctx.key, { method: 'DELETE' });
+
+	await removeRulesetFromDb(ruleset_id, ctx.db);
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.rulesets.delete',

--- a/packages/cloudflare/endpoints/rulesets.ts
+++ b/packages/cloudflare/endpoints/rulesets.ts
@@ -1,0 +1,86 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeCloudflareRequest } from '../client';
+import type { CloudflareEndpoints } from '../index';
+import type { CloudflareEndpointOutputs } from './types';
+
+export const list: CloudflareEndpoints['rulesetsList'] = async (ctx, input) => {
+	const { zone_id } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['rulesetsList']
+	>(`/zones/${zone_id}/rulesets`, ctx.key, { method: 'GET' });
+	await logEventFromContext(
+		ctx,
+		'cloudflare.rulesets.list',
+		{ zone_id },
+		'completed',
+	);
+	return result;
+};
+
+export const get: CloudflareEndpoints['rulesetsGet'] = async (ctx, input) => {
+	const { zone_id, ruleset_id } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['rulesetsGet']
+	>(`/zones/${zone_id}/rulesets/${ruleset_id}`, ctx.key, { method: 'GET' });
+	await logEventFromContext(
+		ctx,
+		'cloudflare.rulesets.get',
+		{ zone_id, ruleset_id },
+		'completed',
+	);
+	return result;
+};
+
+export const create: CloudflareEndpoints['rulesetsCreate'] = async (
+	ctx,
+	input,
+) => {
+	const { zone_id, ...body } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['rulesetsCreate']
+	>(`/zones/${zone_id}/rulesets`, ctx.key, { method: 'POST', body });
+	await logEventFromContext(
+		ctx,
+		'cloudflare.rulesets.create',
+		{ zone_id },
+		'completed',
+	);
+	return result;
+};
+
+export const update: CloudflareEndpoints['rulesetsUpdate'] = async (
+	ctx,
+	input,
+) => {
+	const { zone_id, ruleset_id, ...body } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['rulesetsUpdate']
+	>(`/zones/${zone_id}/rulesets/${ruleset_id}`, ctx.key, {
+		method: 'PUT',
+		body,
+	});
+	await logEventFromContext(
+		ctx,
+		'cloudflare.rulesets.update',
+		{ zone_id, ruleset_id },
+		'completed',
+	);
+	return result;
+};
+
+export const deleteRuleset: CloudflareEndpoints['rulesetsDelete'] = async (
+	ctx,
+	input,
+) => {
+	const { zone_id, ruleset_id } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['rulesetsDelete']
+	>(`/zones/${zone_id}/rulesets/${ruleset_id}`, ctx.key, { method: 'DELETE' });
+	await logEventFromContext(
+		ctx,
+		'cloudflare.rulesets.delete',
+		{ zone_id, ruleset_id },
+		'completed',
+	);
+	return result;
+};

--- a/packages/cloudflare/endpoints/types.ts
+++ b/packages/cloudflare/endpoints/types.ts
@@ -1,0 +1,387 @@
+import { z } from 'zod';
+
+// ── Shared schemas ────────────────────────────────────────────────────────────
+
+const PaginationInputSchema = z.object({
+	page: z.number().optional(),
+	per_page: z.number().optional(),
+});
+
+const IdDeleteResponseSchema = z.object({ id: z.string() }).passthrough();
+
+const ZoneSchema = z
+	.object({
+		id: z.string(),
+		name: z.string(),
+		status: z.string().optional(),
+		paused: z.boolean().optional(),
+		type: z.string().optional(),
+		account: z.record(z.unknown()).optional(),
+		name_servers: z.array(z.string()).optional(),
+		original_name_servers: z.array(z.string()).optional(),
+		original_registrar: z.string().optional(),
+		original_dnshost: z.string().optional(),
+		created_on: z.string().optional(),
+		modified_on: z.string().optional(),
+		activated_on: z.string().optional(),
+	})
+	.passthrough();
+
+const DnsRecordSchema = z
+	.object({
+		id: z.string(),
+		zone_id: z.string().optional(),
+		zone_name: z.string().optional(),
+		type: z.string(),
+		name: z.string(),
+		content: z.string(),
+		proxiable: z.boolean().optional(),
+		proxied: z.boolean().optional(),
+		ttl: z.number().optional(),
+		locked: z.boolean().optional(),
+		created_on: z.string().optional(),
+		modified_on: z.string().optional(),
+	})
+	.passthrough();
+
+const WorkerScriptSchema = z
+	.object({
+		id: z.string().optional(),
+		created_on: z.string().optional(),
+		modified_on: z.string().optional(),
+	})
+	.passthrough();
+
+const WorkerRouteSchema = z
+	.object({
+		id: z.string(),
+		pattern: z.string(),
+		script: z.string().optional(),
+	})
+	.passthrough();
+
+const RulesetSchema = z
+	.object({
+		id: z.string(),
+		name: z.string(),
+		description: z.string().optional(),
+		kind: z.string(),
+		version: z.string().optional(),
+		last_updated: z.string().optional(),
+		phase: z.string(),
+		rules: z.array(z.record(z.unknown())).optional(),
+	})
+	.passthrough();
+
+// ── Zones ─────────────────────────────────────────────────────────────────────
+
+const ZonesListInputSchema = PaginationInputSchema.extend({
+	name: z.string().optional(),
+	status: z.string().optional(),
+});
+
+const ZonesGetInputSchema = z.object({ zone_id: z.string() });
+
+const ZonesCreateInputSchema = z.object({
+	name: z.string(),
+	account: z.object({ id: z.string() }),
+	jump_start: z.boolean().optional(),
+});
+
+const ZonesEditInputSchema = z.object({
+	zone_id: z.string(),
+	paused: z.boolean().optional(),
+	plan: z.object({ id: z.string() }).optional(),
+	vanity_name_servers: z.array(z.string()).optional(),
+});
+
+const ZonesDeleteInputSchema = z.object({ zone_id: z.string() });
+
+// ── DNS ───────────────────────────────────────────────────────────────────────
+
+const DnsListInputSchema = PaginationInputSchema.extend({
+	zone_id: z.string(),
+	type: z.string().optional(),
+	name: z.string().optional(),
+	content: z.string().optional(),
+});
+
+const DnsGetInputSchema = z.object({
+	zone_id: z.string(),
+	dns_record_id: z.string(),
+});
+
+const DnsCreateInputSchema = z.object({
+	zone_id: z.string(),
+	type: z.string(),
+	name: z.string(),
+	content: z.string(),
+	ttl: z.number().optional(),
+	proxied: z.boolean().optional(),
+});
+
+const DnsEditInputSchema = z.object({
+	zone_id: z.string(),
+	dns_record_id: z.string(),
+	type: z.string().optional(),
+	name: z.string().optional(),
+	content: z.string().optional(),
+	ttl: z.number().optional(),
+	proxied: z.boolean().optional(),
+});
+
+const DnsDeleteInputSchema = z.object({
+	zone_id: z.string(),
+	dns_record_id: z.string(),
+});
+
+// ── Workers scripts ───────────────────────────────────────────────────────────
+
+const WorkersListInputSchema = z.object({ account_id: z.string() });
+
+const WorkersGetInputSchema = z.object({
+	account_id: z.string(),
+	script_name: z.string(),
+});
+
+const WorkersUploadInputSchema = z.object({
+	account_id: z.string(),
+	script_name: z.string(),
+	script_content: z.string(),
+	bindings: z.array(z.record(z.unknown())).optional(),
+	compatibility_date: z.string().optional(),
+});
+
+const WorkersDeleteInputSchema = z.object({
+	account_id: z.string(),
+	script_name: z.string(),
+});
+
+// ── Worker routes ─────────────────────────────────────────────────────────────
+
+const WorkerRoutesListInputSchema = z.object({ zone_id: z.string() });
+
+const WorkerRoutesGetInputSchema = z.object({
+	zone_id: z.string(),
+	route_id: z.string(),
+});
+
+const WorkerRoutesCreateInputSchema = z.object({
+	zone_id: z.string(),
+	pattern: z.string(),
+	script: z.string().optional(),
+});
+
+const WorkerRoutesEditInputSchema = z.object({
+	zone_id: z.string(),
+	route_id: z.string(),
+	pattern: z.string().optional(),
+	script: z.string().optional(),
+});
+
+const WorkerRoutesDeleteInputSchema = z.object({
+	zone_id: z.string(),
+	route_id: z.string(),
+});
+
+// ── Rulesets ──────────────────────────────────────────────────────────────────
+
+const RulesetsListInputSchema = z.object({ zone_id: z.string() });
+
+const RulesetsGetInputSchema = z.object({
+	zone_id: z.string(),
+	ruleset_id: z.string(),
+});
+
+const RulesetsCreateInputSchema = z.object({
+	zone_id: z.string(),
+	name: z.string(),
+	kind: z.string(),
+	phase: z.string(),
+	rules: z.array(z.record(z.unknown())).optional(),
+	description: z.string().optional(),
+});
+
+const RulesetsUpdateInputSchema = z.object({
+	zone_id: z.string(),
+	ruleset_id: z.string(),
+	rules: z.array(z.record(z.unknown())),
+	description: z.string().optional(),
+});
+
+const RulesetsDeleteInputSchema = z.object({
+	zone_id: z.string(),
+	ruleset_id: z.string(),
+});
+
+// ── Type exports ──────────────────────────────────────────────────────────────
+
+export type ZonesListInput = z.infer<typeof ZonesListInputSchema>;
+export type ZonesGetInput = z.infer<typeof ZonesGetInputSchema>;
+export type ZonesCreateInput = z.infer<typeof ZonesCreateInputSchema>;
+export type ZonesEditInput = z.infer<typeof ZonesEditInputSchema>;
+export type ZonesDeleteInput = z.infer<typeof ZonesDeleteInputSchema>;
+
+export type DnsListInput = z.infer<typeof DnsListInputSchema>;
+export type DnsGetInput = z.infer<typeof DnsGetInputSchema>;
+export type DnsCreateInput = z.infer<typeof DnsCreateInputSchema>;
+export type DnsEditInput = z.infer<typeof DnsEditInputSchema>;
+export type DnsDeleteInput = z.infer<typeof DnsDeleteInputSchema>;
+
+export type WorkersListInput = z.infer<typeof WorkersListInputSchema>;
+export type WorkersGetInput = z.infer<typeof WorkersGetInputSchema>;
+export type WorkersUploadInput = z.infer<typeof WorkersUploadInputSchema>;
+export type WorkersDeleteInput = z.infer<typeof WorkersDeleteInputSchema>;
+
+export type WorkerRoutesListInput = z.infer<typeof WorkerRoutesListInputSchema>;
+export type WorkerRoutesGetInput = z.infer<typeof WorkerRoutesGetInputSchema>;
+export type WorkerRoutesCreateInput = z.infer<
+	typeof WorkerRoutesCreateInputSchema
+>;
+export type WorkerRoutesEditInput = z.infer<typeof WorkerRoutesEditInputSchema>;
+export type WorkerRoutesDeleteInput = z.infer<
+	typeof WorkerRoutesDeleteInputSchema
+>;
+
+export type RulesetsListInput = z.infer<typeof RulesetsListInputSchema>;
+export type RulesetsGetInput = z.infer<typeof RulesetsGetInputSchema>;
+export type RulesetsCreateInput = z.infer<typeof RulesetsCreateInputSchema>;
+export type RulesetsUpdateInput = z.infer<typeof RulesetsUpdateInputSchema>;
+export type RulesetsDeleteInput = z.infer<typeof RulesetsDeleteInputSchema>;
+
+export type ZonesListResponse = z.infer<typeof ZoneSchema>[];
+export type ZonesGetResponse = z.infer<typeof ZoneSchema>;
+export type ZonesCreateResponse = z.infer<typeof ZoneSchema>;
+export type ZonesEditResponse = z.infer<typeof ZoneSchema>;
+export type ZonesDeleteResponse = z.infer<typeof IdDeleteResponseSchema>;
+
+export type DnsListResponse = z.infer<typeof DnsRecordSchema>[];
+export type DnsGetResponse = z.infer<typeof DnsRecordSchema>;
+export type DnsCreateResponse = z.infer<typeof DnsRecordSchema>;
+export type DnsEditResponse = z.infer<typeof DnsRecordSchema>;
+export type DnsDeleteResponse = z.infer<typeof IdDeleteResponseSchema>;
+
+export type WorkersListResponse = z.infer<typeof WorkerScriptSchema>[];
+export type WorkersGetResponse = z.infer<typeof WorkerScriptSchema>;
+export type WorkersUploadResponse = z.infer<typeof WorkerScriptSchema>;
+export type WorkersDeleteResponse = Record<string, never>;
+
+export type WorkerRoutesListResponse = z.infer<typeof WorkerRouteSchema>[];
+export type WorkerRoutesGetResponse = z.infer<typeof WorkerRouteSchema>;
+export type WorkerRoutesCreateResponse = z.infer<typeof WorkerRouteSchema>;
+export type WorkerRoutesEditResponse = z.infer<typeof WorkerRouteSchema>;
+export type WorkerRoutesDeleteResponse = z.infer<typeof IdDeleteResponseSchema>;
+
+export type RulesetsListResponse = z.infer<typeof RulesetSchema>[];
+export type RulesetsGetResponse = z.infer<typeof RulesetSchema>;
+export type RulesetsCreateResponse = z.infer<typeof RulesetSchema>;
+export type RulesetsUpdateResponse = z.infer<typeof RulesetSchema>;
+export type RulesetsDeleteResponse = Record<string, never>;
+
+export type CloudflareEndpointInputs = {
+	zonesList: ZonesListInput;
+	zonesGet: ZonesGetInput;
+	zonesCreate: ZonesCreateInput;
+	zonesEdit: ZonesEditInput;
+	zonesDelete: ZonesDeleteInput;
+	dnsList: DnsListInput;
+	dnsGet: DnsGetInput;
+	dnsCreate: DnsCreateInput;
+	dnsEdit: DnsEditInput;
+	dnsDelete: DnsDeleteInput;
+	workersList: WorkersListInput;
+	workersGet: WorkersGetInput;
+	workersUpload: WorkersUploadInput;
+	workersDelete: WorkersDeleteInput;
+	workerRoutesList: WorkerRoutesListInput;
+	workerRoutesGet: WorkerRoutesGetInput;
+	workerRoutesCreate: WorkerRoutesCreateInput;
+	workerRoutesEdit: WorkerRoutesEditInput;
+	workerRoutesDelete: WorkerRoutesDeleteInput;
+	rulesetsList: RulesetsListInput;
+	rulesetsGet: RulesetsGetInput;
+	rulesetsCreate: RulesetsCreateInput;
+	rulesetsUpdate: RulesetsUpdateInput;
+	rulesetsDelete: RulesetsDeleteInput;
+};
+
+export type CloudflareEndpointOutputs = {
+	zonesList: ZonesListResponse;
+	zonesGet: ZonesGetResponse;
+	zonesCreate: ZonesCreateResponse;
+	zonesEdit: ZonesEditResponse;
+	zonesDelete: ZonesDeleteResponse;
+	dnsList: DnsListResponse;
+	dnsGet: DnsGetResponse;
+	dnsCreate: DnsCreateResponse;
+	dnsEdit: DnsEditResponse;
+	dnsDelete: DnsDeleteResponse;
+	workersList: WorkersListResponse;
+	workersGet: WorkersGetResponse;
+	workersUpload: WorkersUploadResponse;
+	workersDelete: WorkersDeleteResponse;
+	workerRoutesList: WorkerRoutesListResponse;
+	workerRoutesGet: WorkerRoutesGetResponse;
+	workerRoutesCreate: WorkerRoutesCreateResponse;
+	workerRoutesEdit: WorkerRoutesEditResponse;
+	workerRoutesDelete: WorkerRoutesDeleteResponse;
+	rulesetsList: RulesetsListResponse;
+	rulesetsGet: RulesetsGetResponse;
+	rulesetsCreate: RulesetsCreateResponse;
+	rulesetsUpdate: RulesetsUpdateResponse;
+	rulesetsDelete: RulesetsDeleteResponse;
+};
+
+export const CloudflareEndpointInputSchemas = {
+	zonesList: ZonesListInputSchema,
+	zonesGet: ZonesGetInputSchema,
+	zonesCreate: ZonesCreateInputSchema,
+	zonesEdit: ZonesEditInputSchema,
+	zonesDelete: ZonesDeleteInputSchema,
+	dnsList: DnsListInputSchema,
+	dnsGet: DnsGetInputSchema,
+	dnsCreate: DnsCreateInputSchema,
+	dnsEdit: DnsEditInputSchema,
+	dnsDelete: DnsDeleteInputSchema,
+	workersList: WorkersListInputSchema,
+	workersGet: WorkersGetInputSchema,
+	workersUpload: WorkersUploadInputSchema,
+	workersDelete: WorkersDeleteInputSchema,
+	workerRoutesList: WorkerRoutesListInputSchema,
+	workerRoutesGet: WorkerRoutesGetInputSchema,
+	workerRoutesCreate: WorkerRoutesCreateInputSchema,
+	workerRoutesEdit: WorkerRoutesEditInputSchema,
+	workerRoutesDelete: WorkerRoutesDeleteInputSchema,
+	rulesetsList: RulesetsListInputSchema,
+	rulesetsGet: RulesetsGetInputSchema,
+	rulesetsCreate: RulesetsCreateInputSchema,
+	rulesetsUpdate: RulesetsUpdateInputSchema,
+	rulesetsDelete: RulesetsDeleteInputSchema,
+} as const;
+
+export const CloudflareEndpointOutputSchemas = {
+	zonesList: z.array(ZoneSchema),
+	zonesGet: ZoneSchema,
+	zonesCreate: ZoneSchema,
+	zonesEdit: ZoneSchema,
+	zonesDelete: IdDeleteResponseSchema,
+	dnsList: z.array(DnsRecordSchema),
+	dnsGet: DnsRecordSchema,
+	dnsCreate: DnsRecordSchema,
+	dnsEdit: DnsRecordSchema,
+	dnsDelete: IdDeleteResponseSchema,
+	workersList: z.array(WorkerScriptSchema),
+	workersGet: WorkerScriptSchema,
+	workersUpload: WorkerScriptSchema,
+	workersDelete: z.object({}).passthrough(),
+	workerRoutesList: z.array(WorkerRouteSchema),
+	workerRoutesGet: WorkerRouteSchema,
+	workerRoutesCreate: WorkerRouteSchema,
+	workerRoutesEdit: WorkerRouteSchema,
+	workerRoutesDelete: IdDeleteResponseSchema,
+	rulesetsList: z.array(RulesetSchema),
+	rulesetsGet: RulesetSchema,
+	rulesetsCreate: RulesetSchema,
+	rulesetsUpdate: RulesetSchema,
+	rulesetsDelete: z.object({}).passthrough(),
+} as const;

--- a/packages/cloudflare/endpoints/types.ts
+++ b/packages/cloudflare/endpoints/types.ts
@@ -2,6 +2,14 @@ import { z } from 'zod';
 
 // ── Shared schemas ────────────────────────────────────────────────────────────
 
+/** Nested CF objects (bindings, rules, account metadata) are API-extensible. */
+const CloudflareLooseObjectSchema = z.record(z.unknown());
+
+const ZoneAccountSchema = z
+	.object({ id: z.string() })
+	.passthrough()
+	.optional();
+
 const PaginationInputSchema = z.object({
 	page: z.number().optional(),
 	per_page: z.number().optional(),
@@ -16,7 +24,7 @@ const ZoneSchema = z
 		status: z.string().optional(),
 		paused: z.boolean().optional(),
 		type: z.string().optional(),
-		account: z.record(z.unknown()).optional(),
+		account: ZoneAccountSchema,
 		name_servers: z.array(z.string()).optional(),
 		original_name_servers: z.array(z.string()).optional(),
 		original_registrar: z.string().optional(),
@@ -69,7 +77,7 @@ const RulesetSchema = z
 		version: z.string().optional(),
 		last_updated: z.string().optional(),
 		phase: z.string(),
-		rules: z.array(z.record(z.unknown())).optional(),
+		rules: z.array(CloudflareLooseObjectSchema).optional(),
 	})
 	.passthrough();
 
@@ -148,7 +156,7 @@ const WorkersUploadInputSchema = z.object({
 	account_id: z.string(),
 	script_name: z.string(),
 	script_content: z.string(),
-	bindings: z.array(z.record(z.unknown())).optional(),
+	bindings: z.array(CloudflareLooseObjectSchema).optional(),
 	compatibility_date: z.string().optional(),
 });
 
@@ -198,14 +206,14 @@ const RulesetsCreateInputSchema = z.object({
 	name: z.string(),
 	kind: z.string(),
 	phase: z.string(),
-	rules: z.array(z.record(z.unknown())).optional(),
+	rules: z.array(CloudflareLooseObjectSchema).optional(),
 	description: z.string().optional(),
 });
 
 const RulesetsUpdateInputSchema = z.object({
 	zone_id: z.string(),
 	ruleset_id: z.string(),
-	rules: z.array(z.record(z.unknown())),
+	rules: z.array(CloudflareLooseObjectSchema),
 	description: z.string().optional(),
 });
 
@@ -262,7 +270,8 @@ export type DnsEditResponse = z.infer<typeof DnsRecordSchema>;
 export type DnsDeleteResponse = z.infer<typeof IdDeleteResponseSchema>;
 
 export type WorkersListResponse = z.infer<typeof WorkerScriptSchema>[];
-export type WorkersGetResponse = z.infer<typeof WorkerScriptSchema>;
+/** Raw Worker script source (`application/javascript`), not JSON metadata. */
+export type WorkersGetResponse = string;
 export type WorkersUploadResponse = z.infer<typeof WorkerScriptSchema>;
 export type WorkersDeleteResponse = Record<string, never>;
 
@@ -371,7 +380,7 @@ export const CloudflareEndpointOutputSchemas = {
 	dnsEdit: DnsRecordSchema,
 	dnsDelete: IdDeleteResponseSchema,
 	workersList: z.array(WorkerScriptSchema),
-	workersGet: WorkerScriptSchema,
+	workersGet: z.string(),
 	workersUpload: WorkerScriptSchema,
 	workersDelete: z.object({}).passthrough(),
 	workerRoutesList: z.array(WorkerRouteSchema),

--- a/packages/cloudflare/endpoints/types.ts
+++ b/packages/cloudflare/endpoints/types.ts
@@ -126,6 +126,8 @@ const DnsCreateInputSchema = z.object({
 	content: z.string(),
 	ttl: z.number().optional(),
 	proxied: z.boolean().optional(),
+	/** Required for MX, SRV, and URI record types. */
+	priority: z.number().optional(),
 });
 
 const DnsEditInputSchema = z.object({
@@ -136,6 +138,7 @@ const DnsEditInputSchema = z.object({
 	content: z.string().optional(),
 	ttl: z.number().optional(),
 	proxied: z.boolean().optional(),
+	priority: z.number().optional(),
 });
 
 const DnsDeleteInputSchema = z.object({
@@ -273,7 +276,8 @@ export type WorkersListResponse = z.infer<typeof WorkerScriptSchema>[];
 /** Raw Worker script source (`application/javascript`), not JSON metadata. */
 export type WorkersGetResponse = string;
 export type WorkersUploadResponse = z.infer<typeof WorkerScriptSchema>;
-export type WorkersDeleteResponse = Record<string, never>;
+/** Cloudflare DELETE scripts returns `{ result: null }`. */
+export type WorkersDeleteResponse = null;
 
 export type WorkerRoutesListResponse = z.infer<typeof WorkerRouteSchema>[];
 export type WorkerRoutesGetResponse = z.infer<typeof WorkerRouteSchema>;
@@ -285,7 +289,8 @@ export type RulesetsListResponse = z.infer<typeof RulesetSchema>[];
 export type RulesetsGetResponse = z.infer<typeof RulesetSchema>;
 export type RulesetsCreateResponse = z.infer<typeof RulesetSchema>;
 export type RulesetsUpdateResponse = z.infer<typeof RulesetSchema>;
-export type RulesetsDeleteResponse = Record<string, never>;
+/** Cloudflare DELETE rulesets returns `{ result: null }`. */
+export type RulesetsDeleteResponse = null;
 
 export type CloudflareEndpointInputs = {
 	zonesList: ZonesListInput;
@@ -382,7 +387,7 @@ export const CloudflareEndpointOutputSchemas = {
 	workersList: z.array(WorkerScriptSchema),
 	workersGet: z.string(),
 	workersUpload: WorkerScriptSchema,
-	workersDelete: z.object({}).passthrough(),
+	workersDelete: z.null(),
 	workerRoutesList: z.array(WorkerRouteSchema),
 	workerRoutesGet: WorkerRouteSchema,
 	workerRoutesCreate: WorkerRouteSchema,
@@ -392,5 +397,5 @@ export const CloudflareEndpointOutputSchemas = {
 	rulesetsGet: RulesetSchema,
 	rulesetsCreate: RulesetSchema,
 	rulesetsUpdate: RulesetSchema,
-	rulesetsDelete: z.object({}).passthrough(),
+	rulesetsDelete: z.null(),
 } as const;

--- a/packages/cloudflare/endpoints/workers.ts
+++ b/packages/cloudflare/endpoints/workers.ts
@@ -1,0 +1,192 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeCloudflareRequest } from '../client';
+import type { CloudflareEndpoints } from '../index';
+import type { CloudflareEndpointOutputs } from './types';
+
+export const list: CloudflareEndpoints['workersList'] = async (ctx, input) => {
+	const { account_id } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['workersList']
+	>(`/accounts/${account_id}/workers/scripts`, ctx.key, { method: 'GET' });
+	await logEventFromContext(
+		ctx,
+		'cloudflare.workers.scripts.list',
+		{ account_id },
+		'completed',
+	);
+	return result;
+};
+
+export const get: CloudflareEndpoints['workersGet'] = async (ctx, input) => {
+	const { account_id, script_name } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['workersGet']
+	>(`/accounts/${account_id}/workers/scripts/${script_name}`, ctx.key, {
+		method: 'GET',
+	});
+	await logEventFromContext(
+		ctx,
+		'cloudflare.workers.scripts.get',
+		{ account_id, script_name },
+		'completed',
+	);
+	return result;
+};
+
+export const upload: CloudflareEndpoints['workersUpload'] = async (
+	ctx,
+	input,
+) => {
+	const {
+		account_id,
+		script_name,
+		script_content,
+		bindings,
+		compatibility_date,
+	} = input;
+
+	const path = `/accounts/${account_id}/workers/scripts/${script_name}`;
+	const hasMetadata = bindings != null || compatibility_date != null;
+
+	const result = hasMetadata
+		? await makeCloudflareRequest<CloudflareEndpointOutputs['workersUpload']>(
+				path,
+				ctx.key,
+				{
+					method: 'PUT',
+					formData: {
+						metadata: JSON.stringify({
+							...(bindings != null ? { bindings } : {}),
+							...(compatibility_date != null ? { compatibility_date } : {}),
+						}),
+						script: script_content,
+					},
+				},
+			)
+		: await makeCloudflareRequest<CloudflareEndpointOutputs['workersUpload']>(
+				path,
+				ctx.key,
+				{
+					method: 'PUT',
+					rawBody: script_content,
+					mediaType: 'application/javascript',
+				},
+			);
+
+	await logEventFromContext(
+		ctx,
+		'cloudflare.workers.scripts.upload',
+		{ account_id, script_name },
+		'completed',
+	);
+	return result;
+};
+
+export const deleteWorker: CloudflareEndpoints['workersDelete'] = async (
+	ctx,
+	input,
+) => {
+	const { account_id, script_name } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['workersDelete']
+	>(`/accounts/${account_id}/workers/scripts/${script_name}`, ctx.key, {
+		method: 'DELETE',
+	});
+	await logEventFromContext(
+		ctx,
+		'cloudflare.workers.scripts.delete',
+		{ account_id, script_name },
+		'completed',
+	);
+	return result;
+};
+
+export const routesList: CloudflareEndpoints['workerRoutesList'] = async (
+	ctx,
+	input,
+) => {
+	const { zone_id } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['workerRoutesList']
+	>(`/zones/${zone_id}/workers/routes`, ctx.key, { method: 'GET' });
+	await logEventFromContext(
+		ctx,
+		'cloudflare.workers.routes.list',
+		{ zone_id },
+		'completed',
+	);
+	return result;
+};
+
+export const routesGet: CloudflareEndpoints['workerRoutesGet'] = async (
+	ctx,
+	input,
+) => {
+	const { zone_id, route_id } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['workerRoutesGet']
+	>(`/zones/${zone_id}/workers/routes/${route_id}`, ctx.key, { method: 'GET' });
+	await logEventFromContext(
+		ctx,
+		'cloudflare.workers.routes.get',
+		{ zone_id, route_id },
+		'completed',
+	);
+	return result;
+};
+
+export const routesCreate: CloudflareEndpoints['workerRoutesCreate'] = async (
+	ctx,
+	input,
+) => {
+	const { zone_id, ...body } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['workerRoutesCreate']
+	>(`/zones/${zone_id}/workers/routes`, ctx.key, { method: 'POST', body });
+	await logEventFromContext(
+		ctx,
+		'cloudflare.workers.routes.create',
+		{ zone_id },
+		'completed',
+	);
+	return result;
+};
+
+export const routesEdit: CloudflareEndpoints['workerRoutesEdit'] = async (
+	ctx,
+	input,
+) => {
+	const { zone_id, route_id, ...body } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['workerRoutesEdit']
+	>(`/zones/${zone_id}/workers/routes/${route_id}`, ctx.key, {
+		method: 'PUT',
+		body,
+	});
+	await logEventFromContext(
+		ctx,
+		'cloudflare.workers.routes.edit',
+		{ zone_id, route_id },
+		'completed',
+	);
+	return result;
+};
+
+export const routesDelete: CloudflareEndpoints['workerRoutesDelete'] = async (
+	ctx,
+	input,
+) => {
+	const { zone_id, route_id } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['workerRoutesDelete']
+	>(`/zones/${zone_id}/workers/routes/${route_id}`, ctx.key, {
+		method: 'DELETE',
+	});
+	await logEventFromContext(
+		ctx,
+		'cloudflare.workers.routes.delete',
+		{ zone_id, route_id },
+		'completed',
+	);
+	return result;
+};

--- a/packages/cloudflare/endpoints/workers.ts
+++ b/packages/cloudflare/endpoints/workers.ts
@@ -1,6 +1,12 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeCloudflareRequest } from '../client';
 import type { CloudflareEndpoints } from '../index';
+import {
+	deleteWorkerRoute,
+	deleteWorkerScript,
+	persistWorkerRoute,
+	persistWorkerScript,
+} from '../persist';
 import type { CloudflareEndpointOutputs } from './types';
 
 export const list: CloudflareEndpoints['workersList'] = async (ctx, input) => {
@@ -8,6 +14,13 @@ export const list: CloudflareEndpoints['workersList'] = async (ctx, input) => {
 	const result = await makeCloudflareRequest<
 		CloudflareEndpointOutputs['workersList']
 	>(`/accounts/${account_id}/workers/scripts`, ctx.key, { method: 'GET' });
+
+	if (ctx.db.workerScripts) {
+		for (const script of result) {
+			await persistWorkerScript(script, account_id, ctx.db);
+		}
+	}
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.workers.scripts.list',
@@ -17,6 +30,7 @@ export const list: CloudflareEndpoints['workersList'] = async (ctx, input) => {
 	return result;
 };
 
+/** Returns raw script source; not persisted locally (use list/upload metadata). */
 export const get: CloudflareEndpoints['workersGet'] = async (ctx, input) => {
 	const { account_id, script_name } = input;
 	const result = await makeCloudflareRequest<
@@ -73,6 +87,12 @@ export const upload: CloudflareEndpoints['workersUpload'] = async (
 				},
 			);
 
+	await persistWorkerScript(
+		{ ...result, id: result.id ?? script_name },
+		account_id,
+		ctx.db,
+	);
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.workers.scripts.upload',
@@ -92,6 +112,9 @@ export const deleteWorker: CloudflareEndpoints['workersDelete'] = async (
 	>(`/accounts/${account_id}/workers/scripts/${script_name}`, ctx.key, {
 		method: 'DELETE',
 	});
+
+	await deleteWorkerScript(script_name, ctx.db);
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.workers.scripts.delete',
@@ -109,6 +132,13 @@ export const routesList: CloudflareEndpoints['workerRoutesList'] = async (
 	const result = await makeCloudflareRequest<
 		CloudflareEndpointOutputs['workerRoutesList']
 	>(`/zones/${zone_id}/workers/routes`, ctx.key, { method: 'GET' });
+
+	if (ctx.db.workerRoutes) {
+		for (const route of result) {
+			await persistWorkerRoute(route, zone_id, ctx.db);
+		}
+	}
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.workers.routes.list',
@@ -126,6 +156,9 @@ export const routesGet: CloudflareEndpoints['workerRoutesGet'] = async (
 	const result = await makeCloudflareRequest<
 		CloudflareEndpointOutputs['workerRoutesGet']
 	>(`/zones/${zone_id}/workers/routes/${route_id}`, ctx.key, { method: 'GET' });
+
+	await persistWorkerRoute(result, zone_id, ctx.db);
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.workers.routes.get',
@@ -143,6 +176,9 @@ export const routesCreate: CloudflareEndpoints['workerRoutesCreate'] = async (
 	const result = await makeCloudflareRequest<
 		CloudflareEndpointOutputs['workerRoutesCreate']
 	>(`/zones/${zone_id}/workers/routes`, ctx.key, { method: 'POST', body });
+
+	await persistWorkerRoute(result, zone_id, ctx.db);
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.workers.routes.create',
@@ -163,6 +199,9 @@ export const routesEdit: CloudflareEndpoints['workerRoutesEdit'] = async (
 		method: 'PUT',
 		body,
 	});
+
+	await persistWorkerRoute(result, zone_id, ctx.db);
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.workers.routes.edit',
@@ -182,6 +221,9 @@ export const routesDelete: CloudflareEndpoints['workerRoutesDelete'] = async (
 	>(`/zones/${zone_id}/workers/routes/${route_id}`, ctx.key, {
 		method: 'DELETE',
 	});
+
+	await deleteWorkerRoute(route_id, ctx.db);
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.workers.routes.delete',

--- a/packages/cloudflare/endpoints/zones.ts
+++ b/packages/cloudflare/endpoints/zones.ts
@@ -1,0 +1,78 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeCloudflareRequest } from '../client';
+import type { CloudflareEndpoints } from '../index';
+import type { CloudflareEndpointOutputs } from './types';
+
+export const list: CloudflareEndpoints['zonesList'] = async (ctx, input) => {
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['zonesList']
+	>('/zones', ctx.key, { method: 'GET', query: { ...input } });
+	await logEventFromContext(
+		ctx,
+		'cloudflare.zones.list',
+		{ ...input },
+		'completed',
+	);
+	return result;
+};
+
+export const get: CloudflareEndpoints['zonesGet'] = async (ctx, input) => {
+	const { zone_id } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['zonesGet']
+	>(`/zones/${zone_id}`, ctx.key, { method: 'GET' });
+	await logEventFromContext(
+		ctx,
+		'cloudflare.zones.get',
+		{ zone_id },
+		'completed',
+	);
+	return result;
+};
+
+export const create: CloudflareEndpoints['zonesCreate'] = async (
+	ctx,
+	input,
+) => {
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['zonesCreate']
+	>('/zones', ctx.key, { method: 'POST', body: { ...input } });
+	await logEventFromContext(
+		ctx,
+		'cloudflare.zones.create',
+		{ ...input },
+		'completed',
+	);
+	return result;
+};
+
+export const edit: CloudflareEndpoints['zonesEdit'] = async (ctx, input) => {
+	const { zone_id, ...body } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['zonesEdit']
+	>(`/zones/${zone_id}`, ctx.key, { method: 'PATCH', body });
+	await logEventFromContext(
+		ctx,
+		'cloudflare.zones.edit',
+		{ zone_id },
+		'completed',
+	);
+	return result;
+};
+
+export const deleteZone: CloudflareEndpoints['zonesDelete'] = async (
+	ctx,
+	input,
+) => {
+	const { zone_id } = input;
+	const result = await makeCloudflareRequest<
+		CloudflareEndpointOutputs['zonesDelete']
+	>(`/zones/${zone_id}`, ctx.key, { method: 'DELETE' });
+	await logEventFromContext(
+		ctx,
+		'cloudflare.zones.delete',
+		{ zone_id },
+		'completed',
+	);
+	return result;
+};

--- a/packages/cloudflare/endpoints/zones.ts
+++ b/packages/cloudflare/endpoints/zones.ts
@@ -1,12 +1,20 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeCloudflareRequest } from '../client';
 import type { CloudflareEndpoints } from '../index';
+import { deleteZone as removeZoneFromDb, persistZone } from '../persist';
 import type { CloudflareEndpointOutputs } from './types';
 
 export const list: CloudflareEndpoints['zonesList'] = async (ctx, input) => {
 	const result = await makeCloudflareRequest<
 		CloudflareEndpointOutputs['zonesList']
 	>('/zones', ctx.key, { method: 'GET', query: { ...input } });
+
+	if (ctx.db.zones) {
+		for (const zone of result) {
+			await persistZone(zone, ctx.db);
+		}
+	}
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.zones.list',
@@ -21,6 +29,9 @@ export const get: CloudflareEndpoints['zonesGet'] = async (ctx, input) => {
 	const result = await makeCloudflareRequest<
 		CloudflareEndpointOutputs['zonesGet']
 	>(`/zones/${zone_id}`, ctx.key, { method: 'GET' });
+
+	await persistZone(result, ctx.db);
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.zones.get',
@@ -37,6 +48,9 @@ export const create: CloudflareEndpoints['zonesCreate'] = async (
 	const result = await makeCloudflareRequest<
 		CloudflareEndpointOutputs['zonesCreate']
 	>('/zones', ctx.key, { method: 'POST', body: { ...input } });
+
+	await persistZone(result, ctx.db);
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.zones.create',
@@ -51,6 +65,9 @@ export const edit: CloudflareEndpoints['zonesEdit'] = async (ctx, input) => {
 	const result = await makeCloudflareRequest<
 		CloudflareEndpointOutputs['zonesEdit']
 	>(`/zones/${zone_id}`, ctx.key, { method: 'PATCH', body });
+
+	await persistZone(result, ctx.db);
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.zones.edit',
@@ -68,6 +85,9 @@ export const deleteZone: CloudflareEndpoints['zonesDelete'] = async (
 	const result = await makeCloudflareRequest<
 		CloudflareEndpointOutputs['zonesDelete']
 	>(`/zones/${zone_id}`, ctx.key, { method: 'DELETE' });
+
+	await removeZoneFromDb(zone_id, ctx.db);
+
 	await logEventFromContext(
 		ctx,
 		'cloudflare.zones.delete',

--- a/packages/cloudflare/error-handlers.ts
+++ b/packages/cloudflare/error-handlers.ts
@@ -1,0 +1,31 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('429');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('unauthorized') || msg.includes('invalid_auth');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 3 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/cloudflare/error-handlers.ts
+++ b/packages/cloudflare/error-handlers.ts
@@ -6,7 +6,7 @@ export const errorHandlers = {
 		match: (error: Error) => {
 			if (error instanceof ApiError && error.status === 429) return true;
 			const msg = error.message.toLowerCase();
-			return msg.includes('rate_limited') || msg.includes('429');
+			return msg.includes('rate_limited') || msg.includes('too many requests');
 		},
 		handler: async (error: Error) => {
 			let retryAfterMs: number | undefined;

--- a/packages/cloudflare/index.ts
+++ b/packages/cloudflare/index.ts
@@ -1,0 +1,408 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+} from 'corsair/core';
+import {
+	DNSEndpoints,
+	RulesetsEndpoints,
+	WorkerRoutesEndpoints,
+	WorkersEndpoints,
+	ZonesEndpoints,
+} from './endpoints';
+import type {
+	CloudflareEndpointInputs,
+	CloudflareEndpointOutputs,
+} from './endpoints/types';
+import {
+	CloudflareEndpointInputSchemas,
+	CloudflareEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { CloudflareSchema } from './schema';
+
+export type CloudflarePluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	hooks?: InternalCloudflarePlugin['hooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof cloudflareEndpointsNested>;
+};
+
+export type CloudflareContext = CorsairPluginContext<
+	typeof CloudflareSchema,
+	CloudflarePluginOptions
+>;
+
+export type CloudflareKeyBuilderContext =
+	KeyBuilderContext<CloudflarePluginOptions>;
+
+export type CloudflareBoundEndpoints = BindEndpoints<
+	typeof cloudflareEndpointsNested
+>;
+
+type CloudflareEndpoint<K extends keyof CloudflareEndpointOutputs> =
+	CorsairEndpoint<
+		CloudflareContext,
+		CloudflareEndpointInputs[K],
+		CloudflareEndpointOutputs[K]
+	>;
+
+export type CloudflareEndpoints = {
+	zonesList: CloudflareEndpoint<'zonesList'>;
+	zonesGet: CloudflareEndpoint<'zonesGet'>;
+	zonesCreate: CloudflareEndpoint<'zonesCreate'>;
+	zonesEdit: CloudflareEndpoint<'zonesEdit'>;
+	zonesDelete: CloudflareEndpoint<'zonesDelete'>;
+	dnsList: CloudflareEndpoint<'dnsList'>;
+	dnsGet: CloudflareEndpoint<'dnsGet'>;
+	dnsCreate: CloudflareEndpoint<'dnsCreate'>;
+	dnsEdit: CloudflareEndpoint<'dnsEdit'>;
+	dnsDelete: CloudflareEndpoint<'dnsDelete'>;
+	workersList: CloudflareEndpoint<'workersList'>;
+	workersGet: CloudflareEndpoint<'workersGet'>;
+	workersUpload: CloudflareEndpoint<'workersUpload'>;
+	workersDelete: CloudflareEndpoint<'workersDelete'>;
+	workerRoutesList: CloudflareEndpoint<'workerRoutesList'>;
+	workerRoutesGet: CloudflareEndpoint<'workerRoutesGet'>;
+	workerRoutesCreate: CloudflareEndpoint<'workerRoutesCreate'>;
+	workerRoutesEdit: CloudflareEndpoint<'workerRoutesEdit'>;
+	workerRoutesDelete: CloudflareEndpoint<'workerRoutesDelete'>;
+	rulesetsList: CloudflareEndpoint<'rulesetsList'>;
+	rulesetsGet: CloudflareEndpoint<'rulesetsGet'>;
+	rulesetsCreate: CloudflareEndpoint<'rulesetsCreate'>;
+	rulesetsUpdate: CloudflareEndpoint<'rulesetsUpdate'>;
+	rulesetsDelete: CloudflareEndpoint<'rulesetsDelete'>;
+};
+
+const cloudflareEndpointsNested = {
+	zones: ZonesEndpoints,
+	dns: DNSEndpoints,
+	workers: {
+		scripts: WorkersEndpoints,
+		routes: WorkerRoutesEndpoints,
+	},
+	rulesets: RulesetsEndpoints,
+} as const;
+
+export const cloudflareEndpointSchemas = {
+	'zones.list': {
+		input: CloudflareEndpointInputSchemas.zonesList,
+		output: CloudflareEndpointOutputSchemas.zonesList,
+	},
+	'zones.get': {
+		input: CloudflareEndpointInputSchemas.zonesGet,
+		output: CloudflareEndpointOutputSchemas.zonesGet,
+	},
+	'zones.create': {
+		input: CloudflareEndpointInputSchemas.zonesCreate,
+		output: CloudflareEndpointOutputSchemas.zonesCreate,
+	},
+	'zones.edit': {
+		input: CloudflareEndpointInputSchemas.zonesEdit,
+		output: CloudflareEndpointOutputSchemas.zonesEdit,
+	},
+	'zones.delete': {
+		input: CloudflareEndpointInputSchemas.zonesDelete,
+		output: CloudflareEndpointOutputSchemas.zonesDelete,
+	},
+	'dns.list': {
+		input: CloudflareEndpointInputSchemas.dnsList,
+		output: CloudflareEndpointOutputSchemas.dnsList,
+	},
+	'dns.get': {
+		input: CloudflareEndpointInputSchemas.dnsGet,
+		output: CloudflareEndpointOutputSchemas.dnsGet,
+	},
+	'dns.create': {
+		input: CloudflareEndpointInputSchemas.dnsCreate,
+		output: CloudflareEndpointOutputSchemas.dnsCreate,
+	},
+	'dns.edit': {
+		input: CloudflareEndpointInputSchemas.dnsEdit,
+		output: CloudflareEndpointOutputSchemas.dnsEdit,
+	},
+	'dns.delete': {
+		input: CloudflareEndpointInputSchemas.dnsDelete,
+		output: CloudflareEndpointOutputSchemas.dnsDelete,
+	},
+	'workers.scripts.list': {
+		input: CloudflareEndpointInputSchemas.workersList,
+		output: CloudflareEndpointOutputSchemas.workersList,
+	},
+	'workers.scripts.get': {
+		input: CloudflareEndpointInputSchemas.workersGet,
+		output: CloudflareEndpointOutputSchemas.workersGet,
+	},
+	'workers.scripts.upload': {
+		input: CloudflareEndpointInputSchemas.workersUpload,
+		output: CloudflareEndpointOutputSchemas.workersUpload,
+	},
+	'workers.scripts.delete': {
+		input: CloudflareEndpointInputSchemas.workersDelete,
+		output: CloudflareEndpointOutputSchemas.workersDelete,
+	},
+	'workers.routes.list': {
+		input: CloudflareEndpointInputSchemas.workerRoutesList,
+		output: CloudflareEndpointOutputSchemas.workerRoutesList,
+	},
+	'workers.routes.get': {
+		input: CloudflareEndpointInputSchemas.workerRoutesGet,
+		output: CloudflareEndpointOutputSchemas.workerRoutesGet,
+	},
+	'workers.routes.create': {
+		input: CloudflareEndpointInputSchemas.workerRoutesCreate,
+		output: CloudflareEndpointOutputSchemas.workerRoutesCreate,
+	},
+	'workers.routes.edit': {
+		input: CloudflareEndpointInputSchemas.workerRoutesEdit,
+		output: CloudflareEndpointOutputSchemas.workerRoutesEdit,
+	},
+	'workers.routes.delete': {
+		input: CloudflareEndpointInputSchemas.workerRoutesDelete,
+		output: CloudflareEndpointOutputSchemas.workerRoutesDelete,
+	},
+	'rulesets.list': {
+		input: CloudflareEndpointInputSchemas.rulesetsList,
+		output: CloudflareEndpointOutputSchemas.rulesetsList,
+	},
+	'rulesets.get': {
+		input: CloudflareEndpointInputSchemas.rulesetsGet,
+		output: CloudflareEndpointOutputSchemas.rulesetsGet,
+	},
+	'rulesets.create': {
+		input: CloudflareEndpointInputSchemas.rulesetsCreate,
+		output: CloudflareEndpointOutputSchemas.rulesetsCreate,
+	},
+	'rulesets.update': {
+		input: CloudflareEndpointInputSchemas.rulesetsUpdate,
+		output: CloudflareEndpointOutputSchemas.rulesetsUpdate,
+	},
+	'rulesets.delete': {
+		input: CloudflareEndpointInputSchemas.rulesetsDelete,
+		output: CloudflareEndpointOutputSchemas.rulesetsDelete,
+	},
+} as const;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const cloudflareEndpointMeta = {
+	'zones.list': {
+		riskLevel: 'read',
+		description: 'List Cloudflare zones',
+	},
+	'zones.get': {
+		riskLevel: 'read',
+		description: 'Retrieve a Cloudflare zone by ID',
+	},
+	'zones.create': {
+		riskLevel: 'write',
+		description: 'Create a new Cloudflare zone',
+	},
+	'zones.edit': {
+		riskLevel: 'write',
+		description: 'Update a Cloudflare zone',
+	},
+	'zones.delete': {
+		riskLevel: 'destructive',
+		description: 'Delete a Cloudflare zone [DESTRUCTIVE]',
+	},
+	'dns.list': {
+		riskLevel: 'read',
+		description: 'List DNS records for a zone',
+	},
+	'dns.get': {
+		riskLevel: 'read',
+		description: 'Retrieve a DNS record by ID',
+	},
+	'dns.create': {
+		riskLevel: 'write',
+		description: 'Create a DNS record in a zone',
+	},
+	'dns.edit': {
+		riskLevel: 'write',
+		description: 'Update a DNS record',
+	},
+	'dns.delete': {
+		riskLevel: 'destructive',
+		description: 'Delete a DNS record [DESTRUCTIVE]',
+	},
+	'workers.scripts.list': {
+		riskLevel: 'read',
+		description: 'List Workers scripts for an account',
+	},
+	'workers.scripts.get': {
+		riskLevel: 'read',
+		description: 'Retrieve a Workers script by name',
+	},
+	'workers.scripts.upload': {
+		riskLevel: 'write',
+		description: 'Upload or overwrite a Workers script',
+	},
+	'workers.scripts.delete': {
+		riskLevel: 'destructive',
+		description: 'Delete a Workers script [DESTRUCTIVE]',
+	},
+	'workers.routes.list': {
+		riskLevel: 'read',
+		description: 'List Workers routes for a zone',
+	},
+	'workers.routes.get': {
+		riskLevel: 'read',
+		description: 'Retrieve a Workers route by ID',
+	},
+	'workers.routes.create': {
+		riskLevel: 'write',
+		description: 'Create a Workers route',
+	},
+	'workers.routes.edit': {
+		riskLevel: 'write',
+		description: 'Update a Workers route',
+	},
+	'workers.routes.delete': {
+		riskLevel: 'destructive',
+		description: 'Delete a Workers route [DESTRUCTIVE]',
+	},
+	'rulesets.list': {
+		riskLevel: 'read',
+		description: 'List rulesets for a zone',
+	},
+	'rulesets.get': {
+		riskLevel: 'read',
+		description: 'Retrieve a ruleset by ID',
+	},
+	'rulesets.create': {
+		riskLevel: 'write',
+		description: 'Create a ruleset in a zone',
+	},
+	'rulesets.update': {
+		riskLevel: 'write',
+		description: 'Update a ruleset',
+	},
+	'rulesets.delete': {
+		riskLevel: 'destructive',
+		description: 'Delete a ruleset [DESTRUCTIVE]',
+	},
+} as const satisfies RequiredPluginEndpointMeta<
+	typeof cloudflareEndpointsNested
+>;
+
+export const cloudflareAuthConfig = {
+	api_key: {
+		account: ['one'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type BaseCloudflarePlugin<T extends CloudflarePluginOptions> =
+	CorsairPlugin<
+		'cloudflare',
+		typeof CloudflareSchema,
+		typeof cloudflareEndpointsNested,
+		{},
+		T,
+		typeof defaultAuthType
+	>;
+
+export type InternalCloudflarePlugin =
+	BaseCloudflarePlugin<CloudflarePluginOptions>;
+
+export type ExternalCloudflarePlugin<T extends CloudflarePluginOptions> =
+	BaseCloudflarePlugin<T>;
+
+export function cloudflare<const T extends CloudflarePluginOptions>(
+	incomingOptions: CloudflarePluginOptions & T = {} as CloudflarePluginOptions &
+		T,
+): ExternalCloudflarePlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'cloudflare',
+		schema: CloudflareSchema,
+		options: options,
+		hooks: options.hooks,
+		endpoints: cloudflareEndpointsNested,
+		webhooks: {},
+		endpointMeta: cloudflareEndpointMeta,
+		endpointSchemas: cloudflareEndpointSchemas,
+		pluginWebhookMatcher: () => false,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: CloudflareKeyBuilderContext, source) => {
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys.get_api_key();
+				return res ?? '';
+			}
+
+			return '';
+		},
+	} satisfies InternalCloudflarePlugin;
+}
+
+export type {
+	CloudflareEndpointInputs,
+	CloudflareEndpointOutputs,
+	DnsCreateInput,
+	DnsCreateResponse,
+	DnsDeleteInput,
+	DnsDeleteResponse,
+	DnsEditInput,
+	DnsEditResponse,
+	DnsGetInput,
+	DnsGetResponse,
+	DnsListInput,
+	DnsListResponse,
+	RulesetsCreateInput,
+	RulesetsCreateResponse,
+	RulesetsDeleteInput,
+	RulesetsDeleteResponse,
+	RulesetsGetInput,
+	RulesetsGetResponse,
+	RulesetsListInput,
+	RulesetsListResponse,
+	RulesetsUpdateInput,
+	RulesetsUpdateResponse,
+	WorkerRoutesCreateInput,
+	WorkerRoutesCreateResponse,
+	WorkerRoutesDeleteInput,
+	WorkerRoutesDeleteResponse,
+	WorkerRoutesEditInput,
+	WorkerRoutesEditResponse,
+	WorkerRoutesGetInput,
+	WorkerRoutesGetResponse,
+	WorkerRoutesListInput,
+	WorkerRoutesListResponse,
+	WorkersDeleteInput,
+	WorkersDeleteResponse,
+	WorkersGetInput,
+	WorkersGetResponse,
+	WorkersListInput,
+	WorkersListResponse,
+	WorkersUploadInput,
+	WorkersUploadResponse,
+	ZonesCreateInput,
+	ZonesCreateResponse,
+	ZonesDeleteInput,
+	ZonesDeleteResponse,
+	ZonesEditInput,
+	ZonesEditResponse,
+	ZonesGetInput,
+	ZonesGetResponse,
+	ZonesListInput,
+	ZonesListResponse,
+} from './endpoints/types';

--- a/packages/cloudflare/index.ts
+++ b/packages/cloudflare/index.ts
@@ -241,7 +241,7 @@ const cloudflareEndpointMeta = {
 	},
 	'workers.scripts.get': {
 		riskLevel: 'read',
-		description: 'Retrieve a Workers script by name',
+		description: 'Download Workers script source code by name',
 	},
 	'workers.scripts.upload': {
 		riskLevel: 'write',

--- a/packages/cloudflare/jest.config.cjs
+++ b/packages/cloudflare/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@corsair-dev/cloudflare",
+  "version": "0.1.0",
+  "description": "Cloudflare plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^3.0.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "dotenv": "^16.4.7",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^3.25.76"
+  },
+  "keywords": [
+    "corsair",
+    "cloudflare",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/cloudflare/persist.ts
+++ b/packages/cloudflare/persist.ts
@@ -1,0 +1,169 @@
+import type { CloudflareContext } from './index';
+
+/** Typed `ctx.db` when a Corsair database is configured. */
+export type CloudflareDb = CloudflareContext['db'];
+
+function parseDate(value: string | undefined): Date | null {
+	return value ? new Date(value) : null;
+}
+
+async function persist(
+	label: string,
+	fn: () => Promise<unknown>,
+): Promise<void> {
+	try {
+		await fn();
+	} catch (error) {
+		console.warn(`Failed to save ${label} to database:`, error);
+	}
+}
+
+export async function persistZone(
+	zone: Record<string, unknown>,
+	db: CloudflareDb,
+): Promise<void> {
+	if (!db.zones || zone.id == null) return;
+	const id = String(zone.id);
+	await persist('zone', () =>
+		db.zones!.upsertByEntityId(id, {
+			id,
+			name: String(zone.name ?? ''),
+			status: zone.status as string | undefined,
+			paused: zone.paused as boolean | undefined,
+			type: zone.type as string | undefined,
+			account: zone.account as { id: string } | undefined,
+			name_servers: zone.name_servers as string[] | undefined,
+			created_on: parseDate(zone.created_on as string | undefined),
+			modified_on: parseDate(zone.modified_on as string | undefined),
+			activated_on: parseDate(zone.activated_on as string | undefined),
+		}),
+	);
+}
+
+export async function deleteZone(zoneId: string, db: CloudflareDb): Promise<void> {
+	if (!db.zones?.deleteByEntityId) return;
+	await persist('zone deletion', () => db.zones!.deleteByEntityId!(zoneId));
+}
+
+export async function persistDnsRecord(
+	record: Record<string, unknown>,
+	zoneId: string,
+	db: CloudflareDb,
+): Promise<void> {
+	if (!db.dnsRecords || record.id == null) return;
+	const id = String(record.id);
+	await persist('DNS record', () =>
+		db.dnsRecords!.upsertByEntityId(id, {
+			id,
+			zone_id: String(record.zone_id ?? zoneId),
+			zone_name: record.zone_name as string | undefined,
+			type: String(record.type ?? ''),
+			name: String(record.name ?? ''),
+			content: String(record.content ?? ''),
+			proxiable: record.proxiable as boolean | undefined,
+			proxied: record.proxied as boolean | undefined,
+			ttl: record.ttl as number | undefined,
+			priority: record.priority as number | undefined,
+			locked: record.locked as boolean | undefined,
+			created_on: parseDate(record.created_on as string | undefined),
+			modified_on: parseDate(record.modified_on as string | undefined),
+		}),
+	);
+}
+
+export async function deleteDnsRecord(
+	dnsRecordId: string,
+	db: CloudflareDb,
+): Promise<void> {
+	if (!db.dnsRecords?.deleteByEntityId) return;
+	await persist('DNS record deletion', () =>
+		db.dnsRecords!.deleteByEntityId!(dnsRecordId),
+	);
+}
+
+export async function persistWorkerScript(
+	script: Record<string, unknown>,
+	accountId: string,
+	db: CloudflareDb,
+): Promise<void> {
+	if (!db.workerScripts) return;
+	const id = String(script.id ?? '');
+	if (!id) return;
+	await persist('Worker script', () =>
+		db.workerScripts!.upsertByEntityId(id, {
+			id,
+			account_id: accountId,
+			created_on: parseDate(script.created_on as string | undefined),
+			modified_on: parseDate(script.modified_on as string | undefined),
+		}),
+	);
+}
+
+export async function deleteWorkerScript(
+	scriptName: string,
+	db: CloudflareDb,
+): Promise<void> {
+	if (!db.workerScripts?.deleteByEntityId) return;
+	await persist('Worker script deletion', () =>
+		db.workerScripts!.deleteByEntityId!(scriptName),
+	);
+}
+
+export async function persistWorkerRoute(
+	route: Record<string, unknown>,
+	zoneId: string,
+	db: CloudflareDb,
+): Promise<void> {
+	if (!db.workerRoutes || route.id == null) return;
+	const id = String(route.id);
+	await persist('Worker route', () =>
+		db.workerRoutes!.upsertByEntityId(id, {
+			id,
+			zone_id: zoneId,
+			pattern: String(route.pattern ?? ''),
+			script: route.script as string | undefined,
+		}),
+	);
+}
+
+export async function deleteWorkerRoute(
+	routeId: string,
+	db: CloudflareDb,
+): Promise<void> {
+	if (!db.workerRoutes?.deleteByEntityId) return;
+	await persist('Worker route deletion', () =>
+		db.workerRoutes!.deleteByEntityId!(routeId),
+	);
+}
+
+export async function persistRuleset(
+	ruleset: Record<string, unknown>,
+	zoneId: string,
+	db: CloudflareDb,
+): Promise<void> {
+	if (!db.rulesets || ruleset.id == null) return;
+	const id = String(ruleset.id);
+	await persist('ruleset', () =>
+		db.rulesets!.upsertByEntityId(id, {
+			id,
+			zone_id: zoneId,
+			name: String(ruleset.name ?? ''),
+			description: ruleset.description as string | undefined,
+			kind: String(ruleset.kind ?? ''),
+			version: ruleset.version as string | undefined,
+			last_updated: parseDate(ruleset.last_updated as string | undefined),
+			phase: String(ruleset.phase ?? ''),
+			rules: ruleset.rules as Record<string, unknown>[] | undefined,
+		}),
+	);
+}
+
+export async function deleteRuleset(
+	rulesetId: string,
+	db: CloudflareDb,
+): Promise<void> {
+	if (!db.rulesets?.deleteByEntityId) return;
+	await persist('ruleset deletion', () =>
+		db.rulesets!.deleteByEntityId!(rulesetId),
+	);
+}

--- a/packages/cloudflare/response.test.ts
+++ b/packages/cloudflare/response.test.ts
@@ -37,6 +37,17 @@ describe('unwrapCloudflareResponse', () => {
 		const payload = { id: 'ruleset-1' };
 		expect(unwrapCloudflareResponse(payload)).toEqual(payload);
 	});
+
+	it('unwraps null result for Workers/Rulesets DELETE', () => {
+		expect(
+			unwrapCloudflareResponse<null>({
+				success: true,
+				result: null,
+				errors: [],
+				messages: [],
+			}),
+		).toBeNull();
+	});
 });
 
 describe('isCloudflareEnvelope', () => {

--- a/packages/cloudflare/response.test.ts
+++ b/packages/cloudflare/response.test.ts
@@ -1,0 +1,59 @@
+import { CloudflareAPIError } from './api-error';
+import {
+	isCloudflareEnvelope,
+	unwrapCloudflareResponse,
+	cloudflareErrorFromApiErrorBody,
+} from './response';
+
+describe('unwrapCloudflareResponse', () => {
+	it('unwraps a successful JSON envelope', () => {
+		const result = unwrapCloudflareResponse<{ id: string }>({
+			success: true,
+			result: { id: 'zone-1' },
+			errors: [],
+			messages: [],
+		});
+		expect(result).toEqual({ id: 'zone-1' });
+	});
+
+	it('throws CloudflareAPIError when success is false', () => {
+		expect(() =>
+			unwrapCloudflareResponse({
+				success: false,
+				result: null,
+				errors: [{ code: 1000, message: 'Invalid request' }],
+				messages: [],
+			}),
+		).toThrow(CloudflareAPIError);
+	});
+
+	it('returns plain string for Workers script download', () => {
+		const source = 'export default { fetch() {} };';
+		const result = unwrapCloudflareResponse<string>(source);
+		expect(result).toBe(source);
+	});
+
+	it('passes through non-envelope delete payloads', () => {
+		const payload = { id: 'ruleset-1' };
+		expect(unwrapCloudflareResponse(payload)).toEqual(payload);
+	});
+});
+
+describe('isCloudflareEnvelope', () => {
+	it('returns false for script source strings', () => {
+		expect(isCloudflareEnvelope('addEventListener("fetch")')).toBe(false);
+	});
+});
+
+describe('cloudflareErrorFromApiErrorBody', () => {
+	it('maps envelope errors', () => {
+		const err = cloudflareErrorFromApiErrorBody({
+			success: false,
+			result: null,
+			errors: [{ code: 9109, message: 'Unauthorized' }],
+			messages: [],
+		});
+		expect(err).toBeInstanceOf(CloudflareAPIError);
+		expect(err?.message).toContain('Unauthorized');
+	});
+});

--- a/packages/cloudflare/response.ts
+++ b/packages/cloudflare/response.ts
@@ -1,0 +1,77 @@
+import { CloudflareAPIError } from './api-error';
+
+export type CloudflareApiResponse<T> = {
+	result: T;
+	success: boolean;
+	errors: Array<{ code: number; message: string }>;
+	// Cloudflare may include diagnostic messages; shape varies by endpoint.
+	messages: unknown[];
+};
+
+/** Runtime check for Cloudflare's `{ success, result, errors }` JSON envelope. */
+export function isCloudflareEnvelope(
+	response: unknown,
+): response is CloudflareApiResponse<unknown> {
+	return (
+		response !== null &&
+		typeof response === 'object' &&
+		'success' in response &&
+		'result' in response
+	);
+}
+
+function isCloudflareErrorsBody(
+	body: unknown,
+): body is { errors: Array<{ code?: number; message: string }> } {
+	return (
+		body !== null &&
+		typeof body === 'object' &&
+		'errors' in body &&
+		Array.isArray((body as { errors: unknown }).errors) &&
+		(body as { errors: unknown[] }).errors.length > 0
+	);
+}
+
+/**
+ * Normalizes Cloudflare API responses. Most endpoints return a JSON envelope;
+ * script download returns plain text; some DELETE paths return a bare object.
+ */
+export function unwrapCloudflareResponse<T>(
+	// HTTP layer returns parsed JSON or text; shape depends on Content-Type.
+	response: unknown,
+): T {
+	if (typeof response === 'string') {
+		// GET /workers/scripts/{name} returns application/javascript, not JSON.
+		return response as T;
+	}
+
+	if (isCloudflareEnvelope(response)) {
+		if (!response.success) {
+			const message =
+				response.errors?.map((e) => e.message).join('; ') ||
+				'Cloudflare API request failed';
+			const code = response.errors?.[0]?.code;
+			throw new CloudflareAPIError(message, code);
+		}
+		return response.result as T;
+	}
+
+	// Some successful responses (e.g. certain deletes) omit the envelope.
+	return response as T;
+}
+
+export function cloudflareErrorFromApiErrorBody(
+	body: unknown,
+): CloudflareAPIError | null {
+	if (isCloudflareEnvelope(body) && !body.success) {
+		const message =
+			body.errors?.map((e) => e.message).join('; ') ||
+			'Cloudflare API request failed';
+		return new CloudflareAPIError(message, body.errors?.[0]?.code);
+	}
+	if (isCloudflareErrorsBody(body)) {
+		const message = body.errors.map((e) => e.message).join('; ');
+		return new CloudflareAPIError(message, body.errors[0]?.code);
+	}
+	return null;
+}

--- a/packages/cloudflare/schema/database.ts
+++ b/packages/cloudflare/schema/database.ts
@@ -1,1 +1,61 @@
-// API-only plugin: no local DB entities. Cloudflare data is accessed via REST endpoints.
+import { z } from 'zod';
+
+/** Zone account metadata from the API; extra keys allowed by Cloudflare. */
+const ZoneAccountSchema = z.object({ id: z.string() }).passthrough().optional();
+
+export const CloudflareZone = z.object({
+	id: z.string(),
+	name: z.string(),
+	status: z.string().optional(),
+	paused: z.boolean().optional(),
+	type: z.string().optional(),
+	account: ZoneAccountSchema,
+	name_servers: z.array(z.string()).optional(),
+	created_on: z.coerce.date().nullable().optional(),
+	modified_on: z.coerce.date().nullable().optional(),
+	activated_on: z.coerce.date().nullable().optional(),
+});
+
+export const CloudflareDnsRecord = z.object({
+	id: z.string(),
+	zone_id: z.string(),
+	zone_name: z.string().optional(),
+	type: z.string(),
+	name: z.string(),
+	content: z.string(),
+	proxiable: z.boolean().optional(),
+	proxied: z.boolean().optional(),
+	ttl: z.number().optional(),
+	priority: z.number().optional(),
+	locked: z.boolean().optional(),
+	created_on: z.coerce.date().nullable().optional(),
+	modified_on: z.coerce.date().nullable().optional(),
+});
+
+/** Script list/upload metadata only — never store full source (see workers.scripts.get). */
+export const CloudflareWorkerScript = z.object({
+	id: z.string(),
+	account_id: z.string().optional(),
+	created_on: z.coerce.date().nullable().optional(),
+	modified_on: z.coerce.date().nullable().optional(),
+});
+
+export const CloudflareWorkerRoute = z.object({
+	id: z.string(),
+	zone_id: z.string(),
+	pattern: z.string(),
+	script: z.string().optional(),
+});
+
+/** Rules array entries vary by phase; stored as loose records for search. */
+export const CloudflareRuleset = z.object({
+	id: z.string(),
+	zone_id: z.string(),
+	name: z.string(),
+	description: z.string().optional(),
+	kind: z.string(),
+	version: z.string().optional(),
+	last_updated: z.coerce.date().nullable().optional(),
+	phase: z.string(),
+	rules: z.array(z.record(z.unknown())).optional(),
+});

--- a/packages/cloudflare/schema/database.ts
+++ b/packages/cloudflare/schema/database.ts
@@ -1,0 +1,1 @@
+// API-only plugin: no local DB entities. Cloudflare data is accessed via REST endpoints.

--- a/packages/cloudflare/schema/index.ts
+++ b/packages/cloudflare/schema/index.ts
@@ -1,0 +1,4 @@
+export const CloudflareSchema = {
+	version: '1.0.0',
+	entities: {},
+} as const;

--- a/packages/cloudflare/schema/index.ts
+++ b/packages/cloudflare/schema/index.ts
@@ -1,4 +1,18 @@
+import {
+	CloudflareDnsRecord,
+	CloudflareRuleset,
+	CloudflareWorkerRoute,
+	CloudflareWorkerScript,
+	CloudflareZone,
+} from './database';
+
 export const CloudflareSchema = {
 	version: '1.0.0',
-	entities: {},
+	entities: {
+		zones: CloudflareZone,
+		dnsRecords: CloudflareDnsRecord,
+		workerScripts: CloudflareWorkerScript,
+		workerRoutes: CloudflareWorkerRoute,
+		rulesets: CloudflareRuleset,
+	},
 } as const;

--- a/packages/cloudflare/tsconfig.json
+++ b/packages/cloudflare/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/cloudflare/tsup.config.ts
+++ b/packages/cloudflare/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -20,6 +20,7 @@ export const BaseProviders = [
 	'box',
 	'cal',
 	'calendly',
+	'cloudflare',
 	'cursor',
 	'discord',
 	'dodopayments',
@@ -77,6 +78,7 @@ export type AllProviders =
 	| 'box'
 	| 'cal'
 	| 'calendly'
+	| 'cloudflare'
 	| 'cursor'
 	| 'discord'
 	| 'dodopayments'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.2.0
         version: 0.2.71(zod@3.25.76)
+      '@corsair-dev/cloudflare':
+        specifier: workspace:*
+        version: link:../../packages/cloudflare
       '@corsair-dev/cursor':
         specifier: workspace:*
         version: link:../../packages/cursor
@@ -466,6 +469,33 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
+
+  packages/cloudflare:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.6.1
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
 
   packages/corsair:
     dependencies:
@@ -13934,7 +13964,7 @@ snapshots:
       '@babel/generator': 7.28.6
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.6)
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.28.6)
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.0
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3


### PR DESCRIPTION
## Summary

Adds `@corsair-dev/cloudflare` — a Corsair plugin for [Cloudflare API v4](https://developers.cloudflare.com/api/) with API token (Bearer) authentication.

**Coverage (24 endpoints):**

| Area | Operations |
|------|------------|
| Zones | list, get, create, edit, delete |
| DNS | list, get, create, edit, delete |
| Workers scripts | list, get, upload, delete |
| Workers routes | list, get, create, edit, delete |
| Rulesets | list, get, create, update, delete |

Closes #197.

## What's included

- **`packages/cloudflare`** — HTTP client (`result` envelope unwrap), Zod schemas, error handlers, endpoint handlers, Jest `api.test.ts`
- **`docs/plugins/cloudflare/`** — overview, credentials, API reference (no local DB entities)
- **`packages/corsair/core/constants.ts`** — registers `cloudflare` in `AllProviders`

## Test plan

- [x] `cd packages/cloudflare && pnpm typecheck`
- [x] `cd packages/cloudflare && pnpm test` (`CLOUDFLARE_API_TOKEN` in `packages/cloudflare/.env`)