### PR TITLE
fix: landing responsive at mobile + tablet

### DIFF
--- a/www/src/components/landing/app-preview/desktop-preview.tsx
+++ b/www/src/components/landing/app-preview/desktop-preview.tsx
@@ -11,7 +11,7 @@ export function DesktopPreview() {
 	return (
 		<div className="relative mx-auto mt-2 w-full max-w-[1280px] text-left md:mt-4">
 			<div
-				className="relative mx-auto w-full max-md:min-h-[560px] max-md:h-[min(72vh,680px)] md:max-h-[740px] md:[aspect-ratio:1280/832]"
+				className="relative mx-auto w-full max-md:min-h-[420px] max-md:h-[min(72vh,640px)] md:max-h-[740px] md:[aspect-ratio:1280/832]"
 			>
 				<PreviewLayoutProvider>
 					<WindowOrderProvider>

--- a/www/src/components/landing/choose-your-path/choose-your-path-section.tsx
+++ b/www/src/components/landing/choose-your-path/choose-your-path-section.tsx
@@ -62,7 +62,7 @@ const PATH_OPTIONS = [
 ] as const;
 
 const CARD_CLASS =
-	'relative flex w-full flex-col rounded-sm border border-[#1c1c1c1a] bg-white p-5 md:p-6';
+	'relative flex w-full flex-col rounded-sm border border-[#1c1c1c1a] bg-white p-4 sm:p-5 md:p-6';
 
 function PathCard({ option }: { option: (typeof PATH_OPTIONS)[number] }) {
 	const headingId = `choose-your-path-${option.id}-title`;
@@ -111,10 +111,10 @@ export function ChooseYourPathSection() {
 	return (
 		<section
 			id="choose-your-path"
-			className="relative w-full scroll-mt-16 bg-[#f4f4f4] py-20 md:py-28 lg:py-32"
+			className="relative w-full scroll-mt-16 bg-[#f4f4f4] py-16 sm:py-20 md:py-28 lg:py-32"
 			aria-labelledby="choose-your-path-heading"
 		>
-			<div className="mx-auto max-w-[1440px] px-4 md:px-10">
+			<div className="mx-auto max-w-[1440px] px-4 sm:px-6 md:px-10">
 				<div className="mx-auto mb-14 flex max-w-[720px] flex-col items-center gap-6 text-center md:mb-20 md:max-w-[800px] md:gap-8">
 					<p className="font-[family-name:var(--landing-font-mono)] text-xs font-medium uppercase tracking-[0.02em] text-[#1c1c1c99]">
 						Choose your path
@@ -129,7 +129,7 @@ export function ChooseYourPathSection() {
 					</h2>
 				</div>
 
-				<ul className="grid grid-cols-1 gap-6 lg:grid-cols-3 lg:gap-8">
+				<ul className="grid grid-cols-1 gap-6 md:grid-cols-2 md:[&>li:nth-child(3)]:col-span-2 lg:grid-cols-3 lg:gap-8 lg:[&>li:nth-child(3)]:col-span-1">
 					{PATH_OPTIONS.map((option) => (
 						<PathCard key={option.id} option={option} />
 					))}

--- a/www/src/components/landing/faq/faq-section.tsx
+++ b/www/src/components/landing/faq/faq-section.tsx
@@ -49,10 +49,10 @@ export function FaqSection() {
 	return (
 		<section
 			id="faq"
-			className="relative w-full scroll-mt-16 bg-[#f4f4f4] py-20 md:py-28 lg:py-32"
+			className="relative w-full scroll-mt-16 bg-[#f4f4f4] py-16 sm:py-20 md:py-28 lg:py-32"
 			aria-labelledby="faq-heading"
 		>
-			<div className="mx-auto max-w-[1440px] px-4 md:px-10">
+			<div className="mx-auto max-w-[1440px] px-4 sm:px-6 md:px-10">
 				<h2
 					id="faq-heading"
 					className="mb-14 text-center font-[family-name:var(--landing-font-mono)] text-xs font-medium uppercase tracking-[0.02em] text-[#1c1c1c99] md:mb-20"
@@ -77,13 +77,13 @@ export function FaqSection() {
 					<div className="divide-y divide-[#1c1c1c1a]">
 						{FAQ_ITEMS.map((item) => (
 							<details key={item.id} className="group">
-								<summary className="flex cursor-pointer list-none items-start justify-between gap-4 px-6 py-5 text-left transition-colors hover:bg-[#1c1c1c05] md:px-8 md:py-6 [&::-webkit-details-marker]:hidden">
+								<summary className="flex cursor-pointer list-none items-start justify-between gap-3 px-4 py-4 text-left transition-colors hover:bg-[#1c1c1c05] sm:gap-4 sm:px-6 sm:py-5 md:px-8 md:py-6 [&::-webkit-details-marker]:hidden">
 									<span className="text-[15px] font-medium leading-snug text-[#1c1c1c] md:text-base">
 										{item.question}
 									</span>
 									<ChevronIcon />
 								</summary>
-								<div className="px-6 pb-5 md:px-8 md:pb-6">
+								<div className="px-4 pb-4 sm:px-6 sm:pb-5 md:px-8 md:pb-6">
 									<p className="text-[15px] leading-[1.65] text-[#1c1c1c99] md:text-base md:leading-[1.7]">
 										{item.answer}
 									</p>

--- a/www/src/components/landing/hero/landing-hero.tsx
+++ b/www/src/components/landing/hero/landing-hero.tsx
@@ -12,8 +12,8 @@ export function LandingHero() {
 				aria-hidden
 			/>
 			<HeroBackground />
-			<div className="relative z-[1] mx-auto grid max-w-[1440px] grid-cols-1 justify-items-center gap-6 px-4 pt-16 text-center sm:gap-8 sm:pt-20 md:px-10 md:pt-24">
-				<div className="flex w-full max-w-[360px] flex-col items-center gap-5 md:max-w-[720px]">
+			<div className="relative z-[1] mx-auto grid max-w-[1440px] grid-cols-1 justify-items-center gap-6 px-4 pt-12 text-center sm:gap-8 sm:px-6 sm:pt-20 md:px-10 md:pt-24">
+				<div className="flex w-full flex-col items-center gap-4 sm:max-w-[360px] sm:gap-5 md:max-w-[720px]">
 					{/* High-Fidelity Typography Headline */}
 					<h1 className="animate-hero-fade-up delay-[100ms] w-full text-[clamp(2.25rem,6vw,4.5rem)] font-light leading-[1.05] tracking-tight text-[#1c1c1c]">
 						<span className="font-[family-name:var(--landing-font-serif)] italic text-transparent bg-clip-text bg-gradient-to-br from-[#1c1c1c] to-[#555]">

--- a/www/src/components/landing/menu/site-menu.tsx
+++ b/www/src/components/landing/menu/site-menu.tsx
@@ -25,7 +25,7 @@ export function SiteMenu() {
 
 	return (
 		<header
-			className="sticky top-4 z-50 mx-4 md:mx-10 transition-all duration-300"
+			className="sticky top-3 z-50 mx-3 sm:top-4 sm:mx-4 md:mx-10 transition-all duration-300"
 		>
 			<div
 				className={`relative mx-auto max-w-[1440px] transition-all duration-300 ${
@@ -49,23 +49,23 @@ export function SiteMenu() {
 				</span>
 
 				<nav
-					className="flex min-h-16 w-full min-w-0 items-center justify-between gap-4 px-4 md:px-6"
+					className="flex min-h-14 sm:min-h-16 w-full min-w-0 items-center justify-between gap-2 sm:gap-4 px-3 sm:px-4 md:px-6"
 					aria-label="Primary navigation"
 				>
 					<Link
 						href="/"
 						aria-label="Corsair home"
-						className="inline-flex shrink-0 items-center gap-2.5 no-underline transition-opacity hover:opacity-80"
+						className="inline-flex shrink-0 items-center gap-2 sm:gap-2.5 no-underline transition-opacity hover:opacity-80"
 					>
 						<Image
 							src="/corsair-logo.png"
 							alt=""
 							width={32}
 							height={32}
-							className="rounded-sm"
+							className="size-7 sm:size-8 rounded-sm"
 							priority
 						/>
-						<span className="font-[family-name:var(--landing-font-sans)] text-lg font-semibold tracking-tight text-[#1c1c1c]">
+						<span className="font-[family-name:var(--landing-font-sans)] text-base sm:text-lg font-semibold tracking-tight text-[#1c1c1c]">
 							Corsair
 						</span>
 					</Link>
@@ -75,7 +75,7 @@ export function SiteMenu() {
 							href={DOCS_URL}
 							target="_blank"
 							rel="noopener noreferrer"
-							className="px-3 py-2 text-sm font-[family-name:var(--landing-font-sans)] font-medium text-[#1c1c1c]/60 no-underline transition-colors hover:text-[#1c1c1c]"
+							className="px-2 py-2 text-[13px] sm:px-3 sm:text-sm font-[family-name:var(--landing-font-sans)] font-medium text-[#1c1c1c]/60 no-underline transition-colors hover:text-[#1c1c1c]"
 						>
 							Docs
 						</a>
@@ -83,18 +83,19 @@ export function SiteMenu() {
 							href={GITHUB_URL}
 							target="_blank"
 							rel="noopener noreferrer"
-							className="px-3 py-2 text-sm font-[family-name:var(--landing-font-sans)] font-medium text-[#1c1c1c]/60 no-underline transition-colors hover:text-[#1c1c1c]"
+							className="px-2 py-2 text-[13px] sm:px-3 sm:text-sm font-[family-name:var(--landing-font-sans)] font-medium text-[#1c1c1c]/60 no-underline transition-colors hover:text-[#1c1c1c]"
 						>
 							Github
 						</a>
-						<div className="ml-2 sm:ml-4 flex items-center">
+						<div className="ml-1 sm:ml-4 flex items-center">
 							<a
 								href={APP_URL}
 								target="_blank"
 								rel="noopener noreferrer"
-								className="group inline-flex items-center justify-center gap-2 rounded-lg border border-[#1c1c1c] bg-[#1c1c1c] px-4 py-2 text-sm font-[family-name:var(--landing-font-sans)] font-medium text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.2)] no-underline transition-all duration-300 ease-out hover:bg-[#2a2a2a] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.2),0_4px_16px_rgba(0,0,0,0.15)] hover:-translate-y-0.5 active:translate-y-0"
+								className="group inline-flex min-h-9 items-center justify-center gap-1.5 sm:gap-2 rounded-lg border border-[#1c1c1c] bg-[#1c1c1c] px-3 py-2 text-[13px] sm:min-h-0 sm:px-4 sm:py-2 sm:text-sm font-[family-name:var(--landing-font-sans)] font-medium text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.2)] no-underline transition-all duration-300 ease-out hover:bg-[#2a2a2a] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.2),0_4px_16px_rgba(0,0,0,0.15)] hover:-translate-y-0.5 active:translate-y-0"
 							>
-								Go to app
+								<span className="sm:hidden">App</span>
+								<span className="hidden sm:inline">Go to app</span>
 								<span className="transition-transform duration-300 ease-out group-hover:translate-x-0.5">
 									<ArrowRightIcon />
 								</span>

--- a/www/src/components/landing/problem-statement/problem-statement-section.tsx
+++ b/www/src/components/landing/problem-statement/problem-statement-section.tsx
@@ -15,10 +15,10 @@ export function ProblemStatementSection() {
 	return (
 		<section
 			id="problem"
-			className="relative w-full scroll-mt-16 bg-[#f4f4f4] pt-10 pb-20 md:pt-12 md:pb-28 lg:pb-32"
+			className="relative w-full scroll-mt-16 bg-[#f4f4f4] pt-8 pb-16 sm:pt-10 sm:pb-20 md:pt-12 md:pb-28 lg:pb-32"
 			aria-labelledby="problem-heading"
 		>
-			<div className="mx-auto max-w-[1440px] px-4 md:px-10">
+			<div className="mx-auto max-w-[1440px] px-4 sm:px-6 md:px-10">
 				<div className="mx-auto flex max-w-[720px] flex-col items-center gap-6 text-center md:max-w-[800px] md:gap-8">
 					<p className="font-[family-name:var(--landing-font-mono)] text-xs font-medium uppercase tracking-[0.02em] text-[#1c1c1c99]">
 						The problem
@@ -53,13 +53,13 @@ export function ProblemStatementSection() {
 						<PlusCorner />
 					</span>
 
-					<div className="grid grid-cols-1 lg:grid-cols-2">
+					<div className="grid grid-cols-1 md:grid-cols-2">
 						{SUPPLEMENTAL_POINTS.map((point, index) => (
 							<div
 								key={point.lead}
-								className={`px-6 py-8 md:px-10 md:py-10 ${
+								className={`px-5 py-6 sm:px-6 sm:py-8 md:px-10 md:py-10 ${
 									index === 0
-										? 'border-b border-[#1c1c1c1a] lg:border-b-0 lg:border-r'
+										? 'border-b border-[#1c1c1c1a] md:border-b-0 md:border-r'
 										: ''
 								}`}
 							>

--- a/www/src/components/landing/solution-framing/solution-framing-section.tsx
+++ b/www/src/components/landing/solution-framing/solution-framing-section.tsx
@@ -26,7 +26,7 @@ const SOLUTION_PILLARS = [
 ] as const;
 
 const CARD_CLASS =
-	'relative flex min-h-[420px] w-full flex-col border border-[#1c1c1c1a] bg-white p-5 md:min-h-[480px] md:p-6 lg:h-[550px] lg:min-h-0';
+	'relative flex w-full flex-col border border-[#1c1c1c1a] bg-white p-4 sm:min-h-[420px] sm:p-5 md:min-h-[480px] md:p-6 lg:h-[550px] lg:min-h-0';
 
 function SolutionCard({
 	pillar,
@@ -68,10 +68,10 @@ export function SolutionFramingSection() {
 	return (
 		<section
 			id="solution"
-			className="relative w-full scroll-mt-16 bg-[#f4f4f4] py-20 md:py-28 lg:py-32"
+			className="relative w-full scroll-mt-16 bg-[#f4f4f4] py-16 sm:py-20 md:py-28 lg:py-32"
 			aria-labelledby="solution-heading"
 		>
-			<div className="mx-auto max-w-[1440px] px-4 md:px-10">
+			<div className="mx-auto max-w-[1440px] px-4 sm:px-6 md:px-10">
 				<div className="mx-auto flex max-w-[720px] flex-col items-center gap-6 text-center md:max-w-[960px] md:gap-8">
 					<p className="font-[family-name:var(--landing-font-mono)] text-xs font-medium uppercase tracking-[0.02em] text-[#1c1c1c99]">
 						The solution
@@ -92,7 +92,7 @@ export function SolutionFramingSection() {
 					</h2>
 				</div>
 
-				<ul className="mt-14 grid grid-cols-1 gap-6 md:mt-20 lg:grid-cols-3 lg:gap-8">
+				<ul className="mt-14 grid grid-cols-1 gap-6 md:mt-20 md:grid-cols-2 md:[&>li:nth-child(3)]:col-span-2 lg:grid-cols-3 lg:gap-8 lg:[&>li:nth-child(3)]:col-span-1">
 					{SOLUTION_PILLARS.map((pillar) => (
 						<SolutionCard key={pillar.id} pillar={pillar} />
 					))}

--- a/www/src/components/landing/terminal-trio/corsair-demo-modal.tsx
+++ b/www/src/components/landing/terminal-trio/corsair-demo-modal.tsx
@@ -103,7 +103,7 @@ export function OAuthModalContent({
 			subtitle="Corsair hosted auth"
 			onClose={onClose}
 		>
-			<div className="px-6 py-8 sm:px-10 sm:py-10">
+			<div className="px-4 py-6 sm:px-10 sm:py-10">
 				<div className="mb-8 flex flex-col items-center gap-3 text-center">
 					<FaviconLogo
 						domain={integration.iconDomain}
@@ -174,7 +174,7 @@ export function PermissionModalContent({
 			subtitle="Permission required"
 			onClose={onClose}
 		>
-			<div className="px-6 py-7 sm:px-8 sm:py-8">
+			<div className="px-4 py-5 sm:px-8 sm:py-8">
 				<div className="mb-6 flex items-center gap-3">
 					<FaviconLogo
 						domain={integration.iconDomain}

--- a/www/src/components/landing/terminal-trio/terminal-trio-section.tsx
+++ b/www/src/components/landing/terminal-trio/terminal-trio-section.tsx
@@ -82,7 +82,7 @@ function TerminalTrioGrid() {
 	const { isOpen } = useTrioModal();
 
 	return (
-		<div className="grid grid-cols-1 gap-12 lg:grid-cols-3 lg:gap-8">
+		<div className="grid grid-cols-1 gap-10 sm:gap-12 md:grid-cols-2 md:gap-10 lg:grid-cols-3 lg:gap-8">
 			{TRIO_COLUMNS.map(({ id, title, Window }) => (
 				<TerminalTrioColumn
 					key={id}
@@ -99,10 +99,10 @@ export function TerminalTrioSection() {
 	return (
 		<section
 			id="terminal-trio"
-			className="relative w-full scroll-mt-16 bg-[#f4f4f4] py-20 md:py-28 lg:py-32"
+			className="relative w-full scroll-mt-16 bg-[#f4f4f4] py-16 sm:py-20 md:py-28 lg:py-32"
 			aria-labelledby="terminal-trio-heading"
 		>
-			<div className="mx-auto max-w-[1440px] px-4 md:px-10">
+			<div className="mx-auto max-w-[1440px] px-4 sm:px-6 md:px-10">
 				<div className="mx-auto mb-14 flex max-w-[720px] flex-col items-center gap-6 text-center md:mb-20 md:max-w-[800px] md:gap-8">
 					<h2
 						id="terminal-trio-heading"

--- a/www/src/components/landing/terminal-trio/terminal-trio-section.tsx
+++ b/www/src/components/landing/terminal-trio/terminal-trio-section.tsx
@@ -82,7 +82,7 @@ function TerminalTrioGrid() {
 	const { isOpen } = useTrioModal();
 
 	return (
-		<div className="grid grid-cols-1 gap-10 sm:gap-12 md:grid-cols-2 md:gap-10 lg:grid-cols-3 lg:gap-8">
+		<div className="grid grid-cols-1 gap-10 sm:gap-12 md:grid-cols-2 md:gap-10 md:[&>div:nth-child(3)]:col-span-2 lg:grid-cols-3 lg:gap-8 lg:[&>div:nth-child(3)]:col-span-1">
 			{TRIO_COLUMNS.map(({ id, title, Window }) => (
 				<TerminalTrioColumn
 					key={id}


### PR DESCRIPTION
#### Responsive landing pass — mobile + tablet
Desktop-first grids jumped 1→3 columns at `lg`, leaving iPads in portrait as a tall single column and phones with overflow at narrow widths. This fixes both.

- **Tablet:** Trio, Solution, Choose-your-path, and Problem sections now step through `md:grid-cols-2`. 3rd card spans both columns at `md` where needed.
- **Mobile menu:** Tighter padding, shorter button label, `min-h-9` touch target. Fixes 320–375px overflow.
- **Hero:** Less top padding, removed `max-w-[360px]` below `sm`.
- **Cards/modals:** Dropped forced `min-h-[420px]` on Solution cards, tighter modal padding, desktop preview heights trimmed.

No logic changes. Tailwind only, 9 files. Verified at 320–1920px via headless Chrome. 
Recommend a DevTools mobile pass before merge.