### PR TITLE
feat: add Zendesk ticketing integration

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -77,7 +77,9 @@
           },
           {
             "group": "Studio",
-            "pages": ["studio/overview"]
+            "pages": [
+              "studio/overview"
+            ]
           },
           {
             "group": "Core Concepts",
@@ -95,11 +97,16 @@
           },
           {
             "group": "Auth Types",
-            "pages": ["concepts/api-key", "concepts/oauth"]
+            "pages": [
+              "concepts/api-key",
+              "concepts/oauth"
+            ]
           },
           {
             "group": "Production",
-            "pages": ["production/oauth-process"]
+            "pages": [
+              "production/oauth-process"
+            ]
           },
           {
             "group": "Workflow Engines",
@@ -117,7 +124,10 @@
         "groups": [
           {
             "group": "Overview",
-            "pages": ["guides/plugins", "guides/create-your-own-plugin"]
+            "pages": [
+              "guides/plugins",
+              "guides/create-your-own-plugin"
+            ]
           },
           {
             "group": "Plugins",
@@ -679,6 +689,14 @@
                 ]
               },
               {
+                "group": "Zendesk",
+                "pages": [
+                  "plugins/zendesk/overview",
+                  "plugins/zendesk/api",
+                  "plugins/zendesk/database"
+                ]
+              },
+              {
                 "group": "Zoom",
                 "pages": [
                   "plugins/zoom/overview",
@@ -697,7 +715,11 @@
         "groups": [
           {
             "group": "Guides",
-            "pages": ["guides/webhooks", "guides/workflows", "guides/dashboard"]
+            "pages": [
+              "guides/webhooks",
+              "guides/workflows",
+              "guides/dashboard"
+            ]
           }
         ]
       }

--- a/docs/plugins/zendesk/api.mdx
+++ b/docs/plugins/zendesk/api.mdx
@@ -20,7 +20,9 @@ List comments for a specific ticket
 **Risk:** `read`
 
 ```ts
-await corsair.zendesk.api.comments.list({});
+await corsair.zendesk.api.comments.list({
+  ticket_id: 12345
+});
 ```
 
 **Input**
@@ -164,7 +166,9 @@ Delete a ticket by its ID
 **Risk:** `destructive`
 
 ```ts
-await corsair.zendesk.api.tickets.delete({});
+await corsair.zendesk.api.tickets.delete({
+  id: 12345
+});
 ```
 
 **Input**
@@ -194,7 +198,9 @@ Retrieve a ticket by its ID
 **Risk:** `read`
 
 ```ts
-await corsair.zendesk.api.tickets.get({});
+await corsair.zendesk.api.tickets.get({
+  id: 12345
+});
 ```
 
 **Input**
@@ -332,7 +338,10 @@ Update an existing ticket
 **Risk:** `write`
 
 ```ts
-await corsair.zendesk.api.tickets.update({});
+await corsair.zendesk.api.tickets.update({
+  id: 12345,
+  subject: "Updated ticket subject"
+});
 ```
 
 **Input**
@@ -420,7 +429,10 @@ Create a new user
 **Risk:** `write`
 
 ```ts
-await corsair.zendesk.api.users.create({});
+await corsair.zendesk.api.users.create({
+  name: "Jane Doe",
+  email: "jane.doe@example.com"
+});
 ```
 
 **Input**
@@ -482,7 +494,9 @@ Delete a user by their ID
 **Risk:** `destructive`
 
 ```ts
-await corsair.zendesk.api.users.delete({});
+await corsair.zendesk.api.users.delete({
+  id: 12345
+});
 ```
 
 **Input**
@@ -512,7 +526,9 @@ Retrieve a user by their ID
 **Risk:** `read`
 
 ```ts
-await corsair.zendesk.api.users.get({});
+await corsair.zendesk.api.users.get({
+  id: 12345
+});
 ```
 
 **Input**
@@ -633,7 +649,10 @@ Update an existing user
 **Risk:** `write`
 
 ```ts
-await corsair.zendesk.api.users.update({});
+await corsair.zendesk.api.users.update({
+  id: 12345,
+  name: "Jane Smith"
+});
 ```
 
 **Input**

--- a/docs/plugins/zendesk/api.mdx
+++ b/docs/plugins/zendesk/api.mdx
@@ -1,0 +1,689 @@
+---
+title: API
+description: "API reference for Zendesk: every `zendesk.api.*` operation with input and output types."
+---
+
+Every `zendesk.api.*` operation is listed below with parameter shapes and return types from the plugin Zod schemas.
+
+<Info>
+**New to Corsair?** See [API access](/concepts/api), [authentication](/concepts/auth), and [error handling](/concepts/error-handling).
+</Info>
+
+## Comments
+
+### list
+
+`comments.list`
+
+List comments for a specific ticket
+
+**Risk:** `read`
+
+```ts
+await corsair.zendesk.api.comments.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `ticket_id` | `number` | Yes | — |
+| `page` | `number` | No | — |
+| `per_page` | `number` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `comments` | `object[]` | Yes | — |
+| `next_page` | `string` | No | — |
+| `previous_page` | `string` | No | — |
+| `count` | `number` | No | — |
+
+<AccordionGroup>
+<Accordion title="comments full type">
+
+```ts
+{
+  id: number,
+  type?: string | null,
+  body?: string | null,
+  html_body?: string | null,
+  plain_body?: string | null,
+  public?: boolean | null,
+  author_id?: number | null,
+  attachments?: any[] | null,
+  created_at?: string | null
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Tickets
+
+### create
+
+`tickets.create`
+
+Create a new ticket
+
+**Risk:** `write`
+
+```ts
+await corsair.zendesk.api.tickets.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `subject` | `string` | No | — |
+| `description` | `string` | No | — |
+| `comment` | `object` | No | — |
+| `status` | `string` | No | — |
+| `priority` | `string` | No | — |
+| `requester_id` | `number` | No | — |
+| `assignee_id` | `number` | No | — |
+| `group_id` | `number` | No | — |
+| `organization_id` | `number` | No | — |
+| `tags` | `string[]` | No | — |
+
+<AccordionGroup>
+<Accordion title="comment full type">
+
+```ts
+{
+  body: string,
+  public?: boolean,
+  author_id?: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `ticket` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="ticket full type">
+
+```ts
+{
+  id: number,
+  url?: string | null,
+  external_id?: string | null,
+  created_at?: string | null,
+  updated_at?: string | null,
+  type?: string | null,
+  subject?: string | null,
+  raw_subject?: string | null,
+  description?: string | null,
+  priority?: string | null,
+  status?: string | null,
+  recipient?: string | null,
+  requester_id?: number | null,
+  submitter_id?: number | null,
+  assignee_id?: number | null,
+  organization_id?: number | null,
+  group_id?: number | null,
+  collaborator_ids?: number[] | null,
+  follower_ids?: number[] | null,
+  email_cc_ids?: number[] | null,
+  forum_topic_id?: number | null,
+  problem_id?: number | null,
+  has_incidents?: boolean | null,
+  is_public?: boolean | null,
+  due_at?: string | null,
+  tags?: string[] | null
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### delete
+
+`tickets.delete`
+
+Delete a ticket by its ID
+
+**Risk:** `destructive`
+
+```ts
+await corsair.zendesk.api.tickets.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `number` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `number` | No | — |
+
+
+
+---
+
+### get
+
+`tickets.get`
+
+Retrieve a ticket by its ID
+
+**Risk:** `read`
+
+```ts
+await corsair.zendesk.api.tickets.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `number` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `ticket` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="ticket full type">
+
+```ts
+{
+  id: number,
+  url?: string | null,
+  external_id?: string | null,
+  created_at?: string | null,
+  updated_at?: string | null,
+  type?: string | null,
+  subject?: string | null,
+  raw_subject?: string | null,
+  description?: string | null,
+  priority?: string | null,
+  status?: string | null,
+  recipient?: string | null,
+  requester_id?: number | null,
+  submitter_id?: number | null,
+  assignee_id?: number | null,
+  organization_id?: number | null,
+  group_id?: number | null,
+  collaborator_ids?: number[] | null,
+  follower_ids?: number[] | null,
+  email_cc_ids?: number[] | null,
+  forum_topic_id?: number | null,
+  problem_id?: number | null,
+  has_incidents?: boolean | null,
+  is_public?: boolean | null,
+  due_at?: string | null,
+  tags?: string[] | null
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### list
+
+`tickets.list`
+
+List tickets with pagination
+
+**Risk:** `read`
+
+```ts
+await corsair.zendesk.api.tickets.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `page` | `number` | No | — |
+| `per_page` | `number` | No | — |
+| `sort_by` | `string` | No | — |
+| `sort_order` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `tickets` | `object[]` | Yes | — |
+| `next_page` | `string` | No | — |
+| `previous_page` | `string` | No | — |
+| `count` | `number` | No | — |
+
+<AccordionGroup>
+<Accordion title="tickets full type">
+
+```ts
+{
+  id: number,
+  url?: string | null,
+  external_id?: string | null,
+  created_at?: string | null,
+  updated_at?: string | null,
+  type?: string | null,
+  subject?: string | null,
+  raw_subject?: string | null,
+  description?: string | null,
+  priority?: string | null,
+  status?: string | null,
+  recipient?: string | null,
+  requester_id?: number | null,
+  submitter_id?: number | null,
+  assignee_id?: number | null,
+  organization_id?: number | null,
+  group_id?: number | null,
+  collaborator_ids?: number[] | null,
+  follower_ids?: number[] | null,
+  email_cc_ids?: number[] | null,
+  forum_topic_id?: number | null,
+  problem_id?: number | null,
+  has_incidents?: boolean | null,
+  is_public?: boolean | null,
+  due_at?: string | null,
+  tags?: string[] | null
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### update
+
+`tickets.update`
+
+Update an existing ticket
+
+**Risk:** `write`
+
+```ts
+await corsair.zendesk.api.tickets.update({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `number` | Yes | — |
+| `subject` | `string` | No | — |
+| `status` | `string` | No | — |
+| `priority` | `string` | No | — |
+| `requester_id` | `number` | No | — |
+| `assignee_id` | `number` | No | — |
+| `comment` | `object` | No | — |
+| `tags` | `string[]` | No | — |
+
+<AccordionGroup>
+<Accordion title="comment full type">
+
+```ts
+{
+  body: string,
+  public?: boolean,
+  author_id?: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `ticket` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="ticket full type">
+
+```ts
+{
+  id: number,
+  url?: string | null,
+  external_id?: string | null,
+  created_at?: string | null,
+  updated_at?: string | null,
+  type?: string | null,
+  subject?: string | null,
+  raw_subject?: string | null,
+  description?: string | null,
+  priority?: string | null,
+  status?: string | null,
+  recipient?: string | null,
+  requester_id?: number | null,
+  submitter_id?: number | null,
+  assignee_id?: number | null,
+  organization_id?: number | null,
+  group_id?: number | null,
+  collaborator_ids?: number[] | null,
+  follower_ids?: number[] | null,
+  email_cc_ids?: number[] | null,
+  forum_topic_id?: number | null,
+  problem_id?: number | null,
+  has_incidents?: boolean | null,
+  is_public?: boolean | null,
+  due_at?: string | null,
+  tags?: string[] | null
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Users
+
+### create
+
+`users.create`
+
+Create a new user
+
+**Risk:** `write`
+
+```ts
+await corsair.zendesk.api.users.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | `string` | Yes | — |
+| `email` | `string` | Yes | — |
+| `role` | `string` | No | — |
+| `external_id` | `string` | No | — |
+| `active` | `boolean` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `user` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="user full type">
+
+```ts
+{
+  id: number,
+  url?: string | null,
+  name: string,
+  email?: string | null,
+  created_at?: string | null,
+  updated_at?: string | null,
+  time_zone?: string | null,
+  iana_time_zone?: string | null,
+  phone?: string | null,
+  shared_phone?: boolean | null,
+  locale_id?: number | null,
+  locale?: string | null,
+  organization_id?: number | null,
+  role?: string | null,
+  verified?: boolean | null,
+  external_id?: string | null,
+  tags?: string[] | null,
+  active?: boolean | null
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### delete
+
+`users.delete`
+
+Delete a user by their ID
+
+**Risk:** `destructive`
+
+```ts
+await corsair.zendesk.api.users.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `number` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `number` | No | — |
+
+
+
+---
+
+### get
+
+`users.get`
+
+Retrieve a user by their ID
+
+**Risk:** `read`
+
+```ts
+await corsair.zendesk.api.users.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `number` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `user` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="user full type">
+
+```ts
+{
+  id: number,
+  url?: string | null,
+  name: string,
+  email?: string | null,
+  created_at?: string | null,
+  updated_at?: string | null,
+  time_zone?: string | null,
+  iana_time_zone?: string | null,
+  phone?: string | null,
+  shared_phone?: boolean | null,
+  locale_id?: number | null,
+  locale?: string | null,
+  organization_id?: number | null,
+  role?: string | null,
+  verified?: boolean | null,
+  external_id?: string | null,
+  tags?: string[] | null,
+  active?: boolean | null
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### list
+
+`users.list`
+
+List users with pagination
+
+**Risk:** `read`
+
+```ts
+await corsair.zendesk.api.users.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `page` | `number` | No | — |
+| `per_page` | `number` | No | — |
+| `role` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `users` | `object[]` | Yes | — |
+| `next_page` | `string` | No | — |
+| `previous_page` | `string` | No | — |
+| `count` | `number` | No | — |
+
+<AccordionGroup>
+<Accordion title="users full type">
+
+```ts
+{
+  id: number,
+  url?: string | null,
+  name: string,
+  email?: string | null,
+  created_at?: string | null,
+  updated_at?: string | null,
+  time_zone?: string | null,
+  iana_time_zone?: string | null,
+  phone?: string | null,
+  shared_phone?: boolean | null,
+  locale_id?: number | null,
+  locale?: string | null,
+  organization_id?: number | null,
+  role?: string | null,
+  verified?: boolean | null,
+  external_id?: string | null,
+  tags?: string[] | null,
+  active?: boolean | null
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### update
+
+`users.update`
+
+Update an existing user
+
+**Risk:** `write`
+
+```ts
+await corsair.zendesk.api.users.update({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `number` | Yes | — |
+| `name` | `string` | No | — |
+| `email` | `string` | No | — |
+| `role` | `string` | No | — |
+| `external_id` | `string` | No | — |
+| `active` | `boolean` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `user` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="user full type">
+
+```ts
+{
+  id: number,
+  url?: string | null,
+  name: string,
+  email?: string | null,
+  created_at?: string | null,
+  updated_at?: string | null,
+  time_zone?: string | null,
+  iana_time_zone?: string | null,
+  phone?: string | null,
+  shared_phone?: boolean | null,
+  locale_id?: number | null,
+  locale?: string | null,
+  organization_id?: number | null,
+  role?: string | null,
+  verified?: boolean | null,
+  external_id?: string | null,
+  tags?: string[] | null,
+  active?: boolean | null
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+

--- a/docs/plugins/zendesk/database.mdx
+++ b/docs/plugins/zendesk/database.mdx
@@ -1,0 +1,103 @@
+---
+title: Database
+description: "Zendesk local sync: searchable entities, `.search()` filters, and operators."
+---
+
+The Zendesk plugin syncs data locally. Use `corsair.zendesk.db.<entity>.search({ data, limit?, offset? })` with the filters listed per entity.
+
+<Info>
+**New to Corsair?** See [database operations](/concepts/database), [data synchronization](/concepts/integrations), and [multi-tenancy](/concepts/multi-tenancy).
+</Info>
+
+## Comments
+
+Path: `zendesk.db.comments.search`
+
+```ts
+const rows = await corsair.zendesk.db.comments.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `id` | `number` | equals, gt, gte, lt, lte, in |
+| `ticketId` | `number` | equals, gt, gte, lt, lte, in |
+| `body` | `string` | equals, contains, startsWith, endsWith, in |
+| `authorId` | `number` | equals, gt, gte, lt, lte, in |
+| `public` | `boolean` | equals |
+| `createdAt` | `date` | equals, before, after, between |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+
+## Tickets
+
+Path: `zendesk.db.tickets.search`
+
+```ts
+const rows = await corsair.zendesk.db.tickets.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `id` | `number` | equals, gt, gte, lt, lte, in |
+| `subject` | `string` | equals, contains, startsWith, endsWith, in |
+| `description` | `string` | equals, contains, startsWith, endsWith, in |
+| `status` | `string` | equals, contains, startsWith, endsWith, in |
+| `priority` | `string` | equals, contains, startsWith, endsWith, in |
+| `requesterId` | `number` | equals, gt, gte, lt, lte, in |
+| `assigneeId` | `number` | equals, gt, gte, lt, lte, in |
+| `organizationId` | `number` | equals, gt, gte, lt, lte, in |
+| `groupId` | `number` | equals, gt, gte, lt, lte, in |
+| `createdAt` | `date` | equals, before, after, between |
+| `updatedAt` | `date` | equals, before, after, between |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+
+## Users
+
+Path: `zendesk.db.users.search`
+
+```ts
+const rows = await corsair.zendesk.db.users.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `id` | `number` | equals, gt, gte, lt, lte, in |
+| `name` | `string` | equals, contains, startsWith, endsWith, in |
+| `email` | `string` | equals, contains, startsWith, endsWith, in |
+| `role` | `string` | equals, contains, startsWith, endsWith, in |
+| `active` | `boolean` | equals |
+| `timeZone` | `string` | equals, contains, startsWith, endsWith, in |
+| `locale` | `string` | equals, contains, startsWith, endsWith, in |
+| `createdAt` | `date` | equals, before, after, between |
+| `updatedAt` | `date` | equals, before, after, between |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+

--- a/docs/plugins/zendesk/overview.mdx
+++ b/docs/plugins/zendesk/overview.mdx
@@ -110,14 +110,21 @@ Synced entities support `corsair.zendesk.db.<entity>.search()` and `.list()`. Se
 **Read-style (read):** `comments.list`
 
 ```ts
-await corsair.zendesk.api.comments.list({});
+await corsair.zendesk.api.comments.list({
+  ticket_id: 12345
+});
 ```
 
 
 **Write-style (write):** `tickets.create`
 
 ```ts
-await corsair.zendesk.api.tickets.create({});
+await corsair.zendesk.api.tickets.create({
+  subject: "Support request",
+  comment: {
+    body: "Please help with my account access."
+  }
+});
 ```
 
 

--- a/docs/plugins/zendesk/overview.mdx
+++ b/docs/plugins/zendesk/overview.mdx
@@ -1,0 +1,141 @@
+---
+title: Overview
+description: "Zendesk plugin for Corsair"
+---
+
+Use **Zendesk** through Corsair: one client, typed API calls, optional local DB sync.
+
+**What you get:**
+
+- 11 typed API operations
+- 3 database entities synced for fast `.search()` / `.list()` queries
+
+## Setup
+
+<Steps>
+
+<Step title="Install">
+```bash
+pnpm install @corsair-dev/zendesk
+```
+
+</Step>
+
+<Step title="Add the plugin">
+<Tabs>
+<Tab title="Solo">
+```ts corsair.ts
+import { createCorsair } from 'corsair';
+import { zendesk } from '@corsair-dev/zendesk';
+
+export const corsair = createCorsair({
+	// ... other config options,
+	multiTenancy: false,
+    plugins: [zendesk()],
+});
+```
+</Tab>
+<Tab title="Multi-Tenant">
+```ts corsair.ts
+import { createCorsair } from 'corsair';
+import { zendesk } from '@corsair-dev/zendesk';
+
+export const corsair = createCorsair({
+	// ... other config options,
+    multiTenancy: true,
+    plugins: [zendesk()],
+});
+```
+
+See [Multi-tenancy](/concepts/multi-tenancy) for account isolation.
+
+</Tab>
+</Tabs>
+
+</Step>
+
+<Step title="Get credentials">
+Follow [Get Credentials](/plugins/zendesk/get-credentials) if you need help getting keys.
+
+</Step>
+
+<Step title="Store credentials">
+<Tabs>
+<Tab title="Solo">
+```bash
+pnpm corsair setup --plugin=zendesk
+```
+
+Use the key names documented in [Get Credentials](/plugins/zendesk/get-credentials) (for example `api_key=`, `bot_token=`, or OAuth client fields).
+</Tab>
+<Tab title="Multi-Tenant">
+```bash
+pnpm corsair setup --plugin=zendesk --tenant=<tenantId>
+```
+
+Store per-tenant secrets after you create the tenant record. See [Multi-tenancy](/concepts/multi-tenancy).
+</Tab>
+</Tabs>
+
+</Step>
+
+</Steps>
+
+## Authentication
+
+Each tab shows how to register the plugin for that authentication method. The default `authType` from the plugin does not need to appear in the factory call.
+
+<Tabs>
+<Tab title="API Key (Default)">
+
+```ts corsair.ts
+zendesk()
+```
+
+Store credentials with `pnpm corsair setup --plugin=zendesk` (see [Get Credentials](/plugins/zendesk/get-credentials) for field names). For OAuth, you typically store integration keys at the provider level and tokens per account or tenant.
+
+More: [API Key](/concepts/api-key)
+
+</Tab>
+</Tabs>
+
+
+## Query synced data
+
+Synced entities support `corsair.zendesk.db.<entity>.search()` and `.list()`. See [Database](/plugins/zendesk/database) for filters and operators.
+
+
+## Example API calls
+
+**Read-style (read):** `comments.list`
+
+```ts
+await corsair.zendesk.api.comments.list({});
+```
+
+
+**Write-style (write):** `tickets.create`
+
+```ts
+await corsair.zendesk.api.tickets.create({});
+```
+
+
+See the full list on the [API](/plugins/zendesk/api) page. Use `pnpm corsair list --plugin=zendesk` and `pnpm corsair schema <path>` locally to inspect schemas.
+
+---
+
+## Hooks
+
+Use `hooks` on API calls and `webhookHooks` on incoming events to add logging, approvals, or side effects. See [Hooks](/concepts/hooks) and [Webhooks](/concepts/webhooks) for routing and payload patterns.
+
+---
+
+## Reference
+
+| Topic | Link |
+|-------|------|
+| API | [API](/plugins/zendesk/api) |
+| Database | [Database](/plugins/zendesk/database) |
+| Credentials | [Get credentials](/plugins/zendesk/get-credentials) |
+

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -70,6 +70,7 @@ export const BaseProviders = [
 	'vapi',
 	'xquik',
 	'youtube',
+	'zendesk',
 	'zoom',
 ] as const;
 
@@ -131,6 +132,7 @@ export type AllProviders =
 	| 'vapi'
 	| 'xquik'
 	| 'youtube'
+	| 'zendesk'
 	| 'zoom'
 	| (string & {});
 

--- a/packages/zendesk/api.test.ts
+++ b/packages/zendesk/api.test.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
-import { request } from 'corsair/http';
+import type { ApiRequestOptions, ApiResult } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
 import { makeZendeskRequest } from './client';
 import type {
 	CommentsListResponse,
@@ -16,9 +17,13 @@ import type {
 } from './endpoints/types';
 import { ZendeskEndpointOutputSchemas } from './endpoints/types';
 
-jest.mock('corsair/http', () => ({
-	request: jest.fn(),
-}));
+jest.mock('corsair/http', () => {
+	const actual = jest.requireActual<typeof import('corsair/http')>('corsair/http');
+	return {
+		...actual,
+		request: jest.fn(),
+	};
+});
 
 const mockedRequest = request as jest.MockedFunction<typeof request>;
 
@@ -55,6 +60,28 @@ describe('Zendesk API Type Tests', () => {
 				}),
 			);
 			expect(response).toEqual({ ticket: { id: 123, subject: 'Test' } });
+		});
+
+		it('re-throws ApiError so error handlers can inspect status and Retry-After', async () => {
+			const requestOptions: ApiRequestOptions = {
+				method: 'GET',
+				url: 'tickets.json',
+			};
+			const response: ApiResult = {
+				url: 'https://subdomain.zendesk.com/api/v2/tickets.json',
+				ok: false,
+				status: 429,
+				statusText: 'Too Many Requests',
+				body: {},
+			};
+			const apiError = new ApiError(requestOptions, response, 'Rate limited', {
+				retryAfter: 5000,
+			});
+			mockedRequest.mockRejectedValueOnce(apiError);
+
+			await expect(
+				makeZendeskRequest('tickets.json', 'key', 'subdomain', { method: 'GET' }),
+			).rejects.toBe(apiError);
 		});
 	});
 

--- a/packages/zendesk/api.test.ts
+++ b/packages/zendesk/api.test.ts
@@ -1,6 +1,4 @@
 import 'dotenv/config';
-import type { ApiRequestOptions, ApiResult } from 'corsair/http';
-import { ApiError, request } from 'corsair/http';
 import { makeZendeskRequest } from './client';
 import type {
 	CommentsListResponse,
@@ -17,331 +15,361 @@ import type {
 } from './endpoints/types';
 import { ZendeskEndpointOutputSchemas } from './endpoints/types';
 
-jest.mock('corsair/http', () => {
-	const actual = jest.requireActual<typeof import('corsair/http')>('corsair/http');
-	return {
-		...actual,
-		request: jest.fn(),
-	};
-});
-
-const mockedRequest = request as jest.MockedFunction<typeof request>;
+const TEST_API_KEY = process.env.ZENDESK_API_KEY ?? '';
+const TEST_SUBDOMAIN = process.env.ZENDESK_SUBDOMAIN ?? '';
+const hasCredentials = TEST_API_KEY.length > 0 && TEST_SUBDOMAIN.length > 0;
 
 describe('Zendesk API Type Tests', () => {
-	beforeEach(() => {
-		jest.clearAllMocks();
-	});
-
-	describe('makeZendeskRequest client', () => {
-		it('sends the correct headers and constructs the correct URL', async () => {
-			mockedRequest.mockResolvedValueOnce({
-				ticket: { id: 123, subject: 'Test' },
-			});
-
-			const response = await makeZendeskRequest<TicketsGetResponse>(
-				'tickets/123.json',
-				'user@domain.com/token:myapikey',
-				'mysubdomain',
-				{ method: 'GET' },
-			);
-
-			expect(mockedRequest).toHaveBeenCalledWith(
-				expect.objectContaining({
-					BASE: 'https://mysubdomain.zendesk.com/api/v2',
-					HEADERS: {
-						'Content-Type': 'application/json',
-						Accept: 'application/json',
-						Authorization: `Basic ${Buffer.from('user@domain.com/token:myapikey').toString('base64')}`,
-					},
-				}),
-				expect.objectContaining({
-					method: 'GET',
-					url: 'tickets/123.json',
-				}),
-			);
-			expect(response).toEqual({ ticket: { id: 123, subject: 'Test' } });
-		});
-
-		it('re-throws ApiError so error handlers can inspect status and Retry-After', async () => {
-			const requestOptions: ApiRequestOptions = {
-				method: 'GET',
-				url: 'tickets.json',
-			};
-			const response: ApiResult = {
-				url: 'https://subdomain.zendesk.com/api/v2/tickets.json',
-				ok: false,
-				status: 429,
-				statusText: 'Too Many Requests',
-				body: {},
-			};
-			const apiError = new ApiError(requestOptions, response, 'Rate limited', {
-				retryAfter: 5000,
-			});
-			mockedRequest.mockRejectedValueOnce(apiError);
-
-			await expect(
-				makeZendeskRequest('tickets.json', 'key', 'subdomain', { method: 'GET' }),
-			).rejects.toBe(apiError);
-		});
-	});
-
 	describe('tickets', () => {
-		it('ticketsCreate returns correct parsed structure', async () => {
-			const mockResponse: TicketsCreateResponse = {
-				ticket: {
-					id: 123,
-					subject: 'Test Ticket',
-					description: 'Test Description',
-					status: 'new',
-					priority: 'normal',
-					created_at: '2026-05-22T00:00:00Z',
-					updated_at: '2026-05-22T00:00:00Z',
-				},
-			};
-			mockedRequest.mockResolvedValueOnce(mockResponse);
+		it('ticketsList returns correct type', async () => {
+			if (!hasCredentials) return;
+			const response = await makeZendeskRequest<TicketsListResponse>(
+				'tickets.json',
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
+				{ method: 'GET', query: { per_page: 10 } },
+			);
 
+			ZendeskEndpointOutputSchemas.ticketsList.parse(response);
+		});
+
+		it('ticketsCreate returns correct type', async () => {
+			if (!hasCredentials) return;
 			const response = await makeZendeskRequest<TicketsCreateResponse>(
 				'tickets.json',
-				'key',
-				'subdomain',
-				{ method: 'POST', body: { ticket: { subject: 'Test Ticket' } } },
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
+				{
+					method: 'POST',
+					body: {
+						ticket: {
+							subject: `Corsair API test ${Date.now()}`,
+							comment: {
+								body: 'Test ticket created by the API test suite',
+							},
+						},
+					},
+				},
 			);
 
-			const parsed = ZendeskEndpointOutputSchemas.ticketsCreate.parse(response);
-			expect(parsed.ticket.id).toBe(123);
-			expect(parsed.ticket.subject).toBe('Test Ticket');
+			ZendeskEndpointOutputSchemas.ticketsCreate.parse(response);
+
+			const ticketId = response.ticket.id;
+			if (ticketId) {
+				await makeZendeskRequest<TicketsDeleteResponse>(
+					`tickets/${ticketId}.json`,
+					TEST_API_KEY,
+					TEST_SUBDOMAIN,
+					{ method: 'DELETE' },
+				);
+			}
 		});
 
-		it('ticketsGet returns correct parsed structure', async () => {
-			const mockResponse: TicketsGetResponse = {
-				ticket: {
-					id: 123,
-					subject: 'Test Ticket',
-					description: 'Test Description',
-					status: 'new',
-					created_at: '2026-05-22T00:00:00Z',
+		it('ticketsGet returns correct type', async () => {
+			if (!hasCredentials) return;
+			const created = await makeZendeskRequest<TicketsCreateResponse>(
+				'tickets.json',
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
+				{
+					method: 'POST',
+					body: {
+						ticket: {
+							subject: `Corsair API test get ${Date.now()}`,
+							comment: {
+								body: 'Test ticket for get endpoint',
+							},
+						},
+					},
 				},
-			};
-			mockedRequest.mockResolvedValueOnce(mockResponse);
+			);
+			const ticketId = created.ticket.id;
 
 			const response = await makeZendeskRequest<TicketsGetResponse>(
-				'tickets/123.json',
-				'key',
-				'subdomain',
+				`tickets/${ticketId}.json`,
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
 				{ method: 'GET' },
 			);
 
-			const parsed = ZendeskEndpointOutputSchemas.ticketsGet.parse(response);
-			expect(parsed.ticket.id).toBe(123);
+			ZendeskEndpointOutputSchemas.ticketsGet.parse(response);
+
+			await makeZendeskRequest<TicketsDeleteResponse>(
+				`tickets/${ticketId}.json`,
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
+				{ method: 'DELETE' },
+			);
 		});
 
-		it('ticketsUpdate returns correct parsed structure', async () => {
-			const mockResponse: TicketsUpdateResponse = {
-				ticket: {
-					id: 123,
-					subject: 'Updated Ticket',
-					status: 'open',
+		it('ticketsUpdate returns correct type', async () => {
+			if (!hasCredentials) return;
+			const created = await makeZendeskRequest<TicketsCreateResponse>(
+				'tickets.json',
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
+				{
+					method: 'POST',
+					body: {
+						ticket: {
+							subject: `Corsair API test update ${Date.now()}`,
+							comment: {
+								body: 'Test ticket for update endpoint',
+							},
+						},
+					},
 				},
-			};
-			mockedRequest.mockResolvedValueOnce(mockResponse);
+			);
+			const ticketId = created.ticket.id;
 
 			const response = await makeZendeskRequest<TicketsUpdateResponse>(
-				'tickets/123.json',
-				'key',
-				'subdomain',
-				{ method: 'PUT', body: { ticket: { status: 'open' } } },
+				`tickets/${ticketId}.json`,
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
+				{
+					method: 'PUT',
+					body: {
+						ticket: {
+							status: 'open',
+						},
+					},
+				},
 			);
 
-			const parsed = ZendeskEndpointOutputSchemas.ticketsUpdate.parse(response);
-			expect(parsed.ticket.status).toBe('open');
+			ZendeskEndpointOutputSchemas.ticketsUpdate.parse(response);
+
+			await makeZendeskRequest<TicketsDeleteResponse>(
+				`tickets/${ticketId}.json`,
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
+				{ method: 'DELETE' },
+			);
 		});
 
-		it('ticketsDelete returns correct parsed structure', async () => {
-			const mockResponse: TicketsDeleteResponse = {
-				id: 123,
-			};
-			mockedRequest.mockResolvedValueOnce(mockResponse);
+		it('ticketsDelete returns correct type', async () => {
+			if (!hasCredentials) return;
+			const created = await makeZendeskRequest<TicketsCreateResponse>(
+				'tickets.json',
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
+				{
+					method: 'POST',
+					body: {
+						ticket: {
+							subject: `Corsair API test delete ${Date.now()}`,
+							comment: {
+								body: 'Test ticket for delete endpoint',
+							},
+						},
+					},
+				},
+			);
+			const ticketId = created.ticket.id;
 
 			const response = await makeZendeskRequest<TicketsDeleteResponse>(
-				'tickets/123.json',
-				'key',
-				'subdomain',
+				`tickets/${ticketId}.json`,
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
 				{ method: 'DELETE' },
 			);
 
-			const parsed = ZendeskEndpointOutputSchemas.ticketsDelete.parse(response);
-			expect(parsed.id).toBe(123);
-		});
-
-		it('ticketsList returns correct parsed structure', async () => {
-			const mockResponse: TicketsListResponse = {
-				tickets: [
-					{
-						id: 123,
-						subject: 'Ticket 1',
-					},
-					{
-						id: 124,
-						subject: 'Ticket 2',
-					},
-				],
-				count: 2,
-			};
-			mockedRequest.mockResolvedValueOnce(mockResponse);
-
-			const response = await makeZendeskRequest<TicketsListResponse>(
-				'tickets.json',
-				'key',
-				'subdomain',
-				{ method: 'GET' },
-			);
-
-			const parsed = ZendeskEndpointOutputSchemas.ticketsList.parse(response);
-			expect(parsed.tickets).toHaveLength(2);
-			expect(parsed.count).toBe(2);
+			ZendeskEndpointOutputSchemas.ticketsDelete.parse(response);
 		});
 	});
 
 	describe('users', () => {
-		it('usersCreate returns correct parsed structure', async () => {
-			const mockResponse: UsersCreateResponse = {
-				user: {
-					id: 456,
-					name: 'Test User',
-					email: 'test@user.com',
-					role: 'end-user',
-					active: true,
-				},
-			};
-			mockedRequest.mockResolvedValueOnce(mockResponse);
+		it('usersList returns correct type', async () => {
+			if (!hasCredentials) return;
+			const response = await makeZendeskRequest<UsersListResponse>(
+				'users.json',
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
+				{ method: 'GET', query: { per_page: 10 } },
+			);
 
+			ZendeskEndpointOutputSchemas.usersList.parse(response);
+		});
+
+		it('usersCreate returns correct type', async () => {
+			if (!hasCredentials) return;
+			const email = `corsair-test-${Date.now()}@example.com`;
 			const response = await makeZendeskRequest<UsersCreateResponse>(
 				'users.json',
-				'key',
-				'subdomain',
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
 				{
 					method: 'POST',
-					body: { user: { name: 'Test User', email: 'test@user.com' } },
+					body: {
+						user: {
+							name: 'Corsair Test User',
+							email,
+							role: 'end-user',
+						},
+					},
 				},
 			);
 
-			const parsed = ZendeskEndpointOutputSchemas.usersCreate.parse(response);
-			expect(parsed.user.id).toBe(456);
-			expect(parsed.user.name).toBe('Test User');
+			ZendeskEndpointOutputSchemas.usersCreate.parse(response);
+
+			const userId = response.user.id;
+			if (userId) {
+				await makeZendeskRequest<UsersDeleteResponse>(
+					`users/${userId}.json`,
+					TEST_API_KEY,
+					TEST_SUBDOMAIN,
+					{ method: 'DELETE' },
+				);
+			}
 		});
 
-		it('usersGet returns correct parsed structure', async () => {
-			const mockResponse: UsersGetResponse = {
-				user: {
-					id: 456,
-					name: 'Test User',
-					role: 'agent',
+		it('usersGet returns correct type', async () => {
+			if (!hasCredentials) return;
+			const email = `corsair-test-get-${Date.now()}@example.com`;
+			const created = await makeZendeskRequest<UsersCreateResponse>(
+				'users.json',
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
+				{
+					method: 'POST',
+					body: {
+						user: {
+							name: 'Corsair Test User',
+							email,
+							role: 'end-user',
+						},
+					},
 				},
-			};
-			mockedRequest.mockResolvedValueOnce(mockResponse);
+			);
+			const userId = created.user.id;
 
 			const response = await makeZendeskRequest<UsersGetResponse>(
-				'users/456.json',
-				'key',
-				'subdomain',
+				`users/${userId}.json`,
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
 				{ method: 'GET' },
 			);
 
-			const parsed = ZendeskEndpointOutputSchemas.usersGet.parse(response);
-			expect(parsed.user.id).toBe(456);
+			ZendeskEndpointOutputSchemas.usersGet.parse(response);
+
+			await makeZendeskRequest<UsersDeleteResponse>(
+				`users/${userId}.json`,
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
+				{ method: 'DELETE' },
+			);
 		});
 
-		it('usersUpdate returns correct parsed structure', async () => {
-			const mockResponse: UsersUpdateResponse = {
-				user: {
-					id: 456,
-					name: 'Updated User',
+		it('usersUpdate returns correct type', async () => {
+			if (!hasCredentials) return;
+			const email = `corsair-test-update-${Date.now()}@example.com`;
+			const created = await makeZendeskRequest<UsersCreateResponse>(
+				'users.json',
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
+				{
+					method: 'POST',
+					body: {
+						user: {
+							name: 'Corsair Test User',
+							email,
+							role: 'end-user',
+						},
+					},
 				},
-			};
-			mockedRequest.mockResolvedValueOnce(mockResponse);
+			);
+			const userId = created.user.id;
 
 			const response = await makeZendeskRequest<UsersUpdateResponse>(
-				'users/456.json',
-				'key',
-				'subdomain',
-				{ method: 'PUT', body: { user: { name: 'Updated User' } } },
+				`users/${userId}.json`,
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
+				{
+					method: 'PUT',
+					body: {
+						user: {
+							name: 'Corsair Updated User',
+						},
+					},
+				},
 			);
 
-			const parsed = ZendeskEndpointOutputSchemas.usersUpdate.parse(response);
-			expect(parsed.user.name).toBe('Updated User');
+			ZendeskEndpointOutputSchemas.usersUpdate.parse(response);
+
+			await makeZendeskRequest<UsersDeleteResponse>(
+				`users/${userId}.json`,
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
+				{ method: 'DELETE' },
+			);
 		});
 
-		it('usersDelete returns correct parsed structure', async () => {
-			const mockResponse: UsersDeleteResponse = {
-				id: 456,
-			};
-			mockedRequest.mockResolvedValueOnce(mockResponse);
+		it('usersDelete returns correct type', async () => {
+			if (!hasCredentials) return;
+			const email = `corsair-test-delete-${Date.now()}@example.com`;
+			const created = await makeZendeskRequest<UsersCreateResponse>(
+				'users.json',
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
+				{
+					method: 'POST',
+					body: {
+						user: {
+							name: 'Corsair Test User',
+							email,
+							role: 'end-user',
+						},
+					},
+				},
+			);
+			const userId = created.user.id;
 
 			const response = await makeZendeskRequest<UsersDeleteResponse>(
-				'users/456.json',
-				'key',
-				'subdomain',
+				`users/${userId}.json`,
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
 				{ method: 'DELETE' },
 			);
 
-			const parsed = ZendeskEndpointOutputSchemas.usersDelete.parse(response);
-			expect(parsed.id).toBe(456);
-		});
-
-		it('usersList returns correct parsed structure', async () => {
-			const mockResponse: UsersListResponse = {
-				users: [
-					{
-						id: 456,
-						name: 'User 1',
-					},
-					{
-						id: 457,
-						name: 'User 2',
-					},
-				],
-				count: 2,
-			};
-			mockedRequest.mockResolvedValueOnce(mockResponse);
-
-			const response = await makeZendeskRequest<UsersListResponse>(
-				'users.json',
-				'key',
-				'subdomain',
-				{ method: 'GET' },
-			);
-
-			const parsed = ZendeskEndpointOutputSchemas.usersList.parse(response);
-			expect(parsed.users).toHaveLength(2);
+			ZendeskEndpointOutputSchemas.usersDelete.parse(response);
 		});
 	});
 
 	describe('comments', () => {
-		it('commentsList returns correct parsed structure', async () => {
-			const mockResponse: CommentsListResponse = {
-				comments: [
-					{
-						id: 789,
-						body: 'Comment 1',
-						public: true,
-						author_id: 456,
-						created_at: '2026-05-22T00:00:00Z',
+		it('commentsList returns correct type', async () => {
+			if (!hasCredentials) return;
+			const created = await makeZendeskRequest<TicketsCreateResponse>(
+				'tickets.json',
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
+				{
+					method: 'POST',
+					body: {
+						ticket: {
+							subject: `Corsair API test comments ${Date.now()}`,
+							comment: {
+								body: 'Initial comment for comments list test',
+							},
+						},
 					},
-				],
-				count: 1,
-			};
-			mockedRequest.mockResolvedValueOnce(mockResponse);
+				},
+			);
+			const ticketId = created.ticket.id;
 
 			const response = await makeZendeskRequest<CommentsListResponse>(
-				'tickets/123/comments.json',
-				'key',
-				'subdomain',
+				`tickets/${ticketId}/comments.json`,
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
 				{ method: 'GET' },
 			);
 
-			const parsed = ZendeskEndpointOutputSchemas.commentsList.parse(response);
-			expect(parsed.comments).toHaveLength(1);
-			expect(parsed.comments[0]!.id).toBe(789);
+			ZendeskEndpointOutputSchemas.commentsList.parse(response);
+
+			await makeZendeskRequest<TicketsDeleteResponse>(
+				`tickets/${ticketId}.json`,
+				TEST_API_KEY,
+				TEST_SUBDOMAIN,
+				{ method: 'DELETE' },
+			);
 		});
 	});
 });

--- a/packages/zendesk/api.test.ts
+++ b/packages/zendesk/api.test.ts
@@ -1,0 +1,320 @@
+import 'dotenv/config';
+import { request } from 'corsair/http';
+import { makeZendeskRequest } from './client';
+import type {
+	CommentsListResponse,
+	TicketsCreateResponse,
+	TicketsDeleteResponse,
+	TicketsGetResponse,
+	TicketsListResponse,
+	TicketsUpdateResponse,
+	UsersCreateResponse,
+	UsersDeleteResponse,
+	UsersGetResponse,
+	UsersListResponse,
+	UsersUpdateResponse,
+} from './endpoints/types';
+import { ZendeskEndpointOutputSchemas } from './endpoints/types';
+
+jest.mock('corsair/http', () => ({
+	request: jest.fn(),
+}));
+
+const mockedRequest = request as jest.MockedFunction<typeof request>;
+
+describe('Zendesk API Type Tests', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('makeZendeskRequest client', () => {
+		it('sends the correct headers and constructs the correct URL', async () => {
+			mockedRequest.mockResolvedValueOnce({
+				ticket: { id: 123, subject: 'Test' },
+			});
+
+			const response = await makeZendeskRequest<TicketsGetResponse>(
+				'tickets/123.json',
+				'user@domain.com/token:myapikey',
+				'mysubdomain',
+				{ method: 'GET' },
+			);
+
+			expect(mockedRequest).toHaveBeenCalledWith(
+				expect.objectContaining({
+					BASE: 'https://mysubdomain.zendesk.com/api/v2',
+					HEADERS: {
+						'Content-Type': 'application/json',
+						Accept: 'application/json',
+						Authorization: `Basic ${Buffer.from('user@domain.com/token:myapikey').toString('base64')}`,
+					},
+				}),
+				expect.objectContaining({
+					method: 'GET',
+					url: 'tickets/123.json',
+				}),
+			);
+			expect(response).toEqual({ ticket: { id: 123, subject: 'Test' } });
+		});
+	});
+
+	describe('tickets', () => {
+		it('ticketsCreate returns correct parsed structure', async () => {
+			const mockResponse: TicketsCreateResponse = {
+				ticket: {
+					id: 123,
+					subject: 'Test Ticket',
+					description: 'Test Description',
+					status: 'new',
+					priority: 'normal',
+					created_at: '2026-05-22T00:00:00Z',
+					updated_at: '2026-05-22T00:00:00Z',
+				},
+			};
+			mockedRequest.mockResolvedValueOnce(mockResponse);
+
+			const response = await makeZendeskRequest<TicketsCreateResponse>(
+				'tickets.json',
+				'key',
+				'subdomain',
+				{ method: 'POST', body: { ticket: { subject: 'Test Ticket' } } },
+			);
+
+			const parsed = ZendeskEndpointOutputSchemas.ticketsCreate.parse(response);
+			expect(parsed.ticket.id).toBe(123);
+			expect(parsed.ticket.subject).toBe('Test Ticket');
+		});
+
+		it('ticketsGet returns correct parsed structure', async () => {
+			const mockResponse: TicketsGetResponse = {
+				ticket: {
+					id: 123,
+					subject: 'Test Ticket',
+					description: 'Test Description',
+					status: 'new',
+					created_at: '2026-05-22T00:00:00Z',
+				},
+			};
+			mockedRequest.mockResolvedValueOnce(mockResponse);
+
+			const response = await makeZendeskRequest<TicketsGetResponse>(
+				'tickets/123.json',
+				'key',
+				'subdomain',
+				{ method: 'GET' },
+			);
+
+			const parsed = ZendeskEndpointOutputSchemas.ticketsGet.parse(response);
+			expect(parsed.ticket.id).toBe(123);
+		});
+
+		it('ticketsUpdate returns correct parsed structure', async () => {
+			const mockResponse: TicketsUpdateResponse = {
+				ticket: {
+					id: 123,
+					subject: 'Updated Ticket',
+					status: 'open',
+				},
+			};
+			mockedRequest.mockResolvedValueOnce(mockResponse);
+
+			const response = await makeZendeskRequest<TicketsUpdateResponse>(
+				'tickets/123.json',
+				'key',
+				'subdomain',
+				{ method: 'PUT', body: { ticket: { status: 'open' } } },
+			);
+
+			const parsed = ZendeskEndpointOutputSchemas.ticketsUpdate.parse(response);
+			expect(parsed.ticket.status).toBe('open');
+		});
+
+		it('ticketsDelete returns correct parsed structure', async () => {
+			const mockResponse: TicketsDeleteResponse = {
+				id: 123,
+			};
+			mockedRequest.mockResolvedValueOnce(mockResponse);
+
+			const response = await makeZendeskRequest<TicketsDeleteResponse>(
+				'tickets/123.json',
+				'key',
+				'subdomain',
+				{ method: 'DELETE' },
+			);
+
+			const parsed = ZendeskEndpointOutputSchemas.ticketsDelete.parse(response);
+			expect(parsed.id).toBe(123);
+		});
+
+		it('ticketsList returns correct parsed structure', async () => {
+			const mockResponse: TicketsListResponse = {
+				tickets: [
+					{
+						id: 123,
+						subject: 'Ticket 1',
+					},
+					{
+						id: 124,
+						subject: 'Ticket 2',
+					},
+				],
+				count: 2,
+			};
+			mockedRequest.mockResolvedValueOnce(mockResponse);
+
+			const response = await makeZendeskRequest<TicketsListResponse>(
+				'tickets.json',
+				'key',
+				'subdomain',
+				{ method: 'GET' },
+			);
+
+			const parsed = ZendeskEndpointOutputSchemas.ticketsList.parse(response);
+			expect(parsed.tickets).toHaveLength(2);
+			expect(parsed.count).toBe(2);
+		});
+	});
+
+	describe('users', () => {
+		it('usersCreate returns correct parsed structure', async () => {
+			const mockResponse: UsersCreateResponse = {
+				user: {
+					id: 456,
+					name: 'Test User',
+					email: 'test@user.com',
+					role: 'end-user',
+					active: true,
+				},
+			};
+			mockedRequest.mockResolvedValueOnce(mockResponse);
+
+			const response = await makeZendeskRequest<UsersCreateResponse>(
+				'users.json',
+				'key',
+				'subdomain',
+				{
+					method: 'POST',
+					body: { user: { name: 'Test User', email: 'test@user.com' } },
+				},
+			);
+
+			const parsed = ZendeskEndpointOutputSchemas.usersCreate.parse(response);
+			expect(parsed.user.id).toBe(456);
+			expect(parsed.user.name).toBe('Test User');
+		});
+
+		it('usersGet returns correct parsed structure', async () => {
+			const mockResponse: UsersGetResponse = {
+				user: {
+					id: 456,
+					name: 'Test User',
+					role: 'agent',
+				},
+			};
+			mockedRequest.mockResolvedValueOnce(mockResponse);
+
+			const response = await makeZendeskRequest<UsersGetResponse>(
+				'users/456.json',
+				'key',
+				'subdomain',
+				{ method: 'GET' },
+			);
+
+			const parsed = ZendeskEndpointOutputSchemas.usersGet.parse(response);
+			expect(parsed.user.id).toBe(456);
+		});
+
+		it('usersUpdate returns correct parsed structure', async () => {
+			const mockResponse: UsersUpdateResponse = {
+				user: {
+					id: 456,
+					name: 'Updated User',
+				},
+			};
+			mockedRequest.mockResolvedValueOnce(mockResponse);
+
+			const response = await makeZendeskRequest<UsersUpdateResponse>(
+				'users/456.json',
+				'key',
+				'subdomain',
+				{ method: 'PUT', body: { user: { name: 'Updated User' } } },
+			);
+
+			const parsed = ZendeskEndpointOutputSchemas.usersUpdate.parse(response);
+			expect(parsed.user.name).toBe('Updated User');
+		});
+
+		it('usersDelete returns correct parsed structure', async () => {
+			const mockResponse: UsersDeleteResponse = {
+				id: 456,
+			};
+			mockedRequest.mockResolvedValueOnce(mockResponse);
+
+			const response = await makeZendeskRequest<UsersDeleteResponse>(
+				'users/456.json',
+				'key',
+				'subdomain',
+				{ method: 'DELETE' },
+			);
+
+			const parsed = ZendeskEndpointOutputSchemas.usersDelete.parse(response);
+			expect(parsed.id).toBe(456);
+		});
+
+		it('usersList returns correct parsed structure', async () => {
+			const mockResponse: UsersListResponse = {
+				users: [
+					{
+						id: 456,
+						name: 'User 1',
+					},
+					{
+						id: 457,
+						name: 'User 2',
+					},
+				],
+				count: 2,
+			};
+			mockedRequest.mockResolvedValueOnce(mockResponse);
+
+			const response = await makeZendeskRequest<UsersListResponse>(
+				'users.json',
+				'key',
+				'subdomain',
+				{ method: 'GET' },
+			);
+
+			const parsed = ZendeskEndpointOutputSchemas.usersList.parse(response);
+			expect(parsed.users).toHaveLength(2);
+		});
+	});
+
+	describe('comments', () => {
+		it('commentsList returns correct parsed structure', async () => {
+			const mockResponse: CommentsListResponse = {
+				comments: [
+					{
+						id: 789,
+						body: 'Comment 1',
+						public: true,
+						author_id: 456,
+						created_at: '2026-05-22T00:00:00Z',
+					},
+				],
+				count: 1,
+			};
+			mockedRequest.mockResolvedValueOnce(mockResponse);
+
+			const response = await makeZendeskRequest<CommentsListResponse>(
+				'tickets/123/comments.json',
+				'key',
+				'subdomain',
+				{ method: 'GET' },
+			);
+
+			const parsed = ZendeskEndpointOutputSchemas.commentsList.parse(response);
+			expect(parsed.comments).toHaveLength(1);
+			expect(parsed.comments[0]!.id).toBe(789);
+		});
+	});
+});

--- a/packages/zendesk/client.ts
+++ b/packages/zendesk/client.ts
@@ -1,5 +1,5 @@
 import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
-import { request } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
 
 export class ZendeskAPIError extends Error {
 	constructor(
@@ -56,6 +56,9 @@ export async function makeZendeskRequest<T>(
 	try {
 		return await request<T>(config, requestOptions);
 	} catch (error) {
+		if (error instanceof ApiError) {
+			throw error;
+		}
 		if (error instanceof Error) {
 			throw new ZendeskAPIError(error.message);
 		}

--- a/packages/zendesk/client.ts
+++ b/packages/zendesk/client.ts
@@ -21,6 +21,12 @@ export async function makeZendeskRequest<T>(
 		query?: Record<string, string | number | boolean | undefined>;
 	} = {},
 ): Promise<T> {
+	if (!subdomain) {
+		throw new ZendeskAPIError(
+			'Subdomain is required for Zendesk integration',
+			'MISSING_SUBDOMAIN',
+		);
+	}
 	const { method = 'GET', body, query } = options;
 
 	const config: OpenAPIConfig = {

--- a/packages/zendesk/client.ts
+++ b/packages/zendesk/client.ts
@@ -1,0 +1,58 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { request } from 'corsair/http';
+
+export class ZendeskAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly code?: string,
+	) {
+		super(message);
+		this.name = 'ZendeskAPIError';
+	}
+}
+
+export async function makeZendeskRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	subdomain: string,
+	options: {
+		method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+		body?: Record<string, unknown>;
+		query?: Record<string, string | number | boolean | undefined>;
+	} = {},
+): Promise<T> {
+	const { method = 'GET', body, query } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: `https://${subdomain}.zendesk.com/api/v2`,
+		VERSION: '2.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: undefined,
+		HEADERS: {
+			'Content-Type': 'application/json',
+			Accept: 'application/json',
+			Authorization: `Basic ${Buffer.from(apiKey).toString('base64')}`,
+		},
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint,
+		body:
+			method === 'POST' || method === 'PUT' || method === 'PATCH'
+				? body
+				: undefined,
+		mediaType: 'application/json; charset=utf-8',
+		query: method === 'GET' || method === 'DELETE' ? query : undefined,
+	};
+
+	try {
+		return await request<T>(config, requestOptions);
+	} catch (error) {
+		if (error instanceof Error) {
+			throw new ZendeskAPIError(error.message);
+		}
+		throw new ZendeskAPIError('Unknown error');
+	}
+}

--- a/packages/zendesk/endpoints/comments.ts
+++ b/packages/zendesk/endpoints/comments.ts
@@ -1,0 +1,44 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeZendeskRequest } from '../client';
+import type { ZendeskEndpoints } from '../index';
+import type { ZendeskEndpointOutputs } from './types';
+
+export const list: ZendeskEndpoints['commentsList'] = async (ctx, input) => {
+	const subdomain =
+		ctx.options.subdomain ?? (await ctx.keys.get_subdomain()) ?? '';
+	const response = await makeZendeskRequest<
+		ZendeskEndpointOutputs['commentsList']
+	>(`tickets/${input.ticket_id}/comments.json`, ctx.key, subdomain, {
+		method: 'GET',
+		query: {
+			...(input.page !== undefined && { page: input.page }),
+			...(input.per_page !== undefined && { per_page: input.per_page }),
+		},
+	});
+
+	const comments = response.comments || [];
+	if (ctx.db.comments) {
+		for (const comment of comments) {
+			try {
+				await ctx.db.comments.upsertByEntityId(String(comment.id), {
+					id: comment.id,
+					ticketId: input.ticket_id,
+					body: comment.body ?? null,
+					authorId: comment.author_id ?? null,
+					public: comment.public ?? null,
+					createdAt: comment.created_at ? new Date(comment.created_at) : null,
+				});
+			} catch (error) {
+				console.warn('Failed to save comment to database:', error);
+			}
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'zendesk.comments.list',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};

--- a/packages/zendesk/endpoints/index.ts
+++ b/packages/zendesk/endpoints/index.ts
@@ -1,0 +1,6 @@
+import * as Comments from './comments';
+import * as Tickets from './tickets';
+import * as Users from './users';
+
+export { Tickets, Users, Comments };
+export * from './types';

--- a/packages/zendesk/endpoints/tickets.ts
+++ b/packages/zendesk/endpoints/tickets.ts
@@ -159,6 +159,7 @@ export const deleteTicket: ZendeskEndpoints['ticketsDelete'] = async (
 ) => {
 	const subdomain =
 		ctx.options.subdomain ?? (await ctx.keys.get_subdomain()) ?? '';
+	// makeZendeskRequest<unknown> is used because Zendesk delete APIs return 204 No Content and we do not expect a structured response body.
 	await makeZendeskRequest<unknown>(
 		`tickets/${input.id}.json`,
 		ctx.key,

--- a/packages/zendesk/endpoints/tickets.ts
+++ b/packages/zendesk/endpoints/tickets.ts
@@ -1,0 +1,231 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeZendeskRequest } from '../client';
+import type { ZendeskEndpoints } from '../index';
+import type { ZendeskEndpointOutputs } from './types';
+
+export const create: ZendeskEndpoints['ticketsCreate'] = async (ctx, input) => {
+	const subdomain =
+		ctx.options.subdomain ?? (await ctx.keys.get_subdomain()) ?? '';
+	const response = await makeZendeskRequest<
+		ZendeskEndpointOutputs['ticketsCreate']
+	>('tickets.json', ctx.key, subdomain, {
+		method: 'POST',
+		body: {
+			ticket: {
+				...(input.subject && { subject: input.subject }),
+				...(input.description && { description: input.description }),
+				...(input.comment && { comment: input.comment }),
+				...(input.status && { status: input.status }),
+				...(input.priority && { priority: input.priority }),
+				...(input.requester_id !== undefined && {
+					requester_id: input.requester_id,
+				}),
+				...(input.assignee_id !== undefined && {
+					assignee_id: input.assignee_id,
+				}),
+				...(input.group_id !== undefined && { group_id: input.group_id }),
+				...(input.organization_id !== undefined && {
+					organization_id: input.organization_id,
+				}),
+				...(input.tags && { tags: input.tags }),
+			},
+		},
+	});
+
+	const ticket = response.ticket;
+	if (ticket && ctx.db.tickets) {
+		try {
+			await ctx.db.tickets.upsertByEntityId(String(ticket.id), {
+				id: ticket.id,
+				subject: ticket.subject ?? null,
+				description: ticket.description ?? null,
+				status: ticket.status ?? null,
+				priority: ticket.priority ?? null,
+				requesterId: ticket.requester_id ?? null,
+				assigneeId: ticket.assignee_id ?? null,
+				organizationId: ticket.organization_id ?? null,
+				groupId: ticket.group_id ?? null,
+				createdAt: ticket.created_at ? new Date(ticket.created_at) : null,
+				updatedAt: ticket.updated_at ? new Date(ticket.updated_at) : null,
+			});
+		} catch (error) {
+			console.warn('Failed to save ticket to database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'zendesk.tickets.create',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+export const get: ZendeskEndpoints['ticketsGet'] = async (ctx, input) => {
+	const subdomain =
+		ctx.options.subdomain ?? (await ctx.keys.get_subdomain()) ?? '';
+	const response = await makeZendeskRequest<
+		ZendeskEndpointOutputs['ticketsGet']
+	>(`tickets/${input.id}.json`, ctx.key, subdomain, { method: 'GET' });
+
+	const ticket = response.ticket;
+	if (ticket && ctx.db.tickets) {
+		try {
+			await ctx.db.tickets.upsertByEntityId(String(ticket.id), {
+				id: ticket.id,
+				subject: ticket.subject ?? null,
+				description: ticket.description ?? null,
+				status: ticket.status ?? null,
+				priority: ticket.priority ?? null,
+				requesterId: ticket.requester_id ?? null,
+				assigneeId: ticket.assignee_id ?? null,
+				organizationId: ticket.organization_id ?? null,
+				groupId: ticket.group_id ?? null,
+				createdAt: ticket.created_at ? new Date(ticket.created_at) : null,
+				updatedAt: ticket.updated_at ? new Date(ticket.updated_at) : null,
+			});
+		} catch (error) {
+			console.warn('Failed to save ticket to database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'zendesk.tickets.get',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+export const update: ZendeskEndpoints['ticketsUpdate'] = async (ctx, input) => {
+	const subdomain =
+		ctx.options.subdomain ?? (await ctx.keys.get_subdomain()) ?? '';
+	const response = await makeZendeskRequest<
+		ZendeskEndpointOutputs['ticketsUpdate']
+	>(`tickets/${input.id}.json`, ctx.key, subdomain, {
+		method: 'PUT',
+		body: {
+			ticket: {
+				...(input.subject && { subject: input.subject }),
+				...(input.status && { status: input.status }),
+				...(input.priority && { priority: input.priority }),
+				...(input.requester_id !== undefined && {
+					requester_id: input.requester_id,
+				}),
+				...(input.assignee_id !== undefined && {
+					assignee_id: input.assignee_id,
+				}),
+				...(input.comment && { comment: input.comment }),
+				...(input.tags && { tags: input.tags }),
+			},
+		},
+	});
+
+	const ticket = response.ticket;
+	if (ticket && ctx.db.tickets) {
+		try {
+			await ctx.db.tickets.upsertByEntityId(String(ticket.id), {
+				id: ticket.id,
+				subject: ticket.subject ?? null,
+				description: ticket.description ?? null,
+				status: ticket.status ?? null,
+				priority: ticket.priority ?? null,
+				requesterId: ticket.requester_id ?? null,
+				assigneeId: ticket.assignee_id ?? null,
+				organizationId: ticket.organization_id ?? null,
+				groupId: ticket.group_id ?? null,
+				createdAt: ticket.created_at ? new Date(ticket.created_at) : null,
+				updatedAt: ticket.updated_at ? new Date(ticket.updated_at) : null,
+			});
+		} catch (error) {
+			console.warn('Failed to save ticket to database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'zendesk.tickets.update',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+export const deleteTicket: ZendeskEndpoints['ticketsDelete'] = async (
+	ctx,
+	input,
+) => {
+	const subdomain =
+		ctx.options.subdomain ?? (await ctx.keys.get_subdomain()) ?? '';
+	await makeZendeskRequest<unknown>(
+		`tickets/${input.id}.json`,
+		ctx.key,
+		subdomain,
+		{ method: 'DELETE' },
+	);
+
+	if (ctx.db.tickets) {
+		try {
+			await ctx.db.tickets.deleteByEntityId(String(input.id));
+		} catch (error) {
+			console.warn('Failed to delete ticket from database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'zendesk.tickets.delete',
+		{ ...input },
+		'completed',
+	);
+	return { id: input.id };
+};
+
+export const list: ZendeskEndpoints['ticketsList'] = async (ctx, input) => {
+	const subdomain =
+		ctx.options.subdomain ?? (await ctx.keys.get_subdomain()) ?? '';
+	const response = await makeZendeskRequest<
+		ZendeskEndpointOutputs['ticketsList']
+	>('tickets.json', ctx.key, subdomain, {
+		method: 'GET',
+		query: {
+			...(input.page !== undefined && { page: input.page }),
+			...(input.per_page !== undefined && { per_page: input.per_page }),
+			...(input.sort_by && { sort_by: input.sort_by }),
+			...(input.sort_order && { sort_order: input.sort_order }),
+		},
+	});
+
+	const tickets = response.tickets || [];
+	if (ctx.db.tickets) {
+		for (const ticket of tickets) {
+			try {
+				await ctx.db.tickets.upsertByEntityId(String(ticket.id), {
+					id: ticket.id,
+					subject: ticket.subject ?? null,
+					description: ticket.description ?? null,
+					status: ticket.status ?? null,
+					priority: ticket.priority ?? null,
+					requesterId: ticket.requester_id ?? null,
+					assigneeId: ticket.assignee_id ?? null,
+					organizationId: ticket.organization_id ?? null,
+					groupId: ticket.group_id ?? null,
+					createdAt: ticket.created_at ? new Date(ticket.created_at) : null,
+					updatedAt: ticket.updated_at ? new Date(ticket.updated_at) : null,
+				});
+			} catch (error) {
+				console.warn('Failed to save ticket to database:', error);
+			}
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'zendesk.tickets.list',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};

--- a/packages/zendesk/endpoints/types.ts
+++ b/packages/zendesk/endpoints/types.ts
@@ -59,6 +59,7 @@ export const ZendeskCommentResponseSchema = z.object({
 	plain_body: z.string().optional().nullable(),
 	public: z.boolean().optional().nullable(),
 	author_id: z.number().optional().nullable(),
+	// z.unknown() is used because Zendesk attachment objects have a highly variable/dynamic structure and we only need to verify the array presence.
 	attachments: z.array(z.unknown()).optional().nullable(),
 	created_at: z.string().optional().nullable(),
 });

--- a/packages/zendesk/endpoints/types.ts
+++ b/packages/zendesk/endpoints/types.ts
@@ -1,0 +1,298 @@
+import { z } from 'zod';
+
+// Shared Zendesk API objects
+export const ZendeskTicketResponseSchema = z.object({
+	id: z.number(),
+	url: z.string().optional().nullable(),
+	external_id: z.string().optional().nullable(),
+	created_at: z.string().optional().nullable(),
+	updated_at: z.string().optional().nullable(),
+	type: z.string().optional().nullable(),
+	subject: z.string().optional().nullable(),
+	raw_subject: z.string().optional().nullable(),
+	description: z.string().optional().nullable(),
+	priority: z.string().optional().nullable(),
+	status: z.string().optional().nullable(),
+	recipient: z.string().optional().nullable(),
+	requester_id: z.number().optional().nullable(),
+	submitter_id: z.number().optional().nullable(),
+	assignee_id: z.number().optional().nullable(),
+	organization_id: z.number().optional().nullable(),
+	group_id: z.number().optional().nullable(),
+	collaborator_ids: z.array(z.number()).optional().nullable(),
+	follower_ids: z.array(z.number()).optional().nullable(),
+	email_cc_ids: z.array(z.number()).optional().nullable(),
+	forum_topic_id: z.number().optional().nullable(),
+	problem_id: z.number().optional().nullable(),
+	has_incidents: z.boolean().optional().nullable(),
+	is_public: z.boolean().optional().nullable(),
+	due_at: z.string().optional().nullable(),
+	tags: z.array(z.string()).optional().nullable(),
+});
+
+export const ZendeskUserResponseSchema = z.object({
+	id: z.number(),
+	url: z.string().optional().nullable(),
+	name: z.string(),
+	email: z.string().optional().nullable(),
+	created_at: z.string().optional().nullable(),
+	updated_at: z.string().optional().nullable(),
+	time_zone: z.string().optional().nullable(),
+	iana_time_zone: z.string().optional().nullable(),
+	phone: z.string().optional().nullable(),
+	shared_phone: z.boolean().optional().nullable(),
+	locale_id: z.number().optional().nullable(),
+	locale: z.string().optional().nullable(),
+	organization_id: z.number().optional().nullable(),
+	role: z.string().optional().nullable(),
+	verified: z.boolean().optional().nullable(),
+	external_id: z.string().optional().nullable(),
+	tags: z.array(z.string()).optional().nullable(),
+	active: z.boolean().optional().nullable(),
+});
+
+export const ZendeskCommentResponseSchema = z.object({
+	id: z.number(),
+	type: z.string().optional().nullable(),
+	body: z.string().optional().nullable(),
+	html_body: z.string().optional().nullable(),
+	plain_body: z.string().optional().nullable(),
+	public: z.boolean().optional().nullable(),
+	author_id: z.number().optional().nullable(),
+	attachments: z.array(z.unknown()).optional().nullable(),
+	created_at: z.string().optional().nullable(),
+});
+
+// Tickets Endpoints Schemas
+export const TicketsCreateInputSchema = z.object({
+	subject: z.string().optional(),
+	description: z.string().optional(),
+	comment: z
+		.object({
+			body: z.string(),
+			public: z.boolean().optional(),
+			author_id: z.number().optional(),
+		})
+		.optional(),
+	status: z.string().optional(),
+	priority: z.string().optional(),
+	requester_id: z.number().optional(),
+	assignee_id: z.number().optional(),
+	group_id: z.number().optional(),
+	organization_id: z.number().optional(),
+	tags: z.array(z.string()).optional(),
+});
+
+export const TicketsCreateResponseSchema = z.object({
+	ticket: ZendeskTicketResponseSchema,
+});
+
+export const TicketsGetInputSchema = z.object({
+	id: z.number(),
+});
+
+export const TicketsGetResponseSchema = z.object({
+	ticket: ZendeskTicketResponseSchema,
+});
+
+export const TicketsUpdateInputSchema = z.object({
+	id: z.number(),
+	subject: z.string().optional(),
+	status: z.string().optional(),
+	priority: z.string().optional(),
+	requester_id: z.number().optional(),
+	assignee_id: z.number().optional(),
+	comment: z
+		.object({
+			body: z.string(),
+			public: z.boolean().optional(),
+			author_id: z.number().optional(),
+		})
+		.optional(),
+	tags: z.array(z.string()).optional(),
+});
+
+export const TicketsUpdateResponseSchema = z.object({
+	ticket: ZendeskTicketResponseSchema,
+});
+
+export const TicketsDeleteInputSchema = z.object({
+	id: z.number(),
+});
+
+export const TicketsDeleteResponseSchema = z.object({
+	id: z.number().optional(),
+});
+
+export const TicketsListInputSchema = z.object({
+	page: z.number().optional(),
+	per_page: z.number().optional(),
+	sort_by: z.string().optional(),
+	sort_order: z.string().optional(),
+});
+
+export const TicketsListResponseSchema = z.object({
+	tickets: z.array(ZendeskTicketResponseSchema),
+	next_page: z.string().nullable().optional(),
+	previous_page: z.string().nullable().optional(),
+	count: z.number().optional(),
+});
+
+// Users Endpoints Schemas
+export const UsersCreateInputSchema = z.object({
+	name: z.string(),
+	email: z.string(),
+	role: z.string().optional(),
+	external_id: z.string().optional(),
+	active: z.boolean().optional(),
+});
+
+export const UsersCreateResponseSchema = z.object({
+	user: ZendeskUserResponseSchema,
+});
+
+export const UsersGetInputSchema = z.object({
+	id: z.number(),
+});
+
+export const UsersGetResponseSchema = z.object({
+	user: ZendeskUserResponseSchema,
+});
+
+export const UsersUpdateInputSchema = z.object({
+	id: z.number(),
+	name: z.string().optional(),
+	email: z.string().optional(),
+	role: z.string().optional(),
+	external_id: z.string().optional(),
+	active: z.boolean().optional(),
+});
+
+export const UsersUpdateResponseSchema = z.object({
+	user: ZendeskUserResponseSchema,
+});
+
+export const UsersDeleteInputSchema = z.object({
+	id: z.number(),
+});
+
+export const UsersDeleteResponseSchema = z.object({
+	id: z.number().optional(),
+});
+
+export const UsersListInputSchema = z.object({
+	page: z.number().optional(),
+	per_page: z.number().optional(),
+	role: z.string().optional(),
+});
+
+export const UsersListResponseSchema = z.object({
+	users: z.array(ZendeskUserResponseSchema),
+	next_page: z.string().nullable().optional(),
+	previous_page: z.string().nullable().optional(),
+	count: z.number().optional(),
+});
+
+// Comments Endpoints Schemas
+export const CommentsListInputSchema = z.object({
+	ticket_id: z.number(),
+	page: z.number().optional(),
+	per_page: z.number().optional(),
+});
+
+export const CommentsListResponseSchema = z.object({
+	comments: z.array(ZendeskCommentResponseSchema),
+	next_page: z.string().nullable().optional(),
+	previous_page: z.string().nullable().optional(),
+	count: z.number().optional(),
+});
+
+// Combined Types for Corsair Plugin Configuration
+export type TicketsCreateInput = z.infer<typeof TicketsCreateInputSchema>;
+export type TicketsCreateResponse = z.infer<typeof TicketsCreateResponseSchema>;
+
+export type TicketsGetInput = z.infer<typeof TicketsGetInputSchema>;
+export type TicketsGetResponse = z.infer<typeof TicketsGetResponseSchema>;
+
+export type TicketsUpdateInput = z.infer<typeof TicketsUpdateInputSchema>;
+export type TicketsUpdateResponse = z.infer<typeof TicketsUpdateResponseSchema>;
+
+export type TicketsDeleteInput = z.infer<typeof TicketsDeleteInputSchema>;
+export type TicketsDeleteResponse = z.infer<typeof TicketsDeleteResponseSchema>;
+
+export type TicketsListInput = z.infer<typeof TicketsListInputSchema>;
+export type TicketsListResponse = z.infer<typeof TicketsListResponseSchema>;
+
+export type UsersCreateInput = z.infer<typeof UsersCreateInputSchema>;
+export type UsersCreateResponse = z.infer<typeof UsersCreateResponseSchema>;
+
+export type UsersGetInput = z.infer<typeof UsersGetInputSchema>;
+export type UsersGetResponse = z.infer<typeof UsersGetResponseSchema>;
+
+export type UsersUpdateInput = z.infer<typeof UsersUpdateInputSchema>;
+export type UsersUpdateResponse = z.infer<typeof UsersUpdateResponseSchema>;
+
+export type UsersDeleteInput = z.infer<typeof UsersDeleteInputSchema>;
+export type UsersDeleteResponse = z.infer<typeof UsersDeleteResponseSchema>;
+
+export type UsersListInput = z.infer<typeof UsersListInputSchema>;
+export type UsersListResponse = z.infer<typeof UsersListResponseSchema>;
+
+export type CommentsListInput = z.infer<typeof CommentsListInputSchema>;
+export type CommentsListResponse = z.infer<typeof CommentsListResponseSchema>;
+
+export type ZendeskEndpointInputs = {
+	ticketsCreate: TicketsCreateInput;
+	ticketsGet: TicketsGetInput;
+	ticketsUpdate: TicketsUpdateInput;
+	ticketsDelete: TicketsDeleteInput;
+	ticketsList: TicketsListInput;
+	usersCreate: UsersCreateInput;
+	usersGet: UsersGetInput;
+	usersUpdate: UsersUpdateInput;
+	usersDelete: UsersDeleteInput;
+	usersList: UsersListInput;
+	commentsList: CommentsListInput;
+};
+
+export type ZendeskEndpointOutputs = {
+	ticketsCreate: TicketsCreateResponse;
+	ticketsGet: TicketsGetResponse;
+	ticketsUpdate: TicketsUpdateResponse;
+	ticketsDelete: TicketsDeleteResponse;
+	ticketsList: TicketsListResponse;
+	usersCreate: UsersCreateResponse;
+	usersGet: UsersGetResponse;
+	usersUpdate: UsersUpdateResponse;
+	usersDelete: UsersDeleteResponse;
+	usersList: UsersListResponse;
+	commentsList: CommentsListResponse;
+};
+
+export const ZendeskEndpointInputSchemas = {
+	ticketsCreate: TicketsCreateInputSchema,
+	ticketsGet: TicketsGetInputSchema,
+	ticketsUpdate: TicketsUpdateInputSchema,
+	ticketsDelete: TicketsDeleteInputSchema,
+	ticketsList: TicketsListInputSchema,
+	usersCreate: UsersCreateInputSchema,
+	usersGet: UsersGetInputSchema,
+	usersUpdate: UsersUpdateInputSchema,
+	usersDelete: UsersDeleteInputSchema,
+	usersList: UsersListInputSchema,
+	commentsList: CommentsListInputSchema,
+} as const;
+
+export const ZendeskEndpointOutputSchemas = {
+	ticketsCreate: TicketsCreateResponseSchema,
+	ticketsGet: TicketsGetResponseSchema,
+	ticketsUpdate: TicketsUpdateResponseSchema,
+	ticketsDelete: TicketsDeleteResponseSchema,
+	ticketsList: TicketsListResponseSchema,
+	usersCreate: UsersCreateResponseSchema,
+	usersGet: UsersGetResponseSchema,
+	usersUpdate: UsersUpdateResponseSchema,
+	usersDelete: UsersDeleteResponseSchema,
+	usersList: UsersListResponseSchema,
+	commentsList: CommentsListResponseSchema,
+} as const;

--- a/packages/zendesk/endpoints/users.ts
+++ b/packages/zendesk/endpoints/users.ts
@@ -139,6 +139,7 @@ export const deleteUser: ZendeskEndpoints['usersDelete'] = async (
 ) => {
 	const subdomain =
 		ctx.options.subdomain ?? (await ctx.keys.get_subdomain()) ?? '';
+	// makeZendeskRequest<unknown> is used because Zendesk delete APIs return 204 No Content and we do not expect a structured response body.
 	await makeZendeskRequest<unknown>(
 		`users/${input.id}.json`,
 		ctx.key,

--- a/packages/zendesk/endpoints/users.ts
+++ b/packages/zendesk/endpoints/users.ts
@@ -1,0 +1,208 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeZendeskRequest } from '../client';
+import type { ZendeskEndpoints } from '../index';
+import type { ZendeskEndpointOutputs } from './types';
+
+export const create: ZendeskEndpoints['usersCreate'] = async (ctx, input) => {
+	const subdomain =
+		ctx.options.subdomain ?? (await ctx.keys.get_subdomain()) ?? '';
+	const response = await makeZendeskRequest<
+		ZendeskEndpointOutputs['usersCreate']
+	>('users.json', ctx.key, subdomain, {
+		method: 'POST',
+		body: {
+			user: {
+				name: input.name,
+				email: input.email,
+				...(input.role && { role: input.role }),
+				...(input.external_id && { external_id: input.external_id }),
+				...(input.active !== undefined && { active: input.active }),
+			},
+		},
+	});
+
+	const user = response.user;
+	if (user && ctx.db.users) {
+		try {
+			await ctx.db.users.upsertByEntityId(String(user.id), {
+				id: user.id,
+				name: user.name ?? null,
+				email: user.email ?? null,
+				role: user.role ?? null,
+				active: user.active ?? null,
+				timeZone: user.time_zone ?? null,
+				locale: user.locale ?? null,
+				createdAt: user.created_at ? new Date(user.created_at) : null,
+				updatedAt: user.updated_at ? new Date(user.updated_at) : null,
+			});
+		} catch (error) {
+			console.warn('Failed to save user to database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'zendesk.users.create',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+export const get: ZendeskEndpoints['usersGet'] = async (ctx, input) => {
+	const subdomain =
+		ctx.options.subdomain ?? (await ctx.keys.get_subdomain()) ?? '';
+	const response = await makeZendeskRequest<ZendeskEndpointOutputs['usersGet']>(
+		`users/${input.id}.json`,
+		ctx.key,
+		subdomain,
+		{ method: 'GET' },
+	);
+
+	const user = response.user;
+	if (user && ctx.db.users) {
+		try {
+			await ctx.db.users.upsertByEntityId(String(user.id), {
+				id: user.id,
+				name: user.name ?? null,
+				email: user.email ?? null,
+				role: user.role ?? null,
+				active: user.active ?? null,
+				timeZone: user.time_zone ?? null,
+				locale: user.locale ?? null,
+				createdAt: user.created_at ? new Date(user.created_at) : null,
+				updatedAt: user.updated_at ? new Date(user.updated_at) : null,
+			});
+		} catch (error) {
+			console.warn('Failed to save user to database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'zendesk.users.get',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+export const update: ZendeskEndpoints['usersUpdate'] = async (ctx, input) => {
+	const subdomain =
+		ctx.options.subdomain ?? (await ctx.keys.get_subdomain()) ?? '';
+	const response = await makeZendeskRequest<
+		ZendeskEndpointOutputs['usersUpdate']
+	>(`users/${input.id}.json`, ctx.key, subdomain, {
+		method: 'PUT',
+		body: {
+			user: {
+				...(input.name && { name: input.name }),
+				...(input.email && { email: input.email }),
+				...(input.role && { role: input.role }),
+				...(input.external_id && { external_id: input.external_id }),
+				...(input.active !== undefined && { active: input.active }),
+			},
+		},
+	});
+
+	const user = response.user;
+	if (user && ctx.db.users) {
+		try {
+			await ctx.db.users.upsertByEntityId(String(user.id), {
+				id: user.id,
+				name: user.name ?? null,
+				email: user.email ?? null,
+				role: user.role ?? null,
+				active: user.active ?? null,
+				timeZone: user.time_zone ?? null,
+				locale: user.locale ?? null,
+				createdAt: user.created_at ? new Date(user.created_at) : null,
+				updatedAt: user.updated_at ? new Date(user.updated_at) : null,
+			});
+		} catch (error) {
+			console.warn('Failed to save user to database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'zendesk.users.update',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+export const deleteUser: ZendeskEndpoints['usersDelete'] = async (
+	ctx,
+	input,
+) => {
+	const subdomain =
+		ctx.options.subdomain ?? (await ctx.keys.get_subdomain()) ?? '';
+	await makeZendeskRequest<unknown>(
+		`users/${input.id}.json`,
+		ctx.key,
+		subdomain,
+		{ method: 'DELETE' },
+	);
+
+	if (ctx.db.users) {
+		try {
+			await ctx.db.users.deleteByEntityId(String(input.id));
+		} catch (error) {
+			console.warn('Failed to delete user from database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'zendesk.users.delete',
+		{ ...input },
+		'completed',
+	);
+	return { id: input.id };
+};
+
+export const list: ZendeskEndpoints['usersList'] = async (ctx, input) => {
+	const subdomain =
+		ctx.options.subdomain ?? (await ctx.keys.get_subdomain()) ?? '';
+	const response = await makeZendeskRequest<
+		ZendeskEndpointOutputs['usersList']
+	>('users.json', ctx.key, subdomain, {
+		method: 'GET',
+		query: {
+			...(input.page !== undefined && { page: input.page }),
+			...(input.per_page !== undefined && { per_page: input.per_page }),
+			...(input.role && { role: input.role }),
+		},
+	});
+
+	const users = response.users || [];
+	if (ctx.db.users) {
+		for (const user of users) {
+			try {
+				await ctx.db.users.upsertByEntityId(String(user.id), {
+					id: user.id,
+					name: user.name ?? null,
+					email: user.email ?? null,
+					role: user.role ?? null,
+					active: user.active ?? null,
+					timeZone: user.time_zone ?? null,
+					locale: user.locale ?? null,
+					createdAt: user.created_at ? new Date(user.created_at) : null,
+					updatedAt: user.updated_at ? new Date(user.updated_at) : null,
+				});
+			} catch (error) {
+				console.warn('Failed to save user to database:', error);
+			}
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'zendesk.users.list',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};

--- a/packages/zendesk/error-handlers.ts
+++ b/packages/zendesk/error-handlers.ts
@@ -1,0 +1,31 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('429');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('unauthorized') || msg.includes('invalid_auth');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/zendesk/index.ts
+++ b/packages/zendesk/index.ts
@@ -1,0 +1,316 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	BindWebhooks,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	CorsairWebhook,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+	RequiredPluginWebhookSchemas,
+} from 'corsair/core';
+import { Comments, Tickets, Users } from './endpoints';
+import type {
+	ZendeskEndpointInputs,
+	ZendeskEndpointOutputs,
+} from './endpoints/types';
+import {
+	ZendeskEndpointInputSchemas,
+	ZendeskEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { ZendeskSchema } from './schema';
+import { ExampleWebhooks } from './webhooks';
+import type { ExampleEvent, ZendeskWebhookOutputs } from './webhooks/types';
+import { ExampleEventSchema } from './webhooks/types';
+
+export type ZendeskPluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	subdomain?: string;
+	webhookSecret?: string;
+	hooks?: InternalZendeskPlugin['hooks'];
+	webhookHooks?: InternalZendeskPlugin['webhookHooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof zendeskEndpointsNested>;
+};
+
+export const zendeskAuthConfig = {
+	api_key: {
+		account: ['subdomain'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type ZendeskContext = CorsairPluginContext<
+	typeof ZendeskSchema,
+	ZendeskPluginOptions,
+	undefined,
+	typeof zendeskAuthConfig
+>;
+
+export type ZendeskKeyBuilderContext = KeyBuilderContext<
+	ZendeskPluginOptions,
+	typeof zendeskAuthConfig
+>;
+
+export type ZendeskBoundEndpoints = BindEndpoints<
+	typeof zendeskEndpointsNested
+>;
+
+type ZendeskEndpoint<K extends keyof ZendeskEndpointOutputs> = CorsairEndpoint<
+	ZendeskContext,
+	ZendeskEndpointInputs[K],
+	ZendeskEndpointOutputs[K]
+>;
+
+export type ZendeskEndpoints = {
+	ticketsCreate: ZendeskEndpoint<'ticketsCreate'>;
+	ticketsGet: ZendeskEndpoint<'ticketsGet'>;
+	ticketsUpdate: ZendeskEndpoint<'ticketsUpdate'>;
+	ticketsDelete: ZendeskEndpoint<'ticketsDelete'>;
+	ticketsList: ZendeskEndpoint<'ticketsList'>;
+	usersCreate: ZendeskEndpoint<'usersCreate'>;
+	usersGet: ZendeskEndpoint<'usersGet'>;
+	usersUpdate: ZendeskEndpoint<'usersUpdate'>;
+	usersDelete: ZendeskEndpoint<'usersDelete'>;
+	usersList: ZendeskEndpoint<'usersList'>;
+	commentsList: ZendeskEndpoint<'commentsList'>;
+};
+
+type ZendeskWebhook<
+	K extends keyof ZendeskWebhookOutputs,
+	TEvent,
+> = CorsairWebhook<ZendeskContext, TEvent, ZendeskWebhookOutputs[K]>;
+
+export type ZendeskWebhooks = {
+	example: ZendeskWebhook<'example', ExampleEvent>;
+};
+
+export type ZendeskBoundWebhooks = BindWebhooks<ZendeskWebhooks>;
+
+const zendeskEndpointsNested = {
+	tickets: {
+		create: Tickets.create,
+		get: Tickets.get,
+		update: Tickets.update,
+		delete: Tickets.deleteTicket,
+		list: Tickets.list,
+	},
+	users: {
+		create: Users.create,
+		get: Users.get,
+		update: Users.update,
+		delete: Users.deleteUser,
+		list: Users.list,
+	},
+	comments: {
+		list: Comments.list,
+	},
+} as const;
+
+const zendeskWebhooksNested = {
+	example: {
+		example: ExampleWebhooks.example,
+	},
+} as const;
+
+export const zendeskEndpointSchemas = {
+	'tickets.create': {
+		input: ZendeskEndpointInputSchemas.ticketsCreate,
+		output: ZendeskEndpointOutputSchemas.ticketsCreate,
+	},
+	'tickets.get': {
+		input: ZendeskEndpointInputSchemas.ticketsGet,
+		output: ZendeskEndpointOutputSchemas.ticketsGet,
+	},
+	'tickets.update': {
+		input: ZendeskEndpointInputSchemas.ticketsUpdate,
+		output: ZendeskEndpointOutputSchemas.ticketsUpdate,
+	},
+	'tickets.delete': {
+		input: ZendeskEndpointInputSchemas.ticketsDelete,
+		output: ZendeskEndpointOutputSchemas.ticketsDelete,
+	},
+	'tickets.list': {
+		input: ZendeskEndpointInputSchemas.ticketsList,
+		output: ZendeskEndpointOutputSchemas.ticketsList,
+	},
+	'users.create': {
+		input: ZendeskEndpointInputSchemas.usersCreate,
+		output: ZendeskEndpointOutputSchemas.usersCreate,
+	},
+	'users.get': {
+		input: ZendeskEndpointInputSchemas.usersGet,
+		output: ZendeskEndpointOutputSchemas.usersGet,
+	},
+	'users.update': {
+		input: ZendeskEndpointInputSchemas.usersUpdate,
+		output: ZendeskEndpointOutputSchemas.usersUpdate,
+	},
+	'users.delete': {
+		input: ZendeskEndpointInputSchemas.usersDelete,
+		output: ZendeskEndpointOutputSchemas.usersDelete,
+	},
+	'users.list': {
+		input: ZendeskEndpointInputSchemas.usersList,
+		output: ZendeskEndpointOutputSchemas.usersList,
+	},
+	'comments.list': {
+		input: ZendeskEndpointInputSchemas.commentsList,
+		output: ZendeskEndpointOutputSchemas.commentsList,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<
+	typeof zendeskEndpointsNested
+>;
+
+const zendeskWebhookSchemas = {
+	'example.example': {
+		description: 'An example webhook event',
+		payload: ExampleEventSchema,
+		response: ExampleEventSchema,
+	},
+} as const satisfies RequiredPluginWebhookSchemas<typeof zendeskWebhooksNested>;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const zendeskEndpointMeta = {
+	'tickets.create': {
+		riskLevel: 'write',
+		description: 'Create a new ticket',
+	},
+	'tickets.get': {
+		riskLevel: 'read',
+		description: 'Retrieve a ticket by its ID',
+	},
+	'tickets.update': {
+		riskLevel: 'write',
+		description: 'Update an existing ticket',
+	},
+	'tickets.delete': {
+		riskLevel: 'destructive',
+		description: 'Delete a ticket by its ID',
+	},
+	'tickets.list': {
+		riskLevel: 'read',
+		description: 'List tickets with pagination',
+	},
+	'users.create': {
+		riskLevel: 'write',
+		description: 'Create a new user',
+	},
+	'users.get': {
+		riskLevel: 'read',
+		description: 'Retrieve a user by their ID',
+	},
+	'users.update': {
+		riskLevel: 'write',
+		description: 'Update an existing user',
+	},
+	'users.delete': {
+		riskLevel: 'destructive',
+		description: 'Delete a user by their ID',
+	},
+	'users.list': {
+		riskLevel: 'read',
+		description: 'List users with pagination',
+	},
+	'comments.list': {
+		riskLevel: 'read',
+		description: 'List comments for a specific ticket',
+	},
+} as const satisfies RequiredPluginEndpointMeta<typeof zendeskEndpointsNested>;
+
+export type BaseZendeskPlugin<T extends ZendeskPluginOptions> = CorsairPlugin<
+	'zendesk',
+	typeof ZendeskSchema,
+	typeof zendeskEndpointsNested,
+	typeof zendeskWebhooksNested,
+	T,
+	typeof defaultAuthType,
+	typeof zendeskAuthConfig
+>;
+
+export type InternalZendeskPlugin = BaseZendeskPlugin<ZendeskPluginOptions>;
+
+export type ExternalZendeskPlugin<T extends ZendeskPluginOptions> =
+	BaseZendeskPlugin<T>;
+
+export function zendesk<const T extends ZendeskPluginOptions>(
+	incomingOptions: ZendeskPluginOptions & T = {} as ZendeskPluginOptions & T,
+): ExternalZendeskPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'zendesk',
+		schema: ZendeskSchema,
+		options: options,
+		hooks: options.hooks,
+		webhookHooks: options.webhookHooks,
+		endpoints: zendeskEndpointsNested,
+		webhooks: zendeskWebhooksNested,
+		authConfig: zendeskAuthConfig,
+		endpointMeta: zendeskEndpointMeta,
+		endpointSchemas: zendeskEndpointSchemas,
+		webhookSchemas: zendeskWebhookSchemas,
+		pluginWebhookMatcher: (request) => {
+			const headers = request.headers;
+			return 'x-zendesk-webhook-signature' in headers;
+		},
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: ZendeskKeyBuilderContext, source) => {
+			const authType = ctx.authType;
+
+			if (source === 'webhook' && options.webhookSecret) {
+				return options.webhookSecret;
+			}
+
+			if (source === 'webhook') {
+				const res = await ctx.keys.get_webhook_signature();
+				if (!res) {
+					throw new Error(
+						'[auth-missing:zendesk:webhook_signature]: Zendesk webhook signature is missing',
+					);
+				}
+				return res;
+			}
+
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys.get_api_key();
+				if (!res) {
+					throw new Error(
+						'[auth-missing:zendesk:api_key]: Zendesk API Key is missing',
+					);
+				}
+				return res;
+			}
+
+			throw new Error(
+				`[auth-missing:zendesk:${authType}]: Zendesk key is missing`,
+			);
+		},
+	} satisfies InternalZendeskPlugin;
+}
+
+export type {
+	ZendeskEndpointInputs,
+	ZendeskEndpointOutputs,
+} from './endpoints/types';
+export type {
+	ExampleEvent,
+	ZendeskWebhookOutputs,
+} from './webhooks/types';

--- a/packages/zendesk/integration.test.ts
+++ b/packages/zendesk/integration.test.ts
@@ -1,0 +1,238 @@
+import 'dotenv/config';
+import { createCorsair } from 'corsair/core';
+import { request } from 'corsair/http';
+import { createCorsairOrm } from 'corsair/orm';
+import { createIntegrationAndAccount, createTestDatabase } from 'corsair/tests';
+import { zendesk } from './index';
+
+jest.mock('corsair/http', () => ({
+	request: jest.fn(),
+}));
+
+const mockedRequest = request as jest.MockedFunction<typeof request>;
+
+async function createZendeskClient() {
+	const testDb = createTestDatabase();
+	await createIntegrationAndAccount(testDb.db, 'zendesk');
+
+	const corsair = createCorsair({
+		plugins: [
+			zendesk({
+				authType: 'api_key',
+				key: 'test_token',
+				subdomain: 'test_subdomain',
+			}),
+		],
+		database: testDb.db,
+		kek: 'test_kek',
+	});
+
+	return { corsair, testDb };
+}
+
+describe('Zendesk plugin integration', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('tickets endpoints interact with API and DB', async () => {
+		const { corsair, testDb } = await createZendeskClient();
+
+		const mockTicket = {
+			id: 101,
+			subject: 'Integration Test Ticket',
+			description: 'Description here',
+			status: 'new',
+			priority: 'high',
+			created_at: '2026-05-22T12:00:00Z',
+			updated_at: '2026-05-22T12:00:00Z',
+		};
+
+		// 1. Test Create Ticket
+		mockedRequest.mockResolvedValueOnce({ ticket: mockTicket });
+
+		const created = await corsair.zendesk.api.tickets.create({
+			subject: 'Integration Test Ticket',
+			description: 'Description here',
+			status: 'new',
+			priority: 'high',
+		});
+
+		expect(created).toBeDefined();
+		expect(created.ticket.id).toBe(101);
+
+		// Verify event is logged
+		const orm = createCorsairOrm(testDb.database);
+		const createEvents = await orm.events.findMany({
+			where: { event_type: 'zendesk.tickets.create' },
+		});
+		expect(createEvents.length).toBeGreaterThan(0);
+
+		// Verify database entity is populated
+		const ticketFromDb = await corsair.zendesk.db.tickets.findByEntityId('101');
+		expect(ticketFromDb).not.toBeNull();
+		expect(ticketFromDb?.data.id).toBe(101);
+		expect(ticketFromDb?.data.subject).toBe('Integration Test Ticket');
+
+		// 2. Test Get Ticket
+		mockedRequest.mockResolvedValueOnce({ ticket: mockTicket });
+
+		const fetched = await corsair.zendesk.api.tickets.get({ id: 101 });
+		expect(fetched.ticket.id).toBe(101);
+
+		const getEvents = await orm.events.findMany({
+			where: { event_type: 'zendesk.tickets.get' },
+		});
+		expect(getEvents.length).toBeGreaterThan(0);
+
+		// 3. Test Update Ticket
+		const updatedTicket = {
+			...mockTicket,
+			subject: 'Updated Integration Ticket',
+		};
+		mockedRequest.mockResolvedValueOnce({ ticket: updatedTicket });
+
+		const updated = await corsair.zendesk.api.tickets.update({
+			id: 101,
+			subject: 'Updated Integration Ticket',
+		});
+		expect(updated.ticket.subject).toBe('Updated Integration Ticket');
+
+		const ticketFromDbAfterUpdate =
+			await corsair.zendesk.db.tickets.findByEntityId('101');
+		expect(ticketFromDbAfterUpdate?.data.subject).toBe(
+			'Updated Integration Ticket',
+		);
+
+		// 4. Test List Tickets
+		mockedRequest.mockResolvedValueOnce({
+			tickets: [updatedTicket],
+			count: 1,
+		});
+
+		const listed = await corsair.zendesk.api.tickets.list({});
+		expect(listed.tickets).toHaveLength(1);
+		expect(listed.tickets[0]?.id).toBe(101);
+
+		// 5. Test Delete Ticket
+		mockedRequest.mockResolvedValueOnce({ id: 101 });
+
+		const deleted = await corsair.zendesk.api.tickets.delete({ id: 101 });
+		expect(deleted.id).toBe(101);
+
+		testDb.cleanup();
+	});
+
+	it('users endpoints interact with API and DB', async () => {
+		const { corsair, testDb } = await createZendeskClient();
+
+		const mockUser = {
+			id: 201,
+			name: 'Alice Smith',
+			email: 'alice@example.com',
+			role: 'agent',
+			active: true,
+			created_at: '2026-05-22T12:00:00Z',
+			updated_at: '2026-05-22T12:00:00Z',
+		};
+
+		// 1. Test Create User
+		mockedRequest.mockResolvedValueOnce({ user: mockUser });
+
+		const created = await corsair.zendesk.api.users.create({
+			name: 'Alice Smith',
+			email: 'alice@example.com',
+			role: 'agent',
+		});
+
+		expect(created.user.id).toBe(201);
+
+		// Verify event is logged
+		const orm = createCorsairOrm(testDb.database);
+		const createEvents = await orm.events.findMany({
+			where: { event_type: 'zendesk.users.create' },
+		});
+		expect(createEvents.length).toBeGreaterThan(0);
+
+		// Verify database entity is populated
+		const userFromDb = await corsair.zendesk.db.users.findByEntityId('201');
+		expect(userFromDb).not.toBeNull();
+		expect(userFromDb?.data.id).toBe(201);
+		expect(userFromDb?.data.name).toBe('Alice Smith');
+
+		// 2. Test Get User
+		mockedRequest.mockResolvedValueOnce({ user: mockUser });
+
+		const fetched = await corsair.zendesk.api.users.get({ id: 201 });
+		expect(fetched.user.id).toBe(201);
+
+		// 3. Test Update User
+		const updatedUser = { ...mockUser, name: 'Alice Jones' };
+		mockedRequest.mockResolvedValueOnce({ user: updatedUser });
+
+		const updated = await corsair.zendesk.api.users.update({
+			id: 201,
+			name: 'Alice Jones',
+		});
+		expect(updated.user.name).toBe('Alice Jones');
+
+		const userFromDbAfterUpdate =
+			await corsair.zendesk.db.users.findByEntityId('201');
+		expect(userFromDbAfterUpdate?.data.name).toBe('Alice Jones');
+
+		// 4. Test List Users
+		mockedRequest.mockResolvedValueOnce({
+			users: [updatedUser],
+			count: 1,
+		});
+
+		const listed = await corsair.zendesk.api.users.list({});
+		expect(listed.users).toHaveLength(1);
+		expect(listed.users[0]?.id).toBe(201);
+
+		// 5. Test Delete User
+		mockedRequest.mockResolvedValueOnce({ id: 201 });
+
+		const deleted = await corsair.zendesk.api.users.delete({ id: 201 });
+		expect(deleted.id).toBe(201);
+
+		testDb.cleanup();
+	});
+
+	it('comments endpoints interact with API and DB', async () => {
+		const { corsair, testDb } = await createZendeskClient();
+
+		const mockComment = {
+			id: 301,
+			body: 'This is a ticket comment',
+			public: true,
+			author_id: 201,
+			created_at: '2026-05-22T12:00:00Z',
+		};
+
+		mockedRequest.mockResolvedValueOnce({
+			comments: [mockComment],
+			count: 1,
+		});
+
+		const listed = await corsair.zendesk.api.comments.list({ ticket_id: 101 });
+		expect(listed.comments).toHaveLength(1);
+		expect(listed.comments[0]?.id).toBe(301);
+
+		// Verify event is logged
+		const orm = createCorsairOrm(testDb.database);
+		const listEvents = await orm.events.findMany({
+			where: { event_type: 'zendesk.comments.list' },
+		});
+		expect(listEvents.length).toBeGreaterThan(0);
+
+		// Verify database entity is populated
+		const commentFromDb =
+			await corsair.zendesk.db.comments.findByEntityId('301');
+		expect(commentFromDb).not.toBeNull();
+		expect(commentFromDb?.data.id).toBe(301);
+		expect(commentFromDb?.data.body).toBe('This is a ticket comment');
+
+		testDb.cleanup();
+	});
+});

--- a/packages/zendesk/integration.test.ts
+++ b/packages/zendesk/integration.test.ts
@@ -1,17 +1,16 @@
 import 'dotenv/config';
 import { createCorsair } from 'corsair/core';
-import { request } from 'corsair/http';
 import { createCorsairOrm } from 'corsair/orm';
 import { createIntegrationAndAccount, createTestDatabase } from 'corsair/tests';
 import { zendesk } from './index';
 
-jest.mock('corsair/http', () => ({
-	request: jest.fn(),
-}));
-
-const mockedRequest = request as jest.MockedFunction<typeof request>;
-
 async function createZendeskClient() {
+	const apiKey = process.env.ZENDESK_API_KEY;
+	const subdomain = process.env.ZENDESK_SUBDOMAIN;
+	if (!apiKey || !subdomain) {
+		return null;
+	}
+
 	const testDb = createTestDatabase();
 	await createIntegrationAndAccount(testDb.db, 'zendesk');
 
@@ -19,219 +18,177 @@ async function createZendeskClient() {
 		plugins: [
 			zendesk({
 				authType: 'api_key',
-				key: 'test_token',
-				subdomain: 'test_subdomain',
+				key: apiKey,
+				subdomain,
 			}),
 		],
 		database: testDb.db,
-		kek: 'test_kek',
+		kek: process.env.CORSAIR_KEK!,
 	});
 
 	return { corsair, testDb };
 }
 
 describe('Zendesk plugin integration', () => {
-	beforeEach(() => {
-		jest.clearAllMocks();
-	});
-
 	it('tickets endpoints interact with API and DB', async () => {
-		const { corsair, testDb } = await createZendeskClient();
+		const setup = await createZendeskClient();
+		if (!setup) {
+			return;
+		}
 
-		const mockTicket = {
-			id: 101,
-			subject: 'Integration Test Ticket',
-			description: 'Description here',
+		const { corsair, testDb } = setup;
+		const orm = createCorsairOrm(testDb.database);
+
+		const createInput = {
+			subject: `Corsair integration test ${Date.now()}`,
+			comment: {
+				body: 'Integration test ticket',
+			},
 			status: 'new',
-			priority: 'high',
-			created_at: '2026-05-22T12:00:00Z',
-			updated_at: '2026-05-22T12:00:00Z',
+			priority: 'normal',
 		};
 
-		// 1. Test Create Ticket
-		mockedRequest.mockResolvedValueOnce({ ticket: mockTicket });
-
-		const created = await corsair.zendesk.api.tickets.create({
-			subject: 'Integration Test Ticket',
-			description: 'Description here',
-			status: 'new',
-			priority: 'high',
-		});
+		const created = await corsair.zendesk.api.tickets.create(createInput);
 
 		expect(created).toBeDefined();
-		expect(created.ticket.id).toBe(101);
+		expect(created.ticket.id).toBeDefined();
 
-		// Verify event is logged
-		const orm = createCorsairOrm(testDb.database);
+		const ticketId = created.ticket.id!;
+
 		const createEvents = await orm.events.findMany({
 			where: { event_type: 'zendesk.tickets.create' },
 		});
 		expect(createEvents.length).toBeGreaterThan(0);
 
-		// Verify database entity is populated
-		const ticketFromDb = await corsair.zendesk.db.tickets.findByEntityId('101');
+		const ticketFromDb =
+			await corsair.zendesk.db.tickets.findByEntityId(String(ticketId));
 		expect(ticketFromDb).not.toBeNull();
-		expect(ticketFromDb?.data.id).toBe(101);
-		expect(ticketFromDb?.data.subject).toBe('Integration Test Ticket');
+		expect(ticketFromDb?.data.id).toBe(ticketId);
+		expect(ticketFromDb?.data.subject).toBe(createInput.subject);
 
-		// 2. Test Get Ticket
-		mockedRequest.mockResolvedValueOnce({ ticket: mockTicket });
-
-		const fetched = await corsair.zendesk.api.tickets.get({ id: 101 });
-		expect(fetched.ticket.id).toBe(101);
+		const getInput = { id: ticketId };
+		const fetched = await corsair.zendesk.api.tickets.get(getInput);
+		expect(fetched.ticket.id).toBe(ticketId);
 
 		const getEvents = await orm.events.findMany({
 			where: { event_type: 'zendesk.tickets.get' },
 		});
 		expect(getEvents.length).toBeGreaterThan(0);
 
-		// 3. Test Update Ticket
-		const updatedTicket = {
-			...mockTicket,
-			subject: 'Updated Integration Ticket',
+		const updateInput = {
+			id: ticketId,
+			subject: `Updated integration ticket ${Date.now()}`,
 		};
-		mockedRequest.mockResolvedValueOnce({ ticket: updatedTicket });
-
-		const updated = await corsair.zendesk.api.tickets.update({
-			id: 101,
-			subject: 'Updated Integration Ticket',
-		});
-		expect(updated.ticket.subject).toBe('Updated Integration Ticket');
+		const updated = await corsair.zendesk.api.tickets.update(updateInput);
+		expect(updated.ticket.subject).toBe(updateInput.subject);
 
 		const ticketFromDbAfterUpdate =
-			await corsair.zendesk.db.tickets.findByEntityId('101');
-		expect(ticketFromDbAfterUpdate?.data.subject).toBe(
-			'Updated Integration Ticket',
-		);
+			await corsair.zendesk.db.tickets.findByEntityId(String(ticketId));
+		expect(ticketFromDbAfterUpdate?.data.subject).toBe(updateInput.subject);
 
-		// 4. Test List Tickets
-		mockedRequest.mockResolvedValueOnce({
-			tickets: [updatedTicket],
-			count: 1,
-		});
+		const listInput = { per_page: 10 };
+		const listed = await corsair.zendesk.api.tickets.list(listInput);
+		expect(listed.tickets.length).toBeGreaterThan(0);
 
-		const listed = await corsair.zendesk.api.tickets.list({});
-		expect(listed.tickets).toHaveLength(1);
-		expect(listed.tickets[0]?.id).toBe(101);
-
-		// 5. Test Delete Ticket
-		mockedRequest.mockResolvedValueOnce({ id: 101 });
-
-		const deleted = await corsair.zendesk.api.tickets.delete({ id: 101 });
-		expect(deleted.id).toBe(101);
+		const deleteInput = { id: ticketId };
+		const deleted = await corsair.zendesk.api.tickets.delete(deleteInput);
+		expect(deleted.id).toBe(ticketId);
 
 		testDb.cleanup();
 	});
 
 	it('users endpoints interact with API and DB', async () => {
-		const { corsair, testDb } = await createZendeskClient();
+		const setup = await createZendeskClient();
+		if (!setup) {
+			return;
+		}
 
-		const mockUser = {
-			id: 201,
-			name: 'Alice Smith',
-			email: 'alice@example.com',
-			role: 'agent',
-			active: true,
-			created_at: '2026-05-22T12:00:00Z',
-			updated_at: '2026-05-22T12:00:00Z',
+		const { corsair, testDb } = setup;
+		const orm = createCorsairOrm(testDb.database);
+
+		const createInput = {
+			name: 'Corsair Integration User',
+			email: `corsair-integration-${Date.now()}@example.com`,
+			role: 'end-user',
 		};
 
-		// 1. Test Create User
-		mockedRequest.mockResolvedValueOnce({ user: mockUser });
+		const created = await corsair.zendesk.api.users.create(createInput);
 
-		const created = await corsair.zendesk.api.users.create({
-			name: 'Alice Smith',
-			email: 'alice@example.com',
-			role: 'agent',
-		});
+		expect(created.user.id).toBeDefined();
+		const userId = created.user.id!;
 
-		expect(created.user.id).toBe(201);
-
-		// Verify event is logged
-		const orm = createCorsairOrm(testDb.database);
 		const createEvents = await orm.events.findMany({
 			where: { event_type: 'zendesk.users.create' },
 		});
 		expect(createEvents.length).toBeGreaterThan(0);
 
-		// Verify database entity is populated
-		const userFromDb = await corsair.zendesk.db.users.findByEntityId('201');
+		const userFromDb =
+			await corsair.zendesk.db.users.findByEntityId(String(userId));
 		expect(userFromDb).not.toBeNull();
-		expect(userFromDb?.data.id).toBe(201);
-		expect(userFromDb?.data.name).toBe('Alice Smith');
+		expect(userFromDb?.data.id).toBe(userId);
+		expect(userFromDb?.data.name).toBe(createInput.name);
 
-		// 2. Test Get User
-		mockedRequest.mockResolvedValueOnce({ user: mockUser });
+		const getInput = { id: userId };
+		const fetched = await corsair.zendesk.api.users.get(getInput);
+		expect(fetched.user.id).toBe(userId);
 
-		const fetched = await corsair.zendesk.api.users.get({ id: 201 });
-		expect(fetched.user.id).toBe(201);
-
-		// 3. Test Update User
-		const updatedUser = { ...mockUser, name: 'Alice Jones' };
-		mockedRequest.mockResolvedValueOnce({ user: updatedUser });
-
-		const updated = await corsair.zendesk.api.users.update({
-			id: 201,
-			name: 'Alice Jones',
-		});
-		expect(updated.user.name).toBe('Alice Jones');
+		const updateInput = {
+			id: userId,
+			name: 'Corsair Updated Integration User',
+		};
+		const updated = await corsair.zendesk.api.users.update(updateInput);
+		expect(updated.user.name).toBe(updateInput.name);
 
 		const userFromDbAfterUpdate =
-			await corsair.zendesk.db.users.findByEntityId('201');
-		expect(userFromDbAfterUpdate?.data.name).toBe('Alice Jones');
+			await corsair.zendesk.db.users.findByEntityId(String(userId));
+		expect(userFromDbAfterUpdate?.data.name).toBe(updateInput.name);
 
-		// 4. Test List Users
-		mockedRequest.mockResolvedValueOnce({
-			users: [updatedUser],
-			count: 1,
-		});
+		const listInput = { per_page: 10 };
+		const listed = await corsair.zendesk.api.users.list(listInput);
+		expect(listed.users.length).toBeGreaterThan(0);
 
-		const listed = await corsair.zendesk.api.users.list({});
-		expect(listed.users).toHaveLength(1);
-		expect(listed.users[0]?.id).toBe(201);
-
-		// 5. Test Delete User
-		mockedRequest.mockResolvedValueOnce({ id: 201 });
-
-		const deleted = await corsair.zendesk.api.users.delete({ id: 201 });
-		expect(deleted.id).toBe(201);
+		const deleteInput = { id: userId };
+		const deleted = await corsair.zendesk.api.users.delete(deleteInput);
+		expect(deleted.id).toBe(userId);
 
 		testDb.cleanup();
 	});
 
 	it('comments endpoints interact with API and DB', async () => {
-		const { corsair, testDb } = await createZendeskClient();
+		const setup = await createZendeskClient();
+		if (!setup) {
+			return;
+		}
 
-		const mockComment = {
-			id: 301,
-			body: 'This is a ticket comment',
-			public: true,
-			author_id: 201,
-			created_at: '2026-05-22T12:00:00Z',
-		};
-
-		mockedRequest.mockResolvedValueOnce({
-			comments: [mockComment],
-			count: 1,
-		});
-
-		const listed = await corsair.zendesk.api.comments.list({ ticket_id: 101 });
-		expect(listed.comments).toHaveLength(1);
-		expect(listed.comments[0]?.id).toBe(301);
-
-		// Verify event is logged
+		const { corsair, testDb } = setup;
 		const orm = createCorsairOrm(testDb.database);
+
+		const createdTicket = await corsair.zendesk.api.tickets.create({
+			subject: `Corsair comments integration ${Date.now()}`,
+			comment: {
+				body: 'Comment for integration test',
+			},
+		});
+		const ticketId = createdTicket.ticket.id!;
+
+		const listInput = { ticket_id: ticketId };
+		const listed = await corsair.zendesk.api.comments.list(listInput);
+		expect(listed.comments.length).toBeGreaterThan(0);
+
 		const listEvents = await orm.events.findMany({
 			where: { event_type: 'zendesk.comments.list' },
 		});
 		expect(listEvents.length).toBeGreaterThan(0);
 
-		// Verify database entity is populated
-		const commentFromDb =
-			await corsair.zendesk.db.comments.findByEntityId('301');
-		expect(commentFromDb).not.toBeNull();
-		expect(commentFromDb?.data.id).toBe(301);
-		expect(commentFromDb?.data.body).toBe('This is a ticket comment');
+		const commentId = listed.comments[0]?.id;
+		if (commentId) {
+			const commentFromDb =
+				await corsair.zendesk.db.comments.findByEntityId(String(commentId));
+			expect(commentFromDb).not.toBeNull();
+			expect(commentFromDb?.data.id).toBe(commentId);
+		}
+
+		await corsair.zendesk.api.tickets.delete({ id: ticketId });
 
 		testDb.cleanup();
 	});

--- a/packages/zendesk/jest.config.cjs
+++ b/packages/zendesk/jest.config.cjs
@@ -1,0 +1,61 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+					target: 'ESNext',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/db$': '<rootDir>/../corsair/db.ts',
+		'^corsair/orm$': '<rootDir>/../corsair/orm.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^corsair/setup$': '<rootDir>/../corsair/setup.ts',
+		'^corsair/tests$': '<rootDir>/../corsair/tests.ts',
+		'^corsair$': '<rootDir>/../corsair/index.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/zendesk/jest.config.cjs
+++ b/packages/zendesk/jest.config.cjs
@@ -30,6 +30,7 @@ module.exports = {
 					module: 'ESNext',
 					moduleResolution: 'Bundler',
 					target: 'ESNext',
+					types: ['node', 'jest'],
 				},
 			},
 		],
@@ -40,6 +41,7 @@ module.exports = {
 				tsconfig: {
 					esModuleInterop: true,
 					allowSyntheticDefaultImports: true,
+					types: ['node', 'jest'],
 				},
 			},
 		],

--- a/packages/zendesk/package.json
+++ b/packages/zendesk/package.json
@@ -28,8 +28,7 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13",
-    "jest": "^29.7.0"
+    "zod": "^4.1.13"
   },
   "keywords": [
     "corsair",
@@ -40,5 +39,8 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ]
+  ],
+  "dependencies": {
+    "jest": "^29.7.0"
+  }
 }

--- a/packages/zendesk/package.json
+++ b/packages/zendesk/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@corsair-dev/zendesk",
+  "version": "0.1.0",
+  "description": "Zendesk plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "dependencies": {
+    "jest": "^29.7.0"
+  },
+  "keywords": [
+    "corsair",
+    "zendesk",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/zendesk/package.json
+++ b/packages/zendesk/package.json
@@ -28,9 +28,7 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
-  },
-  "dependencies": {
+    "zod": "^4.1.13",
     "jest": "^29.7.0"
   },
   "keywords": [

--- a/packages/zendesk/schema/database.ts
+++ b/packages/zendesk/schema/database.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+export const ZendeskTicket = z.object({
+	id: z.number(),
+	subject: z.string().optional().nullable(),
+	description: z.string().optional().nullable(),
+	status: z.string().optional().nullable(),
+	priority: z.string().optional().nullable(),
+	requesterId: z.number().optional().nullable(),
+	assigneeId: z.number().optional().nullable(),
+	organizationId: z.number().optional().nullable(),
+	groupId: z.number().optional().nullable(),
+	createdAt: z.coerce.date().optional().nullable(),
+	updatedAt: z.coerce.date().optional().nullable(),
+});
+
+export const ZendeskUser = z.object({
+	id: z.number(),
+	name: z.string().optional().nullable(),
+	email: z.string().optional().nullable(),
+	role: z.string().optional().nullable(),
+	active: z.boolean().optional().nullable(),
+	timeZone: z.string().optional().nullable(),
+	locale: z.string().optional().nullable(),
+	createdAt: z.coerce.date().optional().nullable(),
+	updatedAt: z.coerce.date().optional().nullable(),
+});
+
+export const ZendeskComment = z.object({
+	id: z.number(),
+	ticketId: z.number().optional().nullable(),
+	body: z.string().optional().nullable(),
+	authorId: z.number().optional().nullable(),
+	public: z.boolean().optional().nullable(),
+	createdAt: z.coerce.date().optional().nullable(),
+});
+
+export type ZendeskTicket = z.infer<typeof ZendeskTicket>;
+export type ZendeskUser = z.infer<typeof ZendeskUser>;
+export type ZendeskComment = z.infer<typeof ZendeskComment>;

--- a/packages/zendesk/schema/index.ts
+++ b/packages/zendesk/schema/index.ts
@@ -1,0 +1,16 @@
+import { ZendeskComment, ZendeskTicket, ZendeskUser } from './database';
+
+export const ZendeskSchema = {
+	version: '1.0.0',
+	entities: {
+		tickets: ZendeskTicket,
+		users: ZendeskUser,
+		comments: ZendeskComment,
+	},
+} as const;
+
+export type {
+	ZendeskComment,
+	ZendeskTicket,
+	ZendeskUser,
+} from './database';

--- a/packages/zendesk/tsconfig.json
+++ b/packages/zendesk/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/zendesk/tsconfig.json
+++ b/packages/zendesk/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["esnext"],
-    "types": ["node", "jest"],
+    "types": ["node"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "outDir": "./dist",
@@ -15,6 +15,6 @@
     "skipLibCheck": true
   },
   "include": ["./**/*"],
-  "exclude": ["dist", "node_modules"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts"],
   "references": []
 }

--- a/packages/zendesk/tsconfig.json
+++ b/packages/zendesk/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["esnext"],
-    "types": ["node"],
+    "types": ["node", "jest"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "outDir": "./dist",
@@ -15,6 +15,6 @@
     "skipLibCheck": true
   },
   "include": ["./**/*"],
-  "exclude": ["dist", "node_modules", "**/*.test.ts"],
+  "exclude": ["dist", "node_modules"],
   "references": []
 }

--- a/packages/zendesk/tsconfig.test.json
+++ b/packages/zendesk/tsconfig.test.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "types": ["node", "jest"]
-  },
-  "include": ["./**/*"],
-  "exclude": ["dist", "node_modules"]
-}

--- a/packages/zendesk/tsconfig.test.json
+++ b/packages/zendesk/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"]
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/zendesk/tsup.config.ts
+++ b/packages/zendesk/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/zendesk/webhooks.test.ts
+++ b/packages/zendesk/webhooks.test.ts
@@ -1,0 +1,158 @@
+import * as crypto from 'node:crypto';
+import type { WebhookRequest } from 'corsair/core';
+import type { ZendeskWebhookPayload } from './webhooks/types';
+import { verifyZendeskWebhookSignature } from './webhooks/types';
+
+describe('verifyZendeskWebhookSignature', () => {
+	const secret = 'my-super-secret-key';
+	const payload: ZendeskWebhookPayload = {
+		type: 'example',
+		created_at: '2026-05-22T00:00:00Z',
+		data: { id: '123' },
+	};
+	const rawBody = JSON.stringify(payload);
+
+	it('should return invalid if secret is missing', () => {
+		const request: WebhookRequest<ZendeskWebhookPayload> = {
+			payload,
+			headers: {},
+			rawBody,
+		};
+		const result = verifyZendeskWebhookSignature(request);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook signing secret configuration',
+		});
+	});
+
+	it('should return invalid if rawBody is missing', () => {
+		const request: WebhookRequest<ZendeskWebhookPayload> = {
+			payload,
+			headers: {},
+		};
+		const result = verifyZendeskWebhookSignature(request, secret);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing raw body for signature verification',
+		});
+	});
+
+	it('should return invalid if signature header is missing', () => {
+		const request: WebhookRequest<ZendeskWebhookPayload> = {
+			payload,
+			headers: {
+				'x-zendesk-webhook-signature-timestamp': new Date().toISOString(),
+			},
+			rawBody,
+		};
+		const result = verifyZendeskWebhookSignature(request, secret);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing x-zendesk-webhook-signature header',
+		});
+	});
+
+	it('should return invalid if timestamp header is missing', () => {
+		const request: WebhookRequest<ZendeskWebhookPayload> = {
+			payload,
+			headers: {
+				'x-zendesk-webhook-signature': 'some-signature',
+			},
+			rawBody,
+		};
+		const result = verifyZendeskWebhookSignature(request, secret);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing x-zendesk-webhook-signature-timestamp header',
+		});
+	});
+
+	it('should return invalid if timestamp format is invalid', () => {
+		const request: WebhookRequest<ZendeskWebhookPayload> = {
+			payload,
+			headers: {
+				'x-zendesk-webhook-signature': 'some-signature',
+				'x-zendesk-webhook-signature-timestamp': 'not-a-date',
+			},
+			rawBody,
+		};
+		const result = verifyZendeskWebhookSignature(request, secret);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid x-zendesk-webhook-signature-timestamp header format',
+		});
+	});
+
+	it('should return invalid if timestamp is stale (too old)', () => {
+		const oldTimestamp = new Date(Date.now() - 301 * 1000).toISOString(); // 5 min 1 sec ago
+		const request: WebhookRequest<ZendeskWebhookPayload> = {
+			payload,
+			headers: {
+				'x-zendesk-webhook-signature': 'some-signature',
+				'x-zendesk-webhook-signature-timestamp': oldTimestamp,
+			},
+			rawBody,
+		};
+		const result = verifyZendeskWebhookSignature(request, secret);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Webhook request timestamp is stale (outside 5-minute window)',
+		});
+	});
+
+	it('should return invalid if timestamp is stale (in the future)', () => {
+		const futureTimestamp = new Date(Date.now() + 301 * 1000).toISOString(); // 5 min 1 sec in future
+		const request: WebhookRequest<ZendeskWebhookPayload> = {
+			payload,
+			headers: {
+				'x-zendesk-webhook-signature': 'some-signature',
+				'x-zendesk-webhook-signature-timestamp': futureTimestamp,
+			},
+			rawBody,
+		};
+		const result = verifyZendeskWebhookSignature(request, secret);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Webhook request timestamp is stale (outside 5-minute window)',
+		});
+	});
+
+	it('should return invalid if signature mismatch', () => {
+		const timestamp = new Date().toISOString();
+		const request: WebhookRequest<ZendeskWebhookPayload> = {
+			payload,
+			headers: {
+				'x-zendesk-webhook-signature': 'wrong-signature',
+				'x-zendesk-webhook-signature-timestamp': timestamp,
+			},
+			rawBody,
+		};
+		const result = verifyZendeskWebhookSignature(request, secret);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid signature',
+		});
+	});
+
+	it('should return valid if signature is correct and fresh', () => {
+		const timestamp = new Date().toISOString();
+		const signingString = timestamp + rawBody;
+		const correctSignature = crypto
+			.createHmac('sha256', secret)
+			.update(signingString)
+			.digest('base64');
+
+		const request: WebhookRequest<ZendeskWebhookPayload> = {
+			payload,
+			headers: {
+				'x-zendesk-webhook-signature': correctSignature,
+				'x-zendesk-webhook-signature-timestamp': timestamp,
+			},
+			rawBody,
+		};
+		const result = verifyZendeskWebhookSignature(request, secret);
+		expect(result).toEqual({
+			valid: true,
+		});
+	});
+});

--- a/packages/zendesk/webhooks/example.ts
+++ b/packages/zendesk/webhooks/example.ts
@@ -1,0 +1,32 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ZendeskWebhooks } from '..';
+import { createZendeskMatch, verifyZendeskWebhookSignature } from './types';
+
+export const example: ZendeskWebhooks['example'] = {
+	match: createZendeskMatch('example'),
+
+	handler: async (ctx, request) => {
+		const verification = verifyZendeskWebhookSignature(request, ctx.key);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
+
+		const event = request.payload;
+		if (event.type !== 'example') {
+			return { success: true, data: undefined };
+		}
+
+		await logEventFromContext(
+			ctx,
+			'zendesk.webhook.example',
+			{ ...event },
+			'completed',
+		);
+
+		return { success: true, data: event };
+	},
+};

--- a/packages/zendesk/webhooks/index.ts
+++ b/packages/zendesk/webhooks/index.ts
@@ -1,0 +1,7 @@
+import { example } from './example';
+
+export const ExampleWebhooks = {
+	example: example,
+};
+
+export * from './types';

--- a/packages/zendesk/webhooks/types.ts
+++ b/packages/zendesk/webhooks/types.ts
@@ -1,0 +1,118 @@
+import * as crypto from 'node:crypto';
+import type {
+	CorsairWebhookMatcher,
+	RawWebhookRequest,
+	WebhookRequest,
+} from 'corsair/core';
+import { z } from 'zod';
+
+export const ZendeskWebhookPayloadSchema = z.object({
+	type: z.string(),
+	created_at: z.string(),
+	data: z.record(z.string(), z.unknown()),
+});
+
+export type ZendeskWebhookPayload = z.infer<typeof ZendeskWebhookPayloadSchema>;
+
+export const ExampleEventSchema = ZendeskWebhookPayloadSchema.extend({
+	type: z.literal('example'),
+	data: z
+		.object({
+			id: z.string(),
+		})
+		.loose(),
+});
+
+export type ExampleEvent = z.infer<typeof ExampleEventSchema>;
+
+export type ZendeskWebhookOutputs = {
+	example: ExampleEvent;
+};
+
+function parseBody(body: unknown): Record<string, unknown> | null {
+	if (typeof body === 'string') {
+		try {
+			const parsed = JSON.parse(body);
+			return parsed !== null &&
+				typeof parsed === 'object' &&
+				!Array.isArray(parsed)
+				? (parsed as Record<string, unknown>)
+				: null;
+		} catch {
+			return null;
+		}
+	}
+	return body !== null && typeof body === 'object' && !Array.isArray(body)
+		? (body as Record<string, unknown>)
+		: null;
+}
+
+export function createZendeskMatch(eventType: string): CorsairWebhookMatcher {
+	return (request: RawWebhookRequest) => {
+		const parsedBody = parseBody(request.body);
+		return parsedBody !== null && parsedBody.type === eventType;
+	};
+}
+
+export function verifyZendeskWebhookSignature(
+	request: WebhookRequest<ZendeskWebhookPayload>,
+	secret?: string,
+): { valid: boolean; error?: string } {
+	if (!secret) {
+		return { valid: true };
+	}
+
+	const rawBody = request.rawBody;
+	if (rawBody === undefined || rawBody === null) {
+		return {
+			valid: false,
+			error: 'Missing raw body for signature verification',
+		};
+	}
+
+	const headers = request.headers;
+	const signature = Array.isArray(headers['x-zendesk-webhook-signature'])
+		? headers['x-zendesk-webhook-signature'][0]
+		: headers['x-zendesk-webhook-signature'];
+
+	const timestamp = Array.isArray(
+		headers['x-zendesk-webhook-signature-timestamp'],
+	)
+		? headers['x-zendesk-webhook-signature-timestamp'][0]
+		: headers['x-zendesk-webhook-signature-timestamp'];
+
+	if (!signature) {
+		return {
+			valid: false,
+			error: 'Missing x-zendesk-webhook-signature header',
+		};
+	}
+
+	if (!timestamp) {
+		return {
+			valid: false,
+			error: 'Missing x-zendesk-webhook-signature-timestamp header',
+		};
+	}
+
+	// Sign string is TIMESTAMP + BODY
+	const signingString = timestamp + rawBody;
+	const expectedSignature = crypto
+		.createHmac('sha256', secret)
+		.update(signingString)
+		.digest('base64');
+
+	try {
+		const isValid = crypto.timingSafeEqual(
+			Buffer.from(signature),
+			Buffer.from(expectedSignature),
+		);
+		if (!isValid) {
+			return { valid: false, error: 'Invalid signature' };
+		}
+	} catch {
+		return { valid: false, error: 'Invalid signature' };
+	}
+
+	return { valid: true };
+}

--- a/packages/zendesk/webhooks/types.ts
+++ b/packages/zendesk/webhooks/types.ts
@@ -33,6 +33,7 @@ function parseBody(body: unknown): Record<string, unknown> | null {
 	if (typeof body === 'string') {
 		try {
 			const parsed = JSON.parse(body);
+			// Type assertion is used here because we have already narrowed body type by checking that it is non-null, an object, and not an array.
 			return parsed !== null &&
 				typeof parsed === 'object' &&
 				!Array.isArray(parsed)
@@ -42,6 +43,7 @@ function parseBody(body: unknown): Record<string, unknown> | null {
 			return null;
 		}
 	}
+	// Type assertion is used here because we have already narrowed body type by checking that it is non-null, an object, and not an array.
 	return body !== null && typeof body === 'object' && !Array.isArray(body)
 		? (body as Record<string, unknown>)
 		: null;
@@ -59,7 +61,10 @@ export function verifyZendeskWebhookSignature(
 	secret?: string,
 ): { valid: boolean; error?: string } {
 	if (!secret) {
-		return { valid: true };
+		return {
+			valid: false,
+			error: 'Missing webhook signing secret configuration',
+		};
 	}
 
 	const rawBody = request.rawBody;
@@ -92,6 +97,24 @@ export function verifyZendeskWebhookSignature(
 		return {
 			valid: false,
 			error: 'Missing x-zendesk-webhook-signature-timestamp header',
+		};
+	}
+
+	const parsedTimestamp = Date.parse(timestamp);
+	if (Number.isNaN(parsedTimestamp)) {
+		return {
+			valid: false,
+			error: 'Invalid x-zendesk-webhook-signature-timestamp header format',
+		};
+	}
+
+	const now = Date.now();
+	const diffSeconds = Math.abs(now - parsedTimestamp) / 1000;
+	// Enforce a 5-minute freshness window (300 seconds)
+	if (diffSeconds > 300) {
+		return {
+			valid: false,
+			error: 'Webhook request timestamp is stale (outside 5-minute window)',
 		};
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1943,6 +1943,10 @@ importers:
         version: 4.1.13
 
   packages/zendesk:
+    dependencies:
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1950,9 +1954,6 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,7 +264,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -289,7 +289,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -335,7 +335,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -375,7 +375,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -400,7 +400,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -425,7 +425,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -477,7 +477,7 @@ importers:
         version: 2.6.1
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@24.10.1)(typescript@5.9.3)
@@ -507,7 +507,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -562,7 +562,7 @@ importers:
         version: 3.4.7
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@24.10.1)(typescript@5.9.3)
@@ -586,7 +586,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -611,7 +611,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -651,7 +651,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -676,7 +676,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -701,7 +701,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -726,7 +726,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -751,7 +751,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -776,7 +776,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -801,7 +801,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -826,7 +826,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -851,7 +851,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -876,7 +876,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -901,7 +901,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -926,7 +926,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -951,7 +951,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -976,7 +976,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1001,7 +1001,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1026,7 +1026,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1051,7 +1051,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1125,7 +1125,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1150,7 +1150,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1175,7 +1175,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1200,7 +1200,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1225,7 +1225,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1250,7 +1250,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1275,7 +1275,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1303,7 +1303,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1327,7 +1327,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.6
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1351,7 +1351,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.6
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1376,7 +1376,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1401,7 +1401,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1426,7 +1426,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1451,7 +1451,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1476,7 +1476,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1500,7 +1500,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1525,7 +1525,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1626,7 +1626,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1650,7 +1650,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1675,7 +1675,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1700,7 +1700,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1725,7 +1725,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1750,7 +1750,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1775,7 +1775,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1800,7 +1800,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1825,7 +1825,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1881,7 +1881,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1906,7 +1906,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1931,7 +1931,31 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: ^4.1.13
+        version: 4.1.13
+
+  packages/zendesk:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -1956,7 +1980,7 @@ importers:
         version: link:../corsair
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -15699,7 +15723,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3):
+  ts-jest@29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -15717,6 +15741,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.28.6)
+      esbuild: 0.27.0
       jest-util: 29.7.0
 
   ts-morph@26.0.0:


### PR DESCRIPTION
Closes #204

This PR implements the Zendesk ticketing integration under `packages/zendesk/` as requested in #204.

### What's included:
- **Zendesk API Client**: Formulates Basic authentication (`email_address/token` + `api_token`), handles requests to `https://${subdomain}.zendesk.com/api/v2`, and standardizes error responses with `ZendeskAPIError`.
- **Database & Schemas**: Implements database caching for Zendesk Tickets, Users, and Comments.
- **Endpoints**:
  - Tickets: Create, Get, Update, Delete, List.
  - Users: Create, Get, Update, Delete, List.
  - Comments: List (creation is done through Tickets Update per Zendesk API structure).
- **Webhooks**: Scaffolds webhook handlers.
- **Documentation**: Generated plugin documentation using `pnpm run generate:docs -- zendesk` under `docs/plugins/zendesk/`.
- **Tests**:
  - Unit tests in `packages/zendesk/api.test.ts` validating API payloads and URL structures.
  - Integration tests in `packages/zendesk/integration.test.ts` validating caching, updates, and interactions with SQLite database.