### PR TITLE
feat(core): connect link for non-authenticated OAuth users

### DIFF
--- a/packages/corsair/core/auth/errors/auth-missing.ts
+++ b/packages/corsair/core/auth/errors/auth-missing.ts
@@ -1,0 +1,14 @@
+/**
+ * Error thrown when a plugin endpoint is called but the user has not authenticated
+ * with the required OAuth provider. Corsair intercepts this error and returns a
+ * connect link the agent can present to the user.
+ */
+export class AuthMissingError extends Error {
+  pluginId: string
+
+  constructor(pluginId: string, message?: string) {
+    super(message ?? `[auth-missing:${pluginId}]`)
+    this.name = 'AuthMissingError'
+    this.pluginId = pluginId
+  }
+}

--- a/packages/corsair/core/auth/errors/auth-missing.ts
+++ b/packages/corsair/core/auth/errors/auth-missing.ts
@@ -4,11 +4,11 @@
  * connect link the agent can present to the user.
  */
 export class AuthMissingError extends Error {
-  pluginId: string
+	pluginId: string;
 
-  constructor(pluginId: string, message?: string) {
-    super(message ?? `[auth-missing:${pluginId}]`)
-    this.name = 'AuthMissingError'
-    this.pluginId = pluginId
-  }
+	constructor(pluginId: string, message?: string) {
+		super(message ?? `[auth-missing:${pluginId}]`);
+		this.name = 'AuthMissingError';
+		this.pluginId = pluginId;
+	}
 }

--- a/packages/corsair/core/auth/errors/auth-missing.ts
+++ b/packages/corsair/core/auth/errors/auth-missing.ts
@@ -8,6 +8,7 @@ export class AuthMissingError extends Error {
 
 	constructor(pluginId: string, message?: string) {
 		super(message ?? `[auth-missing:${pluginId}]`);
+		Object.setPrototypeOf(this, new.target.prototype);
 		this.name = 'AuthMissingError';
 		this.pluginId = pluginId;
 	}

--- a/packages/corsair/core/auth/errors/index.ts
+++ b/packages/corsair/core/auth/errors/index.ts
@@ -1,2 +1,2 @@
-export { AuthMissingError } from './auth-missing'
-export { createMissingConfigProxy } from './missing-config'
+export { AuthMissingError } from './auth-missing';
+export { createMissingConfigProxy } from './missing-config';

--- a/packages/corsair/core/auth/errors/index.ts
+++ b/packages/corsair/core/auth/errors/index.ts
@@ -1,1 +1,2 @@
-export { createMissingConfigProxy } from './missing-config';
+export { AuthMissingError } from './auth-missing'
+export { createMissingConfigProxy } from './missing-config'

--- a/packages/corsair/core/auth/index.ts
+++ b/packages/corsair/core/auth/index.ts
@@ -1,42 +1,40 @@
 // Encryption utilities
 export {
-  decryptConfig,
-  decryptDEK,
-  decryptWithDEK,
-  encryptConfig,
-  encryptDEK,
-  encryptWithDEK,
-  generateDEK,
-  reEncryptConfig,
-} from './encryption'
-
+	decryptConfig,
+	decryptDEK,
+	decryptWithDEK,
+	encryptConfig,
+	encryptDEK,
+	encryptWithDEK,
+	generateDEK,
+	reEncryptConfig,
+} from './encryption';
 // Auth error utilities
-export { AuthMissingError } from './errors'
-export { createMissingConfigProxy } from './errors'
-export type { TokenResponse } from './exchange'
+export { AuthMissingError, createMissingConfigProxy } from './errors';
+export type { TokenResponse } from './exchange';
 // Token exchange utility
-export { exchangeCodeForTokens } from './exchange'
+export { exchangeCodeForTokens } from './exchange';
 // Key manager factory and utilities
 export {
-  type AccountKeyManagerOptions,
-  createAccountKeyManager,
-  createIntegrationKeyManager,
-  type IntegrationKeyManagerOptions,
-  initializeAccountDEK,
-  initializeIntegrationDEK,
-} from './key-manager'
+	type AccountKeyManagerOptions,
+	createAccountKeyManager,
+	createIntegrationKeyManager,
+	type IntegrationKeyManagerOptions,
+	initializeAccountDEK,
+	initializeIntegrationDEK,
+} from './key-manager';
 // Types
 export type {
-  AccountFieldNames,
-  AccountKeyContext,
-  AccountKeyManagerFor,
-  BaseAuthFieldConfig,
-  BaseKeyManager,
-  IntegrationFieldNames,
-  IntegrationKeyContext,
-  IntegrationKeyManagerFor,
-  KeyManagerContext,
-  OAuth2IntegrationCredentials,
-  PluginAuthConfig,
-} from './types'
-export { BASE_AUTH_FIELDS } from './types'
+	AccountFieldNames,
+	AccountKeyContext,
+	AccountKeyManagerFor,
+	BaseAuthFieldConfig,
+	BaseKeyManager,
+	IntegrationFieldNames,
+	IntegrationKeyContext,
+	IntegrationKeyManagerFor,
+	KeyManagerContext,
+	OAuth2IntegrationCredentials,
+	PluginAuthConfig,
+} from './types';
+export { BASE_AUTH_FIELDS } from './types';

--- a/packages/corsair/core/auth/index.ts
+++ b/packages/corsair/core/auth/index.ts
@@ -1,41 +1,42 @@
 // Encryption utilities
 export {
-	decryptConfig,
-	decryptDEK,
-	decryptWithDEK,
-	encryptConfig,
-	encryptDEK,
-	encryptWithDEK,
-	generateDEK,
-	reEncryptConfig,
-} from './encryption';
+  decryptConfig,
+  decryptDEK,
+  decryptWithDEK,
+  encryptConfig,
+  encryptDEK,
+  encryptWithDEK,
+  generateDEK,
+  reEncryptConfig,
+} from './encryption'
 
 // Auth error utilities
-export { createMissingConfigProxy } from './errors';
-export type { TokenResponse } from './exchange';
+export { AuthMissingError } from './errors'
+export { createMissingConfigProxy } from './errors'
+export type { TokenResponse } from './exchange'
 // Token exchange utility
-export { exchangeCodeForTokens } from './exchange';
+export { exchangeCodeForTokens } from './exchange'
 // Key manager factory and utilities
 export {
-	type AccountKeyManagerOptions,
-	createAccountKeyManager,
-	createIntegrationKeyManager,
-	type IntegrationKeyManagerOptions,
-	initializeAccountDEK,
-	initializeIntegrationDEK,
-} from './key-manager';
+  type AccountKeyManagerOptions,
+  createAccountKeyManager,
+  createIntegrationKeyManager,
+  type IntegrationKeyManagerOptions,
+  initializeAccountDEK,
+  initializeIntegrationDEK,
+} from './key-manager'
 // Types
 export type {
-	AccountFieldNames,
-	AccountKeyContext,
-	AccountKeyManagerFor,
-	BaseAuthFieldConfig,
-	BaseKeyManager,
-	IntegrationFieldNames,
-	IntegrationKeyContext,
-	IntegrationKeyManagerFor,
-	KeyManagerContext,
-	OAuth2IntegrationCredentials,
-	PluginAuthConfig,
-} from './types';
-export { BASE_AUTH_FIELDS } from './types';
+  AccountFieldNames,
+  AccountKeyContext,
+  AccountKeyManagerFor,
+  BaseAuthFieldConfig,
+  BaseKeyManager,
+  IntegrationFieldNames,
+  IntegrationKeyContext,
+  IntegrationKeyManagerFor,
+  KeyManagerContext,
+  OAuth2IntegrationCredentials,
+  PluginAuthConfig,
+} from './types'
+export { BASE_AUTH_FIELDS } from './types'

--- a/packages/corsair/core/auth/state.ts
+++ b/packages/corsair/core/auth/state.ts
@@ -1,0 +1,67 @@
+import * as crypto from 'node:crypto'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OAuth State Encoding — HMAC-signed to prevent forged callbacks
+// Extracted here so both oauth/index.ts and core/endpoints/bind.ts can import
+// without creating circular dependencies.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type OAuthState = { plugin: string; tenantId: string }
+
+export function encodeOAuthState(plugin: string, tenantId: string): string {
+  return Buffer.from(JSON.stringify({ plugin, tenantId })).toString('base64url')
+}
+
+export function decodeOAuthState(state: string): OAuthState | null {
+  try {
+    // Accepts both raw payload (for tests/utilities) and signed `payload.sig` format
+    const payload = state.includes('.') ? state.split('.')[0] : state
+    const decoded = JSON.parse(
+      Buffer.from(payload!, 'base64url').toString('utf-8')
+    ) as unknown
+    if (
+      decoded !== null &&
+      typeof decoded === 'object' &&
+      'plugin' in decoded &&
+      'tenantId' in decoded &&
+      typeof (decoded as OAuthState).plugin === 'string' &&
+      typeof (decoded as OAuthState).tenantId === 'string'
+    ) {
+      return decoded as OAuthState
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+export function signState(payload: string, kek: string): string {
+  const sig = crypto
+    .createHmac('sha256', kek)
+    .update(payload)
+    .digest('base64url')
+  return `${payload}.${sig}`
+}
+
+export function verifyAndDecodeState(
+  signed: string,
+  kek: string
+): OAuthState | null {
+  const dotIdx = signed.lastIndexOf('.')
+  if (dotIdx === -1) return null
+  const payload = signed.slice(0, dotIdx)
+  const sig = signed.slice(dotIdx + 1)
+  const expected = crypto
+    .createHmac('sha256', kek)
+    .update(payload)
+    .digest('base64url')
+  const sigBuf = Buffer.from(sig, 'base64url')
+  const expectedBuf = Buffer.from(expected, 'base64url')
+  if (
+    sigBuf.length !== expectedBuf.length ||
+    !crypto.timingSafeEqual(sigBuf, expectedBuf)
+  ) {
+    return null
+  }
+  return decodeOAuthState(payload)
+}

--- a/packages/corsair/core/auth/state.ts
+++ b/packages/corsair/core/auth/state.ts
@@ -6,17 +6,19 @@ import * as crypto from 'node:crypto';
 // without creating circular dependencies.
 // ─────────────────────────────────────────────────────────────────────────────
 
-export type OAuthState = { plugin: string; tenantId: string };
+export type OAuthState = { plugin: string; tenantId: string; iat: number };
 
 export function encodeOAuthState(plugin: string, tenantId: string): string {
-	return Buffer.from(JSON.stringify({ plugin, tenantId })).toString(
-		'base64url',
-	);
+	return Buffer.from(
+		JSON.stringify({ plugin, tenantId, iat: Date.now() }),
+	).toString('base64url');
 }
 
-export function decodeOAuthState(state: string): OAuthState | null {
+export function decodeOAuthState(
+	state: string,
+	{ maxAgeMs }: { maxAgeMs?: number } = {},
+): OAuthState | null {
 	try {
-		// Accepts both raw payload (for tests/utilities) and signed `payload.sig` format
 		const payload = state.includes('.') ? state.split('.')[0] : state;
 		const decoded = JSON.parse(
 			Buffer.from(payload!, 'base64url').toString('utf-8'),
@@ -29,7 +31,15 @@ export function decodeOAuthState(state: string): OAuthState | null {
 			typeof (decoded as OAuthState).plugin === 'string' &&
 			typeof (decoded as OAuthState).tenantId === 'string'
 		) {
-			return decoded as OAuthState;
+			const result = decoded as OAuthState;
+			if (
+				maxAgeMs !== undefined &&
+				typeof result.iat === 'number' &&
+				Date.now() - result.iat > maxAgeMs
+			) {
+				return null;
+			}
+			return result;
 		}
 		return null;
 	} catch {
@@ -44,6 +54,8 @@ export function signState(payload: string, kek: string): string {
 		.digest('base64url');
 	return `${payload}.${sig}`;
 }
+
+const DEFAULT_STATE_TTL_MS = 10 * 60 * 1000;
 
 export function verifyAndDecodeState(
 	signed: string,
@@ -65,5 +77,5 @@ export function verifyAndDecodeState(
 	) {
 		return null;
 	}
-	return decodeOAuthState(payload);
+	return decodeOAuthState(payload, { maxAgeMs: DEFAULT_STATE_TTL_MS });
 }

--- a/packages/corsair/core/auth/state.ts
+++ b/packages/corsair/core/auth/state.ts
@@ -1,4 +1,4 @@
-import * as crypto from 'node:crypto'
+import * as crypto from 'node:crypto';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // OAuth State Encoding — HMAC-signed to prevent forged callbacks
@@ -6,62 +6,64 @@ import * as crypto from 'node:crypto'
 // without creating circular dependencies.
 // ─────────────────────────────────────────────────────────────────────────────
 
-export type OAuthState = { plugin: string; tenantId: string }
+export type OAuthState = { plugin: string; tenantId: string };
 
 export function encodeOAuthState(plugin: string, tenantId: string): string {
-  return Buffer.from(JSON.stringify({ plugin, tenantId })).toString('base64url')
+	return Buffer.from(JSON.stringify({ plugin, tenantId })).toString(
+		'base64url',
+	);
 }
 
 export function decodeOAuthState(state: string): OAuthState | null {
-  try {
-    // Accepts both raw payload (for tests/utilities) and signed `payload.sig` format
-    const payload = state.includes('.') ? state.split('.')[0] : state
-    const decoded = JSON.parse(
-      Buffer.from(payload!, 'base64url').toString('utf-8')
-    ) as unknown
-    if (
-      decoded !== null &&
-      typeof decoded === 'object' &&
-      'plugin' in decoded &&
-      'tenantId' in decoded &&
-      typeof (decoded as OAuthState).plugin === 'string' &&
-      typeof (decoded as OAuthState).tenantId === 'string'
-    ) {
-      return decoded as OAuthState
-    }
-    return null
-  } catch {
-    return null
-  }
+	try {
+		// Accepts both raw payload (for tests/utilities) and signed `payload.sig` format
+		const payload = state.includes('.') ? state.split('.')[0] : state;
+		const decoded = JSON.parse(
+			Buffer.from(payload!, 'base64url').toString('utf-8'),
+		) as unknown;
+		if (
+			decoded !== null &&
+			typeof decoded === 'object' &&
+			'plugin' in decoded &&
+			'tenantId' in decoded &&
+			typeof (decoded as OAuthState).plugin === 'string' &&
+			typeof (decoded as OAuthState).tenantId === 'string'
+		) {
+			return decoded as OAuthState;
+		}
+		return null;
+	} catch {
+		return null;
+	}
 }
 
 export function signState(payload: string, kek: string): string {
-  const sig = crypto
-    .createHmac('sha256', kek)
-    .update(payload)
-    .digest('base64url')
-  return `${payload}.${sig}`
+	const sig = crypto
+		.createHmac('sha256', kek)
+		.update(payload)
+		.digest('base64url');
+	return `${payload}.${sig}`;
 }
 
 export function verifyAndDecodeState(
-  signed: string,
-  kek: string
+	signed: string,
+	kek: string,
 ): OAuthState | null {
-  const dotIdx = signed.lastIndexOf('.')
-  if (dotIdx === -1) return null
-  const payload = signed.slice(0, dotIdx)
-  const sig = signed.slice(dotIdx + 1)
-  const expected = crypto
-    .createHmac('sha256', kek)
-    .update(payload)
-    .digest('base64url')
-  const sigBuf = Buffer.from(sig, 'base64url')
-  const expectedBuf = Buffer.from(expected, 'base64url')
-  if (
-    sigBuf.length !== expectedBuf.length ||
-    !crypto.timingSafeEqual(sigBuf, expectedBuf)
-  ) {
-    return null
-  }
-  return decodeOAuthState(payload)
+	const dotIdx = signed.lastIndexOf('.');
+	if (dotIdx === -1) return null;
+	const payload = signed.slice(0, dotIdx);
+	const sig = signed.slice(dotIdx + 1);
+	const expected = crypto
+		.createHmac('sha256', kek)
+		.update(payload)
+		.digest('base64url');
+	const sigBuf = Buffer.from(sig, 'base64url');
+	const expectedBuf = Buffer.from(expected, 'base64url');
+	if (
+		sigBuf.length !== expectedBuf.length ||
+		!crypto.timingSafeEqual(sigBuf, expectedBuf)
+	) {
+		return null;
+	}
+	return decodeOAuthState(payload);
 }

--- a/packages/corsair/core/client/index.ts
+++ b/packages/corsair/core/client/index.ts
@@ -1,34 +1,34 @@
-import type { ZodTypeAny } from 'zod';
-import type { CorsairDatabase } from '../../db/kysely/database';
-import { createKyselyEntityClient } from '../../db/kysely/orm';
+import type { ZodTypeAny } from 'zod'
+import type { CorsairDatabase } from '../../db/kysely/database'
+import { createKyselyEntityClient } from '../../db/kysely/orm'
 import type {
-	CorsairPluginSchema,
-	PluginEntityClient,
-	PluginEntityClients,
-} from '../../db/orm';
+  CorsairPluginSchema,
+  PluginEntityClient,
+  PluginEntityClients,
+} from '../../db/orm'
 import {
-	createAccountKeyManager,
-	createIntegrationKeyManager,
-} from '../auth/key-manager';
+  createAccountKeyManager,
+  createIntegrationKeyManager,
+} from '../auth/key-manager'
 import type {
-	AccountKeyManagerFor,
-	IntegrationKeyManagerFor,
-	PluginAuthConfig,
-} from '../auth/types';
-import type { AuthTypes } from '../constants';
-import type { BindEndpoints, EndpointTree } from '../endpoints';
-import { bindEndpointsRecursively } from '../endpoints/bind';
-import type { CorsairErrorHandler } from '../errors';
-import type { CorsairPermissionsNamespace } from '../permissions';
+  AccountKeyManagerFor,
+  IntegrationKeyManagerFor,
+  PluginAuthConfig,
+} from '../auth/types'
+import type { AuthTypes } from '../constants'
+import type { BindEndpoints, EndpointTree } from '../endpoints'
+import { bindEndpointsRecursively } from '../endpoints/bind'
+import type { CorsairErrorHandler } from '../errors'
+import type { CorsairPermissionsNamespace } from '../permissions'
 import type {
-	CorsairKeyBuilderBase,
-	CorsairPlugin,
-	EndpointMetaEntry,
-	PermissionMode,
-	PermissionPolicy,
-} from '../plugins';
-import type { BindWebhooks, RawWebhookRequest, WebhookTree } from '../webhooks';
-import { bindWebhooksRecursively } from '../webhooks/bind';
+  CorsairKeyBuilderBase,
+  CorsairPlugin,
+  EndpointMetaEntry,
+  PermissionMode,
+  PermissionPolicy,
+} from '../plugins'
+import type { BindWebhooks, RawWebhookRequest, WebhookTree } from '../webhooks'
+import { bindWebhooksRecursively } from '../webhooks/bind'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Entity Client Types
@@ -40,10 +40,11 @@ import { bindWebhooksRecursively } from '../webhooks/bind';
  * Entities are nested under `db` to separate them from API endpoints.
  */
 export type InferPluginEntities<
-	Schema extends CorsairPluginSchema<Record<string, ZodTypeAny>> | undefined,
-> = Schema extends CorsairPluginSchema<infer Entities>
-	? { db: PluginEntityClients<Entities> }
-	: {};
+  Schema extends CorsairPluginSchema<Record<string, ZodTypeAny>> | undefined,
+> =
+  Schema extends CorsairPluginSchema<infer Entities>
+    ? { db: PluginEntityClients<Entities> }
+    : {}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Client Types
@@ -53,10 +54,10 @@ export type InferPluginEntities<
  * Utility type that converts a union to an intersection type.
  */
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
-	k: infer I,
+  k: infer I
 ) => void
-	? I
-	: never;
+  ? I
+  : never
 
 /**
  * Extracts the authType from plugin options.
@@ -70,28 +71,28 @@ type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
  * 4. If authType is not in Options at all, fall back to DefaultAuthType
  */
 export type ExtractAuthType<
-	Options,
-	DefaultAuthType extends AuthTypes | undefined = undefined,
+  Options,
+  DefaultAuthType extends AuthTypes | undefined = undefined,
 > = 'authType' extends keyof Options
-	? // Check if authType is a specific single auth type (narrowed, not a union)
-		Options['authType'] extends AuthTypes
-		? // authType is narrowed to a specific type - use it
-			Options['authType']
-		: // authType is optional or a union - use DefaultAuthType if provided
-			DefaultAuthType extends AuthTypes
-			? DefaultAuthType
-			: NonNullable<Options['authType']> extends AuthTypes
-				? NonNullable<Options['authType']>
-				: never
-	: // authType is not in Options - fall back to DefaultAuthType
-		DefaultAuthType extends AuthTypes
-		? DefaultAuthType
-		: never;
+  ? // Check if authType is a specific single auth type (narrowed, not a union)
+    Options['authType'] extends AuthTypes
+    ? // authType is narrowed to a specific type - use it
+      Options['authType']
+    : // authType is optional or a union - use DefaultAuthType if provided
+      DefaultAuthType extends AuthTypes
+      ? DefaultAuthType
+      : NonNullable<Options['authType']> extends AuthTypes
+        ? NonNullable<Options['authType']>
+        : never
+  : // authType is not in Options - fall back to DefaultAuthType
+    DefaultAuthType extends AuthTypes
+    ? DefaultAuthType
+    : never
 
 /**
  * Extracts Options type from plugin's options property.
  */
-type InferPluginOptions<P> = P extends { options?: infer O } ? O : never;
+type InferPluginOptions<P> = P extends { options?: infer O } ? O : never
 
 /**
  * Extracts DefaultAuthType from plugin's __defaultAuthType property.
@@ -99,133 +100,136 @@ type InferPluginOptions<P> = P extends { options?: infer O } ? O : never;
  * which causes TypeScript to infer D as `AuthType | undefined`.
  */
 type InferDefaultAuthType<P> = P extends { __defaultAuthType?: infer D }
-	? NonNullable<D> extends AuthTypes
-		? NonNullable<D>
-		: undefined
-	: undefined;
+  ? NonNullable<D> extends AuthTypes
+    ? NonNullable<D>
+    : undefined
+  : undefined
 
 /**
  * Extracts the AuthConfig from a plugin's authConfig property.
  */
 type InferAuthConfig<P> = P extends { authConfig?: infer C }
-	? C extends PluginAuthConfig
-		? C
-		: undefined
-	: undefined;
+  ? C extends PluginAuthConfig
+    ? C
+    : undefined
+  : undefined
 
 /**
  * Infers the complete namespace for a single plugin, including API endpoints,
  * database entities, webhooks, and account-level keys.
  */
-type InferPluginNamespace<P extends CorsairPlugin> = P extends CorsairPlugin<
-	infer Id,
-	infer Schema,
-	infer Endpoints,
-	infer Webhooks
->
-	? {
-			[K in Id]: (Endpoints extends EndpointTree
-				? { api: BindEndpoints<Endpoints> }
-				: {}) &
-				InferPluginEntities<Schema> &
-				(Webhooks extends WebhookTree
-					? {
-							webhooks: BindWebhooks<Webhooks>;
-							/**
-							 * Synchronously checks if an incoming webhook request is intended for this plugin.
-							 * Only present if the plugin defines a `pluginWebhookMatcher`.
-							 * Use this as a first-level filter before checking individual webhook matchers.
-							 */
-							pluginWebhookMatcher?: (request: RawWebhookRequest) => boolean;
-						}
-					: {}) &
-				// Account-level keys (per-tenant secrets like bot_token, api_key, access_token)
-				(ExtractAuthType<
-					InferPluginOptions<P>,
-					InferDefaultAuthType<P>
-				> extends AuthTypes
-					? {
-							keys: AccountKeyManagerFor<
-								ExtractAuthType<InferPluginOptions<P>, InferDefaultAuthType<P>>,
-								InferAuthConfig<P>
-							>;
-						}
-					: {});
-		}
-	: never;
+type InferPluginNamespace<P extends CorsairPlugin> =
+  P extends CorsairPlugin<
+    infer Id,
+    infer Schema,
+    infer Endpoints,
+    infer Webhooks
+  >
+    ? {
+        [K in Id]: (Endpoints extends EndpointTree
+          ? { api: BindEndpoints<Endpoints> }
+          : {}) &
+          InferPluginEntities<Schema> &
+          (Webhooks extends WebhookTree
+            ? {
+                webhooks: BindWebhooks<Webhooks>
+                /**
+                 * Synchronously checks if an incoming webhook request is intended for this plugin.
+                 * Only present if the plugin defines a `pluginWebhookMatcher`.
+                 * Use this as a first-level filter before checking individual webhook matchers.
+                 */
+                pluginWebhookMatcher?: (request: RawWebhookRequest) => boolean
+              }
+            : {}) &
+          // Account-level keys (per-tenant secrets like bot_token, api_key, access_token)
+          (ExtractAuthType<
+            InferPluginOptions<P>,
+            InferDefaultAuthType<P>
+          > extends AuthTypes
+            ? {
+                keys: AccountKeyManagerFor<
+                  ExtractAuthType<
+                    InferPluginOptions<P>,
+                    InferDefaultAuthType<P>
+                  >,
+                  InferAuthConfig<P>
+                >
+              }
+            : {})
+      }
+    : never
 
 /**
  * Infers the integration-level key manager for a single plugin.
  */
-type InferIntegrationKeys<P extends CorsairPlugin> = P extends CorsairPlugin<
-	infer Id
->
-	? ExtractAuthType<
-			InferPluginOptions<P>,
-			InferDefaultAuthType<P>
-		> extends AuthTypes
-		? {
-				[K in Id]: IntegrationKeyManagerFor<
-					ExtractAuthType<InferPluginOptions<P>, InferDefaultAuthType<P>>,
-					InferAuthConfig<P>
-				>;
-			}
-		: never
-	: never;
+type InferIntegrationKeys<P extends CorsairPlugin> =
+  P extends CorsairPlugin<infer Id>
+    ? ExtractAuthType<
+        InferPluginOptions<P>,
+        InferDefaultAuthType<P>
+      > extends AuthTypes
+      ? {
+          [K in Id]: IntegrationKeyManagerFor<
+            ExtractAuthType<InferPluginOptions<P>, InferDefaultAuthType<P>>,
+            InferAuthConfig<P>
+          >
+        }
+      : never
+    : never
 
 /**
  * Combines all integration-level keys into a single interface.
  */
 type InferAllIntegrationKeys<Plugins extends readonly CorsairPlugin[]> =
-	UnionToIntersection<InferIntegrationKeys<Plugins[number]>>;
+  UnionToIntersection<InferIntegrationKeys<Plugins[number]>>
 
 /**
  * Combines all plugin namespaces into a single client interface.
  */
 type InferPluginNamespaces<Plugins extends readonly CorsairPlugin[]> =
-	UnionToIntersection<InferPluginNamespace<Plugins[number]>>;
+  UnionToIntersection<InferPluginNamespace<Plugins[number]>>
 
 /**
  * The main Corsair client type that provides access to all plugin APIs, entities, webhooks, and keys.
  */
 export type CorsairClient<Plugins extends readonly CorsairPlugin[]> =
-	InferPluginNamespaces<Plugins>;
+  InferPluginNamespaces<Plugins>
 
 /**
  * Multi-tenant wrapper that provides a `withTenant` method to scope operations to a specific tenant.
  * Also includes integration-level `keys` for managing shared secrets (OAuth2 client credentials, etc.)
  */
 export type CorsairTenantWrapper<Plugins extends readonly CorsairPlugin[]> = {
-	withTenant: (tenantId: string) => CorsairClient<Plugins>;
-	/**
-	 * Integration-level key managers for each plugin.
-	 * Used to manage secrets shared across all tenants (e.g., OAuth2 client_id, client_secret).
-	 */
-	keys: InferAllIntegrationKeys<Plugins>;
-	/**
-	 * Permission management namespace. Use this to query and transition permission records.
-	 * Available at the root regardless of multi-tenancy setting.
-	 */
-	permissions: CorsairPermissionsNamespace;
-};
+  withTenant: (tenantId: string) => CorsairClient<Plugins>
+  /**
+   * Integration-level key managers for each plugin.
+   * Used to manage secrets shared across all tenants (e.g., OAuth2 client_id, client_secret).
+   */
+  keys: InferAllIntegrationKeys<Plugins>
+  /**
+   * Permission management namespace. Use this to query and transition permission records.
+   * Available at the root regardless of multi-tenancy setting.
+   */
+  permissions: CorsairPermissionsNamespace
+}
 
 /**
  * Single-tenant client that includes both plugin APIs and integration-level keys.
  */
 export type CorsairSingleTenantClient<
-	Plugins extends readonly CorsairPlugin[],
+  Plugins extends readonly CorsairPlugin[],
 > = CorsairClient<Plugins> & {
-	/**
-	 * Integration-level key managers for each plugin.
-	 * Used to manage secrets shared across all tenants (e.g., OAuth2 client_id, client_secret).
-	 */
-	keys: InferAllIntegrationKeys<Plugins>;
-	/**
-	 * Permission management namespace. Use this to query and transition permission records.
-	 * Available at the root regardless of multi-tenancy setting.
-	 */
-	permissions: CorsairPermissionsNamespace;
-};
+  /**
+   * Integration-level key managers for each plugin.
+   * Used to manage secrets shared across all tenants (e.g., OAuth2 client_id, client_secret).
+   */
+  keys: InferAllIntegrationKeys<Plugins>
+  /**
+   * Permission management namespace. Use this to query and transition permission records.
+   * Available at the root regardless of multi-tenancy setting.
+   */
+  permissions: CorsairPermissionsNamespace
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Account ID Resolver
@@ -236,49 +240,49 @@ export type CorsairSingleTenantClient<
  * The account ID is lazily fetched on first access and cached for subsequent calls.
  */
 function createAccountIdResolver(
-	database: CorsairDatabase | undefined,
-	integrationName: string,
-	tenantId: string,
+  database: CorsairDatabase | undefined,
+  integrationName: string,
+  tenantId: string
 ): () => Promise<string> {
-	let cachedAccountId: string | null = null;
+  let cachedAccountId: string | null = null
 
-	return async () => {
-		if (cachedAccountId) return cachedAccountId;
+  return async () => {
+    if (cachedAccountId) return cachedAccountId
 
-		if (!database) {
-			throw new Error('Database not configured');
-		}
+    if (!database) {
+      throw new Error('Database not configured')
+    }
 
-		// Find the integration by name
-		const integration = await database.db
-			.selectFrom('corsair_integrations')
-			.selectAll()
-			.where('name', '=', integrationName)
-			.executeTakeFirst();
+    // Find the integration by name
+    const integration = await database.db
+      .selectFrom('corsair_integrations')
+      .selectAll()
+      .where('name', '=', integrationName)
+      .executeTakeFirst()
 
-		if (!integration) {
-			throw new Error(
-				`Integration "${integrationName}" not found. Make sure to create the integration first.`,
-			);
-		}
+    if (!integration) {
+      throw new Error(
+        `Integration "${integrationName}" not found. Make sure to create the integration first.`
+      )
+    }
 
-		// Find the account for this tenant and integration
-		const account = await database.db
-			.selectFrom('corsair_accounts')
-			.selectAll()
-			.where('tenant_id', '=', tenantId)
-			.where('integration_id', '=', integration.id)
-			.executeTakeFirst();
+    // Find the account for this tenant and integration
+    const account = await database.db
+      .selectFrom('corsair_accounts')
+      .selectAll()
+      .where('tenant_id', '=', tenantId)
+      .where('integration_id', '=', integration.id)
+      .executeTakeFirst()
 
-		if (!account) {
-			throw new Error(
-				`Account not found for tenant "${tenantId}" and integration "${integrationName}". Make sure to create the account first.`,
-			);
-		}
+    if (!account) {
+      throw new Error(
+        `Account not found for tenant "${tenantId}" and integration "${integrationName}". Make sure to create the account first.`
+      )
+    }
 
-		cachedAccountId = account.id;
-		return cachedAccountId;
-	};
+    cachedAccountId = account.id
+    return cachedAccountId
+  }
 }
 
 /**
@@ -292,35 +296,35 @@ function createAccountIdResolver(
  * @returns An entity client with CRUD operations
  */
 function createEntityClient(
-	database: CorsairDatabase | undefined,
-	getAccountId: () => Promise<string>,
-	entityTypeName: string,
-	version: string,
-	dataSchema: ZodTypeAny,
+  database: CorsairDatabase | undefined,
+  getAccountId: () => Promise<string>,
+  entityTypeName: string,
+  version: string,
+  dataSchema: ZodTypeAny
 ): PluginEntityClient<ZodTypeAny> {
-	if (database) {
-		return createKyselyEntityClient(
-			database.db,
-			getAccountId,
-			entityTypeName,
-			version,
-			dataSchema,
-		);
-	}
+  if (database) {
+    return createKyselyEntityClient(
+      database.db,
+      getAccountId,
+      entityTypeName,
+      version,
+      dataSchema
+    )
+  }
 
-	return {
-		findByEntityId: async () => null,
-		findById: async () => null,
-		findManyByEntityIds: async () => [],
-		list: async () => [],
-		search: async () => [],
-		upsertByEntityId: async () => {
-			throw new Error('Database not configured');
-		},
-		deleteById: async () => false,
-		deleteByEntityId: async () => false,
-		count: async () => 0,
-	};
+  return {
+    findByEntityId: async () => null,
+    findById: async () => null,
+    findManyByEntityIds: async () => [],
+    list: async () => [],
+    search: async () => [],
+    upsertByEntityId: async () => {
+      throw new Error('Database not configured')
+    },
+    deleteById: async () => false,
+    deleteByEntityId: async () => false,
+    count: async () => 0,
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -328,27 +332,37 @@ function createEntityClient(
 // ─────────────────────────────────────────────────────────────────────────────
 
 export type BuildCorsairClientOptions = {
-	database: CorsairDatabase | undefined;
-	tenantId: string | undefined;
-	kek: string | undefined;
-	rootErrorHandlers?: CorsairErrorHandler;
-	/** Approval timeout from createCorsair({ approval: ... }). Forwarded to the permission guard. */
-	approvalConfig?: {
-		timeout: string;
-		onTimeout: 'deny' | 'approve';
-		mode?:
-			| 'synchronous'
-			| 'asynchronous'
-			| (() => 'synchronous' | 'asynchronous');
-		formatAsyncMessage?: (opts: {
-			token: string;
-			id: string;
-			plugin: string;
-			endpoint: string;
-			args: unknown;
-		}) => string;
-	};
-};
+  database: CorsairDatabase | undefined
+  tenantId: string | undefined
+  kek: string | undefined
+  rootErrorHandlers?: CorsairErrorHandler
+  /** Approval timeout from createCorsair({ approval: ... }). Forwarded to the permission guard. */
+  approvalConfig?: {
+    timeout: string
+    onTimeout: 'deny' | 'approve'
+    mode?:
+      | 'synchronous'
+      | 'asynchronous'
+      | (() => 'synchronous' | 'asynchronous')
+    formatAsyncMessage?: (opts: {
+      token: string
+      id: string
+      plugin: string
+      endpoint: string
+      args: unknown
+    }) => string
+  }
+  /** Connect link config from createCorsair({ connect: ... }). Forwarded to endpoint binding. */
+  connectConfig?: {
+    baseUrl: string
+    redirectUri: string
+    onAuthMissing?: (opts: {
+      plugin: string
+      connectUrl: string
+      state: string
+    }) => string
+  }
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Client Builder
@@ -361,169 +375,179 @@ export type BuildCorsairClientOptions = {
  * @returns A fully configured Corsair client with account-level keys
  */
 export function buildCorsairClient<
-	const Plugins extends readonly CorsairPlugin[],
+  const Plugins extends readonly CorsairPlugin[],
 >(
-	plugins: Plugins,
-	options: BuildCorsairClientOptions,
+  plugins: Plugins,
+  options: BuildCorsairClientOptions
 ): CorsairClient<Plugins> {
-	const { database, tenantId, kek, rootErrorHandlers, approvalConfig } =
-		options;
+  const {
+    database,
+    tenantId,
+    kek,
+    rootErrorHandlers,
+    approvalConfig,
+    connectConfig,
+  } = options
 
-	const apiUnsafe: Record<string, Record<string, unknown>> = {};
-	const pluginEntitiesUnsafe: Record<string, Record<string, unknown>> = {};
+  const apiUnsafe: Record<string, Record<string, unknown>> = {}
+  const pluginEntitiesUnsafe: Record<string, Record<string, unknown>> = {}
 
-	for (const plugin of plugins) {
-		apiUnsafe[plugin.id] = {};
-		pluginEntitiesUnsafe[plugin.id] = {};
-	}
+  for (const plugin of plugins) {
+    apiUnsafe[plugin.id] = {}
+    pluginEntitiesUnsafe[plugin.id] = {}
+  }
 
-	for (const plugin of plugins) {
-		const schema = plugin.schema;
-		const effectiveTenantId = tenantId ?? 'default';
+  for (const plugin of plugins) {
+    const schema = plugin.schema
+    const effectiveTenantId = tenantId ?? 'default'
 
-		// Create a shared account ID resolver for this plugin
-		const getAccountId = createAccountIdResolver(
-			database,
-			plugin.id,
-			effectiveTenantId,
-		);
+    // Create a shared account ID resolver for this plugin
+    const getAccountId = createAccountIdResolver(
+      database,
+      plugin.id,
+      effectiveTenantId
+    )
 
-		// Create typed entity clients from plugin schema, nested under `db`
-		if (schema?.entities) {
-			const dbClients: Record<string, unknown> = {};
-			for (const [entityTypeName, dataSchema] of Object.entries(
-				schema.entities,
-			)) {
-				const entityClient = database
-					? createKyselyEntityClient(
-							database.db,
-							getAccountId,
-							entityTypeName,
-							schema.version,
-							dataSchema,
-						)
-					: createEntityClient(
-							undefined,
-							getAccountId,
-							entityTypeName,
-							schema.version,
-							dataSchema,
-						);
-				dbClients[entityTypeName] = entityClient;
-			}
-			pluginEntitiesUnsafe[plugin.id]!.db = dbClients;
-			apiUnsafe[plugin.id]!.db = dbClients;
-		}
+    // Create typed entity clients from plugin schema, nested under `db`
+    if (schema?.entities) {
+      const dbClients: Record<string, unknown> = {}
+      for (const [entityTypeName, dataSchema] of Object.entries(
+        schema.entities
+      )) {
+        const entityClient = database
+          ? createKyselyEntityClient(
+              database.db,
+              getAccountId,
+              entityTypeName,
+              schema.version,
+              dataSchema
+            )
+          : createEntityClient(
+              undefined,
+              getAccountId,
+              entityTypeName,
+              schema.version,
+              dataSchema
+            )
+        dbClients[entityTypeName] = entityClient
+      }
+      pluginEntitiesUnsafe[plugin.id]!.db = dbClients
+      apiUnsafe[plugin.id]!.db = dbClients
+    }
 
-		// Create account-level key manager BEFORE binding endpoints so keyBuilder can access it
-		const pluginOptions = plugin.options as
-			| { authType?: AuthTypes }
-			| undefined;
-		const authConfig = plugin.authConfig as PluginAuthConfig | undefined;
-		let accountKeyManager: AccountKeyManagerFor<AuthTypes> | undefined;
-		if (database && kek && pluginOptions?.authType) {
-			// Extract extra account fields from plugin authConfig
-			const extraAccountFields =
-				authConfig?.[pluginOptions.authType]?.account ?? [];
+    // Create account-level key manager BEFORE binding endpoints so keyBuilder can access it
+    const pluginOptions = plugin.options as { authType?: AuthTypes } | undefined
+    const authConfig = plugin.authConfig as PluginAuthConfig | undefined
+    let accountKeyManager: AccountKeyManagerFor<AuthTypes> | undefined
+    if (database && kek && pluginOptions?.authType) {
+      // Extract extra account fields from plugin authConfig
+      const extraAccountFields =
+        authConfig?.[pluginOptions.authType]?.account ?? []
 
-			accountKeyManager = createAccountKeyManager({
-				authType: pluginOptions.authType,
-				integrationName: plugin.id,
-				tenantId: effectiveTenantId,
-				kek,
-				database,
-				extraAccountFields,
-			});
-			apiUnsafe[plugin.id]!.keys = accountKeyManager;
-		}
+      accountKeyManager = createAccountKeyManager({
+        authType: pluginOptions.authType,
+        integrationName: plugin.id,
+        tenantId: effectiveTenantId,
+        kek,
+        database,
+        extraAccountFields,
+      })
+      apiUnsafe[plugin.id]!.keys = accountKeyManager
+    }
 
-		// Build plugin context with entity clients under `db`, account ID resolver, and keys manager
-		const ctxForPlugin: Record<string, unknown> = {
-			database,
-			db: pluginEntitiesUnsafe[plugin.id]?.db ?? {},
-			$getAccountId: getAccountId,
-			...(plugin.options ? { options: plugin.options } : {}),
-			// Include keys manager and authType in context so keyBuilder can access and narrow types
-			...(accountKeyManager
-				? { keys: accountKeyManager, authType: pluginOptions?.authType }
-				: {}),
-			// Include tenantId in context so it's available in webhook hooks
-			...(tenantId ? { tenantId } : {}),
-		};
+    // Build plugin context with entity clients under `db`, account ID resolver, and keys manager
+    const ctxForPlugin: Record<string, unknown> = {
+      database,
+      db: pluginEntitiesUnsafe[plugin.id]?.db ?? {},
+      $getAccountId: getAccountId,
+      ...(plugin.options ? { options: plugin.options } : {}),
+      // Include keys manager and authType in context so keyBuilder can access and narrow types
+      ...(accountKeyManager
+        ? { keys: accountKeyManager, authType: pluginOptions?.authType }
+        : {}),
+      // Include tenantId in context so it's available in webhook hooks
+      ...(tenantId ? { tenantId } : {}),
+    }
 
-		const endpoints = plugin.endpoints ?? {};
-		const hooks = plugin.hooks;
+    const endpoints = plugin.endpoints ?? {}
+    const hooks = plugin.hooks
 
-		// Combine plugin and root error handlers, plugin handlers first for priority
-		const allErrorHandlers = {
-			...rootErrorHandlers,
-			...plugin.errorHandlers,
-		};
+    // Combine plugin and root error handlers, plugin handlers first for priority
+    const allErrorHandlers = {
+      ...rootErrorHandlers,
+      ...plugin.errorHandlers,
+    }
 
-		// Create bound endpoints under `api` (supports nested structures)
-		const boundTree: Record<string, unknown> = {};
+    // Create bound endpoints under `api` (supports nested structures)
+    const boundTree: Record<string, unknown> = {}
 
-		// Extract permission config from plugin options.
-		// options is Record<string, unknown> — permissions is not in the base CorsairPlugin type
-		// because it's plugin-specific (typed via PluginPermissionsConfig<T> in each plugin).
-		const pluginPermsConfig = (
-			plugin.options as Record<string, unknown> | undefined
-		)?.permissions as
-			| { mode: PermissionMode; overrides?: Record<string, PermissionPolicy> }
-			| undefined;
+    // Extract permission config from plugin options.
+    // options is Record<string, unknown> — permissions is not in the base CorsairPlugin type
+    // because it's plugin-specific (typed via PluginPermissionsConfig<T> in each plugin).
+    const pluginPermsConfig = (
+      plugin.options as Record<string, unknown> | undefined
+    )?.permissions as
+      | { mode: PermissionMode; overrides?: Record<string, PermissionPolicy> }
+      | undefined
 
-		bindEndpointsRecursively({
-			endpoints,
-			hooks,
-			ctx: ctxForPlugin,
-			tree: boundTree,
-			pluginId: plugin.id,
-			errorHandlers: allErrorHandlers,
-			currentPath: [],
-			keyBuilder: plugin.keyBuilder as CorsairKeyBuilderBase | undefined,
-			permissionsConfig: pluginPermsConfig,
-			// endpointMeta is typed with plugin-specific literal keys — cast to runtime Record
-			endpointMeta: plugin.endpointMeta as
-				| Record<string, EndpointMetaEntry>
-				| undefined,
-			database,
-			approvalConfig,
-			tenantId,
-		});
+    bindEndpointsRecursively({
+      endpoints,
+      hooks,
+      ctx: ctxForPlugin,
+      tree: boundTree,
+      pluginId: plugin.id,
+      errorHandlers: allErrorHandlers,
+      currentPath: [],
+      keyBuilder: plugin.keyBuilder as CorsairKeyBuilderBase | undefined,
+      permissionsConfig: pluginPermsConfig,
+      endpointMeta: plugin.endpointMeta as
+        | Record<string, EndpointMetaEntry>
+        | undefined,
+      database,
+      approvalConfig,
+      tenantId,
+      connectConfig: connectConfig
+        ? {
+            ...connectConfig,
+            oauthConfig: (plugin as { oauthConfig?: any }).oauthConfig,
+            kek,
+            tenantId: effectiveTenantId,
+          }
+        : undefined,
+    })
 
-		if (Object.keys(boundTree).length > 0) {
-			apiUnsafe[plugin.id]!.api = boundTree;
-		}
+    if (Object.keys(boundTree).length > 0) {
+      apiUnsafe[plugin.id]!.api = boundTree
+    }
 
-		ctxForPlugin.endpoints = boundTree;
+    ctxForPlugin.endpoints = boundTree
 
-		// Create bound webhooks under `webhooks` (supports nested structures)
-		const webhooks = (plugin.webhooks ?? {}) satisfies Record<string, unknown>;
-		const webhookHooks = plugin.webhookHooks satisfies
-			| Record<string, unknown>
-			| undefined;
+    // Create bound webhooks under `webhooks` (supports nested structures)
+    const webhooks = (plugin.webhooks ?? {}) satisfies Record<string, unknown>
+    const webhookHooks = plugin.webhookHooks satisfies
+      | Record<string, unknown>
+      | undefined
 
-		if (Object.keys(webhooks).length > 0) {
-			const boundWebhooks: Record<string, unknown> = {};
-			bindWebhooksRecursively({
-				webhooks,
-				hooks: webhookHooks,
-				ctx: ctxForPlugin,
-				webhooksTree: boundWebhooks,
-				keyBuilder: plugin.keyBuilder as CorsairKeyBuilderBase | undefined,
-			});
-			apiUnsafe[plugin.id]!.webhooks = boundWebhooks;
+    if (Object.keys(webhooks).length > 0) {
+      const boundWebhooks: Record<string, unknown> = {}
+      bindWebhooksRecursively({
+        webhooks,
+        hooks: webhookHooks,
+        ctx: ctxForPlugin,
+        webhooksTree: boundWebhooks,
+        keyBuilder: plugin.keyBuilder as CorsairKeyBuilderBase | undefined,
+      })
+      apiUnsafe[plugin.id]!.webhooks = boundWebhooks
 
-			// Only expose pluginWebhookMatcher if the plugin has a pluginWebhookMatcher defined
-			// This is the first-level check to see if the webhook is for this plugin
-			if (plugin.pluginWebhookMatcher) {
-				apiUnsafe[plugin.id]!.pluginWebhookMatcher =
-					plugin.pluginWebhookMatcher;
-			}
-		}
-	}
+      // Only expose pluginWebhookMatcher if the plugin has a pluginWebhookMatcher defined
+      // This is the first-level check to see if the webhook is for this plugin
+      if (plugin.pluginWebhookMatcher) {
+        apiUnsafe[plugin.id]!.pluginWebhookMatcher = plugin.pluginWebhookMatcher
+      }
+    }
+  }
 
-	return apiUnsafe as CorsairClient<Plugins>;
+  return apiUnsafe as CorsairClient<Plugins>
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -539,34 +563,32 @@ export function buildCorsairClient<
  * @returns An object with key managers for each plugin
  */
 export function buildIntegrationKeys<
-	const Plugins extends readonly CorsairPlugin[],
+  const Plugins extends readonly CorsairPlugin[],
 >(
-	plugins: Plugins,
-	database: CorsairDatabase,
-	kek: string,
+  plugins: Plugins,
+  database: CorsairDatabase,
+  kek: string
 ): InferAllIntegrationKeys<Plugins> {
-	const keysUnsafe: Record<string, unknown> = {};
+  const keysUnsafe: Record<string, unknown> = {}
 
-	for (const plugin of plugins) {
-		const pluginOptions = plugin.options as
-			| { authType?: AuthTypes }
-			| undefined;
-		const authConfig = plugin.authConfig as PluginAuthConfig | undefined;
-		if (pluginOptions?.authType) {
-			// Extract extra integration fields from plugin authConfig
-			const extraIntegrationFields =
-				authConfig?.[pluginOptions.authType]?.integration ?? [];
+  for (const plugin of plugins) {
+    const pluginOptions = plugin.options as { authType?: AuthTypes } | undefined
+    const authConfig = plugin.authConfig as PluginAuthConfig | undefined
+    if (pluginOptions?.authType) {
+      // Extract extra integration fields from plugin authConfig
+      const extraIntegrationFields =
+        authConfig?.[pluginOptions.authType]?.integration ?? []
 
-			const integrationKeyManager = createIntegrationKeyManager({
-				authType: pluginOptions.authType,
-				integrationName: plugin.id,
-				kek,
-				database,
-				extraIntegrationFields,
-			});
-			keysUnsafe[plugin.id] = integrationKeyManager;
-		}
-	}
+      const integrationKeyManager = createIntegrationKeyManager({
+        authType: pluginOptions.authType,
+        integrationName: plugin.id,
+        kek,
+        database,
+        extraIntegrationFields,
+      })
+      keysUnsafe[plugin.id] = integrationKeyManager
+    }
+  }
 
-	return keysUnsafe as InferAllIntegrationKeys<Plugins>;
+  return keysUnsafe as InferAllIntegrationKeys<Plugins>
 }

--- a/packages/corsair/core/client/index.ts
+++ b/packages/corsair/core/client/index.ts
@@ -1,35 +1,35 @@
-import type { ZodTypeAny } from 'zod'
-import type { CorsairDatabase } from '../../db/kysely/database'
-import { createKyselyEntityClient } from '../../db/kysely/orm'
+import type { ZodTypeAny } from 'zod';
+import type { CorsairDatabase } from '../../db/kysely/database';
+import { createKyselyEntityClient } from '../../db/kysely/orm';
 import type {
-  CorsairPluginSchema,
-  PluginEntityClient,
-  PluginEntityClients,
-} from '../../db/orm'
+	CorsairPluginSchema,
+	PluginEntityClient,
+	PluginEntityClients,
+} from '../../db/orm';
 import {
-  createAccountKeyManager,
-  createIntegrationKeyManager,
-} from '../auth/key-manager'
+	createAccountKeyManager,
+	createIntegrationKeyManager,
+} from '../auth/key-manager';
 import type {
-  AccountKeyManagerFor,
-  IntegrationKeyManagerFor,
-  PluginAuthConfig,
-} from '../auth/types'
-import type { AuthTypes } from '../constants'
-import type { BindEndpoints, EndpointTree } from '../endpoints'
-import { bindEndpointsRecursively } from '../endpoints/bind'
-import type { CorsairErrorHandler } from '../errors'
-import type { CorsairPermissionsNamespace } from '../permissions'
+	AccountKeyManagerFor,
+	IntegrationKeyManagerFor,
+	PluginAuthConfig,
+} from '../auth/types';
+import type { AuthTypes } from '../constants';
+import type { BindEndpoints, EndpointTree } from '../endpoints';
+import { bindEndpointsRecursively } from '../endpoints/bind';
+import type { CorsairErrorHandler } from '../errors';
+import type { CorsairPermissionsNamespace } from '../permissions';
 import type {
-  CorsairKeyBuilderBase,
-  CorsairPlugin,
-  EndpointMetaEntry,
-  OAuthConfig,
-  PermissionMode,
-  PermissionPolicy,
-} from '../plugins'
-import type { BindWebhooks, RawWebhookRequest, WebhookTree } from '../webhooks'
-import { bindWebhooksRecursively } from '../webhooks/bind'
+	CorsairKeyBuilderBase,
+	CorsairPlugin,
+	EndpointMetaEntry,
+	OAuthConfig,
+	PermissionMode,
+	PermissionPolicy,
+} from '../plugins';
+import type { BindWebhooks, RawWebhookRequest, WebhookTree } from '../webhooks';
+import { bindWebhooksRecursively } from '../webhooks/bind';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Entity Client Types
@@ -41,11 +41,10 @@ import { bindWebhooksRecursively } from '../webhooks/bind'
  * Entities are nested under `db` to separate them from API endpoints.
  */
 export type InferPluginEntities<
-  Schema extends CorsairPluginSchema<Record<string, ZodTypeAny>> | undefined,
-> =
-  Schema extends CorsairPluginSchema<infer Entities>
-    ? { db: PluginEntityClients<Entities> }
-    : {}
+	Schema extends CorsairPluginSchema<Record<string, ZodTypeAny>> | undefined,
+> = Schema extends CorsairPluginSchema<infer Entities>
+	? { db: PluginEntityClients<Entities> }
+	: {};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Client Types
@@ -55,10 +54,10 @@ export type InferPluginEntities<
  * Utility type that converts a union to an intersection type.
  */
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
-  k: infer I
+	k: infer I,
 ) => void
-  ? I
-  : never
+	? I
+	: never;
 
 /**
  * Extracts the authType from plugin options.
@@ -72,28 +71,28 @@ type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
  * 4. If authType is not in Options at all, fall back to DefaultAuthType
  */
 export type ExtractAuthType<
-  Options,
-  DefaultAuthType extends AuthTypes | undefined = undefined,
+	Options,
+	DefaultAuthType extends AuthTypes | undefined = undefined,
 > = 'authType' extends keyof Options
-  ? // Check if authType is a specific single auth type (narrowed, not a union)
-    Options['authType'] extends AuthTypes
-    ? // authType is narrowed to a specific type - use it
-      Options['authType']
-    : // authType is optional or a union - use DefaultAuthType if provided
-      DefaultAuthType extends AuthTypes
-      ? DefaultAuthType
-      : NonNullable<Options['authType']> extends AuthTypes
-        ? NonNullable<Options['authType']>
-        : never
-  : // authType is not in Options - fall back to DefaultAuthType
-    DefaultAuthType extends AuthTypes
-    ? DefaultAuthType
-    : never
+	? // Check if authType is a specific single auth type (narrowed, not a union)
+		Options['authType'] extends AuthTypes
+		? // authType is narrowed to a specific type - use it
+			Options['authType']
+		: // authType is optional or a union - use DefaultAuthType if provided
+			DefaultAuthType extends AuthTypes
+			? DefaultAuthType
+			: NonNullable<Options['authType']> extends AuthTypes
+				? NonNullable<Options['authType']>
+				: never
+	: // authType is not in Options - fall back to DefaultAuthType
+		DefaultAuthType extends AuthTypes
+		? DefaultAuthType
+		: never;
 
 /**
  * Extracts Options type from plugin's options property.
  */
-type InferPluginOptions<P> = P extends { options?: infer O } ? O : never
+type InferPluginOptions<P> = P extends { options?: infer O } ? O : never;
 
 /**
  * Extracts DefaultAuthType from plugin's __defaultAuthType property.
@@ -101,136 +100,133 @@ type InferPluginOptions<P> = P extends { options?: infer O } ? O : never
  * which causes TypeScript to infer D as `AuthType | undefined`.
  */
 type InferDefaultAuthType<P> = P extends { __defaultAuthType?: infer D }
-  ? NonNullable<D> extends AuthTypes
-    ? NonNullable<D>
-    : undefined
-  : undefined
+	? NonNullable<D> extends AuthTypes
+		? NonNullable<D>
+		: undefined
+	: undefined;
 
 /**
  * Extracts the AuthConfig from a plugin's authConfig property.
  */
 type InferAuthConfig<P> = P extends { authConfig?: infer C }
-  ? C extends PluginAuthConfig
-    ? C
-    : undefined
-  : undefined
+	? C extends PluginAuthConfig
+		? C
+		: undefined
+	: undefined;
 
 /**
  * Infers the complete namespace for a single plugin, including API endpoints,
  * database entities, webhooks, and account-level keys.
  */
-type InferPluginNamespace<P extends CorsairPlugin> =
-  P extends CorsairPlugin<
-    infer Id,
-    infer Schema,
-    infer Endpoints,
-    infer Webhooks
-  >
-    ? {
-        [K in Id]: (Endpoints extends EndpointTree
-          ? { api: BindEndpoints<Endpoints> }
-          : {}) &
-          InferPluginEntities<Schema> &
-          (Webhooks extends WebhookTree
-            ? {
-                webhooks: BindWebhooks<Webhooks>
-                /**
-                 * Synchronously checks if an incoming webhook request is intended for this plugin.
-                 * Only present if the plugin defines a `pluginWebhookMatcher`.
-                 * Use this as a first-level filter before checking individual webhook matchers.
-                 */
-                pluginWebhookMatcher?: (request: RawWebhookRequest) => boolean
-              }
-            : {}) &
-          // Account-level keys (per-tenant secrets like bot_token, api_key, access_token)
-          (ExtractAuthType<
-            InferPluginOptions<P>,
-            InferDefaultAuthType<P>
-          > extends AuthTypes
-            ? {
-                keys: AccountKeyManagerFor<
-                  ExtractAuthType<
-                    InferPluginOptions<P>,
-                    InferDefaultAuthType<P>
-                  >,
-                  InferAuthConfig<P>
-                >
-              }
-            : {})
-      }
-    : never
+type InferPluginNamespace<P extends CorsairPlugin> = P extends CorsairPlugin<
+	infer Id,
+	infer Schema,
+	infer Endpoints,
+	infer Webhooks
+>
+	? {
+			[K in Id]: (Endpoints extends EndpointTree
+				? { api: BindEndpoints<Endpoints> }
+				: {}) &
+				InferPluginEntities<Schema> &
+				(Webhooks extends WebhookTree
+					? {
+							webhooks: BindWebhooks<Webhooks>;
+							/**
+							 * Synchronously checks if an incoming webhook request is intended for this plugin.
+							 * Only present if the plugin defines a `pluginWebhookMatcher`.
+							 * Use this as a first-level filter before checking individual webhook matchers.
+							 */
+							pluginWebhookMatcher?: (request: RawWebhookRequest) => boolean;
+						}
+					: {}) &
+				// Account-level keys (per-tenant secrets like bot_token, api_key, access_token)
+				(ExtractAuthType<
+					InferPluginOptions<P>,
+					InferDefaultAuthType<P>
+				> extends AuthTypes
+					? {
+							keys: AccountKeyManagerFor<
+								ExtractAuthType<InferPluginOptions<P>, InferDefaultAuthType<P>>,
+								InferAuthConfig<P>
+							>;
+						}
+					: {});
+		}
+	: never;
 
 /**
  * Infers the integration-level key manager for a single plugin.
  */
-type InferIntegrationKeys<P extends CorsairPlugin> =
-  P extends CorsairPlugin<infer Id>
-    ? ExtractAuthType<
-        InferPluginOptions<P>,
-        InferDefaultAuthType<P>
-      > extends AuthTypes
-      ? {
-          [K in Id]: IntegrationKeyManagerFor<
-            ExtractAuthType<InferPluginOptions<P>, InferDefaultAuthType<P>>,
-            InferAuthConfig<P>
-          >
-        }
-      : never
-    : never
+type InferIntegrationKeys<P extends CorsairPlugin> = P extends CorsairPlugin<
+	infer Id
+>
+	? ExtractAuthType<
+			InferPluginOptions<P>,
+			InferDefaultAuthType<P>
+		> extends AuthTypes
+		? {
+				[K in Id]: IntegrationKeyManagerFor<
+					ExtractAuthType<InferPluginOptions<P>, InferDefaultAuthType<P>>,
+					InferAuthConfig<P>
+				>;
+			}
+		: never
+	: never;
 
 /**
  * Combines all integration-level keys into a single interface.
  */
 type InferAllIntegrationKeys<Plugins extends readonly CorsairPlugin[]> =
-  UnionToIntersection<InferIntegrationKeys<Plugins[number]>>
+	UnionToIntersection<InferIntegrationKeys<Plugins[number]>>;
 
 /**
  * Combines all plugin namespaces into a single client interface.
  */
 type InferPluginNamespaces<Plugins extends readonly CorsairPlugin[]> =
-  UnionToIntersection<InferPluginNamespace<Plugins[number]>>
+	UnionToIntersection<InferPluginNamespace<Plugins[number]>>;
 
 /**
  * The main Corsair client type that provides access to all plugin APIs, entities, webhooks, and keys.
  */
 export type CorsairClient<Plugins extends readonly CorsairPlugin[]> =
-  InferPluginNamespaces<Plugins>
+	InferPluginNamespaces<Plugins>;
 
 /**
  * Multi-tenant wrapper that provides a `withTenant` method to scope operations to a specific tenant.
  * Also includes integration-level `keys` for managing shared secrets (OAuth2 client credentials, etc.)
  */
 export type CorsairTenantWrapper<Plugins extends readonly CorsairPlugin[]> = {
-  withTenant: (tenantId: string) => CorsairClient<Plugins>
-  /**
-   * Integration-level key managers for each plugin.
-   * Used to manage secrets shared across all tenants (e.g., OAuth2 client_id, client_secret).
-   */
-  keys: InferAllIntegrationKeys<Plugins>
-  /**
-   * Permission management namespace. Use this to query and transition permission records.
-   * Available at the root regardless of multi-tenancy setting.
-   */
-  permissions: CorsairPermissionsNamespace
-}
+	withTenant: (tenantId: string) => CorsairClient<Plugins>;
+	/**
+	 * Integration-level key managers for each plugin.
+	 * Used to manage secrets shared across all tenants (e.g., OAuth2 client_id, client_secret).
+	 */
+	keys: InferAllIntegrationKeys<Plugins>;
+	/**
+	 * Permission management namespace. Use this to query and transition permission records.
+	 * Available at the root regardless of multi-tenancy setting.
+	 */
+	permissions: CorsairPermissionsNamespace;
+};
 
 /**
  * Single-tenant client that includes both plugin APIs and integration-level keys.
  */
 export type CorsairSingleTenantClient<
-  Plugins extends readonly CorsairPlugin[],
+	Plugins extends readonly CorsairPlugin[],
 > = CorsairClient<Plugins> & {
-  /**
-   * Integration-level key managers for each plugin.
-   * Used to manage secrets shared across all tenants (e.g., OAuth2 client_id, client_secret).
-   */
-  keys: InferAllIntegrationKeys<Plugins>
-  /**
-   * Permission management namespace. Use this to query and transition permission records.
-   * Available at the root regardless of multi-tenancy setting.
-   */
-  permissions: CorsairPermissionsNamespace
-}
+	/**
+	 * Integration-level key managers for each plugin.
+	 * Used to manage secrets shared across all tenants (e.g., OAuth2 client_id, client_secret).
+	 */
+	keys: InferAllIntegrationKeys<Plugins>;
+	/**
+	 * Permission management namespace. Use this to query and transition permission records.
+	 * Available at the root regardless of multi-tenancy setting.
+	 */
+	permissions: CorsairPermissionsNamespace;
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Account ID Resolver
@@ -241,49 +237,49 @@ export type CorsairSingleTenantClient<
  * The account ID is lazily fetched on first access and cached for subsequent calls.
  */
 function createAccountIdResolver(
-  database: CorsairDatabase | undefined,
-  integrationName: string,
-  tenantId: string
+	database: CorsairDatabase | undefined,
+	integrationName: string,
+	tenantId: string,
 ): () => Promise<string> {
-  let cachedAccountId: string | null = null
+	let cachedAccountId: string | null = null;
 
-  return async () => {
-    if (cachedAccountId) return cachedAccountId
+	return async () => {
+		if (cachedAccountId) return cachedAccountId;
 
-    if (!database) {
-      throw new Error('Database not configured')
-    }
+		if (!database) {
+			throw new Error('Database not configured');
+		}
 
-    // Find the integration by name
-    const integration = await database.db
-      .selectFrom('corsair_integrations')
-      .selectAll()
-      .where('name', '=', integrationName)
-      .executeTakeFirst()
+		// Find the integration by name
+		const integration = await database.db
+			.selectFrom('corsair_integrations')
+			.selectAll()
+			.where('name', '=', integrationName)
+			.executeTakeFirst();
 
-    if (!integration) {
-      throw new Error(
-        `Integration "${integrationName}" not found. Make sure to create the integration first.`
-      )
-    }
+		if (!integration) {
+			throw new Error(
+				`Integration "${integrationName}" not found. Make sure to create the integration first.`,
+			);
+		}
 
-    // Find the account for this tenant and integration
-    const account = await database.db
-      .selectFrom('corsair_accounts')
-      .selectAll()
-      .where('tenant_id', '=', tenantId)
-      .where('integration_id', '=', integration.id)
-      .executeTakeFirst()
+		// Find the account for this tenant and integration
+		const account = await database.db
+			.selectFrom('corsair_accounts')
+			.selectAll()
+			.where('tenant_id', '=', tenantId)
+			.where('integration_id', '=', integration.id)
+			.executeTakeFirst();
 
-    if (!account) {
-      throw new Error(
-        `Account not found for tenant "${tenantId}" and integration "${integrationName}". Make sure to create the account first.`
-      )
-    }
+		if (!account) {
+			throw new Error(
+				`Account not found for tenant "${tenantId}" and integration "${integrationName}". Make sure to create the account first.`,
+			);
+		}
 
-    cachedAccountId = account.id
-    return cachedAccountId
-  }
+		cachedAccountId = account.id;
+		return cachedAccountId;
+	};
 }
 
 /**
@@ -297,35 +293,35 @@ function createAccountIdResolver(
  * @returns An entity client with CRUD operations
  */
 function createEntityClient(
-  database: CorsairDatabase | undefined,
-  getAccountId: () => Promise<string>,
-  entityTypeName: string,
-  version: string,
-  dataSchema: ZodTypeAny
+	database: CorsairDatabase | undefined,
+	getAccountId: () => Promise<string>,
+	entityTypeName: string,
+	version: string,
+	dataSchema: ZodTypeAny,
 ): PluginEntityClient<ZodTypeAny> {
-  if (database) {
-    return createKyselyEntityClient(
-      database.db,
-      getAccountId,
-      entityTypeName,
-      version,
-      dataSchema
-    )
-  }
+	if (database) {
+		return createKyselyEntityClient(
+			database.db,
+			getAccountId,
+			entityTypeName,
+			version,
+			dataSchema,
+		);
+	}
 
-  return {
-    findByEntityId: async () => null,
-    findById: async () => null,
-    findManyByEntityIds: async () => [],
-    list: async () => [],
-    search: async () => [],
-    upsertByEntityId: async () => {
-      throw new Error('Database not configured')
-    },
-    deleteById: async () => false,
-    deleteByEntityId: async () => false,
-    count: async () => 0,
-  }
+	return {
+		findByEntityId: async () => null,
+		findById: async () => null,
+		findManyByEntityIds: async () => [],
+		list: async () => [],
+		search: async () => [],
+		upsertByEntityId: async () => {
+			throw new Error('Database not configured');
+		},
+		deleteById: async () => false,
+		deleteByEntityId: async () => false,
+		count: async () => 0,
+	};
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -333,37 +329,37 @@ function createEntityClient(
 // ─────────────────────────────────────────────────────────────────────────────
 
 export type BuildCorsairClientOptions = {
-  database: CorsairDatabase | undefined
-  tenantId: string | undefined
-  kek: string | undefined
-  rootErrorHandlers?: CorsairErrorHandler
-  /** Approval timeout from createCorsair({ approval: ... }). Forwarded to the permission guard. */
-  approvalConfig?: {
-    timeout: string
-    onTimeout: 'deny' | 'approve'
-    mode?:
-      | 'synchronous'
-      | 'asynchronous'
-      | (() => 'synchronous' | 'asynchronous')
-    formatAsyncMessage?: (opts: {
-      token: string
-      id: string
-      plugin: string
-      endpoint: string
-      args: unknown
-    }) => string
-  }
-  /** Connect link config from createCorsair({ connect: ... }). Forwarded to endpoint binding. */
-  connectConfig?: {
-    baseUrl: string
-    redirectUri: string
-    onAuthMissing?: (opts: {
-      plugin: string
-      connectUrl: string
-      state: string
-    }) => string
-  }
-}
+	database: CorsairDatabase | undefined;
+	tenantId: string | undefined;
+	kek: string | undefined;
+	rootErrorHandlers?: CorsairErrorHandler;
+	/** Approval timeout from createCorsair({ approval: ... }). Forwarded to the permission guard. */
+	approvalConfig?: {
+		timeout: string;
+		onTimeout: 'deny' | 'approve';
+		mode?:
+			| 'synchronous'
+			| 'asynchronous'
+			| (() => 'synchronous' | 'asynchronous');
+		formatAsyncMessage?: (opts: {
+			token: string;
+			id: string;
+			plugin: string;
+			endpoint: string;
+			args: unknown;
+		}) => string;
+	};
+	/** Connect link config from createCorsair({ connect: ... }). Forwarded to endpoint binding. */
+	connectConfig?: {
+		baseUrl: string;
+		redirectUri: string;
+		onAuthMissing?: (opts: {
+			plugin: string;
+			connectUrl: string;
+			state: string;
+		}) => string;
+	};
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Client Builder
@@ -376,179 +372,182 @@ export type BuildCorsairClientOptions = {
  * @returns A fully configured Corsair client with account-level keys
  */
 export function buildCorsairClient<
-  const Plugins extends readonly CorsairPlugin[],
+	const Plugins extends readonly CorsairPlugin[],
 >(
-  plugins: Plugins,
-  options: BuildCorsairClientOptions
+	plugins: Plugins,
+	options: BuildCorsairClientOptions,
 ): CorsairClient<Plugins> {
-  const {
-    database,
-    tenantId,
-    kek,
-    rootErrorHandlers,
-    approvalConfig,
-    connectConfig,
-  } = options
+	const {
+		database,
+		tenantId,
+		kek,
+		rootErrorHandlers,
+		approvalConfig,
+		connectConfig,
+	} = options;
 
-  const apiUnsafe: Record<string, Record<string, unknown>> = {}
-  const pluginEntitiesUnsafe: Record<string, Record<string, unknown>> = {}
+	const apiUnsafe: Record<string, Record<string, unknown>> = {};
+	const pluginEntitiesUnsafe: Record<string, Record<string, unknown>> = {};
 
-  for (const plugin of plugins) {
-    apiUnsafe[plugin.id] = {}
-    pluginEntitiesUnsafe[plugin.id] = {}
-  }
+	for (const plugin of plugins) {
+		apiUnsafe[plugin.id] = {};
+		pluginEntitiesUnsafe[plugin.id] = {};
+	}
 
-  for (const plugin of plugins) {
-    const schema = plugin.schema
-    const effectiveTenantId = tenantId ?? 'default'
+	for (const plugin of plugins) {
+		const schema = plugin.schema;
+		const effectiveTenantId = tenantId ?? 'default';
 
-    // Create a shared account ID resolver for this plugin
-    const getAccountId = createAccountIdResolver(
-      database,
-      plugin.id,
-      effectiveTenantId
-    )
+		// Create a shared account ID resolver for this plugin
+		const getAccountId = createAccountIdResolver(
+			database,
+			plugin.id,
+			effectiveTenantId,
+		);
 
-    // Create typed entity clients from plugin schema, nested under `db`
-    if (schema?.entities) {
-      const dbClients: Record<string, unknown> = {}
-      for (const [entityTypeName, dataSchema] of Object.entries(
-        schema.entities
-      )) {
-        const entityClient = database
-          ? createKyselyEntityClient(
-              database.db,
-              getAccountId,
-              entityTypeName,
-              schema.version,
-              dataSchema
-            )
-          : createEntityClient(
-              undefined,
-              getAccountId,
-              entityTypeName,
-              schema.version,
-              dataSchema
-            )
-        dbClients[entityTypeName] = entityClient
-      }
-      pluginEntitiesUnsafe[plugin.id]!.db = dbClients
-      apiUnsafe[plugin.id]!.db = dbClients
-    }
+		// Create typed entity clients from plugin schema, nested under `db`
+		if (schema?.entities) {
+			const dbClients: Record<string, unknown> = {};
+			for (const [entityTypeName, dataSchema] of Object.entries(
+				schema.entities,
+			)) {
+				const entityClient = database
+					? createKyselyEntityClient(
+							database.db,
+							getAccountId,
+							entityTypeName,
+							schema.version,
+							dataSchema,
+						)
+					: createEntityClient(
+							undefined,
+							getAccountId,
+							entityTypeName,
+							schema.version,
+							dataSchema,
+						);
+				dbClients[entityTypeName] = entityClient;
+			}
+			pluginEntitiesUnsafe[plugin.id]!.db = dbClients;
+			apiUnsafe[plugin.id]!.db = dbClients;
+		}
 
-    // Create account-level key manager BEFORE binding endpoints so keyBuilder can access it
-    const pluginOptions = plugin.options as { authType?: AuthTypes } | undefined
-    const authConfig = plugin.authConfig as PluginAuthConfig | undefined
-    let accountKeyManager: AccountKeyManagerFor<AuthTypes> | undefined
-    if (database && kek && pluginOptions?.authType) {
-      // Extract extra account fields from plugin authConfig
-      const extraAccountFields =
-        authConfig?.[pluginOptions.authType]?.account ?? []
+		// Create account-level key manager BEFORE binding endpoints so keyBuilder can access it
+		const pluginOptions = plugin.options as
+			| { authType?: AuthTypes }
+			| undefined;
+		const authConfig = plugin.authConfig as PluginAuthConfig | undefined;
+		let accountKeyManager: AccountKeyManagerFor<AuthTypes> | undefined;
+		if (database && kek && pluginOptions?.authType) {
+			// Extract extra account fields from plugin authConfig
+			const extraAccountFields =
+				authConfig?.[pluginOptions.authType]?.account ?? [];
 
-      accountKeyManager = createAccountKeyManager({
-        authType: pluginOptions.authType,
-        integrationName: plugin.id,
-        tenantId: effectiveTenantId,
-        kek,
-        database,
-        extraAccountFields,
-      })
-      apiUnsafe[plugin.id]!.keys = accountKeyManager
-    }
+			accountKeyManager = createAccountKeyManager({
+				authType: pluginOptions.authType,
+				integrationName: plugin.id,
+				tenantId: effectiveTenantId,
+				kek,
+				database,
+				extraAccountFields,
+			});
+			apiUnsafe[plugin.id]!.keys = accountKeyManager;
+		}
 
-    // Build plugin context with entity clients under `db`, account ID resolver, and keys manager
-    const ctxForPlugin: Record<string, unknown> = {
-      database,
-      db: pluginEntitiesUnsafe[plugin.id]?.db ?? {},
-      $getAccountId: getAccountId,
-      ...(plugin.options ? { options: plugin.options } : {}),
-      // Include keys manager and authType in context so keyBuilder can access and narrow types
-      ...(accountKeyManager
-        ? { keys: accountKeyManager, authType: pluginOptions?.authType }
-        : {}),
-      // Include tenantId in context so it's available in webhook hooks
-      ...(tenantId ? { tenantId } : {}),
-    }
+		// Build plugin context with entity clients under `db`, account ID resolver, and keys manager
+		const ctxForPlugin: Record<string, unknown> = {
+			database,
+			db: pluginEntitiesUnsafe[plugin.id]?.db ?? {},
+			$getAccountId: getAccountId,
+			...(plugin.options ? { options: plugin.options } : {}),
+			// Include keys manager and authType in context so keyBuilder can access and narrow types
+			...(accountKeyManager
+				? { keys: accountKeyManager, authType: pluginOptions?.authType }
+				: {}),
+			// Include tenantId in context so it's available in webhook hooks
+			...(tenantId ? { tenantId } : {}),
+		};
 
-    const endpoints = plugin.endpoints ?? {}
-    const hooks = plugin.hooks
+		const endpoints = plugin.endpoints ?? {};
+		const hooks = plugin.hooks;
 
-    // Combine plugin and root error handlers, plugin handlers first for priority
-    const allErrorHandlers = {
-      ...rootErrorHandlers,
-      ...plugin.errorHandlers,
-    }
+		// Combine plugin and root error handlers, plugin handlers first for priority
+		const allErrorHandlers = {
+			...rootErrorHandlers,
+			...plugin.errorHandlers,
+		};
 
-    // Create bound endpoints under `api` (supports nested structures)
-    const boundTree: Record<string, unknown> = {}
+		// Create bound endpoints under `api` (supports nested structures)
+		const boundTree: Record<string, unknown> = {};
 
-    // Extract permission config from plugin options.
-    // options is Record<string, unknown> — permissions is not in the base CorsairPlugin type
-    // because it's plugin-specific (typed via PluginPermissionsConfig<T> in each plugin).
-    const pluginPermsConfig = (
-      plugin.options as Record<string, unknown> | undefined
-    )?.permissions as
-      | { mode: PermissionMode; overrides?: Record<string, PermissionPolicy> }
-      | undefined
+		// Extract permission config from plugin options.
+		// options is Record<string, unknown> — permissions is not in the base CorsairPlugin type
+		// because it's plugin-specific (typed via PluginPermissionsConfig<T> in each plugin).
+		const pluginPermsConfig = (
+			plugin.options as Record<string, unknown> | undefined
+		)?.permissions as
+			| { mode: PermissionMode; overrides?: Record<string, PermissionPolicy> }
+			| undefined;
 
-    bindEndpointsRecursively({
-      endpoints,
-      hooks,
-      ctx: ctxForPlugin,
-      tree: boundTree,
-      pluginId: plugin.id,
-      errorHandlers: allErrorHandlers,
-      currentPath: [],
-      keyBuilder: plugin.keyBuilder as CorsairKeyBuilderBase | undefined,
-      permissionsConfig: pluginPermsConfig,
-      endpointMeta: plugin.endpointMeta as
-        | Record<string, EndpointMetaEntry>
-        | undefined,
-      database,
-      approvalConfig,
-      tenantId,
-      connectConfig: connectConfig
-        ? {
-            ...connectConfig,
-            oauthConfig: (plugin as { oauthConfig?: OAuthConfig }).oauthConfig,
-            kek,
-            tenantId: effectiveTenantId,
-          }
-        : undefined,
-    })
+		bindEndpointsRecursively({
+			endpoints,
+			hooks,
+			ctx: ctxForPlugin,
+			tree: boundTree,
+			pluginId: plugin.id,
+			errorHandlers: allErrorHandlers,
+			currentPath: [],
+			keyBuilder: plugin.keyBuilder as CorsairKeyBuilderBase | undefined,
+			permissionsConfig: pluginPermsConfig,
+			endpointMeta: plugin.endpointMeta as
+				| Record<string, EndpointMetaEntry>
+				| undefined,
+			database,
+			approvalConfig,
+			tenantId,
+			connectConfig: connectConfig
+				? {
+						...connectConfig,
+						oauthConfig: (plugin as { oauthConfig?: OAuthConfig }).oauthConfig,
+						kek,
+						tenantId: effectiveTenantId,
+					}
+				: undefined,
+		});
 
-    if (Object.keys(boundTree).length > 0) {
-      apiUnsafe[plugin.id]!.api = boundTree
-    }
+		if (Object.keys(boundTree).length > 0) {
+			apiUnsafe[plugin.id]!.api = boundTree;
+		}
 
-    ctxForPlugin.endpoints = boundTree
+		ctxForPlugin.endpoints = boundTree;
 
-    // Create bound webhooks under `webhooks` (supports nested structures)
-    const webhooks = (plugin.webhooks ?? {}) satisfies Record<string, unknown>
-    const webhookHooks = plugin.webhookHooks satisfies
-      | Record<string, unknown>
-      | undefined
+		// Create bound webhooks under `webhooks` (supports nested structures)
+		const webhooks = (plugin.webhooks ?? {}) satisfies Record<string, unknown>;
+		const webhookHooks = plugin.webhookHooks satisfies
+			| Record<string, unknown>
+			| undefined;
 
-    if (Object.keys(webhooks).length > 0) {
-      const boundWebhooks: Record<string, unknown> = {}
-      bindWebhooksRecursively({
-        webhooks,
-        hooks: webhookHooks,
-        ctx: ctxForPlugin,
-        webhooksTree: boundWebhooks,
-        keyBuilder: plugin.keyBuilder as CorsairKeyBuilderBase | undefined,
-      })
-      apiUnsafe[plugin.id]!.webhooks = boundWebhooks
+		if (Object.keys(webhooks).length > 0) {
+			const boundWebhooks: Record<string, unknown> = {};
+			bindWebhooksRecursively({
+				webhooks,
+				hooks: webhookHooks,
+				ctx: ctxForPlugin,
+				webhooksTree: boundWebhooks,
+				keyBuilder: plugin.keyBuilder as CorsairKeyBuilderBase | undefined,
+			});
+			apiUnsafe[plugin.id]!.webhooks = boundWebhooks;
 
-      // Only expose pluginWebhookMatcher if the plugin has a pluginWebhookMatcher defined
-      // This is the first-level check to see if the webhook is for this plugin
-      if (plugin.pluginWebhookMatcher) {
-        apiUnsafe[plugin.id]!.pluginWebhookMatcher = plugin.pluginWebhookMatcher
-      }
-    }
-  }
+			// Only expose pluginWebhookMatcher if the plugin has a pluginWebhookMatcher defined
+			// This is the first-level check to see if the webhook is for this plugin
+			if (plugin.pluginWebhookMatcher) {
+				apiUnsafe[plugin.id]!.pluginWebhookMatcher =
+					plugin.pluginWebhookMatcher;
+			}
+		}
+	}
 
-  return apiUnsafe as CorsairClient<Plugins>
+	return apiUnsafe as CorsairClient<Plugins>;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -564,32 +563,34 @@ export function buildCorsairClient<
  * @returns An object with key managers for each plugin
  */
 export function buildIntegrationKeys<
-  const Plugins extends readonly CorsairPlugin[],
+	const Plugins extends readonly CorsairPlugin[],
 >(
-  plugins: Plugins,
-  database: CorsairDatabase,
-  kek: string
+	plugins: Plugins,
+	database: CorsairDatabase,
+	kek: string,
 ): InferAllIntegrationKeys<Plugins> {
-  const keysUnsafe: Record<string, unknown> = {}
+	const keysUnsafe: Record<string, unknown> = {};
 
-  for (const plugin of plugins) {
-    const pluginOptions = plugin.options as { authType?: AuthTypes } | undefined
-    const authConfig = plugin.authConfig as PluginAuthConfig | undefined
-    if (pluginOptions?.authType) {
-      // Extract extra integration fields from plugin authConfig
-      const extraIntegrationFields =
-        authConfig?.[pluginOptions.authType]?.integration ?? []
+	for (const plugin of plugins) {
+		const pluginOptions = plugin.options as
+			| { authType?: AuthTypes }
+			| undefined;
+		const authConfig = plugin.authConfig as PluginAuthConfig | undefined;
+		if (pluginOptions?.authType) {
+			// Extract extra integration fields from plugin authConfig
+			const extraIntegrationFields =
+				authConfig?.[pluginOptions.authType]?.integration ?? [];
 
-      const integrationKeyManager = createIntegrationKeyManager({
-        authType: pluginOptions.authType,
-        integrationName: plugin.id,
-        kek,
-        database,
-        extraIntegrationFields,
-      })
-      keysUnsafe[plugin.id] = integrationKeyManager
-    }
-  }
+			const integrationKeyManager = createIntegrationKeyManager({
+				authType: pluginOptions.authType,
+				integrationName: plugin.id,
+				kek,
+				database,
+				extraIntegrationFields,
+			});
+			keysUnsafe[plugin.id] = integrationKeyManager;
+		}
+	}
 
-  return keysUnsafe as InferAllIntegrationKeys<Plugins>
+	return keysUnsafe as InferAllIntegrationKeys<Plugins>;
 }

--- a/packages/corsair/core/client/index.ts
+++ b/packages/corsair/core/client/index.ts
@@ -24,6 +24,7 @@ import type {
   CorsairKeyBuilderBase,
   CorsairPlugin,
   EndpointMetaEntry,
+  OAuthConfig,
   PermissionMode,
   PermissionPolicy,
 } from '../plugins'
@@ -509,7 +510,7 @@ export function buildCorsairClient<
       connectConfig: connectConfig
         ? {
             ...connectConfig,
-            oauthConfig: (plugin as { oauthConfig?: any }).oauthConfig,
+            oauthConfig: (plugin as { oauthConfig?: OAuthConfig }).oauthConfig,
             kek,
             tenantId: effectiveTenantId,
           }

--- a/packages/corsair/core/connect/index.ts
+++ b/packages/corsair/core/connect/index.ts
@@ -1,0 +1,126 @@
+import * as querystring from 'node:querystring'
+import type { CorsairInternalConfig, CorsairPlugin, OAuthConfig } from '..'
+import { CORSAIR_INTERNAL, createIntegrationKeyManager } from '..'
+import { verifyAndDecodeState } from '../auth/state'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function getInternal(corsair: unknown): CorsairInternalConfig {
+  const internal = (corsair as Record<symbol, unknown>)[CORSAIR_INTERNAL] as
+    | CorsairInternalConfig
+    | undefined
+  if (!internal) throw new Error('Invalid corsair instance')
+  return internal
+}
+
+function findPlugin(
+  internal: CorsairInternalConfig,
+  pluginId: string
+): CorsairPlugin {
+  const plugin = internal.plugins.find(p => p.id === pluginId)
+  if (!plugin) throw new Error(`Plugin '${pluginId}' not found`)
+  return plugin
+}
+
+function getOAuthConfig(plugin: CorsairPlugin): OAuthConfig {
+  const cfg = (plugin as { oauthConfig?: OAuthConfig }).oauthConfig
+  if (!cfg) throw new Error(`Plugin '${plugin.id}' has no oauthConfig`)
+  return cfg
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type ResolveConnectLinkResult = {
+  /** Plugin ID extracted from the signed state. */
+  plugin: string
+  /** Tenant ID extracted from the signed state. */
+  tenantId: string
+  /** Human-readable provider name from the plugin's oauthConfig. */
+  providerName: string
+  /** The full OAuth authorization URL. Redirect the user here to start the OAuth flow. */
+  oauthUrl: string
+  /** The signed state parameter (pass to processOAuthCallback after redirect). */
+  state: string
+}
+
+/**
+ * Resolves a connect link request on the consumer's `/connect` page.
+ *
+ * Call this when your connect page receives a `state` query parameter.
+ * It verifies the HMAC-signed state, looks up the plugin's OAuth config,
+ * and returns the full OAuth authorization URL so you just have to render
+ * a "Connect" button linking to `result.oauthUrl`.
+ *
+ * Uses the `redirectUri` from `createCorsair({ connect: { redirectUri } })`.
+ *
+ * @param corsair - The corsair instance
+ * @param state - The `state` query parameter from the connect URL
+ * @returns Plugin info and the full OAuth authorization URL
+ *
+ * @example
+ * ```ts
+ * // On your /connect page handler:
+ * const { providerName, oauthUrl } = await resolveConnectLink(corsair, stateQueryParam)
+ * // Render a "Connect {providerName}" button linking to oauthUrl
+ * // After OAuth redirect, call processOAuthCallback(corsair, { code, state, redirectUri })
+ * ```
+ */
+export async function resolveConnectLink(
+  corsair: unknown,
+  state: string
+): Promise<ResolveConnectLinkResult> {
+  const internal = getInternal(corsair)
+
+  if (!internal.database) {
+    throw new Error('No database configured on corsair instance')
+  }
+
+  const redirectUri = internal.connect?.redirectUri
+  if (!redirectUri) {
+    throw new Error(
+      'No redirectUri configured. Set connect.redirectUri in createCorsair().'
+    )
+  }
+
+  const decoded = verifyAndDecodeState(state, internal.kek)
+  if (!decoded) throw new Error('Invalid or tampered state parameter')
+
+  const { plugin: pluginId, tenantId } = decoded
+  const plugin = findPlugin(internal, pluginId)
+  const oauthCfg = getOAuthConfig(plugin)
+
+  const integrationKm = createIntegrationKeyManager({
+    authType: 'oauth_2',
+    integrationName: pluginId,
+    kek: internal.kek,
+    database: internal.database,
+  })
+
+  const clientId = await integrationKm.get_client_id()
+  if (!clientId) {
+    throw new Error(`client_id not configured for '${pluginId}'`)
+  }
+
+  const params: Record<string, string> = {
+    ...oauthCfg.authParams,
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: oauthCfg.scopes.join(' '),
+    state,
+  }
+
+  const oauthUrl = `${oauthCfg.authUrl}?${querystring.stringify(params)}`
+
+  return {
+    plugin: pluginId,
+    tenantId,
+    providerName: oauthCfg.providerName,
+    oauthUrl,
+    state,
+  }
+}

--- a/packages/corsair/core/connect/index.ts
+++ b/packages/corsair/core/connect/index.ts
@@ -1,33 +1,33 @@
-import * as querystring from 'node:querystring'
-import type { CorsairInternalConfig, CorsairPlugin, OAuthConfig } from '..'
-import { CORSAIR_INTERNAL, createIntegrationKeyManager } from '..'
-import { verifyAndDecodeState } from '../auth/state'
+import * as querystring from 'node:querystring';
+import type { CorsairInternalConfig, CorsairPlugin, OAuthConfig } from '..';
+import { CORSAIR_INTERNAL, createIntegrationKeyManager } from '..';
+import { verifyAndDecodeState } from '../auth/state';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Internal helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
 function getInternal(corsair: unknown): CorsairInternalConfig {
-  const internal = (corsair as Record<symbol, unknown>)[CORSAIR_INTERNAL] as
-    | CorsairInternalConfig
-    | undefined
-  if (!internal) throw new Error('Invalid corsair instance')
-  return internal
+	const internal = (corsair as Record<symbol, unknown>)[CORSAIR_INTERNAL] as
+		| CorsairInternalConfig
+		| undefined;
+	if (!internal) throw new Error('Invalid corsair instance');
+	return internal;
 }
 
 function findPlugin(
-  internal: CorsairInternalConfig,
-  pluginId: string
+	internal: CorsairInternalConfig,
+	pluginId: string,
 ): CorsairPlugin {
-  const plugin = internal.plugins.find(p => p.id === pluginId)
-  if (!plugin) throw new Error(`Plugin '${pluginId}' not found`)
-  return plugin
+	const plugin = internal.plugins.find((p) => p.id === pluginId);
+	if (!plugin) throw new Error(`Plugin '${pluginId}' not found`);
+	return plugin;
 }
 
 function getOAuthConfig(plugin: CorsairPlugin): OAuthConfig {
-  const cfg = (plugin as { oauthConfig?: OAuthConfig }).oauthConfig
-  if (!cfg) throw new Error(`Plugin '${plugin.id}' has no oauthConfig`)
-  return cfg
+	const cfg = (plugin as { oauthConfig?: OAuthConfig }).oauthConfig;
+	if (!cfg) throw new Error(`Plugin '${plugin.id}' has no oauthConfig`);
+	return cfg;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -35,17 +35,17 @@ function getOAuthConfig(plugin: CorsairPlugin): OAuthConfig {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export type ResolveConnectLinkResult = {
-  /** Plugin ID extracted from the signed state. */
-  plugin: string
-  /** Tenant ID extracted from the signed state. */
-  tenantId: string
-  /** Human-readable provider name from the plugin's oauthConfig. */
-  providerName: string
-  /** The full OAuth authorization URL. Redirect the user here to start the OAuth flow. */
-  oauthUrl: string
-  /** The signed state parameter (pass to processOAuthCallback after redirect). */
-  state: string
-}
+	/** Plugin ID extracted from the signed state. */
+	plugin: string;
+	/** Tenant ID extracted from the signed state. */
+	tenantId: string;
+	/** Human-readable provider name from the plugin's oauthConfig. */
+	providerName: string;
+	/** The full OAuth authorization URL. Redirect the user here to start the OAuth flow. */
+	oauthUrl: string;
+	/** The signed state parameter (pass to processOAuthCallback after redirect). */
+	state: string;
+};
 
 /**
  * Resolves a connect link request on the consumer's `/connect` page.
@@ -70,57 +70,57 @@ export type ResolveConnectLinkResult = {
  * ```
  */
 export async function resolveConnectLink(
-  corsair: unknown,
-  state: string
+	corsair: unknown,
+	state: string,
 ): Promise<ResolveConnectLinkResult> {
-  const internal = getInternal(corsair)
+	const internal = getInternal(corsair);
 
-  if (!internal.database) {
-    throw new Error('No database configured on corsair instance')
-  }
+	if (!internal.database) {
+		throw new Error('No database configured on corsair instance');
+	}
 
-  const redirectUri = internal.connect?.redirectUri
-  if (!redirectUri) {
-    throw new Error(
-      'No redirectUri configured. Set connect.redirectUri in createCorsair().'
-    )
-  }
+	const redirectUri = internal.connect?.redirectUri;
+	if (!redirectUri) {
+		throw new Error(
+			'No redirectUri configured. Set connect.redirectUri in createCorsair().',
+		);
+	}
 
-  const decoded = verifyAndDecodeState(state, internal.kek)
-  if (!decoded) throw new Error('Invalid or tampered state parameter')
+	const decoded = verifyAndDecodeState(state, internal.kek);
+	if (!decoded) throw new Error('Invalid or tampered state parameter');
 
-  const { plugin: pluginId, tenantId } = decoded
-  const plugin = findPlugin(internal, pluginId)
-  const oauthCfg = getOAuthConfig(plugin)
+	const { plugin: pluginId, tenantId } = decoded;
+	const plugin = findPlugin(internal, pluginId);
+	const oauthCfg = getOAuthConfig(plugin);
 
-  const integrationKm = createIntegrationKeyManager({
-    authType: 'oauth_2',
-    integrationName: pluginId,
-    kek: internal.kek,
-    database: internal.database,
-  })
+	const integrationKm = createIntegrationKeyManager({
+		authType: 'oauth_2',
+		integrationName: pluginId,
+		kek: internal.kek,
+		database: internal.database,
+	});
 
-  const clientId = await integrationKm.get_client_id()
-  if (!clientId) {
-    throw new Error(`client_id not configured for '${pluginId}'`)
-  }
+	const clientId = await integrationKm.get_client_id();
+	if (!clientId) {
+		throw new Error(`client_id not configured for '${pluginId}'`);
+	}
 
-  const params: Record<string, string> = {
-    ...oauthCfg.authParams,
-    client_id: clientId,
-    redirect_uri: redirectUri,
-    response_type: 'code',
-    scope: oauthCfg.scopes.join(' '),
-    state,
-  }
+	const params: Record<string, string> = {
+		...oauthCfg.authParams,
+		client_id: clientId,
+		redirect_uri: redirectUri,
+		response_type: 'code',
+		scope: oauthCfg.scopes.join(' '),
+		state,
+	};
 
-  const oauthUrl = `${oauthCfg.authUrl}?${querystring.stringify(params)}`
+	const oauthUrl = `${oauthCfg.authUrl}?${querystring.stringify(params)}`;
 
-  return {
-    plugin: pluginId,
-    tenantId,
-    providerName: oauthCfg.providerName,
-    oauthUrl,
-    state,
-  }
+	return {
+		plugin: pluginId,
+		tenantId,
+		providerName: oauthCfg.providerName,
+		oauthUrl,
+		state,
+	};
 }

--- a/packages/corsair/core/endpoints/bind.ts
+++ b/packages/corsair/core/endpoints/bind.ts
@@ -48,7 +48,6 @@ function buildConnectError(
 		connectConfig.kek!,
 	);
 	const url = new URL(connectConfig.baseUrl);
-	url.searchParams.set('plugin', pluginId);
 	url.searchParams.set('state', state);
 	const connectUrl = url.toString();
 	const msg = connectConfig.onAuthMissing

--- a/packages/corsair/core/endpoints/bind.ts
+++ b/packages/corsair/core/endpoints/bind.ts
@@ -268,7 +268,12 @@ export function bindEndpointsRecursively({
 					throw err;
 				}
 
-				if (!key && connectConfig?.oauthConfig && connectConfig.kek) {
+				if (
+					!key &&
+					keyBuilder &&
+					connectConfig?.oauthConfig &&
+					connectConfig.kek
+				) {
 					const state = signState(
 						encodeOAuthState(
 							pluginId,
@@ -287,6 +292,7 @@ export function bindEndpointsRecursively({
 							: `[auth-missing:${pluginId}] Authentication required. Direct the user to connect their account: ${connectUrl}`,
 					);
 				}
+
 
 				if (!endpointHooks?.before && !endpointHooks?.after) {
 					const res = await call(0, { ...ctx, key }, args);

--- a/packages/corsair/core/endpoints/bind.ts
+++ b/packages/corsair/core/endpoints/bind.ts
@@ -242,9 +242,6 @@ export function bindEndpointsRecursively({
         let key: string | undefined
         try {
           key = keyBuilder ? await keyBuilder(ctx, 'endpoint') : undefined
-          if (!key && connectConfig?.oauthConfig && connectConfig.kek) {
-            throw new AuthMissingError(pluginId)
-          }
         } catch (err) {
           if (
             connectConfig?.oauthConfig &&
@@ -269,6 +266,26 @@ export function bindEndpointsRecursively({
             throw new Error(msg)
           }
           throw err
+        }
+
+        if (!key && connectConfig?.oauthConfig && connectConfig.kek) {
+          const state = signState(
+            encodeOAuthState(
+              pluginId,
+              connectConfig.tenantId ?? tenantId ?? 'default'
+            ),
+            connectConfig.kek
+          )
+          const connectUrl = `${connectConfig.baseUrl}?plugin=${encodeURIComponent(pluginId)}&state=${encodeURIComponent(state)}`
+          throw new Error(
+            connectConfig.onAuthMissing
+              ? connectConfig.onAuthMissing({
+                  plugin: pluginId,
+                  connectUrl,
+                  state,
+                })
+              : `[auth-missing:${pluginId}] Authentication required. Direct the user to connect their account: ${connectUrl}`
+          )
         }
 
         if (!endpointHooks?.before && !endpointHooks?.after) {

--- a/packages/corsair/core/endpoints/bind.ts
+++ b/packages/corsair/core/endpoints/bind.ts
@@ -26,6 +26,37 @@ export function isEndpoint(value: unknown): value is Function {
 	return typeof value === 'function';
 }
 
+function buildConnectError(
+	pluginId: string,
+	connectConfig: {
+		baseUrl: string;
+		onAuthMissing?: (opts: {
+			plugin: string;
+			connectUrl: string;
+			state: string;
+		}) => string;
+		kek?: string;
+		tenantId?: string;
+	},
+	fallbackTenantId: string | undefined,
+): Error {
+	const state = signState(
+		encodeOAuthState(
+			pluginId,
+			connectConfig.tenantId ?? fallbackTenantId ?? 'default',
+		),
+		connectConfig.kek!,
+	);
+	const url = new URL(connectConfig.baseUrl);
+	url.searchParams.set('plugin', pluginId);
+	url.searchParams.set('state', state);
+	const connectUrl = url.toString();
+	const msg = connectConfig.onAuthMissing
+		? connectConfig.onAuthMissing({ plugin: pluginId, connectUrl, state })
+		: `[auth-missing:${pluginId}] Authentication required. Direct the user to connect their account: ${connectUrl}`;
+	return new Error(msg);
+}
+
 /**
  * Recursively binds endpoints in a tree structure with context and hooks.
  * Handles both flat (key -> fn) and nested (key -> { key -> fn }) structures.
@@ -248,22 +279,7 @@ export function bindEndpointsRecursively({
 						connectConfig.kek &&
 						err instanceof AuthMissingError
 					) {
-						const state = signState(
-							encodeOAuthState(
-								pluginId,
-								connectConfig.tenantId ?? tenantId ?? 'default',
-							),
-							connectConfig.kek,
-						);
-						const connectUrl = `${connectConfig.baseUrl}?plugin=${encodeURIComponent(pluginId)}&state=${encodeURIComponent(state)}`;
-						const msg = connectConfig.onAuthMissing
-							? connectConfig.onAuthMissing({
-									plugin: pluginId,
-									connectUrl,
-									state,
-								})
-							: `[auth-missing:${pluginId}] Authentication required. Direct the user to connect their account: ${connectUrl}`;
-						throw new Error(msg);
+						throw buildConnectError(pluginId, connectConfig, tenantId);
 					}
 					throw err;
 				}
@@ -274,25 +290,8 @@ export function bindEndpointsRecursively({
 					connectConfig?.oauthConfig &&
 					connectConfig.kek
 				) {
-					const state = signState(
-						encodeOAuthState(
-							pluginId,
-							connectConfig.tenantId ?? tenantId ?? 'default',
-						),
-						connectConfig.kek,
-					);
-					const connectUrl = `${connectConfig.baseUrl}?plugin=${encodeURIComponent(pluginId)}&state=${encodeURIComponent(state)}`;
-					throw new Error(
-						connectConfig.onAuthMissing
-							? connectConfig.onAuthMissing({
-									plugin: pluginId,
-									connectUrl,
-									state,
-								})
-							: `[auth-missing:${pluginId}] Authentication required. Direct the user to connect their account: ${connectUrl}`,
-					);
+					throw buildConnectError(pluginId, connectConfig, tenantId);
 				}
-
 
 				if (!endpointHooks?.before && !endpointHooks?.after) {
 					const res = await call(0, { ...ctx, key }, args);

--- a/packages/corsair/core/endpoints/bind.ts
+++ b/packages/corsair/core/endpoints/bind.ts
@@ -1,3 +1,4 @@
+import type { OAuthConfig } from '../plugins'
 import type { CorsairDatabase } from '../../db/kysely/database'
 import type { CorsairErrorHandler } from '../errors'
 import { handleCorsairError } from '../errors/handler'
@@ -98,7 +99,7 @@ export function bindEndpointsRecursively({
       connectUrl: string
       state: string
     }) => string
-    oauthConfig?: any
+    oauthConfig?: OAuthConfig
     kek?: string | undefined
     tenantId?: string
   }
@@ -248,11 +249,7 @@ export function bindEndpointsRecursively({
           if (
             connectConfig?.oauthConfig &&
             connectConfig.kek &&
-            (err instanceof AuthMissingError ||
-              (err instanceof Error &&
-                /Account not found|No DEK found|\[auth-missing:/.test(
-                  err.message
-                )))
+            err instanceof AuthMissingError
           ) {
             const state = signState(
               encodeOAuthState(

--- a/packages/corsair/core/endpoints/bind.ts
+++ b/packages/corsair/core/endpoints/bind.ts
@@ -1,17 +1,17 @@
-import type { OAuthConfig } from '../plugins'
-import type { CorsairDatabase } from '../../db/kysely/database'
-import type { CorsairErrorHandler } from '../errors'
-import { handleCorsairError } from '../errors/handler'
-import { enforcePermission, parseDurationMs } from '../permissions'
+import type { CorsairDatabase } from '../../db/kysely/database';
+import { AuthMissingError } from '../auth/errors/auth-missing';
+import { encodeOAuthState, signState } from '../auth/state';
+import type { CorsairErrorHandler } from '../errors';
+import { handleCorsairError } from '../errors/handler';
+import { enforcePermission, parseDurationMs } from '../permissions';
 import type {
-  CorsairKeyBuilderBase,
-  EndpointHooks,
-  EndpointMetaEntry,
-  PermissionMode,
-  PermissionPolicy,
-} from '../plugins'
-import { AuthMissingError } from '../auth/errors/auth-missing'
-import { encodeOAuthState, signState } from '../auth/state'
+	CorsairKeyBuilderBase,
+	EndpointHooks,
+	EndpointMetaEntry,
+	OAuthConfig,
+	PermissionMode,
+	PermissionPolicy,
+} from '../plugins';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Endpoint Utilities
@@ -23,7 +23,7 @@ import { encodeOAuthState, signState } from '../auth/state'
  * @returns True if the value is a function
  */
 export function isEndpoint(value: unknown): value is Function {
-  return typeof value === 'function'
+	return typeof value === 'function';
 }
 
 /**
@@ -39,304 +39,304 @@ export function isEndpoint(value: unknown): value is Function {
  * @param keyBuilder - Optional async callback to generate a key from the plugin context
  */
 export function bindEndpointsRecursively({
-  endpoints,
-  hooks,
-  ctx,
-  tree,
-  pluginId,
-  errorHandlers,
-  currentPath = [],
-  keyBuilder,
-  permissionsConfig,
-  endpointMeta,
-  database,
-  approvalConfig,
-  tenantId,
-  connectConfig,
+	endpoints,
+	hooks,
+	ctx,
+	tree,
+	pluginId,
+	errorHandlers,
+	currentPath = [],
+	keyBuilder,
+	permissionsConfig,
+	endpointMeta,
+	database,
+	approvalConfig,
+	tenantId,
+	connectConfig,
 }: {
-  endpoints: Record<string, unknown>
-  hooks: Record<string, unknown> | undefined
-  ctx: Record<string, unknown>
-  tree: Record<string, unknown>
-  pluginId: string
-  errorHandlers: CorsairErrorHandler
-  currentPath: string[]
-  keyBuilder?: CorsairKeyBuilderBase
-  /** Permission mode + per-endpoint overrides from plugin options. When set, every call is gated. */
-  permissionsConfig?: {
-    mode: PermissionMode
-    overrides?: Record<string, PermissionPolicy>
-  }
-  /** Risk level metadata per dot-notation endpoint path. Defaults riskLevel to 'write' when missing. */
-  endpointMeta?: Record<string, EndpointMetaEntry>
-  /** Required for 'require_approval' to persist the approval record to the DB. */
-  database?: CorsairDatabase
-  /** Approval timeout config from createCorsair({ approval: ... }). */
-  approvalConfig?: {
-    timeout: string
-    onTimeout: 'deny' | 'approve'
-    mode?:
-      | 'synchronous'
-      | 'asynchronous'
-      | (() => 'synchronous' | 'asynchronous')
-    /** Called when a permission is blocked in async mode. Return the message to throw to the LLM. */
-    formatAsyncMessage?: (opts: {
-      token: string
-      id: string
-      plugin: string
-      endpoint: string
-      args: unknown
-    }) => string
-  }
-  /** Tenant ID for multi-tenant instances. Forwarded to the permission record so executePermission can scope correctly. */
-  tenantId?: string
-  /** Connect link config for generating OAuth connect URLs when auth is missing. */
-  connectConfig?: {
-    baseUrl: string
-    redirectUri: string
-    onAuthMissing?: (opts: {
-      plugin: string
-      connectUrl: string
-      state: string
-    }) => string
-    oauthConfig?: OAuthConfig
-    kek?: string | undefined
-    tenantId?: string
-  }
+	endpoints: Record<string, unknown>;
+	hooks: Record<string, unknown> | undefined;
+	ctx: Record<string, unknown>;
+	tree: Record<string, unknown>;
+	pluginId: string;
+	errorHandlers: CorsairErrorHandler;
+	currentPath: string[];
+	keyBuilder?: CorsairKeyBuilderBase;
+	/** Permission mode + per-endpoint overrides from plugin options. When set, every call is gated. */
+	permissionsConfig?: {
+		mode: PermissionMode;
+		overrides?: Record<string, PermissionPolicy>;
+	};
+	/** Risk level metadata per dot-notation endpoint path. Defaults riskLevel to 'write' when missing. */
+	endpointMeta?: Record<string, EndpointMetaEntry>;
+	/** Required for 'require_approval' to persist the approval record to the DB. */
+	database?: CorsairDatabase;
+	/** Approval timeout config from createCorsair({ approval: ... }). */
+	approvalConfig?: {
+		timeout: string;
+		onTimeout: 'deny' | 'approve';
+		mode?:
+			| 'synchronous'
+			| 'asynchronous'
+			| (() => 'synchronous' | 'asynchronous');
+		/** Called when a permission is blocked in async mode. Return the message to throw to the LLM. */
+		formatAsyncMessage?: (opts: {
+			token: string;
+			id: string;
+			plugin: string;
+			endpoint: string;
+			args: unknown;
+		}) => string;
+	};
+	/** Tenant ID for multi-tenant instances. Forwarded to the permission record so executePermission can scope correctly. */
+	tenantId?: string;
+	/** Connect link config for generating OAuth connect URLs when auth is missing. */
+	connectConfig?: {
+		baseUrl: string;
+		redirectUri: string;
+		onAuthMissing?: (opts: {
+			plugin: string;
+			connectUrl: string;
+			state: string;
+		}) => string;
+		oauthConfig?: OAuthConfig;
+		kek?: string | undefined;
+		tenantId?: string;
+	};
 }): void {
-  for (const [key, value] of Object.entries(endpoints)) {
-    // we have to retype this now because it's nested webhooks
-    const nodeHooks = hooks?.[key] as Record<string, unknown> | undefined
+	for (const [key, value] of Object.entries(endpoints)) {
+		// we have to retype this now because it's nested webhooks
+		const nodeHooks = hooks?.[key] as Record<string, unknown> | undefined;
 
-    if (isEndpoint(value)) {
-      // it's an endpoint function - bind it with context and hooks
-      const endpointHooks = nodeHooks as EndpointHooks | undefined
+		if (isEndpoint(value)) {
+			// it's an endpoint function - bind it with context and hooks
+			const endpointHooks = nodeHooks as EndpointHooks | undefined;
 
-      const operationPath = [...currentPath, key].join('.')
+			const operationPath = [...currentPath, key].join('.');
 
-      const boundFn = async (args: unknown = {}) => {
-        // ── Permission guard ────────────────────────────────────────────────────────────────
-        let onPermissionComplete: (() => Promise<void>) | undefined
-        if (permissionsConfig) {
-          const meta = endpointMeta?.[operationPath]
-          const {
-            result: permResult,
-            reason: permReason,
-            onComplete,
-            token: permToken,
-            id: permId,
-          } = await enforcePermission({
-            pluginId,
-            endpointPath: operationPath,
-            args,
-            mode: permissionsConfig.mode,
-            override: permissionsConfig.overrides?.[operationPath],
-            // Default to 'write' when no meta declared — conservative fallback
-            riskLevel: meta?.riskLevel ?? 'write',
-            meta,
-            db: database,
-            timeoutMs: approvalConfig
-              ? parseDurationMs(approvalConfig.timeout)
-              : undefined,
-            tenantId,
-            approvalMode: approvalConfig?.mode,
-          })
-          if (permResult === 'blocked') {
-            let msg: string
-            if (permReason === 'denied') {
-              msg = `Action '${operationPath}' was denied by the user. Await further instructions before proceeding.`
-            } else if (permReason === 'policy') {
-              msg = `Action '${operationPath}' is blocked by the permission policy. Update the corsair config to allow it.`
-            } else if (permReason === 'timeout') {
-              msg = `Action '${operationPath}' timed out waiting for approval.`
-            } else if (
-              approvalConfig?.formatAsyncMessage &&
-              permToken &&
-              permId
-            ) {
-              msg = approvalConfig.formatAsyncMessage({
-                token: permToken,
-                id: permId,
-                plugin: pluginId,
-                endpoint: operationPath,
-                args,
-              })
-            } else {
-              msg = `Action '${operationPath}' requires user approval before it can run.`
-            }
-            throw new Error(msg)
-          }
-          onPermissionComplete = onComplete
-        }
+			const boundFn = async (args: unknown = {}) => {
+				// ── Permission guard ────────────────────────────────────────────────────────────────
+				let onPermissionComplete: (() => Promise<void>) | undefined;
+				if (permissionsConfig) {
+					const meta = endpointMeta?.[operationPath];
+					const {
+						result: permResult,
+						reason: permReason,
+						onComplete,
+						token: permToken,
+						id: permId,
+					} = await enforcePermission({
+						pluginId,
+						endpointPath: operationPath,
+						args,
+						mode: permissionsConfig.mode,
+						override: permissionsConfig.overrides?.[operationPath],
+						// Default to 'write' when no meta declared — conservative fallback
+						riskLevel: meta?.riskLevel ?? 'write',
+						meta,
+						db: database,
+						timeoutMs: approvalConfig
+							? parseDurationMs(approvalConfig.timeout)
+							: undefined,
+						tenantId,
+						approvalMode: approvalConfig?.mode,
+					});
+					if (permResult === 'blocked') {
+						let msg: string;
+						if (permReason === 'denied') {
+							msg = `Action '${operationPath}' was denied by the user. Await further instructions before proceeding.`;
+						} else if (permReason === 'policy') {
+							msg = `Action '${operationPath}' is blocked by the permission policy. Update the corsair config to allow it.`;
+						} else if (permReason === 'timeout') {
+							msg = `Action '${operationPath}' timed out waiting for approval.`;
+						} else if (
+							approvalConfig?.formatAsyncMessage &&
+							permToken &&
+							permId
+						) {
+							msg = approvalConfig.formatAsyncMessage({
+								token: permToken,
+								id: permId,
+								plugin: pluginId,
+								endpoint: operationPath,
+								args,
+							});
+						} else {
+							msg = `Action '${operationPath}' requires user approval before it can run.`;
+						}
+						throw new Error(msg);
+					}
+					onPermissionComplete = onComplete;
+				}
 
-        const call = async (
-          attemptNumber: number,
-          callCtx: Record<string, unknown>,
-          callArgs: unknown
-        ) => {
-          try {
-            return await value(callCtx, callArgs)
-          } catch (error) {
-            if (error instanceof Error) {
-              const retryStrategy = await handleCorsairError(
-                error,
-                pluginId,
-                operationPath,
-                typeof callArgs === 'object' && callArgs !== null
-                  ? (callArgs as Record<string, unknown>)
-                  : { args: callArgs },
-                errorHandlers
-              )
+				const call = async (
+					attemptNumber: number,
+					callCtx: Record<string, unknown>,
+					callArgs: unknown,
+				) => {
+					try {
+						return await value(callCtx, callArgs);
+					} catch (error) {
+						if (error instanceof Error) {
+							const retryStrategy = await handleCorsairError(
+								error,
+								pluginId,
+								operationPath,
+								typeof callArgs === 'object' && callArgs !== null
+									? (callArgs as Record<string, unknown>)
+									: { args: callArgs },
+								errorHandlers,
+							);
 
-              if (attemptNumber < (retryStrategy.maxRetries || 0)) {
-                const newAttempt = attemptNumber + 1
+							if (attemptNumber < (retryStrategy.maxRetries || 0)) {
+								const newAttempt = attemptNumber + 1;
 
-                console.log(
-                  `Retrying (${newAttempt} / ${retryStrategy.maxRetries})...`
-                )
+								console.log(
+									`Retrying (${newAttempt} / ${retryStrategy.maxRetries})...`,
+								);
 
-                let delayMs: number
-                if (retryStrategy.headersRetryAfterMs) {
-                  delayMs = retryStrategy.headersRetryAfterMs
-                } else {
-                  switch (retryStrategy.retryStrategy) {
-                    case 'exponential_backoff':
-                      delayMs = Math.pow(2, newAttempt - 1) * 1000
-                      break
-                    case 'exponential_backoff_jitter':
-                      const baseDelay = Math.pow(2, newAttempt - 1) * 1000
-                      const jitter = (Math.random() - 0.5) * 1000
-                      delayMs = Math.max(0, baseDelay + jitter)
-                      break
-                    case 'linear_1s':
-                      delayMs = 1000
-                      break
-                    case 'linear_2s':
-                      delayMs = 2000
-                      break
-                    case 'linear_3s':
-                      delayMs = 3000
-                      break
-                    case 'linear_4s':
-                      delayMs = 4000
-                      break
-                    default:
-                      delayMs = 1000
-                      break
-                  }
-                }
+								let delayMs: number;
+								if (retryStrategy.headersRetryAfterMs) {
+									delayMs = retryStrategy.headersRetryAfterMs;
+								} else {
+									switch (retryStrategy.retryStrategy) {
+										case 'exponential_backoff':
+											delayMs = Math.pow(2, newAttempt - 1) * 1000;
+											break;
+										case 'exponential_backoff_jitter':
+											const baseDelay = Math.pow(2, newAttempt - 1) * 1000;
+											const jitter = (Math.random() - 0.5) * 1000;
+											delayMs = Math.max(0, baseDelay + jitter);
+											break;
+										case 'linear_1s':
+											delayMs = 1000;
+											break;
+										case 'linear_2s':
+											delayMs = 2000;
+											break;
+										case 'linear_3s':
+											delayMs = 3000;
+											break;
+										case 'linear_4s':
+											delayMs = 4000;
+											break;
+										default:
+											delayMs = 1000;
+											break;
+									}
+								}
 
-                await new Promise(resolve => setTimeout(resolve, delayMs))
-                await call(newAttempt, callCtx, callArgs)
+								await new Promise((resolve) => setTimeout(resolve, delayMs));
+								await call(newAttempt, callCtx, callArgs);
 
-                console.log(
-                  `[corsair:${pluginId}:${operationPath}] Retry strategy:`,
-                  retryStrategy
-                )
-              }
-            }
-            throw error
-          }
-        }
+								console.log(
+									`[corsair:${pluginId}:${operationPath}] Retry strategy:`,
+									retryStrategy,
+								);
+							}
+						}
+						throw error;
+					}
+				};
 
-        let key: string | undefined
-        try {
-          key = keyBuilder ? await keyBuilder(ctx, 'endpoint') : undefined
-        } catch (err) {
-          if (
-            connectConfig?.oauthConfig &&
-            connectConfig.kek &&
-            err instanceof AuthMissingError
-          ) {
-            const state = signState(
-              encodeOAuthState(
-                pluginId,
-                connectConfig.tenantId ?? tenantId ?? 'default'
-              ),
-              connectConfig.kek
-            )
-            const connectUrl = `${connectConfig.baseUrl}?plugin=${encodeURIComponent(pluginId)}&state=${encodeURIComponent(state)}`
-            const msg = connectConfig.onAuthMissing
-              ? connectConfig.onAuthMissing({
-                  plugin: pluginId,
-                  connectUrl,
-                  state,
-                })
-              : `[auth-missing:${pluginId}] Authentication required. Direct the user to connect their account: ${connectUrl}`
-            throw new Error(msg)
-          }
-          throw err
-        }
+				let key: string | undefined;
+				try {
+					key = keyBuilder ? await keyBuilder(ctx, 'endpoint') : undefined;
+				} catch (err) {
+					if (
+						connectConfig?.oauthConfig &&
+						connectConfig.kek &&
+						err instanceof AuthMissingError
+					) {
+						const state = signState(
+							encodeOAuthState(
+								pluginId,
+								connectConfig.tenantId ?? tenantId ?? 'default',
+							),
+							connectConfig.kek,
+						);
+						const connectUrl = `${connectConfig.baseUrl}?plugin=${encodeURIComponent(pluginId)}&state=${encodeURIComponent(state)}`;
+						const msg = connectConfig.onAuthMissing
+							? connectConfig.onAuthMissing({
+									plugin: pluginId,
+									connectUrl,
+									state,
+								})
+							: `[auth-missing:${pluginId}] Authentication required. Direct the user to connect their account: ${connectUrl}`;
+						throw new Error(msg);
+					}
+					throw err;
+				}
 
-        if (!key && connectConfig?.oauthConfig && connectConfig.kek) {
-          const state = signState(
-            encodeOAuthState(
-              pluginId,
-              connectConfig.tenantId ?? tenantId ?? 'default'
-            ),
-            connectConfig.kek
-          )
-          const connectUrl = `${connectConfig.baseUrl}?plugin=${encodeURIComponent(pluginId)}&state=${encodeURIComponent(state)}`
-          throw new Error(
-            connectConfig.onAuthMissing
-              ? connectConfig.onAuthMissing({
-                  plugin: pluginId,
-                  connectUrl,
-                  state,
-                })
-              : `[auth-missing:${pluginId}] Authentication required. Direct the user to connect their account: ${connectUrl}`
-          )
-        }
+				if (!key && connectConfig?.oauthConfig && connectConfig.kek) {
+					const state = signState(
+						encodeOAuthState(
+							pluginId,
+							connectConfig.tenantId ?? tenantId ?? 'default',
+						),
+						connectConfig.kek,
+					);
+					const connectUrl = `${connectConfig.baseUrl}?plugin=${encodeURIComponent(pluginId)}&state=${encodeURIComponent(state)}`;
+					throw new Error(
+						connectConfig.onAuthMissing
+							? connectConfig.onAuthMissing({
+									plugin: pluginId,
+									connectUrl,
+									state,
+								})
+							: `[auth-missing:${pluginId}] Authentication required. Direct the user to connect their account: ${connectUrl}`,
+					);
+				}
 
-        if (!endpointHooks?.before && !endpointHooks?.after) {
-          const res = await call(0, { ...ctx, key }, args)
-          await onPermissionComplete?.()
-          return res
-        }
+				if (!endpointHooks?.before && !endpointHooks?.after) {
+					const res = await call(0, { ...ctx, key }, args);
+					await onPermissionComplete?.();
+					return res;
+				}
 
-        const ctxWithKey = { ...ctx, key }
-        const beforeResult = endpointHooks.before
-          ? await endpointHooks.before(ctxWithKey, args)
-          : {
-              ctx: ctxWithKey,
-              args,
-              continue: true as const,
-              passToAfter: undefined,
-            }
-        if (beforeResult.continue === false) return
-        const res = await call(0, beforeResult.ctx, beforeResult.args)
-        await endpointHooks.after?.(
-          beforeResult.ctx,
-          res,
-          beforeResult.passToAfter
-        )
-        await onPermissionComplete?.()
-        return res
-      }
+				const ctxWithKey = { ...ctx, key };
+				const beforeResult = endpointHooks.before
+					? await endpointHooks.before(ctxWithKey, args)
+					: {
+							ctx: ctxWithKey,
+							args,
+							continue: true as const,
+							passToAfter: undefined,
+						};
+				if (beforeResult.continue === false) return;
+				const res = await call(0, beforeResult.ctx, beforeResult.args);
+				await endpointHooks.after?.(
+					beforeResult.ctx,
+					res,
+					beforeResult.passToAfter,
+				);
+				await onPermissionComplete?.();
+				return res;
+			};
 
-      tree[key] = boundFn
-    } else if (value && typeof value === 'object') {
-      // it's a nested object - recurse into it
-      const nestedTree: Record<string, unknown> = {}
+			tree[key] = boundFn;
+		} else if (value && typeof value === 'object') {
+			// it's a nested object - recurse into it
+			const nestedTree: Record<string, unknown> = {};
 
-      bindEndpointsRecursively({
-        endpoints: value as Record<string, unknown>,
-        hooks: nodeHooks as Record<string, unknown> | undefined,
-        ctx,
-        tree: nestedTree,
-        pluginId,
-        errorHandlers,
-        currentPath: [...currentPath, key],
-        keyBuilder,
-        permissionsConfig,
-        endpointMeta,
-        database,
-        approvalConfig,
-        tenantId,
-        connectConfig,
-      })
+			bindEndpointsRecursively({
+				endpoints: value as Record<string, unknown>,
+				hooks: nodeHooks as Record<string, unknown> | undefined,
+				ctx,
+				tree: nestedTree,
+				pluginId,
+				errorHandlers,
+				currentPath: [...currentPath, key],
+				keyBuilder,
+				permissionsConfig,
+				endpointMeta,
+				database,
+				approvalConfig,
+				tenantId,
+				connectConfig,
+			});
 
-      tree[key] = nestedTree
-    }
-  }
+			tree[key] = nestedTree;
+		}
+	}
 }

--- a/packages/corsair/core/endpoints/bind.ts
+++ b/packages/corsair/core/endpoints/bind.ts
@@ -1,14 +1,16 @@
-import type { CorsairDatabase } from '../../db/kysely/database';
-import type { CorsairErrorHandler } from '../errors';
-import { handleCorsairError } from '../errors/handler';
-import { enforcePermission, parseDurationMs } from '../permissions';
+import type { CorsairDatabase } from '../../db/kysely/database'
+import type { CorsairErrorHandler } from '../errors'
+import { handleCorsairError } from '../errors/handler'
+import { enforcePermission, parseDurationMs } from '../permissions'
 import type {
-	CorsairKeyBuilderBase,
-	EndpointHooks,
-	EndpointMetaEntry,
-	PermissionMode,
-	PermissionPolicy,
-} from '../plugins';
+  CorsairKeyBuilderBase,
+  EndpointHooks,
+  EndpointMetaEntry,
+  PermissionMode,
+  PermissionPolicy,
+} from '../plugins'
+import { AuthMissingError } from '../auth/errors/auth-missing'
+import { encodeOAuthState, signState } from '../auth/state'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Endpoint Utilities
@@ -20,7 +22,7 @@ import type {
  * @returns True if the value is a function
  */
 export function isEndpoint(value: unknown): value is Function {
-	return typeof value === 'function';
+  return typeof value === 'function'
 }
 
 /**
@@ -36,242 +38,291 @@ export function isEndpoint(value: unknown): value is Function {
  * @param keyBuilder - Optional async callback to generate a key from the plugin context
  */
 export function bindEndpointsRecursively({
-	endpoints,
-	hooks,
-	ctx,
-	tree,
-	pluginId,
-	errorHandlers,
-	currentPath = [],
-	keyBuilder,
-	permissionsConfig,
-	endpointMeta,
-	database,
-	approvalConfig,
-	tenantId,
+  endpoints,
+  hooks,
+  ctx,
+  tree,
+  pluginId,
+  errorHandlers,
+  currentPath = [],
+  keyBuilder,
+  permissionsConfig,
+  endpointMeta,
+  database,
+  approvalConfig,
+  tenantId,
+  connectConfig,
 }: {
-	endpoints: Record<string, unknown>;
-	hooks: Record<string, unknown> | undefined;
-	ctx: Record<string, unknown>;
-	tree: Record<string, unknown>;
-	pluginId: string;
-	errorHandlers: CorsairErrorHandler;
-	currentPath: string[];
-	keyBuilder?: CorsairKeyBuilderBase;
-	/** Permission mode + per-endpoint overrides from plugin options. When set, every call is gated. */
-	permissionsConfig?: {
-		mode: PermissionMode;
-		overrides?: Record<string, PermissionPolicy>;
-	};
-	/** Risk level metadata per dot-notation endpoint path. Defaults riskLevel to 'write' when missing. */
-	endpointMeta?: Record<string, EndpointMetaEntry>;
-	/** Required for 'require_approval' to persist the approval record to the DB. */
-	database?: CorsairDatabase;
-	/** Approval timeout config from createCorsair({ approval: ... }). */
-	approvalConfig?: {
-		timeout: string;
-		onTimeout: 'deny' | 'approve';
-		mode?:
-			| 'synchronous'
-			| 'asynchronous'
-			| (() => 'synchronous' | 'asynchronous');
-		/** Called when a permission is blocked in async mode. Return the message to throw to the LLM. */
-		formatAsyncMessage?: (opts: {
-			token: string;
-			id: string;
-			plugin: string;
-			endpoint: string;
-			args: unknown;
-		}) => string;
-	};
-	/** Tenant ID for multi-tenant instances. Forwarded to the permission record so executePermission can scope correctly. */
-	tenantId?: string;
+  endpoints: Record<string, unknown>
+  hooks: Record<string, unknown> | undefined
+  ctx: Record<string, unknown>
+  tree: Record<string, unknown>
+  pluginId: string
+  errorHandlers: CorsairErrorHandler
+  currentPath: string[]
+  keyBuilder?: CorsairKeyBuilderBase
+  /** Permission mode + per-endpoint overrides from plugin options. When set, every call is gated. */
+  permissionsConfig?: {
+    mode: PermissionMode
+    overrides?: Record<string, PermissionPolicy>
+  }
+  /** Risk level metadata per dot-notation endpoint path. Defaults riskLevel to 'write' when missing. */
+  endpointMeta?: Record<string, EndpointMetaEntry>
+  /** Required for 'require_approval' to persist the approval record to the DB. */
+  database?: CorsairDatabase
+  /** Approval timeout config from createCorsair({ approval: ... }). */
+  approvalConfig?: {
+    timeout: string
+    onTimeout: 'deny' | 'approve'
+    mode?:
+      | 'synchronous'
+      | 'asynchronous'
+      | (() => 'synchronous' | 'asynchronous')
+    /** Called when a permission is blocked in async mode. Return the message to throw to the LLM. */
+    formatAsyncMessage?: (opts: {
+      token: string
+      id: string
+      plugin: string
+      endpoint: string
+      args: unknown
+    }) => string
+  }
+  /** Tenant ID for multi-tenant instances. Forwarded to the permission record so executePermission can scope correctly. */
+  tenantId?: string
+  /** Connect link config for generating OAuth connect URLs when auth is missing. */
+  connectConfig?: {
+    baseUrl: string
+    redirectUri: string
+    onAuthMissing?: (opts: {
+      plugin: string
+      connectUrl: string
+      state: string
+    }) => string
+    oauthConfig?: any
+    kek?: string | undefined
+    tenantId?: string
+  }
 }): void {
-	for (const [key, value] of Object.entries(endpoints)) {
-		// we have to retype this now because it's nested webhooks
-		const nodeHooks = hooks?.[key] as Record<string, unknown> | undefined;
+  for (const [key, value] of Object.entries(endpoints)) {
+    // we have to retype this now because it's nested webhooks
+    const nodeHooks = hooks?.[key] as Record<string, unknown> | undefined
 
-		if (isEndpoint(value)) {
-			// it's an endpoint function - bind it with context and hooks
-			const endpointHooks = nodeHooks as EndpointHooks | undefined;
+    if (isEndpoint(value)) {
+      // it's an endpoint function - bind it with context and hooks
+      const endpointHooks = nodeHooks as EndpointHooks | undefined
 
-			const operationPath = [...currentPath, key].join('.');
+      const operationPath = [...currentPath, key].join('.')
 
-			const boundFn = async (args: unknown = {}) => {
-				// ── Permission guard ────────────────────────────────────────────────────────────────
-				let onPermissionComplete: (() => Promise<void>) | undefined;
-				if (permissionsConfig) {
-					const meta = endpointMeta?.[operationPath];
-					const {
-						result: permResult,
-						reason: permReason,
-						onComplete,
-						token: permToken,
-						id: permId,
-					} = await enforcePermission({
-						pluginId,
-						endpointPath: operationPath,
-						args,
-						mode: permissionsConfig.mode,
-						override: permissionsConfig.overrides?.[operationPath],
-						// Default to 'write' when no meta declared — conservative fallback
-						riskLevel: meta?.riskLevel ?? 'write',
-						meta,
-						db: database,
-						timeoutMs: approvalConfig
-							? parseDurationMs(approvalConfig.timeout)
-							: undefined,
-						tenantId,
-						approvalMode: approvalConfig?.mode,
-					});
-					if (permResult === 'blocked') {
-						let msg: string;
-						if (permReason === 'denied') {
-							msg = `Action '${operationPath}' was denied by the user. Await further instructions before proceeding.`;
-						} else if (permReason === 'policy') {
-							msg = `Action '${operationPath}' is blocked by the permission policy. Update the corsair config to allow it.`;
-						} else if (permReason === 'timeout') {
-							msg = `Action '${operationPath}' timed out waiting for approval.`;
-						} else if (
-							approvalConfig?.formatAsyncMessage &&
-							permToken &&
-							permId
-						) {
-							msg = approvalConfig.formatAsyncMessage({
-								token: permToken,
-								id: permId,
-								plugin: pluginId,
-								endpoint: operationPath,
-								args,
-							});
-						} else {
-							msg = `Action '${operationPath}' requires user approval before it can run.`;
-						}
-						throw new Error(msg);
-					}
-					onPermissionComplete = onComplete;
-				}
+      const boundFn = async (args: unknown = {}) => {
+        // ── Permission guard ────────────────────────────────────────────────────────────────
+        let onPermissionComplete: (() => Promise<void>) | undefined
+        if (permissionsConfig) {
+          const meta = endpointMeta?.[operationPath]
+          const {
+            result: permResult,
+            reason: permReason,
+            onComplete,
+            token: permToken,
+            id: permId,
+          } = await enforcePermission({
+            pluginId,
+            endpointPath: operationPath,
+            args,
+            mode: permissionsConfig.mode,
+            override: permissionsConfig.overrides?.[operationPath],
+            // Default to 'write' when no meta declared — conservative fallback
+            riskLevel: meta?.riskLevel ?? 'write',
+            meta,
+            db: database,
+            timeoutMs: approvalConfig
+              ? parseDurationMs(approvalConfig.timeout)
+              : undefined,
+            tenantId,
+            approvalMode: approvalConfig?.mode,
+          })
+          if (permResult === 'blocked') {
+            let msg: string
+            if (permReason === 'denied') {
+              msg = `Action '${operationPath}' was denied by the user. Await further instructions before proceeding.`
+            } else if (permReason === 'policy') {
+              msg = `Action '${operationPath}' is blocked by the permission policy. Update the corsair config to allow it.`
+            } else if (permReason === 'timeout') {
+              msg = `Action '${operationPath}' timed out waiting for approval.`
+            } else if (
+              approvalConfig?.formatAsyncMessage &&
+              permToken &&
+              permId
+            ) {
+              msg = approvalConfig.formatAsyncMessage({
+                token: permToken,
+                id: permId,
+                plugin: pluginId,
+                endpoint: operationPath,
+                args,
+              })
+            } else {
+              msg = `Action '${operationPath}' requires user approval before it can run.`
+            }
+            throw new Error(msg)
+          }
+          onPermissionComplete = onComplete
+        }
 
-				const call = async (
-					attemptNumber: number,
-					callCtx: Record<string, unknown>,
-					callArgs: unknown,
-				) => {
-					try {
-						return await value(callCtx, callArgs);
-					} catch (error) {
-						if (error instanceof Error) {
-							const retryStrategy = await handleCorsairError(
-								error,
-								pluginId,
-								operationPath,
-								typeof callArgs === 'object' && callArgs !== null
-									? (callArgs as Record<string, unknown>)
-									: { args: callArgs },
-								errorHandlers,
-							);
+        const call = async (
+          attemptNumber: number,
+          callCtx: Record<string, unknown>,
+          callArgs: unknown
+        ) => {
+          try {
+            return await value(callCtx, callArgs)
+          } catch (error) {
+            if (error instanceof Error) {
+              const retryStrategy = await handleCorsairError(
+                error,
+                pluginId,
+                operationPath,
+                typeof callArgs === 'object' && callArgs !== null
+                  ? (callArgs as Record<string, unknown>)
+                  : { args: callArgs },
+                errorHandlers
+              )
 
-							if (attemptNumber < (retryStrategy.maxRetries || 0)) {
-								const newAttempt = attemptNumber + 1;
+              if (attemptNumber < (retryStrategy.maxRetries || 0)) {
+                const newAttempt = attemptNumber + 1
 
-								console.log(
-									`Retrying (${newAttempt} / ${retryStrategy.maxRetries})...`,
-								);
+                console.log(
+                  `Retrying (${newAttempt} / ${retryStrategy.maxRetries})...`
+                )
 
-								let delayMs: number;
-								if (retryStrategy.headersRetryAfterMs) {
-									delayMs = retryStrategy.headersRetryAfterMs;
-								} else {
-									switch (retryStrategy.retryStrategy) {
-										case 'exponential_backoff':
-											delayMs = Math.pow(2, newAttempt - 1) * 1000;
-											break;
-										case 'exponential_backoff_jitter':
-											const baseDelay = Math.pow(2, newAttempt - 1) * 1000;
-											const jitter = (Math.random() - 0.5) * 1000;
-											delayMs = Math.max(0, baseDelay + jitter);
-											break;
-										case 'linear_1s':
-											delayMs = 1000;
-											break;
-										case 'linear_2s':
-											delayMs = 2000;
-											break;
-										case 'linear_3s':
-											delayMs = 3000;
-											break;
-										case 'linear_4s':
-											delayMs = 4000;
-											break;
-										default:
-											delayMs = 1000;
-											break;
-									}
-								}
+                let delayMs: number
+                if (retryStrategy.headersRetryAfterMs) {
+                  delayMs = retryStrategy.headersRetryAfterMs
+                } else {
+                  switch (retryStrategy.retryStrategy) {
+                    case 'exponential_backoff':
+                      delayMs = Math.pow(2, newAttempt - 1) * 1000
+                      break
+                    case 'exponential_backoff_jitter':
+                      const baseDelay = Math.pow(2, newAttempt - 1) * 1000
+                      const jitter = (Math.random() - 0.5) * 1000
+                      delayMs = Math.max(0, baseDelay + jitter)
+                      break
+                    case 'linear_1s':
+                      delayMs = 1000
+                      break
+                    case 'linear_2s':
+                      delayMs = 2000
+                      break
+                    case 'linear_3s':
+                      delayMs = 3000
+                      break
+                    case 'linear_4s':
+                      delayMs = 4000
+                      break
+                    default:
+                      delayMs = 1000
+                      break
+                  }
+                }
 
-								await new Promise((resolve) => setTimeout(resolve, delayMs));
-								await call(newAttempt, callCtx, callArgs);
+                await new Promise(resolve => setTimeout(resolve, delayMs))
+                await call(newAttempt, callCtx, callArgs)
 
-								console.log(
-									`[corsair:${pluginId}:${operationPath}] Retry strategy:`,
-									retryStrategy,
-								);
-							}
-						}
-						throw error;
-					}
-				};
+                console.log(
+                  `[corsair:${pluginId}:${operationPath}] Retry strategy:`,
+                  retryStrategy
+                )
+              }
+            }
+            throw error
+          }
+        }
 
-				const key = keyBuilder ? await keyBuilder(ctx, 'endpoint') : undefined;
+        let key: string | undefined
+        try {
+          key = keyBuilder ? await keyBuilder(ctx, 'endpoint') : undefined
+          if (!key && connectConfig?.oauthConfig && connectConfig.kek) {
+            throw new AuthMissingError(pluginId)
+          }
+        } catch (err) {
+          if (
+            connectConfig?.oauthConfig &&
+            connectConfig.kek &&
+            (err instanceof AuthMissingError ||
+              (err instanceof Error &&
+                /Account not found|No DEK found|\[auth-missing:/.test(
+                  err.message
+                )))
+          ) {
+            const state = signState(
+              encodeOAuthState(
+                pluginId,
+                connectConfig.tenantId ?? tenantId ?? 'default'
+              ),
+              connectConfig.kek
+            )
+            const connectUrl = `${connectConfig.baseUrl}?plugin=${encodeURIComponent(pluginId)}&state=${encodeURIComponent(state)}`
+            const msg = connectConfig.onAuthMissing
+              ? connectConfig.onAuthMissing({
+                  plugin: pluginId,
+                  connectUrl,
+                  state,
+                })
+              : `[auth-missing:${pluginId}] Authentication required. Direct the user to connect their account: ${connectUrl}`
+            throw new Error(msg)
+          }
+          throw err
+        }
 
-				if (!endpointHooks?.before && !endpointHooks?.after) {
-					const res = await call(0, { ...ctx, key }, args);
-					await onPermissionComplete?.();
-					return res;
-				}
+        if (!endpointHooks?.before && !endpointHooks?.after) {
+          const res = await call(0, { ...ctx, key }, args)
+          await onPermissionComplete?.()
+          return res
+        }
 
-				const ctxWithKey = { ...ctx, key };
-				const beforeResult = endpointHooks.before
-					? await endpointHooks.before(ctxWithKey, args)
-					: {
-							ctx: ctxWithKey,
-							args,
-							continue: true as const,
-							passToAfter: undefined,
-						};
-				if (beforeResult.continue === false) return;
-				const res = await call(0, beforeResult.ctx, beforeResult.args);
-				await endpointHooks.after?.(
-					beforeResult.ctx,
-					res,
-					beforeResult.passToAfter,
-				);
-				await onPermissionComplete?.();
-				return res;
-			};
+        const ctxWithKey = { ...ctx, key }
+        const beforeResult = endpointHooks.before
+          ? await endpointHooks.before(ctxWithKey, args)
+          : {
+              ctx: ctxWithKey,
+              args,
+              continue: true as const,
+              passToAfter: undefined,
+            }
+        if (beforeResult.continue === false) return
+        const res = await call(0, beforeResult.ctx, beforeResult.args)
+        await endpointHooks.after?.(
+          beforeResult.ctx,
+          res,
+          beforeResult.passToAfter
+        )
+        await onPermissionComplete?.()
+        return res
+      }
 
-			tree[key] = boundFn;
-		} else if (value && typeof value === 'object') {
-			// it's a nested object - recurse into it
-			const nestedTree: Record<string, unknown> = {};
+      tree[key] = boundFn
+    } else if (value && typeof value === 'object') {
+      // it's a nested object - recurse into it
+      const nestedTree: Record<string, unknown> = {}
 
-			bindEndpointsRecursively({
-				endpoints: value as Record<string, unknown>,
-				hooks: nodeHooks as Record<string, unknown> | undefined,
-				ctx,
-				tree: nestedTree,
-				pluginId,
-				errorHandlers,
-				currentPath: [...currentPath, key],
-				keyBuilder,
-				permissionsConfig,
-				endpointMeta,
-				database,
-				approvalConfig,
-				tenantId,
-			});
+      bindEndpointsRecursively({
+        endpoints: value as Record<string, unknown>,
+        hooks: nodeHooks as Record<string, unknown> | undefined,
+        ctx,
+        tree: nestedTree,
+        pluginId,
+        errorHandlers,
+        currentPath: [...currentPath, key],
+        keyBuilder,
+        permissionsConfig,
+        endpointMeta,
+        database,
+        approvalConfig,
+        tenantId,
+        connectConfig,
+      })
 
-			tree[key] = nestedTree;
-		}
-	}
+      tree[key] = nestedTree
+    }
+  }
 }

--- a/packages/corsair/core/index.ts
+++ b/packages/corsair/core/index.ts
@@ -1,48 +1,48 @@
-import type { CorsairDatabase } from '../db/kysely/database'
-import { createCorsairDatabase } from '../db/kysely/database'
-import { createMissingConfigProxy } from './auth/errors'
-import type { CorsairSingleTenantClient, CorsairTenantWrapper } from './client'
-import { buildCorsairClient, buildIntegrationKeys } from './client'
-import { buildPermissionsNamespace } from './permissions'
-import type { CorsairIntegration, CorsairPlugin } from './plugins'
+import type { CorsairDatabase } from '../db/kysely/database';
+import { createCorsairDatabase } from '../db/kysely/database';
+import { createMissingConfigProxy } from './auth/errors';
+import type { CorsairSingleTenantClient, CorsairTenantWrapper } from './client';
+import { buildCorsairClient, buildIntegrationKeys } from './client';
+import { buildPermissionsNamespace } from './permissions';
+import type { CorsairIntegration, CorsairPlugin } from './plugins';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Internal access for CLI tooling
 // ─────────────────────────────────────────────────────────────────────────────
 
-export const CORSAIR_INTERNAL = Symbol.for('corsair:internal')
+export const CORSAIR_INTERNAL = Symbol.for('corsair:internal');
 
 export type CorsairInternalConfig = {
-  plugins: readonly CorsairPlugin[]
-  database: CorsairDatabase | undefined
-  kek: string
-  multiTenancy: boolean
-  approval?: {
-    timeout: string
-    onTimeout: 'deny' | 'approve'
-    mode?:
-      | 'synchronous'
-      | 'asynchronous'
-      | (() => 'synchronous' | 'asynchronous')
-    /** Called when a permission is blocked in async mode. Return the message surfaced to the LLM. */
-    formatAsyncMessage?: (opts: {
-      token: string
-      id: string
-      plugin: string
-      endpoint: string
-      args: unknown
-    }) => string
-  }
-  connect?: {
-    baseUrl: string
-    redirectUri: string
-    onAuthMissing?: (opts: {
-      plugin: string
-      connectUrl: string
-      state: string
-    }) => string
-  }
-}
+	plugins: readonly CorsairPlugin[];
+	database: CorsairDatabase | undefined;
+	kek: string;
+	multiTenancy: boolean;
+	approval?: {
+		timeout: string;
+		onTimeout: 'deny' | 'approve';
+		mode?:
+			| 'synchronous'
+			| 'asynchronous'
+			| (() => 'synchronous' | 'asynchronous');
+		/** Called when a permission is blocked in async mode. Return the message surfaced to the LLM. */
+		formatAsyncMessage?: (opts: {
+			token: string;
+			id: string;
+			plugin: string;
+			endpoint: string;
+			args: unknown;
+		}) => string;
+	};
+	connect?: {
+		baseUrl: string;
+		redirectUri: string;
+		onAuthMissing?: (opts: {
+			plugin: string;
+			connectUrl: string;
+			state: string;
+		}) => string;
+	};
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Main Corsair Factory Functions
@@ -56,8 +56,8 @@ export type CorsairInternalConfig = {
  * @returns A tenant wrapper with `withTenant(tenantId)` method and integration-level `keys`
  */
 export function createCorsair<const Plugins extends readonly CorsairPlugin[]>(
-  config: CorsairIntegration<Plugins> & { multiTenancy: true }
-): CorsairTenantWrapper<Plugins>
+	config: CorsairIntegration<Plugins> & { multiTenancy: true },
+): CorsairTenantWrapper<Plugins>;
 
 /**
  * Creates a Corsair integration without multi-tenancy.
@@ -66,8 +66,8 @@ export function createCorsair<const Plugins extends readonly CorsairPlugin[]>(
  * @returns A Corsair client instance with plugin APIs and integration-level `keys`
  */
 export function createCorsair<const Plugins extends readonly CorsairPlugin[]>(
-  config: CorsairIntegration<Plugins> & { multiTenancy?: false | undefined }
-): CorsairSingleTenantClient<Plugins>
+	config: CorsairIntegration<Plugins> & { multiTenancy?: false | undefined },
+): CorsairSingleTenantClient<Plugins>;
 
 /**
  * Main factory function that creates a Corsair integration.
@@ -76,205 +76,205 @@ export function createCorsair<const Plugins extends readonly CorsairPlugin[]>(
  * @returns Either a direct client (with keys) or a tenant wrapper (with keys)
  */
 export function createCorsair<const Plugins extends readonly CorsairPlugin[]>(
-  config: CorsairIntegration<Plugins>
+	config: CorsairIntegration<Plugins>,
 ): CorsairSingleTenantClient<Plugins> | CorsairTenantWrapper<Plugins> {
-  const resolvedDatabase = config.database
-    ? createCorsairDatabase(config.database)
-    : undefined
+	const resolvedDatabase = config.database
+		? createCorsairDatabase(config.database)
+		: undefined;
 
-  // Build integration-level keys if database and kek are configured
-  // Otherwise create a proxy that throws helpful errors
-  type IntegrationKeysType = ReturnType<typeof buildIntegrationKeys<Plugins>>
+	// Build integration-level keys if database and kek are configured
+	// Otherwise create a proxy that throws helpful errors
+	type IntegrationKeysType = ReturnType<typeof buildIntegrationKeys<Plugins>>;
 
-  const integrationKeys: IntegrationKeysType =
-    resolvedDatabase && config.kek
-      ? buildIntegrationKeys(config.plugins, resolvedDatabase, config.kek)
-      : createMissingConfigProxy<IntegrationKeysType>(
-          !!resolvedDatabase,
-          !!config.kek
-        )
+	const integrationKeys: IntegrationKeysType =
+		resolvedDatabase && config.kek
+			? buildIntegrationKeys(config.plugins, resolvedDatabase, config.kek)
+			: createMissingConfigProxy<IntegrationKeysType>(
+					!!resolvedDatabase,
+					!!config.kek,
+				);
 
-  const internalConfig: CorsairInternalConfig = {
-    plugins: config.plugins,
-    database: resolvedDatabase,
-    kek: config.kek,
-    multiTenancy: !!config.multiTenancy,
-    approval: config.approval,
-    connect: config.connect,
-  }
+	const internalConfig: CorsairInternalConfig = {
+		plugins: config.plugins,
+		database: resolvedDatabase,
+		kek: config.kek,
+		multiTenancy: !!config.multiTenancy,
+		approval: config.approval,
+		connect: config.connect,
+	};
 
-  const permissions = buildPermissionsNamespace(resolvedDatabase)
+	const permissions = buildPermissionsNamespace(resolvedDatabase);
 
-  if (config.multiTenancy) {
-    return Object.assign(
-      {
-        withTenant: (tenantId: string) => {
-          if (!tenantId) {
-            throw new Error(
-              'corsair.withTenant(tenantId): tenantId must be a non-empty string'
-            )
-          }
-          const client = buildCorsairClient(config.plugins, {
-            database: resolvedDatabase,
-            tenantId,
-            kek: config.kek,
-            rootErrorHandlers: config.errorHandlers,
-            approvalConfig: config.approval,
-            connectConfig: config.connect,
-          })
-          return Object.assign(client as object, {
-            [CORSAIR_INTERNAL]: internalConfig,
-          }) as unknown as typeof client
-        },
-        keys: integrationKeys,
-        permissions,
-      },
-      { [CORSAIR_INTERNAL]: internalConfig }
-    )
-  }
+	if (config.multiTenancy) {
+		return Object.assign(
+			{
+				withTenant: (tenantId: string) => {
+					if (!tenantId) {
+						throw new Error(
+							'corsair.withTenant(tenantId): tenantId must be a non-empty string',
+						);
+					}
+					const client = buildCorsairClient(config.plugins, {
+						database: resolvedDatabase,
+						tenantId,
+						kek: config.kek,
+						rootErrorHandlers: config.errorHandlers,
+						approvalConfig: config.approval,
+						connectConfig: config.connect,
+					});
+					return Object.assign(client as object, {
+						[CORSAIR_INTERNAL]: internalConfig,
+					}) as unknown as typeof client;
+				},
+				keys: integrationKeys,
+				permissions,
+			},
+			{ [CORSAIR_INTERNAL]: internalConfig },
+		);
+	}
 
-  const client = buildCorsairClient(config.plugins, {
-    database: resolvedDatabase,
-    tenantId: undefined,
-    kek: config.kek,
-    rootErrorHandlers: config.errorHandlers,
-    approvalConfig: config.approval,
-    connectConfig: config.connect,
-  })
+	const client = buildCorsairClient(config.plugins, {
+		database: resolvedDatabase,
+		tenantId: undefined,
+		kek: config.kek,
+		rootErrorHandlers: config.errorHandlers,
+		approvalConfig: config.approval,
+		connectConfig: config.connect,
+	});
 
-  return Object.assign({}, client, {
-    keys: integrationKeys,
-    permissions,
-    [CORSAIR_INTERNAL]: internalConfig,
-  }) as CorsairSingleTenantClient<Plugins>
+	return Object.assign({}, client, {
+		keys: integrationKeys,
+		permissions,
+		[CORSAIR_INTERNAL]: internalConfig,
+	}) as CorsairSingleTenantClient<Plugins>;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Re-exports
 // ─────────────────────────────────────────────────────────────────────────────
 
-export type { EventLoggingContext } from '../plugins/utils/events'
+export type { EventLoggingContext } from '../plugins/utils/events';
 // Event logging utilities for plugins
-export { logEvent, logEventFromContext } from '../plugins/utils/events'
+export { logEvent, logEventFromContext } from '../plugins/utils/events';
 export type {
-  AccountFieldNames,
-  AccountKeyManagerFor,
-  BaseAuthFieldConfig,
-  BaseKeyManager,
-  IntegrationFieldNames,
-  IntegrationKeyManagerFor,
-  OAuth2IntegrationCredentials,
-  PluginAuthConfig,
-  TokenResponse,
-} from './auth'
+	AccountFieldNames,
+	AccountKeyManagerFor,
+	BaseAuthFieldConfig,
+	BaseKeyManager,
+	IntegrationFieldNames,
+	IntegrationKeyManagerFor,
+	OAuth2IntegrationCredentials,
+	PluginAuthConfig,
+	TokenResponse,
+} from './auth';
 // Auth utilities and types
 export {
-  AuthMissingError,
-  BASE_AUTH_FIELDS,
-  createAccountKeyManager,
-  createIntegrationKeyManager,
-  decryptConfig,
-  decryptDEK,
-  decryptWithDEK,
-  encryptConfig,
-  encryptDEK,
-  encryptWithDEK,
-  exchangeCodeForTokens,
-  generateDEK,
-  initializeAccountDEK,
-  initializeIntegrationDEK,
-  reEncryptConfig,
-} from './auth'
-// Connect link utilities
-export type { ResolveConnectLinkResult } from './connect'
-export { resolveConnectLink } from './connect'
+	AuthMissingError,
+	BASE_AUTH_FIELDS,
+	createAccountKeyManager,
+	createIntegrationKeyManager,
+	decryptConfig,
+	decryptDEK,
+	decryptWithDEK,
+	encryptConfig,
+	encryptDEK,
+	encryptWithDEK,
+	exchangeCodeForTokens,
+	generateDEK,
+	initializeAccountDEK,
+	initializeIntegrationDEK,
+	reEncryptConfig,
+} from './auth';
 // Core types
 export type {
-  CorsairClient,
-  CorsairSingleTenantClient,
-  CorsairTenantWrapper,
-} from './client'
+	CorsairClient,
+	CorsairSingleTenantClient,
+	CorsairTenantWrapper,
+} from './client';
+// Connect link utilities
+export type { ResolveConnectLinkResult } from './connect';
+export { resolveConnectLink } from './connect';
 // Constants
 export type {
-  AllProviders,
-  AuthTypes,
-  BaseProviders,
-  PickAuth,
-} from './constants'
+	AllProviders,
+	AuthTypes,
+	BaseProviders,
+	PickAuth,
+} from './constants';
 // Endpoint types
 export type {
-  BindEndpoints,
-  BoundEndpointFn,
-  BoundEndpointTree,
-  CorsairContext,
-  CorsairEndpoint,
-  EndpointPathsOf,
-  EndpointTree,
-} from './endpoints'
+	BindEndpoints,
+	BoundEndpointFn,
+	BoundEndpointTree,
+	CorsairContext,
+	CorsairEndpoint,
+	EndpointPathsOf,
+	EndpointTree,
+} from './endpoints';
 // Error handling types
 export type {
-  CorsairErrorHandler,
-  ErrorContext,
-  ErrorHandler,
-  ErrorHandlerAndMatchFunction,
-  ErrorMatcher,
-  RetryStrategies,
-  RetryStrategy,
-} from './errors'
+	CorsairErrorHandler,
+	ErrorContext,
+	ErrorHandler,
+	ErrorHandlerAndMatchFunction,
+	ErrorMatcher,
+	RetryStrategies,
+	RetryStrategy,
+} from './errors';
 // Inspection types
 export type {
-  DocSchemaFieldRow,
-  DocSchemaShape,
-  DocsApiEndpoint,
-  DocsDbEntity,
-  DocsDbFilterField,
-  DocsWebhook,
-  EndpointSchemaResult,
-  IntrospectPluginForDocsResult,
-  ListOperationsOptions,
-  PluginDocsIntrospection,
-} from './inspect'
-export { formatDocSchemaShape, introspectPluginForDocs } from './inspect'
+	DocSchemaFieldRow,
+	DocSchemaShape,
+	DocsApiEndpoint,
+	DocsDbEntity,
+	DocsDbFilterField,
+	DocsWebhook,
+	EndpointSchemaResult,
+	IntrospectPluginForDocsResult,
+	ListOperationsOptions,
+	PluginDocsIntrospection,
+} from './inspect';
+export { formatDocSchemaShape, introspectPluginForDocs } from './inspect';
 export type {
-  CorsairPermissionsNamespace,
-  EnforcePermissionOptions,
-  EnforcePermissionResult,
-} from './permissions'
+	CorsairPermissionsNamespace,
+	EnforcePermissionOptions,
+	EnforcePermissionResult,
+} from './permissions';
 // Plugin types
 export type {
-  BeforeHookResult,
-  CorsairIntegration,
-  CorsairKeyBuilder,
-  CorsairKeyBuilderBase,
-  CorsairPlugin,
-  CorsairPluginContext,
-  EndpointHooks,
-  EndpointMetaEntry,
-  EndpointRiskLevel,
-  KeyBuilderContext,
-  OAuthConfig,
-  PermissionMode,
-  PermissionPolicy,
-  PluginEndpointMeta,
-  PluginPermissionsConfig,
-  RequiredPluginEndpointMeta,
-  RequiredPluginEndpointSchemas,
-  RequiredPluginWebhookSchemas,
-  WebhookHooks,
-} from './plugins'
+	BeforeHookResult,
+	CorsairIntegration,
+	CorsairKeyBuilder,
+	CorsairKeyBuilderBase,
+	CorsairPlugin,
+	CorsairPluginContext,
+	EndpointHooks,
+	EndpointMetaEntry,
+	EndpointRiskLevel,
+	KeyBuilderContext,
+	OAuthConfig,
+	PermissionMode,
+	PermissionPolicy,
+	PluginEndpointMeta,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+	RequiredPluginWebhookSchemas,
+	WebhookHooks,
+} from './plugins';
 // Utility types
-export type { Bivariant, UnionToIntersection } from './utils'
+export type { Bivariant, UnionToIntersection } from './utils';
 // Webhook types
 export type {
-  BindWebhooks,
-  BoundWebhook,
-  BoundWebhookTree,
-  CorsairWebhook,
-  CorsairWebhookHandler,
-  CorsairWebhookMatcher,
-  RawWebhookRequest,
-  WebhookPathsOf,
-  WebhookRequest,
-  WebhookResponse,
-  WebhookTree,
-} from './webhooks'
+	BindWebhooks,
+	BoundWebhook,
+	BoundWebhookTree,
+	CorsairWebhook,
+	CorsairWebhookHandler,
+	CorsairWebhookMatcher,
+	RawWebhookRequest,
+	WebhookPathsOf,
+	WebhookRequest,
+	WebhookResponse,
+	WebhookTree,
+} from './webhooks';

--- a/packages/corsair/core/index.ts
+++ b/packages/corsair/core/index.ts
@@ -1,39 +1,48 @@
-import type { CorsairDatabase } from '../db/kysely/database';
-import { createCorsairDatabase } from '../db/kysely/database';
-import { createMissingConfigProxy } from './auth/errors';
-import type { CorsairSingleTenantClient, CorsairTenantWrapper } from './client';
-import { buildCorsairClient, buildIntegrationKeys } from './client';
-import { buildPermissionsNamespace } from './permissions';
-import type { CorsairIntegration, CorsairPlugin } from './plugins';
+import type { CorsairDatabase } from '../db/kysely/database'
+import { createCorsairDatabase } from '../db/kysely/database'
+import { createMissingConfigProxy } from './auth/errors'
+import type { CorsairSingleTenantClient, CorsairTenantWrapper } from './client'
+import { buildCorsairClient, buildIntegrationKeys } from './client'
+import { buildPermissionsNamespace } from './permissions'
+import type { CorsairIntegration, CorsairPlugin } from './plugins'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Internal access for CLI tooling
 // ─────────────────────────────────────────────────────────────────────────────
 
-export const CORSAIR_INTERNAL = Symbol.for('corsair:internal');
+export const CORSAIR_INTERNAL = Symbol.for('corsair:internal')
 
 export type CorsairInternalConfig = {
-	plugins: readonly CorsairPlugin[];
-	database: CorsairDatabase | undefined;
-	kek: string;
-	multiTenancy: boolean;
-	approval?: {
-		timeout: string;
-		onTimeout: 'deny' | 'approve';
-		mode?:
-			| 'synchronous'
-			| 'asynchronous'
-			| (() => 'synchronous' | 'asynchronous');
-		/** Called when a permission is blocked in async mode. Return the message surfaced to the LLM. */
-		formatAsyncMessage?: (opts: {
-			token: string;
-			id: string;
-			plugin: string;
-			endpoint: string;
-			args: unknown;
-		}) => string;
-	};
-};
+  plugins: readonly CorsairPlugin[]
+  database: CorsairDatabase | undefined
+  kek: string
+  multiTenancy: boolean
+  approval?: {
+    timeout: string
+    onTimeout: 'deny' | 'approve'
+    mode?:
+      | 'synchronous'
+      | 'asynchronous'
+      | (() => 'synchronous' | 'asynchronous')
+    /** Called when a permission is blocked in async mode. Return the message surfaced to the LLM. */
+    formatAsyncMessage?: (opts: {
+      token: string
+      id: string
+      plugin: string
+      endpoint: string
+      args: unknown
+    }) => string
+  }
+  connect?: {
+    baseUrl: string
+    redirectUri: string
+    onAuthMissing?: (opts: {
+      plugin: string
+      connectUrl: string
+      state: string
+    }) => string
+  }
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Main Corsair Factory Functions
@@ -47,8 +56,8 @@ export type CorsairInternalConfig = {
  * @returns A tenant wrapper with `withTenant(tenantId)` method and integration-level `keys`
  */
 export function createCorsair<const Plugins extends readonly CorsairPlugin[]>(
-	config: CorsairIntegration<Plugins> & { multiTenancy: true },
-): CorsairTenantWrapper<Plugins>;
+  config: CorsairIntegration<Plugins> & { multiTenancy: true }
+): CorsairTenantWrapper<Plugins>
 
 /**
  * Creates a Corsair integration without multi-tenancy.
@@ -57,8 +66,8 @@ export function createCorsair<const Plugins extends readonly CorsairPlugin[]>(
  * @returns A Corsair client instance with plugin APIs and integration-level `keys`
  */
 export function createCorsair<const Plugins extends readonly CorsairPlugin[]>(
-	config: CorsairIntegration<Plugins> & { multiTenancy?: false | undefined },
-): CorsairSingleTenantClient<Plugins>;
+  config: CorsairIntegration<Plugins> & { multiTenancy?: false | undefined }
+): CorsairSingleTenantClient<Plugins>
 
 /**
  * Main factory function that creates a Corsair integration.
@@ -67,198 +76,205 @@ export function createCorsair<const Plugins extends readonly CorsairPlugin[]>(
  * @returns Either a direct client (with keys) or a tenant wrapper (with keys)
  */
 export function createCorsair<const Plugins extends readonly CorsairPlugin[]>(
-	config: CorsairIntegration<Plugins>,
+  config: CorsairIntegration<Plugins>
 ): CorsairSingleTenantClient<Plugins> | CorsairTenantWrapper<Plugins> {
-	const resolvedDatabase = config.database
-		? createCorsairDatabase(config.database)
-		: undefined;
+  const resolvedDatabase = config.database
+    ? createCorsairDatabase(config.database)
+    : undefined
 
-	// Build integration-level keys if database and kek are configured
-	// Otherwise create a proxy that throws helpful errors
-	type IntegrationKeysType = ReturnType<typeof buildIntegrationKeys<Plugins>>;
+  // Build integration-level keys if database and kek are configured
+  // Otherwise create a proxy that throws helpful errors
+  type IntegrationKeysType = ReturnType<typeof buildIntegrationKeys<Plugins>>
 
-	const integrationKeys: IntegrationKeysType =
-		resolvedDatabase && config.kek
-			? buildIntegrationKeys(config.plugins, resolvedDatabase, config.kek)
-			: createMissingConfigProxy<IntegrationKeysType>(
-					!!resolvedDatabase,
-					!!config.kek,
-				);
+  const integrationKeys: IntegrationKeysType =
+    resolvedDatabase && config.kek
+      ? buildIntegrationKeys(config.plugins, resolvedDatabase, config.kek)
+      : createMissingConfigProxy<IntegrationKeysType>(
+          !!resolvedDatabase,
+          !!config.kek
+        )
 
-	const internalConfig: CorsairInternalConfig = {
-		plugins: config.plugins,
-		database: resolvedDatabase,
-		kek: config.kek,
-		multiTenancy: !!config.multiTenancy,
-		approval: config.approval,
-	};
+  const internalConfig: CorsairInternalConfig = {
+    plugins: config.plugins,
+    database: resolvedDatabase,
+    kek: config.kek,
+    multiTenancy: !!config.multiTenancy,
+    approval: config.approval,
+    connect: config.connect,
+  }
 
-	const permissions = buildPermissionsNamespace(resolvedDatabase);
+  const permissions = buildPermissionsNamespace(resolvedDatabase)
 
-	if (config.multiTenancy) {
-		return Object.assign(
-			{
-				withTenant: (tenantId: string) => {
-					if (!tenantId) {
-						throw new Error(
-							'corsair.withTenant(tenantId): tenantId must be a non-empty string',
-						);
-					}
-					const client = buildCorsairClient(config.plugins, {
-						database: resolvedDatabase,
-						tenantId,
-						kek: config.kek,
-						rootErrorHandlers: config.errorHandlers,
-						approvalConfig: config.approval,
-					});
-					return Object.assign(client as object, {
-						[CORSAIR_INTERNAL]: internalConfig,
-					}) as unknown as typeof client;
-				},
-				keys: integrationKeys,
-				permissions,
-			},
-			{ [CORSAIR_INTERNAL]: internalConfig },
-		);
-	}
+  if (config.multiTenancy) {
+    return Object.assign(
+      {
+        withTenant: (tenantId: string) => {
+          if (!tenantId) {
+            throw new Error(
+              'corsair.withTenant(tenantId): tenantId must be a non-empty string'
+            )
+          }
+          const client = buildCorsairClient(config.plugins, {
+            database: resolvedDatabase,
+            tenantId,
+            kek: config.kek,
+            rootErrorHandlers: config.errorHandlers,
+            approvalConfig: config.approval,
+            connectConfig: config.connect,
+          })
+          return Object.assign(client as object, {
+            [CORSAIR_INTERNAL]: internalConfig,
+          }) as unknown as typeof client
+        },
+        keys: integrationKeys,
+        permissions,
+      },
+      { [CORSAIR_INTERNAL]: internalConfig }
+    )
+  }
 
-	const client = buildCorsairClient(config.plugins, {
-		database: resolvedDatabase,
-		tenantId: undefined,
-		kek: config.kek,
-		rootErrorHandlers: config.errorHandlers,
-		approvalConfig: config.approval,
-	});
+  const client = buildCorsairClient(config.plugins, {
+    database: resolvedDatabase,
+    tenantId: undefined,
+    kek: config.kek,
+    rootErrorHandlers: config.errorHandlers,
+    approvalConfig: config.approval,
+    connectConfig: config.connect,
+  })
 
-	return Object.assign({}, client, {
-		keys: integrationKeys,
-		permissions,
-		[CORSAIR_INTERNAL]: internalConfig,
-	}) as CorsairSingleTenantClient<Plugins>;
+  return Object.assign({}, client, {
+    keys: integrationKeys,
+    permissions,
+    [CORSAIR_INTERNAL]: internalConfig,
+  }) as CorsairSingleTenantClient<Plugins>
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Re-exports
 // ─────────────────────────────────────────────────────────────────────────────
 
-export type { EventLoggingContext } from '../plugins/utils/events';
+export type { EventLoggingContext } from '../plugins/utils/events'
 // Event logging utilities for plugins
-export { logEvent, logEventFromContext } from '../plugins/utils/events';
+export { logEvent, logEventFromContext } from '../plugins/utils/events'
 export type {
-	AccountFieldNames,
-	AccountKeyManagerFor,
-	BaseAuthFieldConfig,
-	BaseKeyManager,
-	IntegrationFieldNames,
-	IntegrationKeyManagerFor,
-	OAuth2IntegrationCredentials,
-	PluginAuthConfig,
-	TokenResponse,
-} from './auth';
+  AccountFieldNames,
+  AccountKeyManagerFor,
+  BaseAuthFieldConfig,
+  BaseKeyManager,
+  IntegrationFieldNames,
+  IntegrationKeyManagerFor,
+  OAuth2IntegrationCredentials,
+  PluginAuthConfig,
+  TokenResponse,
+} from './auth'
 // Auth utilities and types
 export {
-	BASE_AUTH_FIELDS,
-	createAccountKeyManager,
-	createIntegrationKeyManager,
-	decryptConfig,
-	decryptDEK,
-	decryptWithDEK,
-	encryptConfig,
-	encryptDEK,
-	encryptWithDEK,
-	exchangeCodeForTokens,
-	generateDEK,
-	initializeAccountDEK,
-	initializeIntegrationDEK,
-	reEncryptConfig,
-} from './auth';
+  AuthMissingError,
+  BASE_AUTH_FIELDS,
+  createAccountKeyManager,
+  createIntegrationKeyManager,
+  decryptConfig,
+  decryptDEK,
+  decryptWithDEK,
+  encryptConfig,
+  encryptDEK,
+  encryptWithDEK,
+  exchangeCodeForTokens,
+  generateDEK,
+  initializeAccountDEK,
+  initializeIntegrationDEK,
+  reEncryptConfig,
+} from './auth'
+// Connect link utilities
+export type { ResolveConnectLinkResult } from './connect'
+export { resolveConnectLink } from './connect'
 // Core types
 export type {
-	CorsairClient,
-	CorsairSingleTenantClient,
-	CorsairTenantWrapper,
-} from './client';
+  CorsairClient,
+  CorsairSingleTenantClient,
+  CorsairTenantWrapper,
+} from './client'
 // Constants
 export type {
-	AllProviders,
-	AuthTypes,
-	BaseProviders,
-	PickAuth,
-} from './constants';
+  AllProviders,
+  AuthTypes,
+  BaseProviders,
+  PickAuth,
+} from './constants'
 // Endpoint types
 export type {
-	BindEndpoints,
-	BoundEndpointFn,
-	BoundEndpointTree,
-	CorsairContext,
-	CorsairEndpoint,
-	EndpointPathsOf,
-	EndpointTree,
-} from './endpoints';
+  BindEndpoints,
+  BoundEndpointFn,
+  BoundEndpointTree,
+  CorsairContext,
+  CorsairEndpoint,
+  EndpointPathsOf,
+  EndpointTree,
+} from './endpoints'
 // Error handling types
 export type {
-	CorsairErrorHandler,
-	ErrorContext,
-	ErrorHandler,
-	ErrorHandlerAndMatchFunction,
-	ErrorMatcher,
-	RetryStrategies,
-	RetryStrategy,
-} from './errors';
+  CorsairErrorHandler,
+  ErrorContext,
+  ErrorHandler,
+  ErrorHandlerAndMatchFunction,
+  ErrorMatcher,
+  RetryStrategies,
+  RetryStrategy,
+} from './errors'
 // Inspection types
 export type {
-	DocSchemaFieldRow,
-	DocSchemaShape,
-	DocsApiEndpoint,
-	DocsDbEntity,
-	DocsDbFilterField,
-	DocsWebhook,
-	EndpointSchemaResult,
-	IntrospectPluginForDocsResult,
-	ListOperationsOptions,
-	PluginDocsIntrospection,
-} from './inspect';
-export { formatDocSchemaShape, introspectPluginForDocs } from './inspect';
+  DocSchemaFieldRow,
+  DocSchemaShape,
+  DocsApiEndpoint,
+  DocsDbEntity,
+  DocsDbFilterField,
+  DocsWebhook,
+  EndpointSchemaResult,
+  IntrospectPluginForDocsResult,
+  ListOperationsOptions,
+  PluginDocsIntrospection,
+} from './inspect'
+export { formatDocSchemaShape, introspectPluginForDocs } from './inspect'
 export type {
-	CorsairPermissionsNamespace,
-	EnforcePermissionOptions,
-	EnforcePermissionResult,
-} from './permissions';
+  CorsairPermissionsNamespace,
+  EnforcePermissionOptions,
+  EnforcePermissionResult,
+} from './permissions'
 // Plugin types
 export type {
-	BeforeHookResult,
-	CorsairIntegration,
-	CorsairKeyBuilder,
-	CorsairKeyBuilderBase,
-	CorsairPlugin,
-	CorsairPluginContext,
-	EndpointHooks,
-	EndpointMetaEntry,
-	EndpointRiskLevel,
-	KeyBuilderContext,
-	OAuthConfig,
-	PermissionMode,
-	PermissionPolicy,
-	PluginEndpointMeta,
-	PluginPermissionsConfig,
-	RequiredPluginEndpointMeta,
-	RequiredPluginEndpointSchemas,
-	RequiredPluginWebhookSchemas,
-	WebhookHooks,
-} from './plugins';
+  BeforeHookResult,
+  CorsairIntegration,
+  CorsairKeyBuilder,
+  CorsairKeyBuilderBase,
+  CorsairPlugin,
+  CorsairPluginContext,
+  EndpointHooks,
+  EndpointMetaEntry,
+  EndpointRiskLevel,
+  KeyBuilderContext,
+  OAuthConfig,
+  PermissionMode,
+  PermissionPolicy,
+  PluginEndpointMeta,
+  PluginPermissionsConfig,
+  RequiredPluginEndpointMeta,
+  RequiredPluginEndpointSchemas,
+  RequiredPluginWebhookSchemas,
+  WebhookHooks,
+} from './plugins'
 // Utility types
-export type { Bivariant, UnionToIntersection } from './utils';
+export type { Bivariant, UnionToIntersection } from './utils'
 // Webhook types
 export type {
-	BindWebhooks,
-	BoundWebhook,
-	BoundWebhookTree,
-	CorsairWebhook,
-	CorsairWebhookHandler,
-	CorsairWebhookMatcher,
-	RawWebhookRequest,
-	WebhookPathsOf,
-	WebhookRequest,
-	WebhookResponse,
-	WebhookTree,
-} from './webhooks';
+  BindWebhooks,
+  BoundWebhook,
+  BoundWebhookTree,
+  CorsairWebhook,
+  CorsairWebhookHandler,
+  CorsairWebhookMatcher,
+  RawWebhookRequest,
+  WebhookPathsOf,
+  WebhookRequest,
+  WebhookResponse,
+  WebhookTree,
+} from './webhooks'

--- a/packages/corsair/core/plugins/index.ts
+++ b/packages/corsair/core/plugins/index.ts
@@ -1,27 +1,27 @@
-import type { ZodTypeAny } from 'zod';
-import type { CorsairDatabaseInput } from '../../db/kysely/database';
-import type { CorsairPluginSchema } from '../../db/orm';
-import type { AccountKeyManagerFor, PluginAuthConfig } from '../auth/types';
-import type { ExtractAuthType, InferPluginEntities } from '../client';
-import type { AllProviders, AuthTypes } from '../constants';
+import type { ZodTypeAny } from 'zod'
+import type { CorsairDatabaseInput } from '../../db/kysely/database'
+import type { CorsairPluginSchema } from '../../db/orm'
+import type { AccountKeyManagerFor, PluginAuthConfig } from '../auth/types'
+import type { ExtractAuthType, InferPluginEntities } from '../client'
+import type { AllProviders, AuthTypes } from '../constants'
 import type {
-	BindEndpoints,
-	BoundEndpointTree,
-	CorsairContext,
-	CorsairEndpoint,
-	EndpointPathsOf,
-	EndpointTree,
-} from '../endpoints';
-import type { CorsairErrorHandler } from '../errors';
+  BindEndpoints,
+  BoundEndpointTree,
+  CorsairContext,
+  CorsairEndpoint,
+  EndpointPathsOf,
+  EndpointTree,
+} from '../endpoints'
+import type { CorsairErrorHandler } from '../errors'
 import type {
-	CorsairWebhook,
-	CorsairWebhookHandler,
-	CorsairWebhookMatcher,
-	WebhookPathsOf,
-	WebhookRequest,
-	WebhookResponse,
-	WebhookTree,
-} from '../webhooks';
+  CorsairWebhook,
+  CorsairWebhookHandler,
+  CorsairWebhookMatcher,
+  WebhookPathsOf,
+  WebhookRequest,
+  WebhookResponse,
+  WebhookTree,
+} from '../webhooks'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Permission System Types
@@ -31,7 +31,7 @@ import type {
  * Risk level classification for plugin endpoints.
  * The permission mode maps each risk level to a policy (allow / deny / require_approval).
  */
-export type EndpointRiskLevel = 'read' | 'write' | 'destructive';
+export type EndpointRiskLevel = 'read' | 'write' | 'destructive'
 
 /**
  * Permission mode controlling what the AI agent is allowed to do by default.
@@ -43,7 +43,7 @@ export type EndpointRiskLevel = 'read' | 'write' | 'destructive';
  * | strict   | allow | require_approval | deny                |
  * | readonly | allow | deny             | deny                |
  */
-export type PermissionMode = 'open' | 'cautious' | 'strict' | 'readonly';
+export type PermissionMode = 'open' | 'cautious' | 'strict' | 'readonly'
 
 /**
  * The resolved policy for a specific endpoint after combining mode + overrides.
@@ -51,26 +51,26 @@ export type PermissionMode = 'open' | 'cautious' | 'strict' | 'readonly';
  * - `deny`             → returns a denied response, does not call the API
  * - `require_approval` → stores a pending approval, returns a review URL to the agent
  */
-export type PermissionPolicy = 'allow' | 'deny' | 'require_approval';
+export type PermissionPolicy = 'allow' | 'deny' | 'require_approval'
 
 /**
  * Metadata for a single endpoint entry. Drives permission decisions and MCP tool descriptions.
  * Plugin authors populate this on the `endpointMeta` field of their plugin definition.
  */
 export type EndpointMetaEntry = {
-	/** Risk classification — determines the default policy given the active permission mode. */
-	riskLevel: EndpointRiskLevel;
-	/**
-	 * If true, this action cannot be undone. Shown prominently on the approval review page
-	 * and in the MCP tool description so the agent can warn users proactively.
-	 */
-	irreversible?: boolean;
-	/**
-	 * Human-readable description of what this endpoint does.
-	 * Included in the MCP tool description surfaced to the AI agent.
-	 */
-	description?: string;
-};
+  /** Risk classification — determines the default policy given the active permission mode. */
+  riskLevel: EndpointRiskLevel
+  /**
+   * If true, this action cannot be undone. Shown prominently on the approval review page
+   * and in the MCP tool description so the agent can warn users proactively.
+   */
+  irreversible?: boolean
+  /**
+   * Human-readable description of what this endpoint does.
+   * Included in the MCP tool description surfaced to the AI agent.
+   */
+  description?: string
+}
 
 /**
  * A partial map from dot-notation endpoint paths to their metadata entries.
@@ -80,8 +80,8 @@ export type EndpointMetaEntry = {
  * @template T - The plugin's endpoint tree (e.g. `typeof githubEndpointsNested`)
  */
 export type PluginEndpointMeta<T extends EndpointTree> = Partial<
-	Record<EndpointPathsOf<T>, EndpointMetaEntry>
->;
+  Record<EndpointPathsOf<T>, EndpointMetaEntry>
+>
 
 /**
  * A **required** map from dot-notation endpoint paths to their metadata entries.
@@ -92,9 +92,9 @@ export type PluginEndpointMeta<T extends EndpointTree> = Partial<
  * @template T - The plugin's endpoint tree (e.g. `typeof githubEndpointsNested`)
  */
 export type RequiredPluginEndpointMeta<T extends EndpointTree> = Record<
-	EndpointPathsOf<T>,
-	EndpointMetaEntry
->;
+  EndpointPathsOf<T>,
+  EndpointMetaEntry
+>
 
 /**
  * A **required** map from dot-notation endpoint paths to their `{ input, output }` schema
@@ -105,9 +105,9 @@ export type RequiredPluginEndpointMeta<T extends EndpointTree> = Record<
  * @template T - The plugin's endpoint tree (e.g. `typeof githubEndpointsNested`)
  */
 export type RequiredPluginEndpointSchemas<T extends EndpointTree> = Record<
-	EndpointPathsOf<T>,
-	{ input?: ZodTypeAny; output?: ZodTypeAny }
->;
+  EndpointPathsOf<T>,
+  { input?: ZodTypeAny; output?: ZodTypeAny }
+>
 
 /**
  * A **required** map from dot-notation webhook paths to their `{ description, payload, response }`
@@ -118,9 +118,9 @@ export type RequiredPluginEndpointSchemas<T extends EndpointTree> = Record<
  * @template T - The plugin's webhook tree (e.g. `typeof slackWebhooksNested`)
  */
 export type RequiredPluginWebhookSchemas<T extends WebhookTree> = Record<
-	WebhookPathsOf<T>,
-	{ description?: string; payload?: ZodTypeAny; response?: ZodTypeAny }
->;
+  WebhookPathsOf<T>,
+  { description?: string; payload?: ZodTypeAny; response?: ZodTypeAny }
+>
 
 /**
  * Permission configuration for a plugin, passed as `permissions` in the plugin options.
@@ -146,15 +146,15 @@ export type RequiredPluginWebhookSchemas<T extends WebhookTree> = Record<
  * ```
  */
 export type PluginPermissionsConfig<T extends EndpointTree = EndpointTree> = {
-	/** The default permission mode for all endpoints in this plugin. */
-	mode: PermissionMode;
-	/**
-	 * Per-endpoint policy overrides.
-	 * Keys are strongly-typed dot-notation paths through this plugin's endpoint tree.
-	 * Only valid paths for this specific plugin compile — typos are type errors.
-	 */
-	overrides?: Partial<Record<EndpointPathsOf<T>, PermissionPolicy>>;
-};
+  /** The default permission mode for all endpoints in this plugin. */
+  mode: PermissionMode
+  /**
+   * Per-endpoint policy overrides.
+   * Keys are strongly-typed dot-notation paths through this plugin's endpoint tree.
+   * Only valid paths for this specific plugin compile — typos are type errors.
+   */
+  overrides?: Partial<Record<EndpointPathsOf<T>, PermissionPolicy>>
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Hook Types for Endpoints
@@ -163,111 +163,108 @@ export type PluginPermissionsConfig<T extends EndpointTree = EndpointTree> = {
 /**
  * Extracts the context type from an endpoint function.
  */
-type EndpointContext<E> = E extends CorsairEndpoint<infer Ctx, any, any>
-	? Ctx
-	: never;
+type EndpointContext<E> =
+  E extends CorsairEndpoint<infer Ctx, any, any> ? Ctx : never
 
 /**
  * Extracts the arguments type from an endpoint function.
  */
-type EndpointArgs<E> = E extends CorsairEndpoint<any, infer Args, any>
-	? Args
-	: never;
+type EndpointArgs<E> =
+  E extends CorsairEndpoint<any, infer Args, any> ? Args : never
 
 /**
  * Extracts the return type from an endpoint function.
  */
-type EndpointResult<E> = E extends CorsairEndpoint<any, any, infer Res>
-	? Res
-	: never;
+type EndpointResult<E> =
+  E extends CorsairEndpoint<any, any, infer Res> ? Res : never
 
 /**
  * Return type for the before hook, containing optionally updated context and args.
  */
 export type BeforeHookResult<Ctx, Args> = {
-	ctx: Ctx;
-	args: Args;
-	continue?: boolean;
-	passToAfter?: string;
-};
+  ctx: Ctx
+  args: Args
+  continue?: boolean
+  passToAfter?: string
+}
 
 /**
  * Type for endpoint hooks used internally by the bind function.
  */
 export type EndpointHooks = {
-	before?: (
-		ctx: Record<string, unknown>,
-		args: unknown,
-	) =>
-		| BeforeHookResult<Record<string, unknown>, unknown>
-		| Promise<BeforeHookResult<Record<string, unknown>, unknown>>;
-	after?: (
-		ctx: Record<string, unknown>,
-		res: unknown,
-		passToAfter?: string,
-	) => void | Promise<void>;
-};
+  before?: (
+    ctx: Record<string, unknown>,
+    args: unknown
+  ) =>
+    | BeforeHookResult<Record<string, unknown>, unknown>
+    | Promise<BeforeHookResult<Record<string, unknown>, unknown>>
+  after?: (
+    ctx: Record<string, unknown>,
+    res: unknown,
+    passToAfter?: string
+  ) => void | Promise<void>
+}
 
 /**
  * Type for webhook hooks used internally by the bind function.
  */
 export type WebhookHooks = {
-	before?: (
-		ctx: Record<string, unknown>,
-		request: unknown,
-	) =>
-		| BeforeHookResult<Record<string, unknown>, unknown>
-		| Promise<BeforeHookResult<Record<string, unknown>, unknown>>;
-	after?: (
-		ctx: Record<string, unknown>,
-		response: unknown,
-		passToAfter?: string,
-	) => void | Promise<void>;
-};
+  before?: (
+    ctx: Record<string, unknown>,
+    request: unknown
+  ) =>
+    | BeforeHookResult<Record<string, unknown>, unknown>
+    | Promise<BeforeHookResult<Record<string, unknown>, unknown>>
+  after?: (
+    ctx: Record<string, unknown>,
+    response: unknown,
+    passToAfter?: string
+  ) => void | Promise<void>
+}
 
 /**
  * Recursively maps an endpoint tree to a hooks map with the same structure.
  * Each endpoint gets optional before/after hooks.
  */
 type CorsairEndpointHooksMap<Endpoints extends EndpointTree> = {
-	[K in keyof Endpoints]?: Endpoints[K] extends CorsairEndpoint
-		? {
-				/**
-				 * Hook that runs before the endpoint is executed.
-				 * @param ctx - The endpoint context
-				 * @param args - The endpoint arguments
-				 * @returns An object containing the updated context and args to pass to the endpoint
-				 */
-				before?: (
-					ctx: EndpointContext<Endpoints[K]>,
-					args: EndpointArgs<Endpoints[K]>,
-				) =>
-					| BeforeHookResult<
-							EndpointContext<Endpoints[K]>,
-							EndpointArgs<Endpoints[K]>
-					  >
-					| Promise<
-							BeforeHookResult<
-								EndpointContext<Endpoints[K]>,
-								EndpointArgs<Endpoints[K]>
-							>
-					  >;
-				/**
-				 * Hook that runs after the endpoint is executed.
-				 * @param ctx - The endpoint context
-				 * @param res - The endpoint result
-				 * @param passToAfter - Optional string passed from the before hook
-				 */
-				after?: (
-					ctx: EndpointContext<Endpoints[K]>,
-					res: EndpointResult<Endpoints[K]>,
-					passToAfter?: string,
-				) => void | Promise<void>;
-			}
-		: Endpoints[K] extends EndpointTree
-			? CorsairEndpointHooksMap<Endpoints[K]>
-			: never;
-};
+  [K in keyof Endpoints]?: Endpoints[K] extends CorsairEndpoint
+    ? {
+        /**
+         * Hook that runs before the endpoint is executed.
+         * @param ctx - The endpoint context
+         * @param args - The endpoint arguments
+         * @returns An object containing the updated context and args to pass to the endpoint
+         */
+        before?: (
+          ctx: EndpointContext<Endpoints[K]>,
+          args: EndpointArgs<Endpoints[K]>
+        ) =>
+          | BeforeHookResult<
+              EndpointContext<Endpoints[K]>,
+              EndpointArgs<Endpoints[K]>
+            >
+          | Promise<
+              BeforeHookResult<
+                EndpointContext<Endpoints[K]>,
+                EndpointArgs<Endpoints[K]>
+              >
+            >
+        /**
+         * Hook that runs after the endpoint is executed.
+         * @param ctx - The endpoint context
+         * @param res - The endpoint result
+         * @param passToAfter - Optional string passed from the before hook
+         */
+        after?: (
+          ctx: EndpointContext<Endpoints[K]>,
+          res: EndpointResult<Endpoints[K]>,
+          passToAfter?: string
+        ) => void | Promise<void>
+      }
+    : Endpoints[K] extends EndpointTree
+      ? CorsairEndpointHooksMap<Endpoints[K]>
+      : never
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Hook Types for Webhooks
@@ -276,73 +273,76 @@ type CorsairEndpointHooksMap<Endpoints extends EndpointTree> = {
 /**
  * Extracts the context type from a webhook handler.
  */
-type WebhookContext<W> = W extends CorsairWebhook<infer Ctx, any, any>
-	? Ctx
-	: W extends { handler: CorsairWebhookHandler<infer Ctx, any, any> }
-		? Ctx
-		: never;
+type WebhookContext<W> =
+  W extends CorsairWebhook<infer Ctx, any, any>
+    ? Ctx
+    : W extends { handler: CorsairWebhookHandler<infer Ctx, any, any> }
+      ? Ctx
+      : never
 
 /**
  * Extracts the payload type from a webhook handler.
  */
-type WebhookPayload<W> = W extends CorsairWebhook<any, infer P, any>
-	? P
-	: W extends { handler: CorsairWebhookHandler<any, infer P, any> }
-		? P
-		: never;
+type WebhookPayload<W> =
+  W extends CorsairWebhook<any, infer P, any>
+    ? P
+    : W extends { handler: CorsairWebhookHandler<any, infer P, any> }
+      ? P
+      : never
 
 /**
  * Extracts the response data type from a webhook handler.
  */
-type WebhookResponseData<W> = W extends CorsairWebhook<any, any, infer R>
-	? R
-	: W extends { handler: CorsairWebhookHandler<any, any, infer R> }
-		? R
-		: never;
+type WebhookResponseData<W> =
+  W extends CorsairWebhook<any, any, infer R>
+    ? R
+    : W extends { handler: CorsairWebhookHandler<any, any, infer R> }
+      ? R
+      : never
 
 /**
  * Recursively maps a webhook tree to a hooks map with the same structure.
  * Each webhook gets optional before/after hooks.
  */
 type CorsairWebhookHooksMap<Webhooks extends WebhookTree> = {
-	[K in keyof Webhooks]?: Webhooks[K] extends CorsairWebhook<any, any, any>
-		? {
-				/**
-				 * Hook that runs before the webhook is processed.
-				 * @param ctx - The webhook context
-				 * @param request - The webhook request
-				 * @returns An object containing the updated context and request to pass to the webhook handler
-				 */
-				before?: (
-					ctx: WebhookContext<Webhooks[K]>,
-					request: WebhookRequest<WebhookPayload<Webhooks[K]>>,
-				) =>
-					| BeforeHookResult<
-							WebhookContext<Webhooks[K]>,
-							WebhookRequest<WebhookPayload<Webhooks[K]>>
-					  >
-					| Promise<
-							BeforeHookResult<
-								WebhookContext<Webhooks[K]>,
-								WebhookRequest<WebhookPayload<Webhooks[K]>>
-							>
-					  >;
-				/**
-				 * Hook that runs after the webhook is processed.
-				 * @param ctx - The webhook context
-				 * @param response - The webhook response
-				 * @param passToAfter - Optional string passed from the before hook
-				 */
-				after?: (
-					ctx: WebhookContext<Webhooks[K]>,
-					response: WebhookResponse<WebhookResponseData<Webhooks[K]>>,
-					passToAfter?: string,
-				) => void | Promise<void>;
-			}
-		: Webhooks[K] extends WebhookTree
-			? CorsairWebhookHooksMap<Webhooks[K]>
-			: never;
-};
+  [K in keyof Webhooks]?: Webhooks[K] extends CorsairWebhook<any, any, any>
+    ? {
+        /**
+         * Hook that runs before the webhook is processed.
+         * @param ctx - The webhook context
+         * @param request - The webhook request
+         * @returns An object containing the updated context and request to pass to the webhook handler
+         */
+        before?: (
+          ctx: WebhookContext<Webhooks[K]>,
+          request: WebhookRequest<WebhookPayload<Webhooks[K]>>
+        ) =>
+          | BeforeHookResult<
+              WebhookContext<Webhooks[K]>,
+              WebhookRequest<WebhookPayload<Webhooks[K]>>
+            >
+          | Promise<
+              BeforeHookResult<
+                WebhookContext<Webhooks[K]>,
+                WebhookRequest<WebhookPayload<Webhooks[K]>>
+              >
+            >
+        /**
+         * Hook that runs after the webhook is processed.
+         * @param ctx - The webhook context
+         * @param response - The webhook response
+         * @param passToAfter - Optional string passed from the before hook
+         */
+        after?: (
+          ctx: WebhookContext<Webhooks[K]>,
+          response: WebhookResponse<WebhookResponseData<Webhooks[K]>>,
+          passToAfter?: string
+        ) => void | Promise<void>
+      }
+    : Webhooks[K] extends WebhookTree
+      ? CorsairWebhookHooksMap<Webhooks[K]>
+      : never
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Plugin Types
@@ -353,10 +353,10 @@ type CorsairWebhookHooksMap<Webhooks extends WebhookTree> = {
  * Used for internal types like KeyBuilderContext where all auth types must be handled.
  */
 type ExtractAllAuthTypes<Options> = 'authType' extends keyof Options
-	? NonNullable<Options['authType']> extends AuthTypes
-		? NonNullable<Options['authType']>
-		: never
-	: never;
+  ? NonNullable<Options['authType']> extends AuthTypes
+    ? NonNullable<Options['authType']>
+    : never
+  : never
 
 /**
  * Context passed to keyBuilder as a discriminated union.
@@ -380,20 +380,21 @@ type ExtractAllAuthTypes<Options> = 'authType' extends keyof Options
  * ```
  */
 export type KeyBuilderContext<
-	Options extends Record<string, unknown>,
-	AuthConfig extends PluginAuthConfig | undefined = undefined,
-> = ExtractAllAuthTypes<Options> extends infer A
-	? A extends AuthTypes
-		? {
-				/** The auth type - use this for narrowing ctx.keys */
-				authType: A;
-				/** Plugin-specific options */
-				options: Options;
-				/** Account-level key manager - type narrows based on authType check */
-				keys: AccountKeyManagerFor<A, AuthConfig>;
-			}
-		: never
-	: never;
+  Options extends Record<string, unknown>,
+  AuthConfig extends PluginAuthConfig | undefined = undefined,
+> =
+  ExtractAllAuthTypes<Options> extends infer A
+    ? A extends AuthTypes
+      ? {
+          /** The auth type - use this for narrowing ctx.keys */
+          authType: A
+          /** Plugin-specific options */
+          options: Options
+          /** Account-level key manager - type narrows based on authType check */
+          keys: AccountKeyManagerFor<A, AuthConfig>
+        }
+      : never
+    : never
 
 /**
  * Type for the keyBuilder callback function that retrieves the authentication key.
@@ -402,21 +403,21 @@ export type KeyBuilderContext<
  * @template AuthConfig - Optional plugin auth config for extension fields
  */
 export type CorsairKeyBuilder<
-	Options extends Record<string, unknown>,
-	AuthConfig extends PluginAuthConfig | undefined = undefined,
+  Options extends Record<string, unknown>,
+  AuthConfig extends PluginAuthConfig | undefined = undefined,
 > = (
-	ctx: KeyBuilderContext<Options, AuthConfig>,
-	source: 'endpoint' | 'webhook',
-) => string | Promise<string>;
+  ctx: KeyBuilderContext<Options, AuthConfig>,
+  source: 'endpoint' | 'webhook'
+) => string | Promise<string>
 
 /**
  * Base keyBuilder type used internally for type compatibility.
  * Uses `any` to avoid contravariance issues when plugins are stored in arrays.
  */
 export type CorsairKeyBuilderBase = (
-	ctx: any,
-	source: 'endpoint' | 'webhook',
-) => string | Promise<string>;
+  ctx: any,
+  source: 'endpoint' | 'webhook'
+) => string | Promise<string>
 
 /**
  * Defines a Corsair plugin with endpoints, webhooks, schema, and configuration.
@@ -429,164 +430,163 @@ export type CorsairKeyBuilderBase = (
  * @template AuthConfig - Optional auth config for extending base auth fields with plugin-specific fields
  */
 export type CorsairPlugin<
-	Id extends AllProviders = AllProviders,
-	Schema extends CorsairPluginSchema<
-		Record<string, ZodTypeAny>
-	> = CorsairPluginSchema<Record<string, ZodTypeAny>>,
-	Endpoints extends EndpointTree = EndpointTree,
-	Webhooks extends WebhookTree = WebhookTree,
-	Options extends Record<string, unknown> = Record<string, unknown>,
-	DefaultAuthType extends AuthTypes | undefined = AuthTypes | undefined,
-	AuthConfig extends PluginAuthConfig | undefined =
-		| PluginAuthConfig
-		| undefined,
+  Id extends AllProviders = AllProviders,
+  Schema extends CorsairPluginSchema<Record<string, ZodTypeAny>> =
+    CorsairPluginSchema<Record<string, ZodTypeAny>>,
+  Endpoints extends EndpointTree = EndpointTree,
+  Webhooks extends WebhookTree = WebhookTree,
+  Options extends Record<string, unknown> = Record<string, unknown>,
+  DefaultAuthType extends AuthTypes | undefined = AuthTypes | undefined,
+  AuthConfig extends PluginAuthConfig | undefined =
+    | PluginAuthConfig
+    | undefined,
 > = {
-	/** Unique identifier for the plugin */
-	id: Id;
-	/** API endpoint definitions */
-	endpoints?: Endpoints;
-	/** Database schema for ORM services */
-	schema?: Schema;
-	/** Plugin-specific options (e.g. credentials, API keys, tokens) */
-	options?: Options;
-	/** Webhook handlers for incoming webhook events from external services */
-	webhooks?: Webhooks;
-	/** Hooks for endpoint handlers */
-	hooks?: Endpoints extends EndpointTree
-		? CorsairEndpointHooksMap<Endpoints>
-		: never;
-	/** Hooks for webhook handlers */
-	webhookHooks?: Webhooks extends WebhookTree
-		? CorsairWebhookHooksMap<Webhooks>
-		: never;
-	/**
-	 * Top-level matcher to quickly determine if any webhook in this plugin
-	 * should handle an incoming request. Acts as a first-level filter.
-	 */
-	pluginWebhookMatcher?: CorsairWebhookMatcher;
-	/** Plugin-specific error handlers */
-	errorHandlers?: CorsairErrorHandler;
-	/**
-	 * Async callback to retrieve the authentication key for API calls.
-	 * The keyBuilder receives a typed context with access to the keys manager,
-	 * allowing it to retrieve or refresh tokens as needed.
-	 * @param ctx - Context with `options` and `keys` (the account-level key manager)
-	 * @returns The authentication key string to use for API calls
-	 */
-	keyBuilder?: CorsairKeyBuilder<Options, AuthConfig>;
-	/**
-	 * @internal Type-only field for inference. Do not set at runtime.
-	 * Specifies the default auth type when authType is optional and not provided.
-	 */
-	__defaultAuthType?: DefaultAuthType;
-	/**
-	 * Auth config that extends the base auth fields with plugin-specific fields.
-	 * Each auth type can define extra integration-level and/or account-level fields
-	 * that will get auto-generated getters/setters on the key managers.
-	 *
-	 * @example
-	 * ```ts
-	 * authConfig: {
-	 *   oauth_2: {
-	 *     integration: ["topic_id"],
-	 *     account: ["history_id"],
-	 *   },
-	 * }
-	 * ```
-	 */
-	authConfig?: AuthConfig;
-	/**
-	 * Risk metadata for each endpoint in this plugin. Drives the permission system:
-	 * riskLevel against the active mode determines the policy (allow / deny / require_approval).
-	 * Also used by list_operations() and get_schema() to surface descriptions to the agent.
-	 *
-	 * Keys are dot-notation paths derived from `Endpoints` — only valid paths compile.
-	 *
-	 * @example
-	 * ```ts
-	 * endpointMeta: {
-	 *   'issues.list':          { riskLevel: 'read' },
-	 *   'issues.create':        { riskLevel: 'write' },
-	 *   'repositories.delete':  { riskLevel: 'destructive', irreversible: true },
-	 * }
-	 * ```
-	 */
-	endpointMeta?: Endpoints extends EndpointTree
-		? PluginEndpointMeta<Endpoints>
-		: never;
-	/**
-	 * Zod input and output schemas for each endpoint, keyed by dot-notation path.
-	 * Used by get_schema() to expose structured endpoint type information to the agent.
-	 * Keys must match the endpoint dot-paths used in endpointMeta.
-	 *
-	 * @example
-	 * ```ts
-	 * endpointSchemas: {
-	 *   'issues.list': { input: IssuesListInputSchema, output: IssuesListOutputSchema },
-	 *   'issues.create': { input: IssuesCreateInputSchema, output: IssuesCreateOutputSchema },
-	 * }
-	 * ```
-	 */
-	endpointSchemas?: Record<string, { input?: ZodTypeAny; output?: ZodTypeAny }>;
-	/**
-	 * Zod schemas for each webhook, keyed by dot-notation path.
-	 * Used by get_schema() to expose structured webhook type information to the agent.
-	 * Keys must match the dot-paths of the webhook tree (e.g. 'messages.message').
-	 *
-	 * - `payload` — the type of `request.payload` in the before hook
-	 * - `response` — the type of `response.data` in the after hook
-	 * - `description` — optional human-readable description of what triggers this webhook
-	 *
-	 * @example
-	 * ```ts
-	 * webhookSchemas: {
-	 *   'messages.message': { description: 'Fires when a message is posted', payload: MessageEventSchema, response: z.object({ ... }) },
-	 * }
-	 * ```
-	 */
-	webhookSchemas?: Record<
-		string,
-		{ description?: string; payload?: ZodTypeAny; response?: ZodTypeAny }
-	>;
-	/**
-	 * OAuth 2.0 configuration for this plugin.
-	 * When set, the CLI uses these values to drive the authorization flow
-	 * instead of a hardcoded lookup table — so any OAuth provider works
-	 * without changes to the CLI itself.
-	 */
-	oauthConfig?: OAuthConfig;
-};
+  /** Unique identifier for the plugin */
+  id: Id
+  /** API endpoint definitions */
+  endpoints?: Endpoints
+  /** Database schema for ORM services */
+  schema?: Schema
+  /** Plugin-specific options (e.g. credentials, API keys, tokens) */
+  options?: Options
+  /** Webhook handlers for incoming webhook events from external services */
+  webhooks?: Webhooks
+  /** Hooks for endpoint handlers */
+  hooks?: Endpoints extends EndpointTree
+    ? CorsairEndpointHooksMap<Endpoints>
+    : never
+  /** Hooks for webhook handlers */
+  webhookHooks?: Webhooks extends WebhookTree
+    ? CorsairWebhookHooksMap<Webhooks>
+    : never
+  /**
+   * Top-level matcher to quickly determine if any webhook in this plugin
+   * should handle an incoming request. Acts as a first-level filter.
+   */
+  pluginWebhookMatcher?: CorsairWebhookMatcher
+  /** Plugin-specific error handlers */
+  errorHandlers?: CorsairErrorHandler
+  /**
+   * Async callback to retrieve the authentication key for API calls.
+   * The keyBuilder receives a typed context with access to the keys manager,
+   * allowing it to retrieve or refresh tokens as needed.
+   * @param ctx - Context with `options` and `keys` (the account-level key manager)
+   * @returns The authentication key string to use for API calls
+   */
+  keyBuilder?: CorsairKeyBuilder<Options, AuthConfig>
+  /**
+   * @internal Type-only field for inference. Do not set at runtime.
+   * Specifies the default auth type when authType is optional and not provided.
+   */
+  __defaultAuthType?: DefaultAuthType
+  /**
+   * Auth config that extends the base auth fields with plugin-specific fields.
+   * Each auth type can define extra integration-level and/or account-level fields
+   * that will get auto-generated getters/setters on the key managers.
+   *
+   * @example
+   * ```ts
+   * authConfig: {
+   *   oauth_2: {
+   *     integration: ["topic_id"],
+   *     account: ["history_id"],
+   *   },
+   * }
+   * ```
+   */
+  authConfig?: AuthConfig
+  /**
+   * Risk metadata for each endpoint in this plugin. Drives the permission system:
+   * riskLevel against the active mode determines the policy (allow / deny / require_approval).
+   * Also used by list_operations() and get_schema() to surface descriptions to the agent.
+   *
+   * Keys are dot-notation paths derived from `Endpoints` — only valid paths compile.
+   *
+   * @example
+   * ```ts
+   * endpointMeta: {
+   *   'issues.list':          { riskLevel: 'read' },
+   *   'issues.create':        { riskLevel: 'write' },
+   *   'repositories.delete':  { riskLevel: 'destructive', irreversible: true },
+   * }
+   * ```
+   */
+  endpointMeta?: Endpoints extends EndpointTree
+    ? PluginEndpointMeta<Endpoints>
+    : never
+  /**
+   * Zod input and output schemas for each endpoint, keyed by dot-notation path.
+   * Used by get_schema() to expose structured endpoint type information to the agent.
+   * Keys must match the endpoint dot-paths used in endpointMeta.
+   *
+   * @example
+   * ```ts
+   * endpointSchemas: {
+   *   'issues.list': { input: IssuesListInputSchema, output: IssuesListOutputSchema },
+   *   'issues.create': { input: IssuesCreateInputSchema, output: IssuesCreateOutputSchema },
+   * }
+   * ```
+   */
+  endpointSchemas?: Record<string, { input?: ZodTypeAny; output?: ZodTypeAny }>
+  /**
+   * Zod schemas for each webhook, keyed by dot-notation path.
+   * Used by get_schema() to expose structured webhook type information to the agent.
+   * Keys must match the dot-paths of the webhook tree (e.g. 'messages.message').
+   *
+   * - `payload` — the type of `request.payload` in the before hook
+   * - `response` — the type of `response.data` in the after hook
+   * - `description` — optional human-readable description of what triggers this webhook
+   *
+   * @example
+   * ```ts
+   * webhookSchemas: {
+   *   'messages.message': { description: 'Fires when a message is posted', payload: MessageEventSchema, response: z.object({ ... }) },
+   * }
+   * ```
+   */
+  webhookSchemas?: Record<
+    string,
+    { description?: string; payload?: ZodTypeAny; response?: ZodTypeAny }
+  >
+  /**
+   * OAuth 2.0 configuration for this plugin.
+   * When set, the CLI uses these values to drive the authorization flow
+   * instead of a hardcoded lookup table — so any OAuth provider works
+   * without changes to the CLI itself.
+   */
+  oauthConfig?: OAuthConfig
+}
 
 /**
  * OAuth 2.0 provider configuration, declared on the plugin so the CLI can
  * drive the authorization flow for any provider generically.
  */
 export type OAuthConfig = {
-	/** Human-readable provider name shown in CLI prompts, e.g. "Google". */
-	providerName: string;
-	/** Authorization endpoint URL, e.g. "https://accounts.google.com/o/oauth2/v2/auth". */
-	authUrl: string;
-	/** Token exchange endpoint URL. */
-	tokenUrl: string;
-	/** OAuth scopes to request. */
-	scopes: string[];
-	/**
-	 * How client credentials are sent to the token endpoint.
-	 * - `'body'` (default): client_id + client_secret sent as form body params (Google, etc.)
-	 * - `'basic'`: Base64-encoded "client_id:client_secret" sent as an Authorization header (Spotify, etc.)
-	 */
-	tokenAuthMethod?: 'body' | 'basic';
-	/**
-	 * When true, the user must supply a pre-registered redirect URI rather than
-	 * using an auto-generated localhost URL. Defaults to false.
-	 */
-	requiresRegisteredRedirect?: boolean;
-	/**
-	 * Extra query params merged into the authorization URL.
-	 * e.g. `{ access_type: 'offline', prompt: 'consent' }` for Google offline access.
-	 */
-	authParams?: Record<string, string>;
-};
+  /** Human-readable provider name shown in CLI prompts, e.g. "Google". */
+  providerName: string
+  /** Authorization endpoint URL, e.g. "https://accounts.google.com/o/oauth2/v2/auth". */
+  authUrl: string
+  /** Token exchange endpoint URL. */
+  tokenUrl: string
+  /** OAuth scopes to request. */
+  scopes: string[]
+  /**
+   * How client credentials are sent to the token endpoint.
+   * - `'body'` (default): client_id + client_secret sent as form body params (Google, etc.)
+   * - `'basic'`: Base64-encoded "client_id:client_secret" sent as an Authorization header (Spotify, etc.)
+   */
+  tokenAuthMethod?: 'body' | 'basic'
+  /**
+   * When true, the user must supply a pre-registered redirect URI rather than
+   * using an auto-generated localhost URL. Defaults to false.
+   */
+  requiresRegisteredRedirect?: boolean
+  /**
+   * Extra query params merged into the authorization URL.
+   * e.g. `{ access_type: 'offline', prompt: 'consent' }` for Google offline access.
+   */
+  authParams?: Record<string, string>
+}
 
 /**
  * The full context type for a plugin, combining base context with typed services and options.
@@ -596,96 +596,110 @@ export type OAuthConfig = {
  * @template AuthConfig - Optional plugin auth config for extension fields
  */
 export type CorsairPluginContext<
-	Schema extends
-		| CorsairPluginSchema<Record<string, ZodTypeAny>>
-		| undefined = undefined,
-	Options extends Record<string, unknown> | undefined = undefined,
-	Endpoints extends EndpointTree | undefined = undefined,
-	AuthConfig extends PluginAuthConfig | undefined = undefined,
+  Schema extends CorsairPluginSchema<Record<string, ZodTypeAny>> | undefined =
+    undefined,
+  Options extends Record<string, unknown> | undefined = undefined,
+  Endpoints extends EndpointTree | undefined = undefined,
+  AuthConfig extends PluginAuthConfig | undefined = undefined,
 > = CorsairContext<
-	Endpoints extends EndpointTree ? BindEndpoints<Endpoints> : BoundEndpointTree
+  Endpoints extends EndpointTree ? BindEndpoints<Endpoints> : BoundEndpointTree
 > &
-	InferPluginEntities<Schema> & {
-		/**
-		 * Get the account ID for this plugin's tenant and integration.
-		 * The result is cached after the first call.
-		 */
-		$getAccountId: () => Promise<string>;
-		/**
-		 * The resolved authentication key string for making API calls.
-		 * This is populated by the keyBuilder before endpoint execution.
-		 */
-		key: string;
-		/**
-		 * The tenant ID for this context (when multi-tenancy is enabled).
-		 * Available in webhook hooks and endpoint hooks.
-		 */
-		tenantId?: string;
-	} & (Options extends undefined ? {} : { options: Options }) &
-	// Include keys manager if authType is defined in options
-	(ExtractAuthType<Options> extends AuthTypes
-		? { keys: AccountKeyManagerFor<ExtractAuthType<Options>, AuthConfig> }
-		: {});
+  InferPluginEntities<Schema> & {
+    /**
+     * Get the account ID for this plugin's tenant and integration.
+     * The result is cached after the first call.
+     */
+    $getAccountId: () => Promise<string>
+    /**
+     * The resolved authentication key string for making API calls.
+     * This is populated by the keyBuilder before endpoint execution.
+     */
+    key: string
+    /**
+     * The tenant ID for this context (when multi-tenancy is enabled).
+     * Available in webhook hooks and endpoint hooks.
+     */
+    tenantId?: string
+  } & (Options extends undefined ? {} : { options: Options }) &
+  // Include keys manager if authType is defined in options
+  (ExtractAuthType<Options> extends AuthTypes
+    ? { keys: AccountKeyManagerFor<ExtractAuthType<Options>, AuthConfig> }
+    : {})
 
 /**
  * Configuration for creating a Corsair integration with plugins.
  * @template Plugins - Array of plugin definitions
  */
 export type CorsairIntegration<Plugins extends readonly CorsairPlugin[]> = {
-	/** Database connection for ORM entities (e.g. `slack.api.messages.post(...)` for API, `slack.db.messages.findByEntityId(...)` for DB) */
-	database?: CorsairDatabaseInput;
-	/** Array of plugin definitions to include */
-	plugins: Plugins;
-	/** If true, enables tenant-scoped access via `withTenant()` */
-	multiTenancy?: boolean;
-	/** Root-level error handlers that apply when plugin-specific handlers are not defined */
-	errorHandlers?: CorsairErrorHandler;
-	/** Key Encryption Key (KEK) for envelope encryption. Used to encrypt/decrypt Data Encryption Keys (DEK) stored in the database. */
-	kek: string;
-	/**
-	 * Global approval configuration for the permission system.
-	 * Controls how long approval requests stay active and what happens when they expire.
-	 * Only relevant when the MCP server is used and a plugin is in `cautious` or `strict` mode.
-	 */
-	approval?: {
-		/**
-		 * How long an approval request remains valid before expiring.
-		 * Accepts duration strings: '10m', '1h', '30s', '2h30m'.
-		 * Defaults to '10m' if not specified.
-		 */
-		timeout: string;
-		/**
-		 * What to do when an approval request expires without a response.
-		 * - `'deny'`    → the action is automatically denied (recommended)
-		 * - `'approve'` → the action is automatically approved (use only in low-risk setups)
-		 */
-		onTimeout: 'deny' | 'approve';
-		/**
-		 * How approval requests are handled when execution is blocked.
-		 * - `'synchronous'`  → the tool call blocks (polls the DB) until the user approves or denies.
-		 *                      The model is unaware anything happened — it just sees a slow tool call.
-		 *                      On denial, the tool returns an error and the model stops.
-		 * - `'asynchronous'` → the tool call returns immediately with a blocked result.
-		 *                      The model must handle the denial and stop on its own.
-		 * - A no-arg function → called per-request, return value selects the mode dynamically.
-		 *                       Use this to switch modes based on runtime context (e.g. auth type).
-		 * Defaults to `'asynchronous'` if not specified.
-		 */
-		mode?:
-			| 'synchronous'
-			| 'asynchronous'
-			| (() => 'synchronous' | 'asynchronous');
-		/**
-		 * Called when a permission is blocked in async mode. Return the string that the LLM receives
-		 * as the tool result — this is what gets surfaced to the user in the chat.
-		 * Receives the permission token, record ID, plugin name, endpoint path, and args.
-		 */
-		formatAsyncMessage?: (opts: {
-			token: string;
-			id: string;
-			plugin: string;
-			endpoint: string;
-			args: unknown;
-		}) => string;
-	};
-};
+  /** Database connection for ORM entities (e.g. `slack.api.messages.post(...)` for API, `slack.db.messages.findByEntityId(...)` for DB) */
+  database?: CorsairDatabaseInput
+  /** Array of plugin definitions to include */
+  plugins: Plugins
+  /** If true, enables tenant-scoped access via `withTenant()` */
+  multiTenancy?: boolean
+  /** Root-level error handlers that apply when plugin-specific handlers are not defined */
+  errorHandlers?: CorsairErrorHandler
+  /** Key Encryption Key (KEK) for envelope encryption. Used to encrypt/decrypt Data Encryption Keys (DEK) stored in the database. */
+  kek: string
+  /**
+   * Global approval configuration for the permission system.
+   * Controls how long approval requests stay active and what happens when they expire.
+   * Only relevant when the MCP server is used and a plugin is in `cautious` or `strict` mode.
+   */
+  approval?: {
+    /**
+     * How long an approval request remains valid before expiring.
+     * Accepts duration strings: '10m', '1h', '30s', '2h30m'.
+     * Defaults to '10m' if not specified.
+     */
+    timeout: string
+    /**
+     * What to do when an approval request expires without a response.
+     * - `'deny'`    → the action is automatically denied (recommended)
+     * - `'approve'` → the action is automatically approved (use only in low-risk setups)
+     */
+    onTimeout: 'deny' | 'approve'
+    /**
+     * How approval requests are handled when execution is blocked.
+     * - `'synchronous'`  → the tool call blocks (polls the DB) until the user approves or denies.
+     *                      The model is unaware anything happened — it just sees a slow tool call.
+     *                      On denial, the tool returns an error and the model stops.
+     * - `'asynchronous'` → the tool call returns immediately with a blocked result.
+     *                      The model must handle the denial and stop on its own.
+     * - A no-arg function → called per-request, return value selects the mode dynamically.
+     *                       Use this to switch modes based on runtime context (e.g. auth type).
+     * Defaults to `'asynchronous'` if not specified.
+     */
+    mode?:
+      | 'synchronous'
+      | 'asynchronous'
+      | (() => 'synchronous' | 'asynchronous')
+    /**
+     * Called when a permission is blocked in async mode. Return the string that the LLM receives
+     * as the tool result — this is what gets surfaced to the user in the chat.
+     * Receives the permission token, record ID, plugin name, endpoint path, and args.
+     */
+    formatAsyncMessage?: (opts: {
+      token: string
+      id: string
+      plugin: string
+      endpoint: string
+      args: unknown
+    }) => string
+  }
+  /**
+   * Connect link configuration for non-authenticated users.
+   * When a plugin endpoint is called but the user hasn't authenticated,
+   * Corsair generates a connect link the agent can present to the user.
+   * Only applies to plugins with an `oauthConfig`.
+   */
+  connect?: {
+    baseUrl: string
+    redirectUri: string
+    onAuthMissing?: (opts: {
+      plugin: string
+      connectUrl: string
+      state: string
+    }) => string
+  }
+}

--- a/packages/corsair/core/plugins/index.ts
+++ b/packages/corsair/core/plugins/index.ts
@@ -1,27 +1,27 @@
-import type { ZodTypeAny } from 'zod'
-import type { CorsairDatabaseInput } from '../../db/kysely/database'
-import type { CorsairPluginSchema } from '../../db/orm'
-import type { AccountKeyManagerFor, PluginAuthConfig } from '../auth/types'
-import type { ExtractAuthType, InferPluginEntities } from '../client'
-import type { AllProviders, AuthTypes } from '../constants'
+import type { ZodTypeAny } from 'zod';
+import type { CorsairDatabaseInput } from '../../db/kysely/database';
+import type { CorsairPluginSchema } from '../../db/orm';
+import type { AccountKeyManagerFor, PluginAuthConfig } from '../auth/types';
+import type { ExtractAuthType, InferPluginEntities } from '../client';
+import type { AllProviders, AuthTypes } from '../constants';
 import type {
-  BindEndpoints,
-  BoundEndpointTree,
-  CorsairContext,
-  CorsairEndpoint,
-  EndpointPathsOf,
-  EndpointTree,
-} from '../endpoints'
-import type { CorsairErrorHandler } from '../errors'
+	BindEndpoints,
+	BoundEndpointTree,
+	CorsairContext,
+	CorsairEndpoint,
+	EndpointPathsOf,
+	EndpointTree,
+} from '../endpoints';
+import type { CorsairErrorHandler } from '../errors';
 import type {
-  CorsairWebhook,
-  CorsairWebhookHandler,
-  CorsairWebhookMatcher,
-  WebhookPathsOf,
-  WebhookRequest,
-  WebhookResponse,
-  WebhookTree,
-} from '../webhooks'
+	CorsairWebhook,
+	CorsairWebhookHandler,
+	CorsairWebhookMatcher,
+	WebhookPathsOf,
+	WebhookRequest,
+	WebhookResponse,
+	WebhookTree,
+} from '../webhooks';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Permission System Types
@@ -31,7 +31,7 @@ import type {
  * Risk level classification for plugin endpoints.
  * The permission mode maps each risk level to a policy (allow / deny / require_approval).
  */
-export type EndpointRiskLevel = 'read' | 'write' | 'destructive'
+export type EndpointRiskLevel = 'read' | 'write' | 'destructive';
 
 /**
  * Permission mode controlling what the AI agent is allowed to do by default.
@@ -43,7 +43,7 @@ export type EndpointRiskLevel = 'read' | 'write' | 'destructive'
  * | strict   | allow | require_approval | deny                |
  * | readonly | allow | deny             | deny                |
  */
-export type PermissionMode = 'open' | 'cautious' | 'strict' | 'readonly'
+export type PermissionMode = 'open' | 'cautious' | 'strict' | 'readonly';
 
 /**
  * The resolved policy for a specific endpoint after combining mode + overrides.
@@ -51,26 +51,26 @@ export type PermissionMode = 'open' | 'cautious' | 'strict' | 'readonly'
  * - `deny`             → returns a denied response, does not call the API
  * - `require_approval` → stores a pending approval, returns a review URL to the agent
  */
-export type PermissionPolicy = 'allow' | 'deny' | 'require_approval'
+export type PermissionPolicy = 'allow' | 'deny' | 'require_approval';
 
 /**
  * Metadata for a single endpoint entry. Drives permission decisions and MCP tool descriptions.
  * Plugin authors populate this on the `endpointMeta` field of their plugin definition.
  */
 export type EndpointMetaEntry = {
-  /** Risk classification — determines the default policy given the active permission mode. */
-  riskLevel: EndpointRiskLevel
-  /**
-   * If true, this action cannot be undone. Shown prominently on the approval review page
-   * and in the MCP tool description so the agent can warn users proactively.
-   */
-  irreversible?: boolean
-  /**
-   * Human-readable description of what this endpoint does.
-   * Included in the MCP tool description surfaced to the AI agent.
-   */
-  description?: string
-}
+	/** Risk classification — determines the default policy given the active permission mode. */
+	riskLevel: EndpointRiskLevel;
+	/**
+	 * If true, this action cannot be undone. Shown prominently on the approval review page
+	 * and in the MCP tool description so the agent can warn users proactively.
+	 */
+	irreversible?: boolean;
+	/**
+	 * Human-readable description of what this endpoint does.
+	 * Included in the MCP tool description surfaced to the AI agent.
+	 */
+	description?: string;
+};
 
 /**
  * A partial map from dot-notation endpoint paths to their metadata entries.
@@ -80,8 +80,8 @@ export type EndpointMetaEntry = {
  * @template T - The plugin's endpoint tree (e.g. `typeof githubEndpointsNested`)
  */
 export type PluginEndpointMeta<T extends EndpointTree> = Partial<
-  Record<EndpointPathsOf<T>, EndpointMetaEntry>
->
+	Record<EndpointPathsOf<T>, EndpointMetaEntry>
+>;
 
 /**
  * A **required** map from dot-notation endpoint paths to their metadata entries.
@@ -92,9 +92,9 @@ export type PluginEndpointMeta<T extends EndpointTree> = Partial<
  * @template T - The plugin's endpoint tree (e.g. `typeof githubEndpointsNested`)
  */
 export type RequiredPluginEndpointMeta<T extends EndpointTree> = Record<
-  EndpointPathsOf<T>,
-  EndpointMetaEntry
->
+	EndpointPathsOf<T>,
+	EndpointMetaEntry
+>;
 
 /**
  * A **required** map from dot-notation endpoint paths to their `{ input, output }` schema
@@ -105,9 +105,9 @@ export type RequiredPluginEndpointMeta<T extends EndpointTree> = Record<
  * @template T - The plugin's endpoint tree (e.g. `typeof githubEndpointsNested`)
  */
 export type RequiredPluginEndpointSchemas<T extends EndpointTree> = Record<
-  EndpointPathsOf<T>,
-  { input?: ZodTypeAny; output?: ZodTypeAny }
->
+	EndpointPathsOf<T>,
+	{ input?: ZodTypeAny; output?: ZodTypeAny }
+>;
 
 /**
  * A **required** map from dot-notation webhook paths to their `{ description, payload, response }`
@@ -118,9 +118,9 @@ export type RequiredPluginEndpointSchemas<T extends EndpointTree> = Record<
  * @template T - The plugin's webhook tree (e.g. `typeof slackWebhooksNested`)
  */
 export type RequiredPluginWebhookSchemas<T extends WebhookTree> = Record<
-  WebhookPathsOf<T>,
-  { description?: string; payload?: ZodTypeAny; response?: ZodTypeAny }
->
+	WebhookPathsOf<T>,
+	{ description?: string; payload?: ZodTypeAny; response?: ZodTypeAny }
+>;
 
 /**
  * Permission configuration for a plugin, passed as `permissions` in the plugin options.
@@ -146,15 +146,15 @@ export type RequiredPluginWebhookSchemas<T extends WebhookTree> = Record<
  * ```
  */
 export type PluginPermissionsConfig<T extends EndpointTree = EndpointTree> = {
-  /** The default permission mode for all endpoints in this plugin. */
-  mode: PermissionMode
-  /**
-   * Per-endpoint policy overrides.
-   * Keys are strongly-typed dot-notation paths through this plugin's endpoint tree.
-   * Only valid paths for this specific plugin compile — typos are type errors.
-   */
-  overrides?: Partial<Record<EndpointPathsOf<T>, PermissionPolicy>>
-}
+	/** The default permission mode for all endpoints in this plugin. */
+	mode: PermissionMode;
+	/**
+	 * Per-endpoint policy overrides.
+	 * Keys are strongly-typed dot-notation paths through this plugin's endpoint tree.
+	 * Only valid paths for this specific plugin compile — typos are type errors.
+	 */
+	overrides?: Partial<Record<EndpointPathsOf<T>, PermissionPolicy>>;
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Hook Types for Endpoints
@@ -163,108 +163,111 @@ export type PluginPermissionsConfig<T extends EndpointTree = EndpointTree> = {
 /**
  * Extracts the context type from an endpoint function.
  */
-type EndpointContext<E> =
-  E extends CorsairEndpoint<infer Ctx, any, any> ? Ctx : never
+type EndpointContext<E> = E extends CorsairEndpoint<infer Ctx, any, any>
+	? Ctx
+	: never;
 
 /**
  * Extracts the arguments type from an endpoint function.
  */
-type EndpointArgs<E> =
-  E extends CorsairEndpoint<any, infer Args, any> ? Args : never
+type EndpointArgs<E> = E extends CorsairEndpoint<any, infer Args, any>
+	? Args
+	: never;
 
 /**
  * Extracts the return type from an endpoint function.
  */
-type EndpointResult<E> =
-  E extends CorsairEndpoint<any, any, infer Res> ? Res : never
+type EndpointResult<E> = E extends CorsairEndpoint<any, any, infer Res>
+	? Res
+	: never;
 
 /**
  * Return type for the before hook, containing optionally updated context and args.
  */
 export type BeforeHookResult<Ctx, Args> = {
-  ctx: Ctx
-  args: Args
-  continue?: boolean
-  passToAfter?: string
-}
+	ctx: Ctx;
+	args: Args;
+	continue?: boolean;
+	passToAfter?: string;
+};
 
 /**
  * Type for endpoint hooks used internally by the bind function.
  */
 export type EndpointHooks = {
-  before?: (
-    ctx: Record<string, unknown>,
-    args: unknown
-  ) =>
-    | BeforeHookResult<Record<string, unknown>, unknown>
-    | Promise<BeforeHookResult<Record<string, unknown>, unknown>>
-  after?: (
-    ctx: Record<string, unknown>,
-    res: unknown,
-    passToAfter?: string
-  ) => void | Promise<void>
-}
+	before?: (
+		ctx: Record<string, unknown>,
+		args: unknown,
+	) =>
+		| BeforeHookResult<Record<string, unknown>, unknown>
+		| Promise<BeforeHookResult<Record<string, unknown>, unknown>>;
+	after?: (
+		ctx: Record<string, unknown>,
+		res: unknown,
+		passToAfter?: string,
+	) => void | Promise<void>;
+};
 
 /**
  * Type for webhook hooks used internally by the bind function.
  */
 export type WebhookHooks = {
-  before?: (
-    ctx: Record<string, unknown>,
-    request: unknown
-  ) =>
-    | BeforeHookResult<Record<string, unknown>, unknown>
-    | Promise<BeforeHookResult<Record<string, unknown>, unknown>>
-  after?: (
-    ctx: Record<string, unknown>,
-    response: unknown,
-    passToAfter?: string
-  ) => void | Promise<void>
-}
+	before?: (
+		ctx: Record<string, unknown>,
+		request: unknown,
+	) =>
+		| BeforeHookResult<Record<string, unknown>, unknown>
+		| Promise<BeforeHookResult<Record<string, unknown>, unknown>>;
+	after?: (
+		ctx: Record<string, unknown>,
+		response: unknown,
+		passToAfter?: string,
+	) => void | Promise<void>;
+};
 
 /**
  * Recursively maps an endpoint tree to a hooks map with the same structure.
  * Each endpoint gets optional before/after hooks.
  */
 type CorsairEndpointHooksMap<Endpoints extends EndpointTree> = {
-  [K in keyof Endpoints]?: Endpoints[K] extends CorsairEndpoint
-    ? {
-        /**
-         * Hook that runs before the endpoint is executed.
-         * @param ctx - The endpoint context
-         * @param args - The endpoint arguments
-         * @returns An object containing the updated context and args to pass to the endpoint
-         */
-        before?: (
-          ctx: EndpointContext<Endpoints[K]>,
-          args: EndpointArgs<Endpoints[K]>
-        ) =>
-          | BeforeHookResult<
-              EndpointContext<Endpoints[K]>,
-              EndpointArgs<Endpoints[K]>
-            >
-          | Promise<
-              BeforeHookResult<
-                EndpointContext<Endpoints[K]>,
-                EndpointArgs<Endpoints[K]>
-              >
-            >
-        /**
-         * Hook that runs after the endpoint is executed.
-         * @param ctx - The endpoint context
-         * @param res - The endpoint result
-         * @param passToAfter - Optional string passed from the before hook
-         */
-        after?: (
-          ctx: EndpointContext<Endpoints[K]>,
-          res: EndpointResult<Endpoints[K]>,
-          passToAfter?: string
-        ) => void | Promise<void>
-      }
-    : Endpoints[K] extends EndpointTree
-      ? CorsairEndpointHooksMap<Endpoints[K]>
-      : never
-}
+	[K in keyof Endpoints]?: Endpoints[K] extends CorsairEndpoint
+		? {
+				/**
+				 * Hook that runs before the endpoint is executed.
+				 * @param ctx - The endpoint context
+				 * @param args - The endpoint arguments
+				 * @returns An object containing the updated context and args to pass to the endpoint
+				 */
+				before?: (
+					ctx: EndpointContext<Endpoints[K]>,
+					args: EndpointArgs<Endpoints[K]>,
+				) =>
+					| BeforeHookResult<
+							EndpointContext<Endpoints[K]>,
+							EndpointArgs<Endpoints[K]>
+					  >
+					| Promise<
+							BeforeHookResult<
+								EndpointContext<Endpoints[K]>,
+								EndpointArgs<Endpoints[K]>
+							>
+					  >;
+				/**
+				 * Hook that runs after the endpoint is executed.
+				 * @param ctx - The endpoint context
+				 * @param res - The endpoint result
+				 * @param passToAfter - Optional string passed from the before hook
+				 */
+				after?: (
+					ctx: EndpointContext<Endpoints[K]>,
+					res: EndpointResult<Endpoints[K]>,
+					passToAfter?: string,
+				) => void | Promise<void>;
+			}
+		: Endpoints[K] extends EndpointTree
+			? CorsairEndpointHooksMap<Endpoints[K]>
+			: never;
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Hook Types for Webhooks
@@ -273,76 +276,73 @@ type CorsairEndpointHooksMap<Endpoints extends EndpointTree> = {
 /**
  * Extracts the context type from a webhook handler.
  */
-type WebhookContext<W> =
-  W extends CorsairWebhook<infer Ctx, any, any>
-    ? Ctx
-    : W extends { handler: CorsairWebhookHandler<infer Ctx, any, any> }
-      ? Ctx
-      : never
+type WebhookContext<W> = W extends CorsairWebhook<infer Ctx, any, any>
+	? Ctx
+	: W extends { handler: CorsairWebhookHandler<infer Ctx, any, any> }
+		? Ctx
+		: never;
 
 /**
  * Extracts the payload type from a webhook handler.
  */
-type WebhookPayload<W> =
-  W extends CorsairWebhook<any, infer P, any>
-    ? P
-    : W extends { handler: CorsairWebhookHandler<any, infer P, any> }
-      ? P
-      : never
+type WebhookPayload<W> = W extends CorsairWebhook<any, infer P, any>
+	? P
+	: W extends { handler: CorsairWebhookHandler<any, infer P, any> }
+		? P
+		: never;
 
 /**
  * Extracts the response data type from a webhook handler.
  */
-type WebhookResponseData<W> =
-  W extends CorsairWebhook<any, any, infer R>
-    ? R
-    : W extends { handler: CorsairWebhookHandler<any, any, infer R> }
-      ? R
-      : never
+type WebhookResponseData<W> = W extends CorsairWebhook<any, any, infer R>
+	? R
+	: W extends { handler: CorsairWebhookHandler<any, any, infer R> }
+		? R
+		: never;
 
 /**
  * Recursively maps a webhook tree to a hooks map with the same structure.
  * Each webhook gets optional before/after hooks.
  */
 type CorsairWebhookHooksMap<Webhooks extends WebhookTree> = {
-  [K in keyof Webhooks]?: Webhooks[K] extends CorsairWebhook<any, any, any>
-    ? {
-        /**
-         * Hook that runs before the webhook is processed.
-         * @param ctx - The webhook context
-         * @param request - The webhook request
-         * @returns An object containing the updated context and request to pass to the webhook handler
-         */
-        before?: (
-          ctx: WebhookContext<Webhooks[K]>,
-          request: WebhookRequest<WebhookPayload<Webhooks[K]>>
-        ) =>
-          | BeforeHookResult<
-              WebhookContext<Webhooks[K]>,
-              WebhookRequest<WebhookPayload<Webhooks[K]>>
-            >
-          | Promise<
-              BeforeHookResult<
-                WebhookContext<Webhooks[K]>,
-                WebhookRequest<WebhookPayload<Webhooks[K]>>
-              >
-            >
-        /**
-         * Hook that runs after the webhook is processed.
-         * @param ctx - The webhook context
-         * @param response - The webhook response
-         * @param passToAfter - Optional string passed from the before hook
-         */
-        after?: (
-          ctx: WebhookContext<Webhooks[K]>,
-          response: WebhookResponse<WebhookResponseData<Webhooks[K]>>,
-          passToAfter?: string
-        ) => void | Promise<void>
-      }
-    : Webhooks[K] extends WebhookTree
-      ? CorsairWebhookHooksMap<Webhooks[K]>
-      : never
-}
+	[K in keyof Webhooks]?: Webhooks[K] extends CorsairWebhook<any, any, any>
+		? {
+				/**
+				 * Hook that runs before the webhook is processed.
+				 * @param ctx - The webhook context
+				 * @param request - The webhook request
+				 * @returns An object containing the updated context and request to pass to the webhook handler
+				 */
+				before?: (
+					ctx: WebhookContext<Webhooks[K]>,
+					request: WebhookRequest<WebhookPayload<Webhooks[K]>>,
+				) =>
+					| BeforeHookResult<
+							WebhookContext<Webhooks[K]>,
+							WebhookRequest<WebhookPayload<Webhooks[K]>>
+					  >
+					| Promise<
+							BeforeHookResult<
+								WebhookContext<Webhooks[K]>,
+								WebhookRequest<WebhookPayload<Webhooks[K]>>
+							>
+					  >;
+				/**
+				 * Hook that runs after the webhook is processed.
+				 * @param ctx - The webhook context
+				 * @param response - The webhook response
+				 * @param passToAfter - Optional string passed from the before hook
+				 */
+				after?: (
+					ctx: WebhookContext<Webhooks[K]>,
+					response: WebhookResponse<WebhookResponseData<Webhooks[K]>>,
+					passToAfter?: string,
+				) => void | Promise<void>;
+			}
+		: Webhooks[K] extends WebhookTree
+			? CorsairWebhookHooksMap<Webhooks[K]>
+			: never;
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Plugin Types
@@ -353,10 +353,10 @@ type CorsairWebhookHooksMap<Webhooks extends WebhookTree> = {
  * Used for internal types like KeyBuilderContext where all auth types must be handled.
  */
 type ExtractAllAuthTypes<Options> = 'authType' extends keyof Options
-  ? NonNullable<Options['authType']> extends AuthTypes
-    ? NonNullable<Options['authType']>
-    : never
-  : never
+	? NonNullable<Options['authType']> extends AuthTypes
+		? NonNullable<Options['authType']>
+		: never
+	: never;
 
 /**
  * Context passed to keyBuilder as a discriminated union.
@@ -380,21 +380,20 @@ type ExtractAllAuthTypes<Options> = 'authType' extends keyof Options
  * ```
  */
 export type KeyBuilderContext<
-  Options extends Record<string, unknown>,
-  AuthConfig extends PluginAuthConfig | undefined = undefined,
-> =
-  ExtractAllAuthTypes<Options> extends infer A
-    ? A extends AuthTypes
-      ? {
-          /** The auth type - use this for narrowing ctx.keys */
-          authType: A
-          /** Plugin-specific options */
-          options: Options
-          /** Account-level key manager - type narrows based on authType check */
-          keys: AccountKeyManagerFor<A, AuthConfig>
-        }
-      : never
-    : never
+	Options extends Record<string, unknown>,
+	AuthConfig extends PluginAuthConfig | undefined = undefined,
+> = ExtractAllAuthTypes<Options> extends infer A
+	? A extends AuthTypes
+		? {
+				/** The auth type - use this for narrowing ctx.keys */
+				authType: A;
+				/** Plugin-specific options */
+				options: Options;
+				/** Account-level key manager - type narrows based on authType check */
+				keys: AccountKeyManagerFor<A, AuthConfig>;
+			}
+		: never
+	: never;
 
 /**
  * Type for the keyBuilder callback function that retrieves the authentication key.
@@ -403,21 +402,21 @@ export type KeyBuilderContext<
  * @template AuthConfig - Optional plugin auth config for extension fields
  */
 export type CorsairKeyBuilder<
-  Options extends Record<string, unknown>,
-  AuthConfig extends PluginAuthConfig | undefined = undefined,
+	Options extends Record<string, unknown>,
+	AuthConfig extends PluginAuthConfig | undefined = undefined,
 > = (
-  ctx: KeyBuilderContext<Options, AuthConfig>,
-  source: 'endpoint' | 'webhook'
-) => string | Promise<string>
+	ctx: KeyBuilderContext<Options, AuthConfig>,
+	source: 'endpoint' | 'webhook',
+) => string | Promise<string>;
 
 /**
  * Base keyBuilder type used internally for type compatibility.
  * Uses `any` to avoid contravariance issues when plugins are stored in arrays.
  */
 export type CorsairKeyBuilderBase = (
-  ctx: any,
-  source: 'endpoint' | 'webhook'
-) => string | Promise<string>
+	ctx: any,
+	source: 'endpoint' | 'webhook',
+) => string | Promise<string>;
 
 /**
  * Defines a Corsair plugin with endpoints, webhooks, schema, and configuration.
@@ -430,163 +429,164 @@ export type CorsairKeyBuilderBase = (
  * @template AuthConfig - Optional auth config for extending base auth fields with plugin-specific fields
  */
 export type CorsairPlugin<
-  Id extends AllProviders = AllProviders,
-  Schema extends CorsairPluginSchema<Record<string, ZodTypeAny>> =
-    CorsairPluginSchema<Record<string, ZodTypeAny>>,
-  Endpoints extends EndpointTree = EndpointTree,
-  Webhooks extends WebhookTree = WebhookTree,
-  Options extends Record<string, unknown> = Record<string, unknown>,
-  DefaultAuthType extends AuthTypes | undefined = AuthTypes | undefined,
-  AuthConfig extends PluginAuthConfig | undefined =
-    | PluginAuthConfig
-    | undefined,
+	Id extends AllProviders = AllProviders,
+	Schema extends CorsairPluginSchema<
+		Record<string, ZodTypeAny>
+	> = CorsairPluginSchema<Record<string, ZodTypeAny>>,
+	Endpoints extends EndpointTree = EndpointTree,
+	Webhooks extends WebhookTree = WebhookTree,
+	Options extends Record<string, unknown> = Record<string, unknown>,
+	DefaultAuthType extends AuthTypes | undefined = AuthTypes | undefined,
+	AuthConfig extends PluginAuthConfig | undefined =
+		| PluginAuthConfig
+		| undefined,
 > = {
-  /** Unique identifier for the plugin */
-  id: Id
-  /** API endpoint definitions */
-  endpoints?: Endpoints
-  /** Database schema for ORM services */
-  schema?: Schema
-  /** Plugin-specific options (e.g. credentials, API keys, tokens) */
-  options?: Options
-  /** Webhook handlers for incoming webhook events from external services */
-  webhooks?: Webhooks
-  /** Hooks for endpoint handlers */
-  hooks?: Endpoints extends EndpointTree
-    ? CorsairEndpointHooksMap<Endpoints>
-    : never
-  /** Hooks for webhook handlers */
-  webhookHooks?: Webhooks extends WebhookTree
-    ? CorsairWebhookHooksMap<Webhooks>
-    : never
-  /**
-   * Top-level matcher to quickly determine if any webhook in this plugin
-   * should handle an incoming request. Acts as a first-level filter.
-   */
-  pluginWebhookMatcher?: CorsairWebhookMatcher
-  /** Plugin-specific error handlers */
-  errorHandlers?: CorsairErrorHandler
-  /**
-   * Async callback to retrieve the authentication key for API calls.
-   * The keyBuilder receives a typed context with access to the keys manager,
-   * allowing it to retrieve or refresh tokens as needed.
-   * @param ctx - Context with `options` and `keys` (the account-level key manager)
-   * @returns The authentication key string to use for API calls
-   */
-  keyBuilder?: CorsairKeyBuilder<Options, AuthConfig>
-  /**
-   * @internal Type-only field for inference. Do not set at runtime.
-   * Specifies the default auth type when authType is optional and not provided.
-   */
-  __defaultAuthType?: DefaultAuthType
-  /**
-   * Auth config that extends the base auth fields with plugin-specific fields.
-   * Each auth type can define extra integration-level and/or account-level fields
-   * that will get auto-generated getters/setters on the key managers.
-   *
-   * @example
-   * ```ts
-   * authConfig: {
-   *   oauth_2: {
-   *     integration: ["topic_id"],
-   *     account: ["history_id"],
-   *   },
-   * }
-   * ```
-   */
-  authConfig?: AuthConfig
-  /**
-   * Risk metadata for each endpoint in this plugin. Drives the permission system:
-   * riskLevel against the active mode determines the policy (allow / deny / require_approval).
-   * Also used by list_operations() and get_schema() to surface descriptions to the agent.
-   *
-   * Keys are dot-notation paths derived from `Endpoints` — only valid paths compile.
-   *
-   * @example
-   * ```ts
-   * endpointMeta: {
-   *   'issues.list':          { riskLevel: 'read' },
-   *   'issues.create':        { riskLevel: 'write' },
-   *   'repositories.delete':  { riskLevel: 'destructive', irreversible: true },
-   * }
-   * ```
-   */
-  endpointMeta?: Endpoints extends EndpointTree
-    ? PluginEndpointMeta<Endpoints>
-    : never
-  /**
-   * Zod input and output schemas for each endpoint, keyed by dot-notation path.
-   * Used by get_schema() to expose structured endpoint type information to the agent.
-   * Keys must match the endpoint dot-paths used in endpointMeta.
-   *
-   * @example
-   * ```ts
-   * endpointSchemas: {
-   *   'issues.list': { input: IssuesListInputSchema, output: IssuesListOutputSchema },
-   *   'issues.create': { input: IssuesCreateInputSchema, output: IssuesCreateOutputSchema },
-   * }
-   * ```
-   */
-  endpointSchemas?: Record<string, { input?: ZodTypeAny; output?: ZodTypeAny }>
-  /**
-   * Zod schemas for each webhook, keyed by dot-notation path.
-   * Used by get_schema() to expose structured webhook type information to the agent.
-   * Keys must match the dot-paths of the webhook tree (e.g. 'messages.message').
-   *
-   * - `payload` — the type of `request.payload` in the before hook
-   * - `response` — the type of `response.data` in the after hook
-   * - `description` — optional human-readable description of what triggers this webhook
-   *
-   * @example
-   * ```ts
-   * webhookSchemas: {
-   *   'messages.message': { description: 'Fires when a message is posted', payload: MessageEventSchema, response: z.object({ ... }) },
-   * }
-   * ```
-   */
-  webhookSchemas?: Record<
-    string,
-    { description?: string; payload?: ZodTypeAny; response?: ZodTypeAny }
-  >
-  /**
-   * OAuth 2.0 configuration for this plugin.
-   * When set, the CLI uses these values to drive the authorization flow
-   * instead of a hardcoded lookup table — so any OAuth provider works
-   * without changes to the CLI itself.
-   */
-  oauthConfig?: OAuthConfig
-}
+	/** Unique identifier for the plugin */
+	id: Id;
+	/** API endpoint definitions */
+	endpoints?: Endpoints;
+	/** Database schema for ORM services */
+	schema?: Schema;
+	/** Plugin-specific options (e.g. credentials, API keys, tokens) */
+	options?: Options;
+	/** Webhook handlers for incoming webhook events from external services */
+	webhooks?: Webhooks;
+	/** Hooks for endpoint handlers */
+	hooks?: Endpoints extends EndpointTree
+		? CorsairEndpointHooksMap<Endpoints>
+		: never;
+	/** Hooks for webhook handlers */
+	webhookHooks?: Webhooks extends WebhookTree
+		? CorsairWebhookHooksMap<Webhooks>
+		: never;
+	/**
+	 * Top-level matcher to quickly determine if any webhook in this plugin
+	 * should handle an incoming request. Acts as a first-level filter.
+	 */
+	pluginWebhookMatcher?: CorsairWebhookMatcher;
+	/** Plugin-specific error handlers */
+	errorHandlers?: CorsairErrorHandler;
+	/**
+	 * Async callback to retrieve the authentication key for API calls.
+	 * The keyBuilder receives a typed context with access to the keys manager,
+	 * allowing it to retrieve or refresh tokens as needed.
+	 * @param ctx - Context with `options` and `keys` (the account-level key manager)
+	 * @returns The authentication key string to use for API calls
+	 */
+	keyBuilder?: CorsairKeyBuilder<Options, AuthConfig>;
+	/**
+	 * @internal Type-only field for inference. Do not set at runtime.
+	 * Specifies the default auth type when authType is optional and not provided.
+	 */
+	__defaultAuthType?: DefaultAuthType;
+	/**
+	 * Auth config that extends the base auth fields with plugin-specific fields.
+	 * Each auth type can define extra integration-level and/or account-level fields
+	 * that will get auto-generated getters/setters on the key managers.
+	 *
+	 * @example
+	 * ```ts
+	 * authConfig: {
+	 *   oauth_2: {
+	 *     integration: ["topic_id"],
+	 *     account: ["history_id"],
+	 *   },
+	 * }
+	 * ```
+	 */
+	authConfig?: AuthConfig;
+	/**
+	 * Risk metadata for each endpoint in this plugin. Drives the permission system:
+	 * riskLevel against the active mode determines the policy (allow / deny / require_approval).
+	 * Also used by list_operations() and get_schema() to surface descriptions to the agent.
+	 *
+	 * Keys are dot-notation paths derived from `Endpoints` — only valid paths compile.
+	 *
+	 * @example
+	 * ```ts
+	 * endpointMeta: {
+	 *   'issues.list':          { riskLevel: 'read' },
+	 *   'issues.create':        { riskLevel: 'write' },
+	 *   'repositories.delete':  { riskLevel: 'destructive', irreversible: true },
+	 * }
+	 * ```
+	 */
+	endpointMeta?: Endpoints extends EndpointTree
+		? PluginEndpointMeta<Endpoints>
+		: never;
+	/**
+	 * Zod input and output schemas for each endpoint, keyed by dot-notation path.
+	 * Used by get_schema() to expose structured endpoint type information to the agent.
+	 * Keys must match the endpoint dot-paths used in endpointMeta.
+	 *
+	 * @example
+	 * ```ts
+	 * endpointSchemas: {
+	 *   'issues.list': { input: IssuesListInputSchema, output: IssuesListOutputSchema },
+	 *   'issues.create': { input: IssuesCreateInputSchema, output: IssuesCreateOutputSchema },
+	 * }
+	 * ```
+	 */
+	endpointSchemas?: Record<string, { input?: ZodTypeAny; output?: ZodTypeAny }>;
+	/**
+	 * Zod schemas for each webhook, keyed by dot-notation path.
+	 * Used by get_schema() to expose structured webhook type information to the agent.
+	 * Keys must match the dot-paths of the webhook tree (e.g. 'messages.message').
+	 *
+	 * - `payload` — the type of `request.payload` in the before hook
+	 * - `response` — the type of `response.data` in the after hook
+	 * - `description` — optional human-readable description of what triggers this webhook
+	 *
+	 * @example
+	 * ```ts
+	 * webhookSchemas: {
+	 *   'messages.message': { description: 'Fires when a message is posted', payload: MessageEventSchema, response: z.object({ ... }) },
+	 * }
+	 * ```
+	 */
+	webhookSchemas?: Record<
+		string,
+		{ description?: string; payload?: ZodTypeAny; response?: ZodTypeAny }
+	>;
+	/**
+	 * OAuth 2.0 configuration for this plugin.
+	 * When set, the CLI uses these values to drive the authorization flow
+	 * instead of a hardcoded lookup table — so any OAuth provider works
+	 * without changes to the CLI itself.
+	 */
+	oauthConfig?: OAuthConfig;
+};
 
 /**
  * OAuth 2.0 provider configuration, declared on the plugin so the CLI can
  * drive the authorization flow for any provider generically.
  */
 export type OAuthConfig = {
-  /** Human-readable provider name shown in CLI prompts, e.g. "Google". */
-  providerName: string
-  /** Authorization endpoint URL, e.g. "https://accounts.google.com/o/oauth2/v2/auth". */
-  authUrl: string
-  /** Token exchange endpoint URL. */
-  tokenUrl: string
-  /** OAuth scopes to request. */
-  scopes: string[]
-  /**
-   * How client credentials are sent to the token endpoint.
-   * - `'body'` (default): client_id + client_secret sent as form body params (Google, etc.)
-   * - `'basic'`: Base64-encoded "client_id:client_secret" sent as an Authorization header (Spotify, etc.)
-   */
-  tokenAuthMethod?: 'body' | 'basic'
-  /**
-   * When true, the user must supply a pre-registered redirect URI rather than
-   * using an auto-generated localhost URL. Defaults to false.
-   */
-  requiresRegisteredRedirect?: boolean
-  /**
-   * Extra query params merged into the authorization URL.
-   * e.g. `{ access_type: 'offline', prompt: 'consent' }` for Google offline access.
-   */
-  authParams?: Record<string, string>
-}
+	/** Human-readable provider name shown in CLI prompts, e.g. "Google". */
+	providerName: string;
+	/** Authorization endpoint URL, e.g. "https://accounts.google.com/o/oauth2/v2/auth". */
+	authUrl: string;
+	/** Token exchange endpoint URL. */
+	tokenUrl: string;
+	/** OAuth scopes to request. */
+	scopes: string[];
+	/**
+	 * How client credentials are sent to the token endpoint.
+	 * - `'body'` (default): client_id + client_secret sent as form body params (Google, etc.)
+	 * - `'basic'`: Base64-encoded "client_id:client_secret" sent as an Authorization header (Spotify, etc.)
+	 */
+	tokenAuthMethod?: 'body' | 'basic';
+	/**
+	 * When true, the user must supply a pre-registered redirect URI rather than
+	 * using an auto-generated localhost URL. Defaults to false.
+	 */
+	requiresRegisteredRedirect?: boolean;
+	/**
+	 * Extra query params merged into the authorization URL.
+	 * e.g. `{ access_type: 'offline', prompt: 'consent' }` for Google offline access.
+	 */
+	authParams?: Record<string, string>;
+};
 
 /**
  * The full context type for a plugin, combining base context with typed services and options.
@@ -596,110 +596,111 @@ export type OAuthConfig = {
  * @template AuthConfig - Optional plugin auth config for extension fields
  */
 export type CorsairPluginContext<
-  Schema extends CorsairPluginSchema<Record<string, ZodTypeAny>> | undefined =
-    undefined,
-  Options extends Record<string, unknown> | undefined = undefined,
-  Endpoints extends EndpointTree | undefined = undefined,
-  AuthConfig extends PluginAuthConfig | undefined = undefined,
+	Schema extends
+		| CorsairPluginSchema<Record<string, ZodTypeAny>>
+		| undefined = undefined,
+	Options extends Record<string, unknown> | undefined = undefined,
+	Endpoints extends EndpointTree | undefined = undefined,
+	AuthConfig extends PluginAuthConfig | undefined = undefined,
 > = CorsairContext<
-  Endpoints extends EndpointTree ? BindEndpoints<Endpoints> : BoundEndpointTree
+	Endpoints extends EndpointTree ? BindEndpoints<Endpoints> : BoundEndpointTree
 > &
-  InferPluginEntities<Schema> & {
-    /**
-     * Get the account ID for this plugin's tenant and integration.
-     * The result is cached after the first call.
-     */
-    $getAccountId: () => Promise<string>
-    /**
-     * The resolved authentication key string for making API calls.
-     * This is populated by the keyBuilder before endpoint execution.
-     */
-    key: string
-    /**
-     * The tenant ID for this context (when multi-tenancy is enabled).
-     * Available in webhook hooks and endpoint hooks.
-     */
-    tenantId?: string
-  } & (Options extends undefined ? {} : { options: Options }) &
-  // Include keys manager if authType is defined in options
-  (ExtractAuthType<Options> extends AuthTypes
-    ? { keys: AccountKeyManagerFor<ExtractAuthType<Options>, AuthConfig> }
-    : {})
+	InferPluginEntities<Schema> & {
+		/**
+		 * Get the account ID for this plugin's tenant and integration.
+		 * The result is cached after the first call.
+		 */
+		$getAccountId: () => Promise<string>;
+		/**
+		 * The resolved authentication key string for making API calls.
+		 * This is populated by the keyBuilder before endpoint execution.
+		 */
+		key: string;
+		/**
+		 * The tenant ID for this context (when multi-tenancy is enabled).
+		 * Available in webhook hooks and endpoint hooks.
+		 */
+		tenantId?: string;
+	} & (Options extends undefined ? {} : { options: Options }) &
+	// Include keys manager if authType is defined in options
+	(ExtractAuthType<Options> extends AuthTypes
+		? { keys: AccountKeyManagerFor<ExtractAuthType<Options>, AuthConfig> }
+		: {});
 
 /**
  * Configuration for creating a Corsair integration with plugins.
  * @template Plugins - Array of plugin definitions
  */
 export type CorsairIntegration<Plugins extends readonly CorsairPlugin[]> = {
-  /** Database connection for ORM entities (e.g. `slack.api.messages.post(...)` for API, `slack.db.messages.findByEntityId(...)` for DB) */
-  database?: CorsairDatabaseInput
-  /** Array of plugin definitions to include */
-  plugins: Plugins
-  /** If true, enables tenant-scoped access via `withTenant()` */
-  multiTenancy?: boolean
-  /** Root-level error handlers that apply when plugin-specific handlers are not defined */
-  errorHandlers?: CorsairErrorHandler
-  /** Key Encryption Key (KEK) for envelope encryption. Used to encrypt/decrypt Data Encryption Keys (DEK) stored in the database. */
-  kek: string
-  /**
-   * Global approval configuration for the permission system.
-   * Controls how long approval requests stay active and what happens when they expire.
-   * Only relevant when the MCP server is used and a plugin is in `cautious` or `strict` mode.
-   */
-  approval?: {
-    /**
-     * How long an approval request remains valid before expiring.
-     * Accepts duration strings: '10m', '1h', '30s', '2h30m'.
-     * Defaults to '10m' if not specified.
-     */
-    timeout: string
-    /**
-     * What to do when an approval request expires without a response.
-     * - `'deny'`    → the action is automatically denied (recommended)
-     * - `'approve'` → the action is automatically approved (use only in low-risk setups)
-     */
-    onTimeout: 'deny' | 'approve'
-    /**
-     * How approval requests are handled when execution is blocked.
-     * - `'synchronous'`  → the tool call blocks (polls the DB) until the user approves or denies.
-     *                      The model is unaware anything happened — it just sees a slow tool call.
-     *                      On denial, the tool returns an error and the model stops.
-     * - `'asynchronous'` → the tool call returns immediately with a blocked result.
-     *                      The model must handle the denial and stop on its own.
-     * - A no-arg function → called per-request, return value selects the mode dynamically.
-     *                       Use this to switch modes based on runtime context (e.g. auth type).
-     * Defaults to `'asynchronous'` if not specified.
-     */
-    mode?:
-      | 'synchronous'
-      | 'asynchronous'
-      | (() => 'synchronous' | 'asynchronous')
-    /**
-     * Called when a permission is blocked in async mode. Return the string that the LLM receives
-     * as the tool result — this is what gets surfaced to the user in the chat.
-     * Receives the permission token, record ID, plugin name, endpoint path, and args.
-     */
-    formatAsyncMessage?: (opts: {
-      token: string
-      id: string
-      plugin: string
-      endpoint: string
-      args: unknown
-    }) => string
-  }
-  /**
-   * Connect link configuration for non-authenticated users.
-   * When a plugin endpoint is called but the user hasn't authenticated,
-   * Corsair generates a connect link the agent can present to the user.
-   * Only applies to plugins with an `oauthConfig`.
-   */
-  connect?: {
-    baseUrl: string
-    redirectUri: string
-    onAuthMissing?: (opts: {
-      plugin: string
-      connectUrl: string
-      state: string
-    }) => string
-  }
-}
+	/** Database connection for ORM entities (e.g. `slack.api.messages.post(...)` for API, `slack.db.messages.findByEntityId(...)` for DB) */
+	database?: CorsairDatabaseInput;
+	/** Array of plugin definitions to include */
+	plugins: Plugins;
+	/** If true, enables tenant-scoped access via `withTenant()` */
+	multiTenancy?: boolean;
+	/** Root-level error handlers that apply when plugin-specific handlers are not defined */
+	errorHandlers?: CorsairErrorHandler;
+	/** Key Encryption Key (KEK) for envelope encryption. Used to encrypt/decrypt Data Encryption Keys (DEK) stored in the database. */
+	kek: string;
+	/**
+	 * Global approval configuration for the permission system.
+	 * Controls how long approval requests stay active and what happens when they expire.
+	 * Only relevant when the MCP server is used and a plugin is in `cautious` or `strict` mode.
+	 */
+	approval?: {
+		/**
+		 * How long an approval request remains valid before expiring.
+		 * Accepts duration strings: '10m', '1h', '30s', '2h30m'.
+		 * Defaults to '10m' if not specified.
+		 */
+		timeout: string;
+		/**
+		 * What to do when an approval request expires without a response.
+		 * - `'deny'`    → the action is automatically denied (recommended)
+		 * - `'approve'` → the action is automatically approved (use only in low-risk setups)
+		 */
+		onTimeout: 'deny' | 'approve';
+		/**
+		 * How approval requests are handled when execution is blocked.
+		 * - `'synchronous'`  → the tool call blocks (polls the DB) until the user approves or denies.
+		 *                      The model is unaware anything happened — it just sees a slow tool call.
+		 *                      On denial, the tool returns an error and the model stops.
+		 * - `'asynchronous'` → the tool call returns immediately with a blocked result.
+		 *                      The model must handle the denial and stop on its own.
+		 * - A no-arg function → called per-request, return value selects the mode dynamically.
+		 *                       Use this to switch modes based on runtime context (e.g. auth type).
+		 * Defaults to `'asynchronous'` if not specified.
+		 */
+		mode?:
+			| 'synchronous'
+			| 'asynchronous'
+			| (() => 'synchronous' | 'asynchronous');
+		/**
+		 * Called when a permission is blocked in async mode. Return the string that the LLM receives
+		 * as the tool result — this is what gets surfaced to the user in the chat.
+		 * Receives the permission token, record ID, plugin name, endpoint path, and args.
+		 */
+		formatAsyncMessage?: (opts: {
+			token: string;
+			id: string;
+			plugin: string;
+			endpoint: string;
+			args: unknown;
+		}) => string;
+	};
+	/**
+	 * Connect link configuration for non-authenticated users.
+	 * When a plugin endpoint is called but the user hasn't authenticated,
+	 * Corsair generates a connect link the agent can present to the user.
+	 * Only applies to plugins with an `oauthConfig`.
+	 */
+	connect?: {
+		baseUrl: string;
+		redirectUri: string;
+		onAuthMissing?: (opts: {
+			plugin: string;
+			connectUrl: string;
+			state: string;
+		}) => string;
+	};
+};

--- a/packages/corsair/index.ts
+++ b/packages/corsair/index.ts
@@ -1,16 +1,15 @@
-export { AuthMissingError, createCorsair } from './core'
-export type { ResolveConnectLinkResult } from './core'
-export { resolveConnectLink } from './core'
+export type { ResolveConnectLinkResult } from './core';
+export { AuthMissingError, createCorsair, resolveConnectLink } from './core';
 export {
-  type AnyCorsairInstance,
-  type FormFieldSchema,
-  formatDocSchemaShape,
-  getSchema,
-  getStructuredSchema,
-  type ListOperationsOptions,
-  listOperations,
-} from './inspect'
-export type { PermissionExecuteResult } from './permissions'
-export { executePermission } from './permissions'
-export { type SetupCorsairOptions, setupCorsair } from './setup/index'
-export { processWebhook } from './webhooks'
+	type AnyCorsairInstance,
+	type FormFieldSchema,
+	formatDocSchemaShape,
+	getSchema,
+	getStructuredSchema,
+	type ListOperationsOptions,
+	listOperations,
+} from './inspect';
+export type { PermissionExecuteResult } from './permissions';
+export { executePermission } from './permissions';
+export { type SetupCorsairOptions, setupCorsair } from './setup/index';
+export { processWebhook } from './webhooks';

--- a/packages/corsair/index.ts
+++ b/packages/corsair/index.ts
@@ -1,14 +1,16 @@
-export { createCorsair } from './core';
+export { AuthMissingError, createCorsair } from './core'
+export type { ResolveConnectLinkResult } from './core'
+export { resolveConnectLink } from './core'
 export {
-	type AnyCorsairInstance,
-	type FormFieldSchema,
-	formatDocSchemaShape,
-	getSchema,
-	getStructuredSchema,
-	type ListOperationsOptions,
-	listOperations,
-} from './inspect';
-export type { PermissionExecuteResult } from './permissions';
-export { executePermission } from './permissions';
-export { type SetupCorsairOptions, setupCorsair } from './setup/index';
-export { processWebhook } from './webhooks';
+  type AnyCorsairInstance,
+  type FormFieldSchema,
+  formatDocSchemaShape,
+  getSchema,
+  getStructuredSchema,
+  type ListOperationsOptions,
+  listOperations,
+} from './inspect'
+export type { PermissionExecuteResult } from './permissions'
+export { executePermission } from './permissions'
+export { type SetupCorsairOptions, setupCorsair } from './setup/index'
+export { processWebhook } from './webhooks'

--- a/packages/corsair/oauth/index.ts
+++ b/packages/corsair/oauth/index.ts
@@ -1,139 +1,80 @@
-import * as crypto from 'node:crypto';
-import * as querystring from 'node:querystring';
-import type {
-	CorsairInternalConfig,
-	CorsairPlugin,
-	OAuthConfig,
-} from '../core';
+import * as querystring from 'node:querystring'
+import type { CorsairInternalConfig, CorsairPlugin, OAuthConfig } from '../core'
 import {
-	CORSAIR_INTERNAL,
-	createAccountKeyManager,
-	createIntegrationKeyManager,
-	encryptDEK,
-	exchangeCodeForTokens,
-	generateDEK,
-} from '../core';
-import { createCorsairOrm } from '../db/orm';
+  CORSAIR_INTERNAL,
+  createAccountKeyManager,
+  createIntegrationKeyManager,
+  encryptDEK,
+  exchangeCodeForTokens,
+  generateDEK,
+} from '../core'
+import {
+  decodeOAuthState,
+  encodeOAuthState,
+  signState,
+  verifyAndDecodeState,
+} from '../core/auth/state'
+import { createCorsairOrm } from '../db/orm'
 
-// ─────────────────────────────────────────────────────────────────────────────
-// State encoding — HMAC-signed to prevent forged callbacks
-// ─────────────────────────────────────────────────────────────────────────────
-
-type OAuthState = { plugin: string; tenantId: string };
-
-export function encodeOAuthState(plugin: string, tenantId: string): string {
-	return Buffer.from(JSON.stringify({ plugin, tenantId })).toString(
-		'base64url',
-	);
-}
-
-export function decodeOAuthState(state: string): OAuthState | null {
-	try {
-		// Accepts both raw payload (for tests/utilities) and signed `payload.sig` format
-		const payload = state.includes('.') ? state.split('.')[0] : state;
-		const decoded = JSON.parse(
-			Buffer.from(payload!, 'base64url').toString('utf-8'),
-		) as unknown;
-		if (
-			decoded !== null &&
-			typeof decoded === 'object' &&
-			'plugin' in decoded &&
-			'tenantId' in decoded &&
-			typeof (decoded as OAuthState).plugin === 'string' &&
-			typeof (decoded as OAuthState).tenantId === 'string'
-		) {
-			return decoded as OAuthState;
-		}
-		return null;
-	} catch {
-		return null;
-	}
-}
-
-function signState(payload: string, kek: string): string {
-	const sig = crypto
-		.createHmac('sha256', kek)
-		.update(payload)
-		.digest('base64url');
-	return `${payload}.${sig}`;
-}
-
-function verifyAndDecodeState(signed: string, kek: string): OAuthState | null {
-	const dotIdx = signed.lastIndexOf('.');
-	if (dotIdx === -1) return null;
-	const payload = signed.slice(0, dotIdx);
-	const sig = signed.slice(dotIdx + 1);
-	const expected = crypto
-		.createHmac('sha256', kek)
-		.update(payload)
-		.digest('base64url');
-	const sigBuf = Buffer.from(sig, 'base64url');
-	const expectedBuf = Buffer.from(expected, 'base64url');
-	if (
-		sigBuf.length !== expectedBuf.length ||
-		!crypto.timingSafeEqual(sigBuf, expectedBuf)
-	) {
-		return null;
-	}
-	return decodeOAuthState(payload);
-}
+// Re-export state utilities for backward compatibility (barrel oauth.ts re-exports these)
+export { decodeOAuthState, encodeOAuthState } from '../core/auth/state'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Internal helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
 function getInternal(corsair: unknown): CorsairInternalConfig {
-	const internal = (corsair as Record<symbol, unknown>)[CORSAIR_INTERNAL] as
-		| CorsairInternalConfig
-		| undefined;
-	if (!internal) throw new Error('Invalid corsair instance');
-	return internal;
+  const internal = (corsair as Record<symbol, unknown>)[CORSAIR_INTERNAL] as
+    | CorsairInternalConfig
+    | undefined
+  if (!internal) throw new Error('Invalid corsair instance')
+  return internal
 }
 
 function findPlugin(
-	internal: CorsairInternalConfig,
-	pluginId: string,
+  internal: CorsairInternalConfig,
+  pluginId: string
 ): CorsairPlugin {
-	const plugin = internal.plugins.find((p) => p.id === pluginId);
-	if (!plugin) throw new Error(`Plugin '${pluginId}' not found`);
-	return plugin;
+  const plugin = internal.plugins.find(p => p.id === pluginId)
+  if (!plugin) throw new Error(`Plugin '${pluginId}' not found`)
+  return plugin
 }
 
 function getOAuthConfig(plugin: CorsairPlugin): OAuthConfig {
-	const cfg = (plugin as { oauthConfig?: OAuthConfig }).oauthConfig;
-	if (!cfg) throw new Error(`Plugin '${plugin.id}' has no oauthConfig`);
-	return cfg;
+  const cfg = (plugin as { oauthConfig?: OAuthConfig }).oauthConfig
+  if (!cfg) throw new Error(`Plugin '${plugin.id}' has no oauthConfig`)
+  return cfg
 }
 
 async function ensureAccount(
-	database: NonNullable<CorsairInternalConfig['database']>,
-	pluginId: string,
-	tenantId: string,
-	kek: string,
+  database: NonNullable<CorsairInternalConfig['database']>,
+  pluginId: string,
+  tenantId: string,
+  kek: string
 ): Promise<void> {
-	const orm = createCorsairOrm(database);
+  const orm = createCorsairOrm(database)
 
-	const integration = await orm.integrations.findByName(pluginId);
-	if (!integration) {
-		throw new Error(
-			`Integration '${pluginId}' not found. Run setupCorsair first.`,
-		);
-	}
+  const integration = await orm.integrations.findByName(pluginId)
+  if (!integration) {
+    throw new Error(
+      `Integration '${pluginId}' not found. Run setupCorsair first.`
+    )
+  }
 
-	const existing = await orm.accounts.findOne({
-		tenant_id: tenantId,
-		integration_id: integration.id,
-	});
-	if (existing) return;
+  const existing = await orm.accounts.findOne({
+    tenant_id: tenantId,
+    integration_id: integration.id,
+  })
+  if (existing) return
 
-	const dek = generateDEK();
-	const encryptedDek = await encryptDEK(dek, kek);
-	await orm.accounts.create({
-		tenant_id: tenantId,
-		integration_id: integration.id,
-		config: {},
-		dek: encryptedDek,
-	});
+  const dek = generateDEK()
+  const encryptedDek = await encryptDEK(dek, kek)
+  await orm.accounts.create({
+    tenant_id: tenantId,
+    integration_id: integration.id,
+    config: {},
+    dek: encryptedDek,
+  })
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -141,14 +82,14 @@ async function ensureAccount(
 // ─────────────────────────────────────────────────────────────────────────────
 
 export type GenerateOAuthUrlOptions = {
-	tenantId: string;
-	redirectUri: string;
-};
+  tenantId: string
+  redirectUri: string
+}
 
 export type GenerateOAuthUrlResult = {
-	url: string;
-	state: string;
-};
+  url: string
+  state: string
+}
 
 /**
  * Builds an OAuth authorization URL for the given plugin and tenant.
@@ -163,60 +104,60 @@ export type GenerateOAuthUrlResult = {
  * Works for both multi-tenant and single-tenant corsair instances.
  */
 export async function generateOAuthUrl(
-	corsair: unknown,
-	pluginId: string,
-	options: GenerateOAuthUrlOptions,
+  corsair: unknown,
+  pluginId: string,
+  options: GenerateOAuthUrlOptions
 ): Promise<GenerateOAuthUrlResult> {
-	const { tenantId, redirectUri } = options;
-	const internal = getInternal(corsair);
+  const { tenantId, redirectUri } = options
+  const internal = getInternal(corsair)
 
-	if (!internal.database) {
-		throw new Error('No database configured on corsair instance');
-	}
+  if (!internal.database) {
+    throw new Error('No database configured on corsair instance')
+  }
 
-	const plugin = findPlugin(internal, pluginId);
-	const oauthCfg = getOAuthConfig(plugin);
+  const plugin = findPlugin(internal, pluginId)
+  const oauthCfg = getOAuthConfig(plugin)
 
-	const integrationKm = createIntegrationKeyManager({
-		authType: 'oauth_2',
-		integrationName: pluginId,
-		kek: internal.kek,
-		database: internal.database,
-	});
+  const integrationKm = createIntegrationKeyManager({
+    authType: 'oauth_2',
+    integrationName: pluginId,
+    kek: internal.kek,
+    database: internal.database,
+  })
 
-	const clientId = await integrationKm.get_client_id();
-	if (!clientId) {
-		throw new Error(`client_id not configured for '${pluginId}'`);
-	}
+  const clientId = await integrationKm.get_client_id()
+  if (!clientId) {
+    throw new Error(`client_id not configured for '${pluginId}'`)
+  }
 
-	const state = signState(encodeOAuthState(pluginId, tenantId), internal.kek);
+  const state = signState(encodeOAuthState(pluginId, tenantId), internal.kek)
 
-	const params: Record<string, string> = {
-		...oauthCfg.authParams,
-		client_id: clientId,
-		redirect_uri: redirectUri,
-		response_type: 'code',
-		scope: oauthCfg.scopes.join(' '),
-		state,
-	};
+  const params: Record<string, string> = {
+    ...oauthCfg.authParams,
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: oauthCfg.scopes.join(' '),
+    state,
+  }
 
-	return {
-		url: `${oauthCfg.authUrl}?${querystring.stringify(params)}`,
-		state,
-	};
+  return {
+    url: `${oauthCfg.authUrl}?${querystring.stringify(params)}`,
+    state,
+  }
 }
 
 export type ProcessOAuthCallbackOptions = {
-	code: string;
-	state: string;
-	/** Must exactly match the redirectUri passed to generateOAuthUrl. */
-	redirectUri: string;
-};
+  code: string
+  state: string
+  /** Must exactly match the redirectUri passed to generateOAuthUrl. */
+  redirectUri: string
+}
 
 export type ProcessOAuthCallbackResult = {
-	plugin: string;
-	tenantId: string;
-};
+  plugin: string
+  tenantId: string
+}
 
 /**
  * Completes the OAuth flow by exchanging the authorization code for tokens
@@ -228,70 +169,70 @@ export type ProcessOAuthCallbackResult = {
  * @throws if state is invalid, credentials are missing, or token exchange fails
  */
 export async function processOAuthCallback(
-	corsair: unknown,
-	options: ProcessOAuthCallbackOptions,
+  corsair: unknown,
+  options: ProcessOAuthCallbackOptions
 ): Promise<ProcessOAuthCallbackResult> {
-	const { code, state, redirectUri } = options;
+  const { code, state, redirectUri } = options
 
-	const internal = getInternal(corsair);
+  const internal = getInternal(corsair)
 
-	const decoded = verifyAndDecodeState(state, internal.kek);
-	if (!decoded) throw new Error('Invalid or tampered state parameter');
+  const decoded = verifyAndDecodeState(state, internal.kek)
+  if (!decoded) throw new Error('Invalid or tampered state parameter')
 
-	const { plugin: pluginId, tenantId } = decoded;
+  const { plugin: pluginId, tenantId } = decoded
 
-	if (!internal.database) {
-		throw new Error('No database configured on corsair instance');
-	}
+  if (!internal.database) {
+    throw new Error('No database configured on corsair instance')
+  }
 
-	const plugin = findPlugin(internal, pluginId);
-	const oauthCfg = getOAuthConfig(plugin);
+  const plugin = findPlugin(internal, pluginId)
+  const oauthCfg = getOAuthConfig(plugin)
 
-	const integrationKm = createIntegrationKeyManager({
-		authType: 'oauth_2',
-		integrationName: pluginId,
-		kek: internal.kek,
-		database: internal.database,
-	});
+  const integrationKm = createIntegrationKeyManager({
+    authType: 'oauth_2',
+    integrationName: pluginId,
+    kek: internal.kek,
+    database: internal.database,
+  })
 
-	const clientId = await integrationKm.get_client_id();
-	const clientSecret = await integrationKm.get_client_secret();
-	if (!clientId || !clientSecret) {
-		throw new Error(`Credentials not configured for '${pluginId}'`);
-	}
+  const clientId = await integrationKm.get_client_id()
+  const clientSecret = await integrationKm.get_client_secret()
+  if (!clientId || !clientSecret) {
+    throw new Error(`Credentials not configured for '${pluginId}'`)
+  }
 
-	// Ensure tenant account row exists before writing tokens
-	await ensureAccount(internal.database, pluginId, tenantId, internal.kek);
+  // Ensure tenant account row exists before writing tokens
+  await ensureAccount(internal.database, pluginId, tenantId, internal.kek)
 
-	const tokens = await exchangeCodeForTokens(
-		code,
-		clientId,
-		clientSecret,
-		oauthCfg,
-		redirectUri,
-	);
+  const tokens = await exchangeCodeForTokens(
+    code,
+    clientId,
+    clientSecret,
+    oauthCfg,
+    redirectUri
+  )
 
-	if (!tokens.access_token) {
-		throw new Error(`No access_token returned from ${oauthCfg.providerName}`);
-	}
+  if (!tokens.access_token) {
+    throw new Error(`No access_token returned from ${oauthCfg.providerName}`)
+  }
 
-	const accountKm = createAccountKeyManager({
-		authType: 'oauth_2',
-		integrationName: pluginId,
-		tenantId,
-		kek: internal.kek,
-		database: internal.database,
-	});
+  const accountKm = createAccountKeyManager({
+    authType: 'oauth_2',
+    integrationName: pluginId,
+    tenantId,
+    kek: internal.kek,
+    database: internal.database,
+  })
 
-	await accountKm.set_access_token(tokens.access_token);
-	if (tokens.refresh_token) {
-		await accountKm.set_refresh_token(tokens.refresh_token);
-	}
-	if (tokens.expires_in) {
-		await accountKm.set_expires_at(
-			String(Math.floor(Date.now() / 1000) + tokens.expires_in),
-		);
-	}
+  await accountKm.set_access_token(tokens.access_token)
+  if (tokens.refresh_token) {
+    await accountKm.set_refresh_token(tokens.refresh_token)
+  }
+  if (tokens.expires_in) {
+    await accountKm.set_expires_at(
+      String(Math.floor(Date.now() / 1000) + tokens.expires_in)
+    )
+  }
 
-	return { plugin: pluginId, tenantId };
+  return { plugin: pluginId, tenantId }
 }

--- a/packages/corsair/oauth/index.ts
+++ b/packages/corsair/oauth/index.ts
@@ -1,80 +1,83 @@
-import * as querystring from 'node:querystring'
-import type { CorsairInternalConfig, CorsairPlugin, OAuthConfig } from '../core'
+import * as querystring from 'node:querystring';
+import type {
+	CorsairInternalConfig,
+	CorsairPlugin,
+	OAuthConfig,
+} from '../core';
 import {
-  CORSAIR_INTERNAL,
-  createAccountKeyManager,
-  createIntegrationKeyManager,
-  encryptDEK,
-  exchangeCodeForTokens,
-  generateDEK,
-} from '../core'
+	CORSAIR_INTERNAL,
+	createAccountKeyManager,
+	createIntegrationKeyManager,
+	encryptDEK,
+	exchangeCodeForTokens,
+	generateDEK,
+} from '../core';
 import {
-  decodeOAuthState,
-  encodeOAuthState,
-  signState,
-  verifyAndDecodeState,
-} from '../core/auth/state'
-import { createCorsairOrm } from '../db/orm'
+	encodeOAuthState,
+	signState,
+	verifyAndDecodeState,
+} from '../core/auth/state';
+import { createCorsairOrm } from '../db/orm';
 
 // Re-export state utilities for backward compatibility (barrel oauth.ts re-exports these)
-export { decodeOAuthState, encodeOAuthState } from '../core/auth/state'
+export { decodeOAuthState, encodeOAuthState } from '../core/auth/state';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Internal helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
 function getInternal(corsair: unknown): CorsairInternalConfig {
-  const internal = (corsair as Record<symbol, unknown>)[CORSAIR_INTERNAL] as
-    | CorsairInternalConfig
-    | undefined
-  if (!internal) throw new Error('Invalid corsair instance')
-  return internal
+	const internal = (corsair as Record<symbol, unknown>)[CORSAIR_INTERNAL] as
+		| CorsairInternalConfig
+		| undefined;
+	if (!internal) throw new Error('Invalid corsair instance');
+	return internal;
 }
 
 function findPlugin(
-  internal: CorsairInternalConfig,
-  pluginId: string
+	internal: CorsairInternalConfig,
+	pluginId: string,
 ): CorsairPlugin {
-  const plugin = internal.plugins.find(p => p.id === pluginId)
-  if (!plugin) throw new Error(`Plugin '${pluginId}' not found`)
-  return plugin
+	const plugin = internal.plugins.find((p) => p.id === pluginId);
+	if (!plugin) throw new Error(`Plugin '${pluginId}' not found`);
+	return plugin;
 }
 
 function getOAuthConfig(plugin: CorsairPlugin): OAuthConfig {
-  const cfg = (plugin as { oauthConfig?: OAuthConfig }).oauthConfig
-  if (!cfg) throw new Error(`Plugin '${plugin.id}' has no oauthConfig`)
-  return cfg
+	const cfg = (plugin as { oauthConfig?: OAuthConfig }).oauthConfig;
+	if (!cfg) throw new Error(`Plugin '${plugin.id}' has no oauthConfig`);
+	return cfg;
 }
 
 async function ensureAccount(
-  database: NonNullable<CorsairInternalConfig['database']>,
-  pluginId: string,
-  tenantId: string,
-  kek: string
+	database: NonNullable<CorsairInternalConfig['database']>,
+	pluginId: string,
+	tenantId: string,
+	kek: string,
 ): Promise<void> {
-  const orm = createCorsairOrm(database)
+	const orm = createCorsairOrm(database);
 
-  const integration = await orm.integrations.findByName(pluginId)
-  if (!integration) {
-    throw new Error(
-      `Integration '${pluginId}' not found. Run setupCorsair first.`
-    )
-  }
+	const integration = await orm.integrations.findByName(pluginId);
+	if (!integration) {
+		throw new Error(
+			`Integration '${pluginId}' not found. Run setupCorsair first.`,
+		);
+	}
 
-  const existing = await orm.accounts.findOne({
-    tenant_id: tenantId,
-    integration_id: integration.id,
-  })
-  if (existing) return
+	const existing = await orm.accounts.findOne({
+		tenant_id: tenantId,
+		integration_id: integration.id,
+	});
+	if (existing) return;
 
-  const dek = generateDEK()
-  const encryptedDek = await encryptDEK(dek, kek)
-  await orm.accounts.create({
-    tenant_id: tenantId,
-    integration_id: integration.id,
-    config: {},
-    dek: encryptedDek,
-  })
+	const dek = generateDEK();
+	const encryptedDek = await encryptDEK(dek, kek);
+	await orm.accounts.create({
+		tenant_id: tenantId,
+		integration_id: integration.id,
+		config: {},
+		dek: encryptedDek,
+	});
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -82,14 +85,14 @@ async function ensureAccount(
 // ─────────────────────────────────────────────────────────────────────────────
 
 export type GenerateOAuthUrlOptions = {
-  tenantId: string
-  redirectUri: string
-}
+	tenantId: string;
+	redirectUri: string;
+};
 
 export type GenerateOAuthUrlResult = {
-  url: string
-  state: string
-}
+	url: string;
+	state: string;
+};
 
 /**
  * Builds an OAuth authorization URL for the given plugin and tenant.
@@ -104,60 +107,60 @@ export type GenerateOAuthUrlResult = {
  * Works for both multi-tenant and single-tenant corsair instances.
  */
 export async function generateOAuthUrl(
-  corsair: unknown,
-  pluginId: string,
-  options: GenerateOAuthUrlOptions
+	corsair: unknown,
+	pluginId: string,
+	options: GenerateOAuthUrlOptions,
 ): Promise<GenerateOAuthUrlResult> {
-  const { tenantId, redirectUri } = options
-  const internal = getInternal(corsair)
+	const { tenantId, redirectUri } = options;
+	const internal = getInternal(corsair);
 
-  if (!internal.database) {
-    throw new Error('No database configured on corsair instance')
-  }
+	if (!internal.database) {
+		throw new Error('No database configured on corsair instance');
+	}
 
-  const plugin = findPlugin(internal, pluginId)
-  const oauthCfg = getOAuthConfig(plugin)
+	const plugin = findPlugin(internal, pluginId);
+	const oauthCfg = getOAuthConfig(plugin);
 
-  const integrationKm = createIntegrationKeyManager({
-    authType: 'oauth_2',
-    integrationName: pluginId,
-    kek: internal.kek,
-    database: internal.database,
-  })
+	const integrationKm = createIntegrationKeyManager({
+		authType: 'oauth_2',
+		integrationName: pluginId,
+		kek: internal.kek,
+		database: internal.database,
+	});
 
-  const clientId = await integrationKm.get_client_id()
-  if (!clientId) {
-    throw new Error(`client_id not configured for '${pluginId}'`)
-  }
+	const clientId = await integrationKm.get_client_id();
+	if (!clientId) {
+		throw new Error(`client_id not configured for '${pluginId}'`);
+	}
 
-  const state = signState(encodeOAuthState(pluginId, tenantId), internal.kek)
+	const state = signState(encodeOAuthState(pluginId, tenantId), internal.kek);
 
-  const params: Record<string, string> = {
-    ...oauthCfg.authParams,
-    client_id: clientId,
-    redirect_uri: redirectUri,
-    response_type: 'code',
-    scope: oauthCfg.scopes.join(' '),
-    state,
-  }
+	const params: Record<string, string> = {
+		...oauthCfg.authParams,
+		client_id: clientId,
+		redirect_uri: redirectUri,
+		response_type: 'code',
+		scope: oauthCfg.scopes.join(' '),
+		state,
+	};
 
-  return {
-    url: `${oauthCfg.authUrl}?${querystring.stringify(params)}`,
-    state,
-  }
+	return {
+		url: `${oauthCfg.authUrl}?${querystring.stringify(params)}`,
+		state,
+	};
 }
 
 export type ProcessOAuthCallbackOptions = {
-  code: string
-  state: string
-  /** Must exactly match the redirectUri passed to generateOAuthUrl. */
-  redirectUri: string
-}
+	code: string;
+	state: string;
+	/** Must exactly match the redirectUri passed to generateOAuthUrl. */
+	redirectUri: string;
+};
 
 export type ProcessOAuthCallbackResult = {
-  plugin: string
-  tenantId: string
-}
+	plugin: string;
+	tenantId: string;
+};
 
 /**
  * Completes the OAuth flow by exchanging the authorization code for tokens
@@ -169,70 +172,70 @@ export type ProcessOAuthCallbackResult = {
  * @throws if state is invalid, credentials are missing, or token exchange fails
  */
 export async function processOAuthCallback(
-  corsair: unknown,
-  options: ProcessOAuthCallbackOptions
+	corsair: unknown,
+	options: ProcessOAuthCallbackOptions,
 ): Promise<ProcessOAuthCallbackResult> {
-  const { code, state, redirectUri } = options
+	const { code, state, redirectUri } = options;
 
-  const internal = getInternal(corsair)
+	const internal = getInternal(corsair);
 
-  const decoded = verifyAndDecodeState(state, internal.kek)
-  if (!decoded) throw new Error('Invalid or tampered state parameter')
+	const decoded = verifyAndDecodeState(state, internal.kek);
+	if (!decoded) throw new Error('Invalid or tampered state parameter');
 
-  const { plugin: pluginId, tenantId } = decoded
+	const { plugin: pluginId, tenantId } = decoded;
 
-  if (!internal.database) {
-    throw new Error('No database configured on corsair instance')
-  }
+	if (!internal.database) {
+		throw new Error('No database configured on corsair instance');
+	}
 
-  const plugin = findPlugin(internal, pluginId)
-  const oauthCfg = getOAuthConfig(plugin)
+	const plugin = findPlugin(internal, pluginId);
+	const oauthCfg = getOAuthConfig(plugin);
 
-  const integrationKm = createIntegrationKeyManager({
-    authType: 'oauth_2',
-    integrationName: pluginId,
-    kek: internal.kek,
-    database: internal.database,
-  })
+	const integrationKm = createIntegrationKeyManager({
+		authType: 'oauth_2',
+		integrationName: pluginId,
+		kek: internal.kek,
+		database: internal.database,
+	});
 
-  const clientId = await integrationKm.get_client_id()
-  const clientSecret = await integrationKm.get_client_secret()
-  if (!clientId || !clientSecret) {
-    throw new Error(`Credentials not configured for '${pluginId}'`)
-  }
+	const clientId = await integrationKm.get_client_id();
+	const clientSecret = await integrationKm.get_client_secret();
+	if (!clientId || !clientSecret) {
+		throw new Error(`Credentials not configured for '${pluginId}'`);
+	}
 
-  // Ensure tenant account row exists before writing tokens
-  await ensureAccount(internal.database, pluginId, tenantId, internal.kek)
+	// Ensure tenant account row exists before writing tokens
+	await ensureAccount(internal.database, pluginId, tenantId, internal.kek);
 
-  const tokens = await exchangeCodeForTokens(
-    code,
-    clientId,
-    clientSecret,
-    oauthCfg,
-    redirectUri
-  )
+	const tokens = await exchangeCodeForTokens(
+		code,
+		clientId,
+		clientSecret,
+		oauthCfg,
+		redirectUri,
+	);
 
-  if (!tokens.access_token) {
-    throw new Error(`No access_token returned from ${oauthCfg.providerName}`)
-  }
+	if (!tokens.access_token) {
+		throw new Error(`No access_token returned from ${oauthCfg.providerName}`);
+	}
 
-  const accountKm = createAccountKeyManager({
-    authType: 'oauth_2',
-    integrationName: pluginId,
-    tenantId,
-    kek: internal.kek,
-    database: internal.database,
-  })
+	const accountKm = createAccountKeyManager({
+		authType: 'oauth_2',
+		integrationName: pluginId,
+		tenantId,
+		kek: internal.kek,
+		database: internal.database,
+	});
 
-  await accountKm.set_access_token(tokens.access_token)
-  if (tokens.refresh_token) {
-    await accountKm.set_refresh_token(tokens.refresh_token)
-  }
-  if (tokens.expires_in) {
-    await accountKm.set_expires_at(
-      String(Math.floor(Date.now() / 1000) + tokens.expires_in)
-    )
-  }
+	await accountKm.set_access_token(tokens.access_token);
+	if (tokens.refresh_token) {
+		await accountKm.set_refresh_token(tokens.refresh_token);
+	}
+	if (tokens.expires_in) {
+		await accountKm.set_expires_at(
+			String(Math.floor(Date.now() / 1000) + tokens.expires_in),
+		);
+	}
 
-  return { plugin: pluginId, tenantId }
+	return { plugin: pluginId, tenantId };
 }

--- a/packages/corsair/tests/connect-link.test.ts
+++ b/packages/corsair/tests/connect-link.test.ts
@@ -139,12 +139,10 @@ describe('connect-link generation in endpoint binding', () => {
     }
   })
 
-  it('generates connect link when keyBuilder throws account-not-found error', async () => {
+  it('propagates non-AuthMissingError from keyBuilder even with connectConfig', async () => {
     const boundFn = createBoundEndpoint({
       keyBuilder: async () => {
-        throw new Error(
-          'Account not found for tenant "tenant-1" and integration "gmail"'
-        )
+        throw new Error('Account not found for tenant "tenant-1"')
       },
       connectConfig: {
         baseUrl: 'https://myapp.com/connect',
@@ -158,13 +156,7 @@ describe('connect-link generation in endpoint binding', () => {
       },
     })
 
-    try {
-      await boundFn()
-      fail('Expected error to be thrown')
-    } catch (err: any) {
-      expect(err.message).toContain('[auth-missing:gmail]')
-      expect(err.message).toContain('https://myapp.com/connect')
-    }
+    await expect(boundFn()).rejects.toThrow('Account not found')
   })
 
   it('uses custom onAuthMissing callback', async () => {

--- a/packages/corsair/tests/connect-link.test.ts
+++ b/packages/corsair/tests/connect-link.test.ts
@@ -1,244 +1,244 @@
-import { AuthMissingError } from '../core/auth/errors/auth-missing'
+import { AuthMissingError } from '../core/auth/errors/auth-missing';
 import {
-  encodeOAuthState,
-  signState,
-  decodeOAuthState,
-  verifyAndDecodeState,
-} from '../core/auth/state'
-import { bindEndpointsRecursively } from '../core/endpoints/bind'
+	decodeOAuthState,
+	encodeOAuthState,
+	signState,
+	verifyAndDecodeState,
+} from '../core/auth/state';
+import { bindEndpointsRecursively } from '../core/endpoints/bind';
 
 describe('AuthMissingError', () => {
-  it('sets name, pluginId, and default message', () => {
-    const err = new AuthMissingError('gmail')
-    expect(err).toBeInstanceOf(Error)
-    expect(err).toBeInstanceOf(AuthMissingError)
-    expect(err.name).toBe('AuthMissingError')
-    expect(err.pluginId).toBe('gmail')
-    expect(err.message).toBe('[auth-missing:gmail]')
-  })
+	it('sets name, pluginId, and default message', () => {
+		const err = new AuthMissingError('gmail');
+		expect(err).toBeInstanceOf(Error);
+		expect(err).toBeInstanceOf(AuthMissingError);
+		expect(err.name).toBe('AuthMissingError');
+		expect(err.pluginId).toBe('gmail');
+		expect(err.message).toBe('[auth-missing:gmail]');
+	});
 
-  it('accepts a custom message', () => {
-    const err = new AuthMissingError('gmail', 'custom message')
-    expect(err.message).toBe('custom message')
-    expect(err.pluginId).toBe('gmail')
-  })
-})
+	it('accepts a custom message', () => {
+		const err = new AuthMissingError('gmail', 'custom message');
+		expect(err.message).toBe('custom message');
+		expect(err.pluginId).toBe('gmail');
+	});
+});
 
 describe('OAuth state utilities', () => {
-  const kek = 'test-kek-value-for-signing'
+	const kek = 'test-kek-value-for-signing';
 
-  it('round-trips encode/decode', () => {
-    const encoded = encodeOAuthState('gmail', 'tenant-1')
-    const decoded = decodeOAuthState(encoded)
-    expect(decoded).toEqual({ plugin: 'gmail', tenantId: 'tenant-1' })
-  })
+	it('round-trips encode/decode', () => {
+		const encoded = encodeOAuthState('gmail', 'tenant-1');
+		const decoded = decodeOAuthState(encoded);
+		expect(decoded).toEqual({ plugin: 'gmail', tenantId: 'tenant-1' });
+	});
 
-  it('signs and verifies state', () => {
-    const payload = encodeOAuthState('slack', 'tenant-2')
-    const signed = signState(payload, kek)
-    const decoded = verifyAndDecodeState(signed, kek)
-    expect(decoded).toEqual({ plugin: 'slack', tenantId: 'tenant-2' })
-  })
+	it('signs and verifies state', () => {
+		const payload = encodeOAuthState('slack', 'tenant-2');
+		const signed = signState(payload, kek);
+		const decoded = verifyAndDecodeState(signed, kek);
+		expect(decoded).toEqual({ plugin: 'slack', tenantId: 'tenant-2' });
+	});
 
-  it('rejects tampered state', () => {
-    const payload = encodeOAuthState('slack', 'tenant-2')
-    const signed = signState(payload, kek)
-    const tampered = signed.slice(0, -5) + 'XXXXX'
-    const decoded = verifyAndDecodeState(tampered, kek)
-    expect(decoded).toBeNull()
-  })
+	it('rejects tampered state', () => {
+		const payload = encodeOAuthState('slack', 'tenant-2');
+		const signed = signState(payload, kek);
+		const tampered = signed.slice(0, -5) + 'XXXXX';
+		const decoded = verifyAndDecodeState(tampered, kek);
+		expect(decoded).toBeNull();
+	});
 
-  it('returns null for invalid state', () => {
-    expect(decodeOAuthState('not-valid-base64!!!')).toBeNull()
-    expect(verifyAndDecodeState('', kek)).toBeNull()
-  })
-})
+	it('returns null for invalid state', () => {
+		expect(decodeOAuthState('not-valid-base64!!!')).toBeNull();
+		expect(verifyAndDecodeState('', kek)).toBeNull();
+	});
+});
 
 describe('connect-link generation in endpoint binding', () => {
-  const kek = 'test-kek-for-connect-link'
+	const kek = 'test-kek-for-connect-link';
 
-  function createBoundEndpoint(opts: {
-    keyBuilder?: (ctx: any, source: string) => Promise<string>
-    connectConfig?: any
-  }) {
-    const endpoints = {
-      sendEmail: async (_ctx: any, _args: any) => 'sent',
-    }
+	function createBoundEndpoint(opts: {
+		keyBuilder?: (ctx: any, source: string) => Promise<string>;
+		connectConfig?: any;
+	}) {
+		const endpoints = {
+			sendEmail: async (_ctx: any, _args: any) => 'sent',
+		};
 
-    const tree: Record<string, unknown> = {}
-    bindEndpointsRecursively({
-      endpoints,
-      hooks: undefined,
-      ctx: {},
-      tree,
-      pluginId: 'gmail',
-      errorHandlers: {},
-      currentPath: [],
-      keyBuilder: opts.keyBuilder,
-      connectConfig: opts.connectConfig,
-    })
+		const tree: Record<string, unknown> = {};
+		bindEndpointsRecursively({
+			endpoints,
+			hooks: undefined,
+			ctx: {},
+			tree,
+			pluginId: 'gmail',
+			errorHandlers: {},
+			currentPath: [],
+			keyBuilder: opts.keyBuilder,
+			connectConfig: opts.connectConfig,
+		});
 
-    return tree.sendEmail as (args?: unknown) => Promise<unknown>
-  }
+		return tree.sendEmail as (args?: unknown) => Promise<unknown>;
+	}
 
-  it('generates connect link when keyBuilder returns empty string', async () => {
-    const boundFn = createBoundEndpoint({
-      keyBuilder: async () => '',
-      connectConfig: {
-        baseUrl: 'https://myapp.com/connect',
-        redirectUri: 'https://myapp.com/api/callback',
-        oauthConfig: {
-          providerName: 'Google',
-          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
-        },
-        kek,
-        tenantId: 'tenant-1',
-      },
-    })
+	it('generates connect link when keyBuilder returns empty string', async () => {
+		const boundFn = createBoundEndpoint({
+			keyBuilder: async () => '',
+			connectConfig: {
+				baseUrl: 'https://myapp.com/connect',
+				redirectUri: 'https://myapp.com/api/callback',
+				oauthConfig: {
+					providerName: 'Google',
+					authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+				},
+				kek,
+				tenantId: 'tenant-1',
+			},
+		});
 
-    try {
-      await boundFn({ to: 'user@example.com' })
-      fail('Expected error to be thrown')
-    } catch (err: any) {
-      expect(err.message).toContain('[auth-missing:gmail]')
-      expect(err.message).toContain('https://myapp.com/connect')
-      expect(err.message).toContain('Authentication required')
+		try {
+			await boundFn({ to: 'user@example.com' });
+			fail('Expected error to be thrown');
+		} catch (err: any) {
+			expect(err.message).toContain('[auth-missing:gmail]');
+			expect(err.message).toContain('https://myapp.com/connect');
+			expect(err.message).toContain('Authentication required');
 
-      // Verify the state parameter in the connect URL is valid
-      const stateMatch = err.message.match(/state=([^&\s]+)/)
-      expect(stateMatch).not.toBeNull()
-      const state = decodeURIComponent(stateMatch![1])
-      const decoded = verifyAndDecodeState(state, kek)
-      expect(decoded).toEqual({ plugin: 'gmail', tenantId: 'tenant-1' })
-    }
-  })
+			// Verify the state parameter in the connect URL is valid
+			const stateMatch = err.message.match(/state=([^&\s]+)/);
+			expect(stateMatch).not.toBeNull();
+			const state = decodeURIComponent(stateMatch![1]);
+			const decoded = verifyAndDecodeState(state, kek);
+			expect(decoded).toEqual({ plugin: 'gmail', tenantId: 'tenant-1' });
+		}
+	});
 
-  it('generates connect link when keyBuilder throws AuthMissingError', async () => {
-    const boundFn = createBoundEndpoint({
-      keyBuilder: async () => {
-        throw new AuthMissingError('gmail')
-      },
-      connectConfig: {
-        baseUrl: 'https://myapp.com/connect',
-        redirectUri: 'https://myapp.com/api/callback',
-        oauthConfig: {
-          providerName: 'Google',
-          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
-        },
-        kek,
-        tenantId: 'tenant-1',
-      },
-    })
+	it('generates connect link when keyBuilder throws AuthMissingError', async () => {
+		const boundFn = createBoundEndpoint({
+			keyBuilder: async () => {
+				throw new AuthMissingError('gmail');
+			},
+			connectConfig: {
+				baseUrl: 'https://myapp.com/connect',
+				redirectUri: 'https://myapp.com/api/callback',
+				oauthConfig: {
+					providerName: 'Google',
+					authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+				},
+				kek,
+				tenantId: 'tenant-1',
+			},
+		});
 
-    try {
-      await boundFn()
-      fail('Expected error to be thrown')
-    } catch (err: any) {
-      expect(err.message).toContain('[auth-missing:gmail]')
-      expect(err.message).toContain('https://myapp.com/connect')
-    }
-  })
+		try {
+			await boundFn();
+			fail('Expected error to be thrown');
+		} catch (err: any) {
+			expect(err.message).toContain('[auth-missing:gmail]');
+			expect(err.message).toContain('https://myapp.com/connect');
+		}
+	});
 
-  it('propagates non-AuthMissingError from keyBuilder even with connectConfig', async () => {
-    const boundFn = createBoundEndpoint({
-      keyBuilder: async () => {
-        throw new Error('Account not found for tenant "tenant-1"')
-      },
-      connectConfig: {
-        baseUrl: 'https://myapp.com/connect',
-        redirectUri: 'https://myapp.com/api/callback',
-        oauthConfig: {
-          providerName: 'Google',
-          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
-        },
-        kek,
-        tenantId: 'tenant-1',
-      },
-    })
+	it('propagates non-AuthMissingError from keyBuilder even with connectConfig', async () => {
+		const boundFn = createBoundEndpoint({
+			keyBuilder: async () => {
+				throw new Error('Account not found for tenant "tenant-1"');
+			},
+			connectConfig: {
+				baseUrl: 'https://myapp.com/connect',
+				redirectUri: 'https://myapp.com/api/callback',
+				oauthConfig: {
+					providerName: 'Google',
+					authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+				},
+				kek,
+				tenantId: 'tenant-1',
+			},
+		});
 
-    await expect(boundFn()).rejects.toThrow('Account not found')
-  })
+		await expect(boundFn()).rejects.toThrow('Account not found');
+	});
 
-  it('uses custom onAuthMissing callback', async () => {
-    const boundFn = createBoundEndpoint({
-      keyBuilder: async () => '',
-      connectConfig: {
-        baseUrl: 'https://myapp.com/connect',
-        redirectUri: 'https://myapp.com/api/callback',
-        oauthConfig: {
-          providerName: 'Google',
-          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
-        },
-        kek,
-        tenantId: 'tenant-1',
-        onAuthMissing: ({
-          plugin,
-          connectUrl,
-        }: {
-          plugin: string
-          connectUrl: string
-          state: string
-        }) => `Please connect ${plugin}: ${connectUrl}`,
-      },
-    })
+	it('uses custom onAuthMissing callback', async () => {
+		const boundFn = createBoundEndpoint({
+			keyBuilder: async () => '',
+			connectConfig: {
+				baseUrl: 'https://myapp.com/connect',
+				redirectUri: 'https://myapp.com/api/callback',
+				oauthConfig: {
+					providerName: 'Google',
+					authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+				},
+				kek,
+				tenantId: 'tenant-1',
+				onAuthMissing: ({
+					plugin,
+					connectUrl,
+				}: {
+					plugin: string;
+					connectUrl: string;
+					state: string;
+				}) => `Please connect ${plugin}: ${connectUrl}`,
+			},
+		});
 
-    try {
-      await boundFn()
-      fail('Expected error to be thrown')
-    } catch (err: any) {
-      expect(err.message).toBe(
-        'Please connect gmail: https://myapp.com/connect?plugin=gmail&state=' +
-          err.message.split('state=')[1]
-      )
-      expect(err.message).toContain('Please connect gmail')
-      expect(err.message).toContain('https://myapp.com/connect')
-    }
-  })
+		try {
+			await boundFn();
+			fail('Expected error to be thrown');
+		} catch (err: any) {
+			expect(err.message).toBe(
+				'Please connect gmail: https://myapp.com/connect?plugin=gmail&state=' +
+					err.message.split('state=')[1],
+			);
+			expect(err.message).toContain('Please connect gmail');
+			expect(err.message).toContain('https://myapp.com/connect');
+		}
+	});
 
-  it('does not intercept errors when connectConfig is not set', async () => {
-    const boundFn = createBoundEndpoint({
-      keyBuilder: async () => {
-        throw new Error('Account not found')
-      },
-    })
+	it('does not intercept errors when connectConfig is not set', async () => {
+		const boundFn = createBoundEndpoint({
+			keyBuilder: async () => {
+				throw new Error('Account not found');
+			},
+		});
 
-    await expect(boundFn()).rejects.toThrow('Account not found')
-  })
+		await expect(boundFn()).rejects.toThrow('Account not found');
+	});
 
-  it('does not intercept errors when plugin has no oauthConfig', async () => {
-    const boundFn = createBoundEndpoint({
-      keyBuilder: async () => {
-        throw new Error('Account not found')
-      },
-      connectConfig: {
-        baseUrl: 'https://myapp.com/connect',
-        redirectUri: 'https://myapp.com/api/callback',
-        oauthConfig: undefined,
-        kek,
-        tenantId: 'tenant-1',
-      },
-    })
+	it('does not intercept errors when plugin has no oauthConfig', async () => {
+		const boundFn = createBoundEndpoint({
+			keyBuilder: async () => {
+				throw new Error('Account not found');
+			},
+			connectConfig: {
+				baseUrl: 'https://myapp.com/connect',
+				redirectUri: 'https://myapp.com/api/callback',
+				oauthConfig: undefined,
+				kek,
+				tenantId: 'tenant-1',
+			},
+		});
 
-    await expect(boundFn()).rejects.toThrow('Account not found')
-  })
+		await expect(boundFn()).rejects.toThrow('Account not found');
+	});
 
-  it('does not intercept unrelated errors when connectConfig is set', async () => {
-    const boundFn = createBoundEndpoint({
-      keyBuilder: async () => {
-        throw new Error('Network timeout')
-      },
-      connectConfig: {
-        baseUrl: 'https://myapp.com/connect',
-        redirectUri: 'https://myapp.com/api/callback',
-        oauthConfig: {
-          providerName: 'Google',
-          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
-        },
-        kek,
-        tenantId: 'tenant-1',
-      },
-    })
+	it('does not intercept unrelated errors when connectConfig is set', async () => {
+		const boundFn = createBoundEndpoint({
+			keyBuilder: async () => {
+				throw new Error('Network timeout');
+			},
+			connectConfig: {
+				baseUrl: 'https://myapp.com/connect',
+				redirectUri: 'https://myapp.com/api/callback',
+				oauthConfig: {
+					providerName: 'Google',
+					authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+				},
+				kek,
+				tenantId: 'tenant-1',
+			},
+		});
 
-    await expect(boundFn()).rejects.toThrow('Network timeout')
-  })
-})
+		await expect(boundFn()).rejects.toThrow('Network timeout');
+	});
+});

--- a/packages/corsair/tests/connect-link.test.ts
+++ b/packages/corsair/tests/connect-link.test.ts
@@ -1,0 +1,252 @@
+import { AuthMissingError } from '../core/auth/errors/auth-missing'
+import {
+  encodeOAuthState,
+  signState,
+  decodeOAuthState,
+  verifyAndDecodeState,
+} from '../core/auth/state'
+import { bindEndpointsRecursively } from '../core/endpoints/bind'
+
+describe('AuthMissingError', () => {
+  it('sets name, pluginId, and default message', () => {
+    const err = new AuthMissingError('gmail')
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(AuthMissingError)
+    expect(err.name).toBe('AuthMissingError')
+    expect(err.pluginId).toBe('gmail')
+    expect(err.message).toBe('[auth-missing:gmail]')
+  })
+
+  it('accepts a custom message', () => {
+    const err = new AuthMissingError('gmail', 'custom message')
+    expect(err.message).toBe('custom message')
+    expect(err.pluginId).toBe('gmail')
+  })
+})
+
+describe('OAuth state utilities', () => {
+  const kek = 'test-kek-value-for-signing'
+
+  it('round-trips encode/decode', () => {
+    const encoded = encodeOAuthState('gmail', 'tenant-1')
+    const decoded = decodeOAuthState(encoded)
+    expect(decoded).toEqual({ plugin: 'gmail', tenantId: 'tenant-1' })
+  })
+
+  it('signs and verifies state', () => {
+    const payload = encodeOAuthState('slack', 'tenant-2')
+    const signed = signState(payload, kek)
+    const decoded = verifyAndDecodeState(signed, kek)
+    expect(decoded).toEqual({ plugin: 'slack', tenantId: 'tenant-2' })
+  })
+
+  it('rejects tampered state', () => {
+    const payload = encodeOAuthState('slack', 'tenant-2')
+    const signed = signState(payload, kek)
+    const tampered = signed.slice(0, -5) + 'XXXXX'
+    const decoded = verifyAndDecodeState(tampered, kek)
+    expect(decoded).toBeNull()
+  })
+
+  it('returns null for invalid state', () => {
+    expect(decodeOAuthState('not-valid-base64!!!')).toBeNull()
+    expect(verifyAndDecodeState('', kek)).toBeNull()
+  })
+})
+
+describe('connect-link generation in endpoint binding', () => {
+  const kek = 'test-kek-for-connect-link'
+
+  function createBoundEndpoint(opts: {
+    keyBuilder?: (ctx: any, source: string) => Promise<string>
+    connectConfig?: any
+  }) {
+    const endpoints = {
+      sendEmail: async (_ctx: any, _args: any) => 'sent',
+    }
+
+    const tree: Record<string, unknown> = {}
+    bindEndpointsRecursively({
+      endpoints,
+      hooks: undefined,
+      ctx: {},
+      tree,
+      pluginId: 'gmail',
+      errorHandlers: {},
+      currentPath: [],
+      keyBuilder: opts.keyBuilder,
+      connectConfig: opts.connectConfig,
+    })
+
+    return tree.sendEmail as (args?: unknown) => Promise<unknown>
+  }
+
+  it('generates connect link when keyBuilder returns empty string', async () => {
+    const boundFn = createBoundEndpoint({
+      keyBuilder: async () => '',
+      connectConfig: {
+        baseUrl: 'https://myapp.com/connect',
+        redirectUri: 'https://myapp.com/api/callback',
+        oauthConfig: {
+          providerName: 'Google',
+          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+        },
+        kek,
+        tenantId: 'tenant-1',
+      },
+    })
+
+    try {
+      await boundFn({ to: 'user@example.com' })
+      fail('Expected error to be thrown')
+    } catch (err: any) {
+      expect(err.message).toContain('[auth-missing:gmail]')
+      expect(err.message).toContain('https://myapp.com/connect')
+      expect(err.message).toContain('Authentication required')
+
+      // Verify the state parameter in the connect URL is valid
+      const stateMatch = err.message.match(/state=([^&\s]+)/)
+      expect(stateMatch).not.toBeNull()
+      const state = decodeURIComponent(stateMatch![1])
+      const decoded = verifyAndDecodeState(state, kek)
+      expect(decoded).toEqual({ plugin: 'gmail', tenantId: 'tenant-1' })
+    }
+  })
+
+  it('generates connect link when keyBuilder throws AuthMissingError', async () => {
+    const boundFn = createBoundEndpoint({
+      keyBuilder: async () => {
+        throw new AuthMissingError('gmail')
+      },
+      connectConfig: {
+        baseUrl: 'https://myapp.com/connect',
+        redirectUri: 'https://myapp.com/api/callback',
+        oauthConfig: {
+          providerName: 'Google',
+          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+        },
+        kek,
+        tenantId: 'tenant-1',
+      },
+    })
+
+    try {
+      await boundFn()
+      fail('Expected error to be thrown')
+    } catch (err: any) {
+      expect(err.message).toContain('[auth-missing:gmail]')
+      expect(err.message).toContain('https://myapp.com/connect')
+    }
+  })
+
+  it('generates connect link when keyBuilder throws account-not-found error', async () => {
+    const boundFn = createBoundEndpoint({
+      keyBuilder: async () => {
+        throw new Error(
+          'Account not found for tenant "tenant-1" and integration "gmail"'
+        )
+      },
+      connectConfig: {
+        baseUrl: 'https://myapp.com/connect',
+        redirectUri: 'https://myapp.com/api/callback',
+        oauthConfig: {
+          providerName: 'Google',
+          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+        },
+        kek,
+        tenantId: 'tenant-1',
+      },
+    })
+
+    try {
+      await boundFn()
+      fail('Expected error to be thrown')
+    } catch (err: any) {
+      expect(err.message).toContain('[auth-missing:gmail]')
+      expect(err.message).toContain('https://myapp.com/connect')
+    }
+  })
+
+  it('uses custom onAuthMissing callback', async () => {
+    const boundFn = createBoundEndpoint({
+      keyBuilder: async () => '',
+      connectConfig: {
+        baseUrl: 'https://myapp.com/connect',
+        redirectUri: 'https://myapp.com/api/callback',
+        oauthConfig: {
+          providerName: 'Google',
+          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+        },
+        kek,
+        tenantId: 'tenant-1',
+        onAuthMissing: ({
+          plugin,
+          connectUrl,
+        }: {
+          plugin: string
+          connectUrl: string
+          state: string
+        }) => `Please connect ${plugin}: ${connectUrl}`,
+      },
+    })
+
+    try {
+      await boundFn()
+      fail('Expected error to be thrown')
+    } catch (err: any) {
+      expect(err.message).toBe(
+        'Please connect gmail: https://myapp.com/connect?plugin=gmail&state=' +
+          err.message.split('state=')[1]
+      )
+      expect(err.message).toContain('Please connect gmail')
+      expect(err.message).toContain('https://myapp.com/connect')
+    }
+  })
+
+  it('does not intercept errors when connectConfig is not set', async () => {
+    const boundFn = createBoundEndpoint({
+      keyBuilder: async () => {
+        throw new Error('Account not found')
+      },
+    })
+
+    await expect(boundFn()).rejects.toThrow('Account not found')
+  })
+
+  it('does not intercept errors when plugin has no oauthConfig', async () => {
+    const boundFn = createBoundEndpoint({
+      keyBuilder: async () => {
+        throw new Error('Account not found')
+      },
+      connectConfig: {
+        baseUrl: 'https://myapp.com/connect',
+        redirectUri: 'https://myapp.com/api/callback',
+        oauthConfig: undefined,
+        kek,
+        tenantId: 'tenant-1',
+      },
+    })
+
+    await expect(boundFn()).rejects.toThrow('Account not found')
+  })
+
+  it('does not intercept unrelated errors when connectConfig is set', async () => {
+    const boundFn = createBoundEndpoint({
+      keyBuilder: async () => {
+        throw new Error('Network timeout')
+      },
+      connectConfig: {
+        baseUrl: 'https://myapp.com/connect',
+        redirectUri: 'https://myapp.com/api/callback',
+        oauthConfig: {
+          providerName: 'Google',
+          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+        },
+        kek,
+        tenantId: 'tenant-1',
+      },
+    })
+
+    await expect(boundFn()).rejects.toThrow('Network timeout')
+  })
+})

--- a/packages/corsair/tests/connect-link.test.ts
+++ b/packages/corsair/tests/connect-link.test.ts
@@ -30,14 +30,15 @@ describe('OAuth state utilities', () => {
 	it('round-trips encode/decode', () => {
 		const encoded = encodeOAuthState('gmail', 'tenant-1');
 		const decoded = decodeOAuthState(encoded);
-		expect(decoded).toEqual({ plugin: 'gmail', tenantId: 'tenant-1' });
+		expect(decoded).toMatchObject({ plugin: 'gmail', tenantId: 'tenant-1' });
+		expect(typeof decoded!.iat).toBe('number');
 	});
 
 	it('signs and verifies state', () => {
 		const payload = encodeOAuthState('slack', 'tenant-2');
 		const signed = signState(payload, kek);
 		const decoded = verifyAndDecodeState(signed, kek);
-		expect(decoded).toEqual({ plugin: 'slack', tenantId: 'tenant-2' });
+		expect(decoded).toMatchObject({ plugin: 'slack', tenantId: 'tenant-2' });
 	});
 
 	it('rejects tampered state', () => {
@@ -51,6 +52,18 @@ describe('OAuth state utilities', () => {
 	it('returns null for invalid state', () => {
 		expect(decodeOAuthState('not-valid-base64!!!')).toBeNull();
 		expect(verifyAndDecodeState('', kek)).toBeNull();
+	});
+
+	it('rejects expired state', () => {
+		const oldPayload = Buffer.from(
+			JSON.stringify({
+				plugin: 'gmail',
+				tenantId: 't1',
+				iat: Date.now() - 11 * 60 * 1000,
+			}),
+		).toString('base64url');
+		const signed = signState(oldPayload, kek);
+		expect(verifyAndDecodeState(signed, kek)).toBeNull();
 	});
 });
 
@@ -109,7 +122,7 @@ describe('connect-link generation in endpoint binding', () => {
 			expect(stateMatch).not.toBeNull();
 			const state = decodeURIComponent(stateMatch![1]);
 			const decoded = verifyAndDecodeState(state, kek);
-			expect(decoded).toEqual({ plugin: 'gmail', tenantId: 'tenant-1' });
+			expect(decoded).toMatchObject({ plugin: 'gmail', tenantId: 'tenant-1' });
 		}
 	});
 
@@ -186,10 +199,6 @@ describe('connect-link generation in endpoint binding', () => {
 			await boundFn();
 			fail('Expected error to be thrown');
 		} catch (err: any) {
-			expect(err.message).toBe(
-				'Please connect gmail: https://myapp.com/connect?plugin=gmail&state=' +
-					err.message.split('state=')[1],
-			);
 			expect(err.message).toContain('Please connect gmail');
 			expect(err.message).toContain('https://myapp.com/connect');
 		}


### PR DESCRIPTION
Closes #237

## Summary

- Adds `AuthMissingError` class for detecting missing authentication during endpoint execution
- Adds `connect` config to `CorsairIntegration` with `baseUrl`, `redirectUri`, and optional `onAuthMissing` callback
- Intercepts auth-missing errors in endpoint binding and generates a signed connect link for the agent
- Adds `resolveConnectLink()` utility for consumer connect pages to get the full OAuth URL in one call
- Extracts OAuth state signing to `core/auth/state.ts` to avoid circular dependencies

## How it works

1. User calls `createCorsair({ plugins, kek, connect: { baseUrl, redirectUri } })`
2. When an endpoint's keyBuilder fails (empty key, missing account, missing DEK), the binding layer catches it
3. Generates a signed state and builds `${baseUrl}?plugin=${id}&state=${signedState}`
4. Returns `[auth-missing:${pluginId}] Authentication required. Direct the user to connect their account: ${connectUrl}`
5. Consumer's connect page calls `resolveConnectLink(corsair, state)` to get the full OAuth URL

## Test plan
- [x] 13 tests passing (unit + integration)
- [x] TypeScript compilation clean (zero non-test errors)
- [x] Connect link generation for empty keyBuilder, AuthMissingError, account-not-found
- [x] Custom onAuthMissing callback
- [x] Negative cases: no config, no oauthConfig, unrelated errors
- [x] OAuth state round-trip with HMAC verification