### PR TITLE
fix(cli): register missing OneDrive webhook subscription commands

### DIFF
--- a/packages/cli/src/commands/onedrive-subscribe.command.ts
+++ b/packages/cli/src/commands/onedrive-subscribe.command.ts
@@ -1,0 +1,11 @@
+import OnedriveCommand from './subscribe/onedrive.command'
+
+export default class OnedriveSubscribeCommand extends OnedriveCommand {
+	getName(): string {
+		return 'onedrive-subscribe';
+	}
+
+	getDescription(): string {
+		return 'Subscribe OneDrive webhooks';
+	}
+}

--- a/packages/cli/src/commands/subscribe.command.ts
+++ b/packages/cli/src/commands/subscribe.command.ts
@@ -3,7 +3,8 @@ import type { CommandActionData, CommandOption } from '../index.types'
 import TeamsCommand from './subscribe/teams.command'
 import SharepointCommand from './subscribe/sharepoint.command'
 import OutlookCommand from './subscribe/outlook.command'
-import { runOutlookSubscribe } from '../lib/microsoft/subscribe-microsoft'
+import OnedriveCommand from './subscribe/onedrive.command'
+import { runOutlookSubscribe, runOnedriveSubscribe } from '../lib/microsoft/subscribe-microsoft'
 
 export default class SubscribeCommand extends BaseCommand {
 	getName(): string {
@@ -29,6 +30,7 @@ export default class SubscribeCommand extends BaseCommand {
 			new SharepointCommand(),
 			new TeamsCommand(),
 			new OutlookCommand(),
+			new OnedriveCommand(),
 		];
 	}
 
@@ -37,7 +39,7 @@ export default class SubscribeCommand extends BaseCommand {
 			console.error(
 				"Usage: corsair subscribe --plugin=<id> or corsair subscribe <plugin>",
 			);
-			console.error('[#corsair]: Supported: outlook');
+			console.error('[#corsair]: Supported: outlook, sharepoint, teams, onedrive');
 			process.exit(1);
 		}
 
@@ -46,8 +48,13 @@ export default class SubscribeCommand extends BaseCommand {
 			return;
 		}
 
+		if (options.plugin === 'onedrive') {
+			await runOnedriveSubscribe({ cwd: process.cwd() });
+			return;
+		}
+
 		console.error(
-			`[#corsair]: Unknown plugin for subscribe: '${options.plugin}'. Supported: outlook`,
+			`[#corsair]: Unknown plugin for subscribe: '${options.plugin}'. Supported: outlook, sharepoint, teams, onedrive`,
 		);
 		process.exit(1);
 	}

--- a/packages/cli/src/commands/subscribe.command.ts
+++ b/packages/cli/src/commands/subscribe.command.ts
@@ -4,7 +4,6 @@ import TeamsCommand from './subscribe/teams.command'
 import SharepointCommand from './subscribe/sharepoint.command'
 import OutlookCommand from './subscribe/outlook.command'
 import OnedriveCommand from './subscribe/onedrive.command'
-import { runOutlookSubscribe, runOnedriveSubscribe } from '../lib/microsoft/subscribe-microsoft'
 
 export default class SubscribeCommand extends BaseCommand {
 	getName(): string {
@@ -44,11 +43,25 @@ export default class SubscribeCommand extends BaseCommand {
 		}
 
 		if (options.plugin === 'outlook') {
+			const { runOutlookSubscribe } = await import('../lib/microsoft/subscribe-microsoft');
 			await runOutlookSubscribe({ cwd: process.cwd() });
 			return;
 		}
 
+		if (options.plugin === 'sharepoint') {
+			const { runSharepointSubscribe } = await import('../lib/microsoft/subscribe-microsoft');
+			await runSharepointSubscribe({ cwd: process.cwd() });
+			return;
+		}
+
+		if (options.plugin === 'teams') {
+			const { runTeamsSubscribe } = await import('../lib/microsoft/subscribe-microsoft');
+			await runTeamsSubscribe({ cwd: process.cwd() });
+			return;
+		}
+
 		if (options.plugin === 'onedrive') {
+			const { runOnedriveSubscribe } = await import('../lib/microsoft/subscribe-microsoft');
 			await runOnedriveSubscribe({ cwd: process.cwd() });
 			return;
 		}
@@ -59,3 +72,4 @@ export default class SubscribeCommand extends BaseCommand {
 		process.exit(1);
 	}
 }
+

--- a/packages/cli/src/commands/subscribe/onedrive.command.ts
+++ b/packages/cli/src/commands/subscribe/onedrive.command.ts
@@ -1,6 +1,5 @@
 import BaseCommand from '../base.command'
 import type { CommandActionData } from '../../index.types'
-import { runOnedriveSubscribe } from '../../lib/microsoft/subscribe-microsoft'
 
 export default class OnedriveCommand extends BaseCommand {
 	getName(): string {
@@ -12,6 +11,7 @@ export default class OnedriveCommand extends BaseCommand {
 	}
 
 	async action({}: CommandActionData) {
+		const { runOnedriveSubscribe } = await import('../../lib/microsoft/subscribe-microsoft');
 		await runOnedriveSubscribe({ cwd: process.cwd() });
 	}
 }

--- a/packages/cli/src/commands/subscribe/onedrive.command.ts
+++ b/packages/cli/src/commands/subscribe/onedrive.command.ts
@@ -1,0 +1,17 @@
+import BaseCommand from '../base.command'
+import type { CommandActionData } from '../../index.types'
+import { runOnedriveSubscribe } from '../../lib/microsoft/subscribe-microsoft'
+
+export default class OnedriveCommand extends BaseCommand {
+	getName(): string {
+		return 'onedrive';
+	}
+
+	getDescription(): string {
+		return 'Subscribe OneDrive webhooks';
+	}
+
+	async action({}: CommandActionData) {
+		await runOnedriveSubscribe({ cwd: process.cwd() });
+	}
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,7 @@ import StudioCommand from './commands/studio.command'
 import SubscribeCommand from './commands/subscribe.command'
 import SharepointSubscribeCommand from './commands/sharepoint-subscribe.command'
 import TeamsSubscribeCommand from './commands/teams-subscribe.command'
+import OnedriveSubscribeCommand from './commands/onedrive-subscribe.command'
 import WatchRenewCommand from './commands/watch-renew.command'
 import {
 	findCorsairConfigPath,
@@ -31,6 +32,7 @@ function createProgram(): Command {
 		new SubscribeCommand(),
 		new SharepointSubscribeCommand(),
 		new TeamsSubscribeCommand(),
+		new OnedriveSubscribeCommand(),
 		new ListCommand(),
 		new SchemaCommand(),
 		new ScriptCommand(),


### PR DESCRIPTION
## Description
Fixes #236
The core processing logic (`runOnedriveSubscribe`) in `lib/microsoft/onedrive.ts` was fully implemented but never wired into the Commander program hierarchy, making OneDrive webhook subscriptions inaccessible from the CLI.
This PR registers the missing commands, mirroring the existing architecture used by SharePoint, Teams, and Outlook.
## Changes
- **`subscribe/onedrive.command.ts`** — New subcommand class exposing `corsair subscribe onedrive`
- **`onedrive-subscribe.command.ts`** — New top-level legacy alias (`corsair onedrive-subscribe`), consistent with `sharepoint-subscribe` and `teams-subscribe`
- **`subscribe.command.ts`** — Mounted `OnedriveCommand` in `getSubCommands()` and added `onedrive` to the legacy `--plugin` flag handler
- **`index.ts`** — Registered `OnedriveSubscribeCommand` in the `COMMANDS` array
## Testing
- `npx tsc --noEmit` — compiles with zero errors
- `corsair --help` — shows `onedrive-subscribe` in top-level commands
- `corsair subscribe --help` — shows `onedrive` subcommand alongside sharepoint, teams, outlook
- `corsair subscribe onedrive` — executes and reaches `runOnedriveSubscribe` backend logic
Screenshots attached below.

<img width="911" height="591" alt="corsair proof 2" src="https://github.com/user-attachments/assets/560305c0-9302-4001-9a2d-43c80f68eedd" />
<img width="897" height="607" alt="corsair proof" src="https://github.com/user-attachments/assets/11b60096-10a2-452b-92a3-904b95228067" />