### PR TITLE
feat(plugins): throw AuthMissingError in all OAuth keyBuilders

### DIFF
--- a/packages/airtable/index.ts
+++ b/packages/airtable/index.ts
@@ -12,6 +12,7 @@ import type {
 	PluginAuthConfig,
 	PluginPermissionsConfig,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { Bases, Records, Webhooks } from './endpoints';
 import type {
 	AirtableEndpointInputs,
@@ -266,17 +267,13 @@ export function airtable<const T extends AirtablePluginOptions>(
 				const res = await ctx.keys.get_api_key();
 
 				if (!res) {
-					throw new Error(
-						'[auth-missing:airtable:api_key]: Airtable API Key is missing',
-					);
+					throw new AuthMissingError('airtable', 'api_key');
 				}
 
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:airtable:${authType}]: Airtable key is missing`,
-			);
+			throw new AuthMissingError('airtable', 'api_key');
 		},
 	} satisfies InternalAirtablePlugin;
 }

--- a/packages/amplitude/index.ts
+++ b/packages/amplitude/index.ts
@@ -13,6 +13,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	Annotations,
 	Charts,
@@ -447,15 +448,11 @@ export function amplitude<const T extends AmplitudePluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'api_key') {
 				const res = await ctx.keys.get_api_key();
 				if (!res) {
-					throw new Error(
-						'[auth-missing:amplitude:api_key]: Amplitude API Key is missing',
-					);
+					throw new AuthMissingError('amplitude', 'api_key');
 				}
 				return res;
 			}
-			throw new Error(
-				`[auth-missing:amplitude:${authType}]: Amplitude key is missing`,
-			);
+			throw new AuthMissingError('amplitude', 'api_key');
 		},
 	} satisfies InternalAmplitudePlugin;
 }

--- a/packages/asana/index.ts
+++ b/packages/asana/index.ts
@@ -12,6 +12,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { getValidAccessToken } from './client';
 import {
 	Projects,
@@ -1034,9 +1035,7 @@ export function asana<const PluginOptions extends AsanaPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new Error(
-						'[auth-missing:asana:refresh_token]: Asana refresh token is missing',
-					);
+					throw new AuthMissingError('asana');
 				}
 
 				const creds = await ctx.keys.get_integration_credentials();
@@ -1093,7 +1092,7 @@ export function asana<const PluginOptions extends AsanaPluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new Error(`[auth-missing:asana:${authType}]: Asana key is missing`);
+			throw new AuthMissingError('asana');
 		},
 	} satisfies InternalAsanaPlugin;
 }

--- a/packages/asana/index.ts
+++ b/packages/asana/index.ts
@@ -1020,9 +1020,7 @@ export function asana<const PluginOptions extends AsanaPluginOptions>(
 			if (ctx.authType === 'api_key') {
 				const res = await ctx.keys.get_api_key();
 				if (!res) {
-					throw new Error(
-						'[auth-missing:asana:api_key]: Asana API Key is missing',
-					);
+					throw new AuthMissingError('asana', 'api_key');
 				}
 				return res;
 			}
@@ -1035,7 +1033,7 @@ export function asana<const PluginOptions extends AsanaPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new AuthMissingError('asana');
+					throw new AuthMissingError('asana', 'oauth_2');
 				}
 
 				const creds = await ctx.keys.get_integration_credentials();
@@ -1092,7 +1090,7 @@ export function asana<const PluginOptions extends AsanaPluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new AuthMissingError('asana');
+			throw new AuthMissingError('asana', 'oauth_2');
 		},
 	} satisfies InternalAsanaPlugin;
 }

--- a/packages/bitwarden/index.ts
+++ b/packages/bitwarden/index.ts
@@ -10,6 +10,7 @@ import type {
 	PickAuth,
 	PluginPermissionsConfig,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { getValidBitwardenAccessToken } from './client';
 import { Collections, Members, Organizations } from './endpoints';
 import type {
@@ -261,9 +262,7 @@ export function bitwarden<const T extends BitwardenPluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new Error(
-				`[auth-missing:bitwarden:${authType}]: Bitwarden key is missing`,
-			);
+			throw new AuthMissingError('bitwarden');
 		},
 	} satisfies InternalBitwardenPlugin;
 }

--- a/packages/bitwarden/index.ts
+++ b/packages/bitwarden/index.ts
@@ -262,7 +262,7 @@ export function bitwarden<const T extends BitwardenPluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new AuthMissingError('bitwarden');
+			throw new AuthMissingError('bitwarden', 'oauth_2');
 		},
 	} satisfies InternalBitwardenPlugin;
 }

--- a/packages/bluesky/index.ts
+++ b/packages/bluesky/index.ts
@@ -10,6 +10,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	BlueskyEndpointInputSchemas,
 	BlueskyEndpointOutputSchemas,
@@ -205,16 +206,12 @@ export function bluesky<const T extends BlueskyPluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'api_key') {
 				const res = await ctx.keys.get_api_key();
 				if (!res) {
-					throw new Error(
-						'[auth-missing:bluesky:api_key]: Bluesky app password is missing',
-					);
+					throw new AuthMissingError('bluesky', 'api_key');
 				}
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:bluesky:${authType}]: Bluesky app password is missing`,
-			);
+			throw new AuthMissingError('bluesky', 'api_key');
 		},
 	} satisfies InternalBlueskyPlugin;
 }

--- a/packages/box/index.ts
+++ b/packages/box/index.ts
@@ -12,6 +12,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { Files, Folders } from './endpoints';
 import type { BoxEndpointInputs, BoxEndpointOutputs } from './endpoints/types';
 import {
@@ -573,14 +574,12 @@ export function box<const T extends BoxPluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'oauth_2') {
 				const res = await ctx.keys.get_access_token();
 				if (!res) {
-					throw new Error(
-						'[auth-missing:box:oauth_2]: Box access token is missing',
-					);
+					throw new AuthMissingError('box');
 				}
 				return res;
 			}
 
-			throw new Error(`[auth-missing:box:${authType}]: Box key is missing`);
+			throw new AuthMissingError('box');
 		},
 	} satisfies InternalBoxPlugin;
 }

--- a/packages/box/index.ts
+++ b/packages/box/index.ts
@@ -574,12 +574,12 @@ export function box<const T extends BoxPluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'oauth_2') {
 				const res = await ctx.keys.get_access_token();
 				if (!res) {
-					throw new AuthMissingError('box');
+					throw new AuthMissingError('box', 'oauth_2');
 				}
 				return res;
 			}
 
-			throw new AuthMissingError('box');
+			throw new AuthMissingError('box', 'oauth_2');
 		},
 	} satisfies InternalBoxPlugin;
 }

--- a/packages/cal/index.ts
+++ b/packages/cal/index.ts
@@ -13,6 +13,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { Bookings } from './endpoints';
 import type { CalEndpointInputs, CalEndpointOutputs } from './endpoints/types';
 import {
@@ -294,13 +295,13 @@ export function cal<const T extends CalPluginOptions>(
 				const res = await ctx.keys.get_api_key();
 
 				if (!res) {
-					throw new Error('[auth-missing:cal:api_key]: Cal API Key is missing');
+					throw new AuthMissingError('cal', 'api_key');
 				}
 
 				return res;
 			}
 
-			throw new Error(`[auth-missing:cal:${authType}]: Cal key is missing`);
+			throw new AuthMissingError('cal', 'api_key');
 		},
 	} satisfies InternalCalPlugin;
 }

--- a/packages/calendly/index.ts
+++ b/packages/calendly/index.ts
@@ -13,6 +13,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	ActivityLog,
 	EventTypes,
@@ -780,16 +781,12 @@ export function calendly<const T extends CalendlyPluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'api_key') {
 				const res = await ctx.keys.get_api_key();
 				if (!res) {
-					throw new Error(
-						'[auth-missing:calendly:api_key]: Calendly API Key is missing',
-					);
+					throw new AuthMissingError('calendly', 'api_key');
 				}
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:calendly:${authType}]: Calendly key is missing`,
-			);
+			throw new AuthMissingError('calendly', 'api_key');
 		},
 	} satisfies InternalCalendlyPlugin;
 }

--- a/packages/corsair/core/auth/errors/auth-missing.ts
+++ b/packages/corsair/core/auth/errors/auth-missing.ts
@@ -4,14 +4,14 @@
  * connect link the agent can present to the user.
  */
 export class AuthMissingError extends Error {
-  pluginId: string
-  authType: string
+	pluginId: string;
+	authType: string;
 
-  constructor(pluginId: string, authType: string, message?: string) {
-    super(message ?? `[auth-missing:${pluginId}:${authType}]`)
-    Object.setPrototypeOf(this, new.target.prototype)
-    this.name = 'AuthMissingError'
-    this.pluginId = pluginId
-    this.authType = authType
-  }
+	constructor(pluginId: string, authType: string, message?: string) {
+		super(message ?? `[auth-missing:${pluginId}:${authType}]`);
+		Object.setPrototypeOf(this, new.target.prototype);
+		this.name = 'AuthMissingError';
+		this.pluginId = pluginId;
+		this.authType = authType;
+	}
 }

--- a/packages/corsair/core/auth/errors/auth-missing.ts
+++ b/packages/corsair/core/auth/errors/auth-missing.ts
@@ -1,15 +1,17 @@
 /**
- * Error thrown when a plugin endpoint is called but the user has not authenticated
- * with the required OAuth provider. Corsair intercepts this error and returns a
+ * Error thrown when a plugin endpoint is called but the required auth credentials
+ * are missing. Corsair intercepts this error and, for OAuth auth types, returns a
  * connect link the agent can present to the user.
  */
 export class AuthMissingError extends Error {
-	pluginId: string;
+  pluginId: string
+  authType: string
 
-	constructor(pluginId: string, message?: string) {
-		super(message ?? `[auth-missing:${pluginId}]`);
-		Object.setPrototypeOf(this, new.target.prototype);
-		this.name = 'AuthMissingError';
-		this.pluginId = pluginId;
-	}
+  constructor(pluginId: string, authType: string, message?: string) {
+    super(message ?? `[auth-missing:${pluginId}:${authType}]`)
+    Object.setPrototypeOf(this, new.target.prototype)
+    this.name = 'AuthMissingError'
+    this.pluginId = pluginId
+    this.authType = authType
+  }
 }

--- a/packages/corsair/core/endpoints/bind.ts
+++ b/packages/corsair/core/endpoints/bind.ts
@@ -276,7 +276,8 @@ export function bindEndpointsRecursively({
 					if (
 						connectConfig?.oauthConfig &&
 						connectConfig.kek &&
-						err instanceof AuthMissingError
+						err instanceof AuthMissingError &&
+							err.authType === 'oauth_2'
 					) {
 						throw buildConnectError(pluginId, connectConfig, tenantId);
 					}

--- a/packages/corsair/core/endpoints/bind.ts
+++ b/packages/corsair/core/endpoints/bind.ts
@@ -284,14 +284,6 @@ export function bindEndpointsRecursively({
 					throw err;
 				}
 
-				if (
-					!key &&
-					keyBuilder &&
-					connectConfig?.oauthConfig &&
-					connectConfig.kek
-				) {
-					throw buildConnectError(pluginId, connectConfig, tenantId);
-				}
 
 				if (!endpointHooks?.before && !endpointHooks?.after) {
 					const res = await call(0, { ...ctx, key }, args);

--- a/packages/corsair/tests/connect-link.test.ts
+++ b/packages/corsair/tests/connect-link.test.ts
@@ -1,253 +1,275 @@
-import { AuthMissingError } from '../core/auth/errors/auth-missing';
+import { AuthMissingError } from '../core/auth/errors/auth-missing'
 import {
-	decodeOAuthState,
-	encodeOAuthState,
-	signState,
-	verifyAndDecodeState,
-} from '../core/auth/state';
-import { bindEndpointsRecursively } from '../core/endpoints/bind';
+  decodeOAuthState,
+  encodeOAuthState,
+  signState,
+  verifyAndDecodeState,
+} from '../core/auth/state'
+import { bindEndpointsRecursively } from '../core/endpoints/bind'
 
 describe('AuthMissingError', () => {
-	it('sets name, pluginId, and default message', () => {
-		const err = new AuthMissingError('gmail');
-		expect(err).toBeInstanceOf(Error);
-		expect(err).toBeInstanceOf(AuthMissingError);
-		expect(err.name).toBe('AuthMissingError');
-		expect(err.pluginId).toBe('gmail');
-		expect(err.message).toBe('[auth-missing:gmail]');
-	});
+  it('sets name, pluginId, authType, and default message', () => {
+    const err = new AuthMissingError('gmail', 'oauth_2')
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(AuthMissingError)
+    expect(err.name).toBe('AuthMissingError')
+    expect(err.pluginId).toBe('gmail')
+    expect(err.authType).toBe('oauth_2')
+    expect(err.message).toBe('[auth-missing:gmail:oauth_2]')
+  })
 
-	it('accepts a custom message', () => {
-		const err = new AuthMissingError('gmail', 'custom message');
-		expect(err.message).toBe('custom message');
-		expect(err.pluginId).toBe('gmail');
-	});
-});
+  it('accepts a custom message', () => {
+    const err = new AuthMissingError('gmail', 'oauth_2', 'custom message')
+    expect(err.message).toBe('custom message')
+    expect(err.pluginId).toBe('gmail')
+    expect(err.authType).toBe('oauth_2')
+  })
+})
 
 describe('OAuth state utilities', () => {
-	const kek = 'test-kek-value-for-signing';
+  const kek = 'test-kek-value-for-signing'
 
-	it('round-trips encode/decode', () => {
-		const encoded = encodeOAuthState('gmail', 'tenant-1');
-		const decoded = decodeOAuthState(encoded);
-		expect(decoded).toMatchObject({ plugin: 'gmail', tenantId: 'tenant-1' });
-		expect(typeof decoded!.iat).toBe('number');
-	});
+  it('round-trips encode/decode', () => {
+    const encoded = encodeOAuthState('gmail', 'tenant-1')
+    const decoded = decodeOAuthState(encoded)
+    expect(decoded).toMatchObject({ plugin: 'gmail', tenantId: 'tenant-1' })
+    expect(typeof decoded!.iat).toBe('number')
+  })
 
-	it('signs and verifies state', () => {
-		const payload = encodeOAuthState('slack', 'tenant-2');
-		const signed = signState(payload, kek);
-		const decoded = verifyAndDecodeState(signed, kek);
-		expect(decoded).toMatchObject({ plugin: 'slack', tenantId: 'tenant-2' });
-	});
+  it('signs and verifies state', () => {
+    const payload = encodeOAuthState('slack', 'tenant-2')
+    const signed = signState(payload, kek)
+    const decoded = verifyAndDecodeState(signed, kek)
+    expect(decoded).toMatchObject({ plugin: 'slack', tenantId: 'tenant-2' })
+  })
 
-	it('rejects tampered state', () => {
-		const payload = encodeOAuthState('slack', 'tenant-2');
-		const signed = signState(payload, kek);
-		const tampered = signed.slice(0, -5) + 'XXXXX';
-		const decoded = verifyAndDecodeState(tampered, kek);
-		expect(decoded).toBeNull();
-	});
+  it('rejects tampered state', () => {
+    const payload = encodeOAuthState('slack', 'tenant-2')
+    const signed = signState(payload, kek)
+    const tampered = signed.slice(0, -5) + 'XXXXX'
+    const decoded = verifyAndDecodeState(tampered, kek)
+    expect(decoded).toBeNull()
+  })
 
-	it('returns null for invalid state', () => {
-		expect(decodeOAuthState('not-valid-base64!!!')).toBeNull();
-		expect(verifyAndDecodeState('', kek)).toBeNull();
-	});
+  it('returns null for invalid state', () => {
+    expect(decodeOAuthState('not-valid-base64!!!')).toBeNull()
+    expect(verifyAndDecodeState('', kek)).toBeNull()
+  })
 
-	it('rejects expired state', () => {
-		const oldPayload = Buffer.from(
-			JSON.stringify({
-				plugin: 'gmail',
-				tenantId: 't1',
-				iat: Date.now() - 11 * 60 * 1000,
-			}),
-		).toString('base64url');
-		const signed = signState(oldPayload, kek);
-		expect(verifyAndDecodeState(signed, kek)).toBeNull();
-	});
-});
+  it('rejects expired state', () => {
+    const oldPayload = Buffer.from(
+      JSON.stringify({
+        plugin: 'gmail',
+        tenantId: 't1',
+        iat: Date.now() - 11 * 60 * 1000,
+      })
+    ).toString('base64url')
+    const signed = signState(oldPayload, kek)
+    expect(verifyAndDecodeState(signed, kek)).toBeNull()
+  })
+})
 
 describe('connect-link generation in endpoint binding', () => {
-	const kek = 'test-kek-for-connect-link';
+  const kek = 'test-kek-for-connect-link'
 
-	function createBoundEndpoint(opts: {
-		keyBuilder?: (ctx: any, source: string) => Promise<string>;
-		connectConfig?: any;
-	}) {
-		const endpoints = {
-			sendEmail: async (_ctx: any, _args: any) => 'sent',
-		};
+  function createBoundEndpoint(opts: {
+    keyBuilder?: (ctx: any, source: string) => Promise<string>
+    connectConfig?: any
+  }) {
+    const endpoints = {
+      sendEmail: async (_ctx: any, _args: any) => 'sent',
+    }
 
-		const tree: Record<string, unknown> = {};
-		bindEndpointsRecursively({
-			endpoints,
-			hooks: undefined,
-			ctx: {},
-			tree,
-			pluginId: 'gmail',
-			errorHandlers: {},
-			currentPath: [],
-			keyBuilder: opts.keyBuilder,
-			connectConfig: opts.connectConfig,
-		});
+    const tree: Record<string, unknown> = {}
+    bindEndpointsRecursively({
+      endpoints,
+      hooks: undefined,
+      ctx: {},
+      tree,
+      pluginId: 'gmail',
+      errorHandlers: {},
+      currentPath: [],
+      keyBuilder: opts.keyBuilder,
+      connectConfig: opts.connectConfig,
+    })
 
-		return tree.sendEmail as (args?: unknown) => Promise<unknown>;
-	}
+    return tree.sendEmail as (args?: unknown) => Promise<unknown>
+  }
 
-	it('generates connect link when keyBuilder returns empty string', async () => {
-		const boundFn = createBoundEndpoint({
-			keyBuilder: async () => '',
-			connectConfig: {
-				baseUrl: 'https://myapp.com/connect',
-				redirectUri: 'https://myapp.com/api/callback',
-				oauthConfig: {
-					providerName: 'Google',
-					authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
-				},
-				kek,
-				tenantId: 'tenant-1',
-			},
-		});
+  it('generates connect link when keyBuilder returns empty string', async () => {
+    const boundFn = createBoundEndpoint({
+      keyBuilder: async () => '',
+      connectConfig: {
+        baseUrl: 'https://myapp.com/connect',
+        redirectUri: 'https://myapp.com/api/callback',
+        oauthConfig: {
+          providerName: 'Google',
+          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+        },
+        kek,
+        tenantId: 'tenant-1',
+      },
+    })
 
-		try {
-			await boundFn({ to: 'user@example.com' });
-			fail('Expected error to be thrown');
-		} catch (err: any) {
-			expect(err.message).toContain('[auth-missing:gmail]');
-			expect(err.message).toContain('https://myapp.com/connect');
-			expect(err.message).toContain('Authentication required');
+    try {
+      await boundFn({ to: 'user@example.com' })
+      fail('Expected error to be thrown')
+    } catch (err: any) {
+      expect(err.message).toContain('[auth-missing:gmail]')
+      expect(err.message).toContain('https://myapp.com/connect')
+      expect(err.message).toContain('Authentication required')
 
-			// Verify the state parameter in the connect URL is valid
-			const stateMatch = err.message.match(/state=([^&\s]+)/);
-			expect(stateMatch).not.toBeNull();
-			const state = decodeURIComponent(stateMatch![1]);
-			const decoded = verifyAndDecodeState(state, kek);
-			expect(decoded).toMatchObject({ plugin: 'gmail', tenantId: 'tenant-1' });
-		}
-	});
+      // Verify the state parameter in the connect URL is valid
+      const stateMatch = err.message.match(/state=([^&\s]+)/)
+      expect(stateMatch).not.toBeNull()
+      const state = decodeURIComponent(stateMatch![1])
+      const decoded = verifyAndDecodeState(state, kek)
+      expect(decoded).toMatchObject({ plugin: 'gmail', tenantId: 'tenant-1' })
+    }
+  })
 
-	it('generates connect link when keyBuilder throws AuthMissingError', async () => {
-		const boundFn = createBoundEndpoint({
-			keyBuilder: async () => {
-				throw new AuthMissingError('gmail');
-			},
-			connectConfig: {
-				baseUrl: 'https://myapp.com/connect',
-				redirectUri: 'https://myapp.com/api/callback',
-				oauthConfig: {
-					providerName: 'Google',
-					authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
-				},
-				kek,
-				tenantId: 'tenant-1',
-			},
-		});
+  it('generates connect link when keyBuilder throws AuthMissingError', async () => {
+    const boundFn = createBoundEndpoint({
+      keyBuilder: async () => {
+        throw new AuthMissingError('gmail', 'oauth_2')
+      },
+      connectConfig: {
+        baseUrl: 'https://myapp.com/connect',
+        redirectUri: 'https://myapp.com/api/callback',
+        oauthConfig: {
+          providerName: 'Google',
+          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+        },
+        kek,
+        tenantId: 'tenant-1',
+      },
+    })
 
-		try {
-			await boundFn();
-			fail('Expected error to be thrown');
-		} catch (err: any) {
-			expect(err.message).toContain('[auth-missing:gmail]');
-			expect(err.message).toContain('https://myapp.com/connect');
-		}
-	});
+    try {
+      await boundFn()
+      fail('Expected error to be thrown')
+    } catch (err: any) {
+      expect(err.message).toContain('[auth-missing:gmail]')
+      expect(err.message).toContain('https://myapp.com/connect')
+    }
+  })
 
-	it('propagates non-AuthMissingError from keyBuilder even with connectConfig', async () => {
-		const boundFn = createBoundEndpoint({
-			keyBuilder: async () => {
-				throw new Error('Account not found for tenant "tenant-1"');
-			},
-			connectConfig: {
-				baseUrl: 'https://myapp.com/connect',
-				redirectUri: 'https://myapp.com/api/callback',
-				oauthConfig: {
-					providerName: 'Google',
-					authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
-				},
-				kek,
-				tenantId: 'tenant-1',
-			},
-		});
+  it('propagates non-AuthMissingError from keyBuilder even with connectConfig', async () => {
+    const boundFn = createBoundEndpoint({
+      keyBuilder: async () => {
+        throw new Error('Account not found for tenant "tenant-1"')
+      },
+      connectConfig: {
+        baseUrl: 'https://myapp.com/connect',
+        redirectUri: 'https://myapp.com/api/callback',
+        oauthConfig: {
+          providerName: 'Google',
+          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+        },
+        kek,
+        tenantId: 'tenant-1',
+      },
+    })
 
-		await expect(boundFn()).rejects.toThrow('Account not found');
-	});
+    await expect(boundFn()).rejects.toThrow('Account not found')
+  })
 
-	it('uses custom onAuthMissing callback', async () => {
-		const boundFn = createBoundEndpoint({
-			keyBuilder: async () => '',
-			connectConfig: {
-				baseUrl: 'https://myapp.com/connect',
-				redirectUri: 'https://myapp.com/api/callback',
-				oauthConfig: {
-					providerName: 'Google',
-					authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
-				},
-				kek,
-				tenantId: 'tenant-1',
-				onAuthMissing: ({
-					plugin,
-					connectUrl,
-				}: {
-					plugin: string;
-					connectUrl: string;
-					state: string;
-				}) => `Please connect ${plugin}: ${connectUrl}`,
-			},
-		});
+  it('uses custom onAuthMissing callback', async () => {
+    const boundFn = createBoundEndpoint({
+      keyBuilder: async () => '',
+      connectConfig: {
+        baseUrl: 'https://myapp.com/connect',
+        redirectUri: 'https://myapp.com/api/callback',
+        oauthConfig: {
+          providerName: 'Google',
+          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+        },
+        kek,
+        tenantId: 'tenant-1',
+        onAuthMissing: ({
+          plugin,
+          connectUrl,
+        }: {
+          plugin: string
+          connectUrl: string
+          state: string
+        }) => `Please connect ${plugin}: ${connectUrl}`,
+      },
+    })
 
-		try {
-			await boundFn();
-			fail('Expected error to be thrown');
-		} catch (err: any) {
-			expect(err.message).toContain('Please connect gmail');
-			expect(err.message).toContain('https://myapp.com/connect');
-		}
-	});
+    try {
+      await boundFn()
+      fail('Expected error to be thrown')
+    } catch (err: any) {
+      expect(err.message).toContain('Please connect gmail')
+      expect(err.message).toContain('https://myapp.com/connect')
+    }
+  })
 
-	it('does not intercept errors when connectConfig is not set', async () => {
-		const boundFn = createBoundEndpoint({
-			keyBuilder: async () => {
-				throw new Error('Account not found');
-			},
-		});
+  it('does not intercept errors when connectConfig is not set', async () => {
+    const boundFn = createBoundEndpoint({
+      keyBuilder: async () => {
+        throw new Error('Account not found')
+      },
+    })
 
-		await expect(boundFn()).rejects.toThrow('Account not found');
-	});
+    await expect(boundFn()).rejects.toThrow('Account not found')
+  })
 
-	it('does not intercept errors when plugin has no oauthConfig', async () => {
-		const boundFn = createBoundEndpoint({
-			keyBuilder: async () => {
-				throw new Error('Account not found');
-			},
-			connectConfig: {
-				baseUrl: 'https://myapp.com/connect',
-				redirectUri: 'https://myapp.com/api/callback',
-				oauthConfig: undefined,
-				kek,
-				tenantId: 'tenant-1',
-			},
-		});
+  it('does not intercept errors when plugin has no oauthConfig', async () => {
+    const boundFn = createBoundEndpoint({
+      keyBuilder: async () => {
+        throw new Error('Account not found')
+      },
+      connectConfig: {
+        baseUrl: 'https://myapp.com/connect',
+        redirectUri: 'https://myapp.com/api/callback',
+        oauthConfig: undefined,
+        kek,
+        tenantId: 'tenant-1',
+      },
+    })
 
-		await expect(boundFn()).rejects.toThrow('Account not found');
-	});
+    await expect(boundFn()).rejects.toThrow('Account not found')
+  })
 
-	it('does not intercept unrelated errors when connectConfig is set', async () => {
-		const boundFn = createBoundEndpoint({
-			keyBuilder: async () => {
-				throw new Error('Network timeout');
-			},
-			connectConfig: {
-				baseUrl: 'https://myapp.com/connect',
-				redirectUri: 'https://myapp.com/api/callback',
-				oauthConfig: {
-					providerName: 'Google',
-					authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
-				},
-				kek,
-				tenantId: 'tenant-1',
-			},
-		});
+  it('does not intercept unrelated errors when connectConfig is set', async () => {
+    const boundFn = createBoundEndpoint({
+      keyBuilder: async () => {
+        throw new Error('Network timeout')
+      },
+      connectConfig: {
+        baseUrl: 'https://myapp.com/connect',
+        redirectUri: 'https://myapp.com/api/callback',
+        oauthConfig: {
+          providerName: 'Google',
+          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+        },
+        kek,
+        tenantId: 'tenant-1',
+      },
+    })
 
-		await expect(boundFn()).rejects.toThrow('Network timeout');
-	});
-});
+    await expect(boundFn()).rejects.toThrow('Network timeout')
+  })
+
+  it('does not generate connect link for api_key AuthMissingError', async () => {
+    const boundFn = createBoundEndpoint({
+      keyBuilder: async () => {
+        throw new AuthMissingError('slack', 'api_key')
+      },
+      connectConfig: {
+        baseUrl: 'https://myapp.com/connect',
+        redirectUri: 'https://myapp.com/api/callback',
+        oauthConfig: {
+          providerName: 'Slack',
+          authUrl: 'https://slack.com/oauth/v2/authorize',
+        },
+        kek,
+        tenantId: 'tenant-1',
+      },
+    })
+
+    await expect(boundFn()).rejects.toThrow('[auth-missing:slack:api_key]')
+  })
+})

--- a/packages/corsair/tests/connect-link.test.ts
+++ b/packages/corsair/tests/connect-link.test.ts
@@ -96,7 +96,7 @@ describe('connect-link generation in endpoint binding', () => {
     return tree.sendEmail as (args?: unknown) => Promise<unknown>
   }
 
-  it('generates connect link when keyBuilder returns empty string', async () => {
+  it('does not generate connect link when keyBuilder returns empty string', async () => {
     const boundFn = createBoundEndpoint({
       keyBuilder: async () => '',
       connectConfig: {
@@ -111,21 +111,9 @@ describe('connect-link generation in endpoint binding', () => {
       },
     })
 
-    try {
-      await boundFn({ to: 'user@example.com' })
-      fail('Expected error to be thrown')
-    } catch (err: any) {
-      expect(err.message).toContain('[auth-missing:gmail]')
-      expect(err.message).toContain('https://myapp.com/connect')
-      expect(err.message).toContain('Authentication required')
-
-      // Verify the state parameter in the connect URL is valid
-      const stateMatch = err.message.match(/state=([^&\s]+)/)
-      expect(stateMatch).not.toBeNull()
-      const state = decodeURIComponent(stateMatch![1])
-      const decoded = verifyAndDecodeState(state, kek)
-      expect(decoded).toMatchObject({ plugin: 'gmail', tenantId: 'tenant-1' })
-    }
+    // keyBuilder returning empty is no longer intercepted - endpoint runs with no key
+    const result = await boundFn({ to: 'user@example.com' })
+    expect(result).toBe('sent')
   })
 
   it('generates connect link when keyBuilder throws AuthMissingError', async () => {
@@ -176,7 +164,9 @@ describe('connect-link generation in endpoint binding', () => {
 
   it('uses custom onAuthMissing callback', async () => {
     const boundFn = createBoundEndpoint({
-      keyBuilder: async () => '',
+      keyBuilder: async () => {
+        throw new AuthMissingError('gmail', 'oauth_2')
+      },
       connectConfig: {
         baseUrl: 'https://myapp.com/connect',
         redirectUri: 'https://myapp.com/api/callback',

--- a/packages/cursor/index.ts
+++ b/packages/cursor/index.ts
@@ -13,6 +13,7 @@ import type {
 	RequiredPluginEndpointMeta,
 	RequiredPluginEndpointSchemas,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { Account, Agents, Models, Repositories } from './endpoints';
 import type {
 	AccountGetMeInput,
@@ -214,16 +215,12 @@ export function cursor<const T extends CursorPluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'api_key') {
 				const res = await ctx.keys.get_api_key();
 				if (!res) {
-					throw new Error(
-						'[auth-missing:cursor:api_key]: Cursor API Key is missing',
-					);
+					throw new AuthMissingError('cursor', 'api_key');
 				}
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:cursor:${authType}]: Cursor key is missing`,
-			);
+			throw new AuthMissingError('cursor', 'api_key');
 		},
 	} satisfies InternalCursorPlugin;
 }

--- a/packages/discord/index.ts
+++ b/packages/discord/index.ts
@@ -13,6 +13,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	Channels,
 	Guilds,
@@ -464,9 +465,7 @@ export function discord<const T extends DiscordPluginOptions>(
 				}
 			}
 
-			throw new Error(
-				`[auth-missing:discord:${authType}]: Discord key is missing`,
-			);
+			throw new AuthMissingError('discord', 'api_key');
 		},
 	} satisfies InternalDiscordPlugin;
 }

--- a/packages/dodopayments/index.ts
+++ b/packages/dodopayments/index.ts
@@ -14,6 +14,7 @@ import type {
 	RequiredPluginEndpointSchemas,
 	RequiredPluginWebhookSchemas,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { Customers, Payments, Refunds, Subscriptions } from './endpoints';
 import type {
 	CustomersCreateInput,
@@ -377,9 +378,7 @@ export function dodopayments<const T extends DodoPaymentsPluginOptions>(
 				return res ?? '';
 			}
 
-			throw new Error(
-				`[auth-missing:dodopayments:${authType}]: Dodo Payments key is missing`,
-			);
+			throw new AuthMissingError('dodopayments', 'api_key');
 		},
 	} satisfies InternalDodoPaymentsPlugin;
 }

--- a/packages/dropbox/index.ts
+++ b/packages/dropbox/index.ts
@@ -11,6 +11,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { getValidAccessToken } from './client';
 import { Files, Folders, Search } from './endpoints';
 import type {
@@ -305,9 +306,7 @@ export function dropbox<const T extends DropboxPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new Error(
-						'[auth-missing:dropbox:refresh_token]: Dropbox refresh token is missing',
-					);
+					throw new AuthMissingError('dropbox');
 				}
 
 				const creds = await ctx.keys.get_integration_credentials();
@@ -364,9 +363,7 @@ export function dropbox<const T extends DropboxPluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new Error(
-				`[auth-missing:dropbox:${authType}]: Dropbox key is missing`,
-			);
+			throw new AuthMissingError('dropbox');
 		},
 	} satisfies InternalDropboxPlugin;
 }

--- a/packages/dropbox/index.ts
+++ b/packages/dropbox/index.ts
@@ -306,7 +306,7 @@ export function dropbox<const T extends DropboxPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new AuthMissingError('dropbox');
+					throw new AuthMissingError('dropbox', 'oauth_2');
 				}
 
 				const creds = await ctx.keys.get_integration_credentials();
@@ -363,7 +363,7 @@ export function dropbox<const T extends DropboxPluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new AuthMissingError('dropbox');
+			throw new AuthMissingError('dropbox', 'oauth_2');
 		},
 	} satisfies InternalDropboxPlugin;
 }

--- a/packages/exa/index.ts
+++ b/packages/exa/index.ts
@@ -12,6 +12,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	Answer,
 	Contents,
@@ -372,13 +373,13 @@ export function exa<const T extends ExaPluginOptions>(
 				const res = await ctx.keys.get_api_key();
 
 				if (!res) {
-					throw new Error('[auth-missing:exa:api_key]: Exa API Key is missing');
+					throw new AuthMissingError('exa', 'api_key');
 				}
 
 				return res;
 			}
 
-			throw new Error(`[auth-missing:exa:${authType}]: Exa key is missing`);
+			throw new AuthMissingError('exa', 'api_key');
 		},
 	} satisfies InternalExaPlugin;
 }

--- a/packages/figma/index.ts
+++ b/packages/figma/index.ts
@@ -13,6 +13,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	ActivityLogs,
 	Comments,
@@ -777,15 +778,13 @@ export function figma<const T extends FigmaPluginOptions>(
 				const res = await ctx.keys.get_api_key();
 
 				if (!res) {
-					throw new Error(
-						'[auth-missing:figma:api_key]: Figma API Key is missing',
-					);
+					throw new AuthMissingError('figma', 'api_key');
 				}
 
 				return res;
 			}
 
-			throw new Error(`[auth-missing:figma:${authType}]: Figma key is missing`);
+			throw new AuthMissingError('figma', 'api_key');
 		},
 	} satisfies InternalFigmaPlugin;
 }

--- a/packages/firecrawl/index.ts
+++ b/packages/firecrawl/index.ts
@@ -9,6 +9,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	AgentEndpoints,
 	CrawlEndpoints,
@@ -353,9 +354,7 @@ export function firecrawl<const T extends FirecrawlPluginOptions>(
 				return res ?? '';
 			}
 
-			throw new Error(
-				`[auth-missing:firecrawl:${authType}]: Firecrawl key is missing`,
-			);
+			throw new AuthMissingError('firecrawl', 'api_key');
 		},
 	} satisfies InternalFirecrawlPlugin;
 }

--- a/packages/fireflies/index.ts
+++ b/packages/fireflies/index.ts
@@ -12,6 +12,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import type {
 	FirefliesEndpointInputs,
 	FirefliesEndpointOutputs,
@@ -427,17 +428,13 @@ export function fireflies<const T extends FirefliesPluginOptions>(
 				const res = await ctx.keys.get_api_key();
 
 				if (!res) {
-					throw new Error(
-						'[auth-missing:fireflies:api_key]: Fireflies API Key is missing',
-					);
+					throw new AuthMissingError('fireflies', 'api_key');
 				}
 
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:fireflies:${authType}]: Fireflies key is missing`,
-			);
+			throw new AuthMissingError('fireflies', 'api_key');
 		},
 	} satisfies InternalFirefliesPlugin;
 }

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -1705,9 +1705,7 @@ export function github<const PluginOptions extends GithubPluginOptions>(
 					const res = await ctx.keys.get_api_key();
 
 					if (!res) {
-						throw new Error(
-							'[auth-missing:github:api_key]: GitHub API Key is missing',
-						);
+						throw new AuthMissingError('github', 'api_key');
 					}
 
 					return res;
@@ -1715,14 +1713,14 @@ export function github<const PluginOptions extends GithubPluginOptions>(
 					const res = await ctx.keys.get_access_token();
 
 					if (!res) {
-						throw new AuthMissingError('github');
+						throw new AuthMissingError('github', 'oauth_2');
 					}
 
 					return res;
 				}
 			}
 
-			throw new AuthMissingError('github');
+			throw new AuthMissingError('github', 'oauth_2');
 		},
 	} satisfies InternalGithubPlugin;
 }

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -11,6 +11,7 @@ import type {
 	RawWebhookRequest,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import type { GithubEndpointInputs, GithubEndpointOutputs } from './endpoints';
 import {
 	CommentsEndpoints,
@@ -1714,18 +1715,14 @@ export function github<const PluginOptions extends GithubPluginOptions>(
 					const res = await ctx.keys.get_access_token();
 
 					if (!res) {
-						throw new Error(
-							'[auth-missing:github:oauth_2]: GitHub access token is missing',
-						);
+						throw new AuthMissingError('github');
 					}
 
 					return res;
 				}
 			}
 
-			throw new Error(
-				`[auth-missing:github:${authType}]: GitHub key is missing`,
-			);
+			throw new AuthMissingError('github');
 		},
 	} satisfies InternalGithubPlugin;
 }

--- a/packages/gitlab/index.ts
+++ b/packages/gitlab/index.ts
@@ -835,7 +835,7 @@ export function gitlab<const T extends GitlabPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new AuthMissingError('gitlab');
+					throw new AuthMissingError('gitlab', 'oauth_2');
 				}
 
 				const res = await ctx.keys.get_integration_credentials();
@@ -907,7 +907,7 @@ export function gitlab<const T extends GitlabPluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new AuthMissingError('gitlab');
+			throw new AuthMissingError('gitlab', 'oauth_2');
 		},
 	} satisfies InternalGitlabPlugin;
 }

--- a/packages/gitlab/index.ts
+++ b/packages/gitlab/index.ts
@@ -14,6 +14,7 @@ import type {
 	RawWebhookRequest,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	getValidGitlabAccessToken,
 	gitlabOAuthTokenUrl,
@@ -834,9 +835,7 @@ export function gitlab<const T extends GitlabPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new Error(
-						'[auth-missing:gitlab:refresh_token]: GitLab refresh token is missing',
-					);
+					throw new AuthMissingError('gitlab');
 				}
 
 				const res = await ctx.keys.get_integration_credentials();
@@ -908,9 +907,7 @@ export function gitlab<const T extends GitlabPluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new Error(
-				`[auth-missing:gitlab:${authType}]: GitLab key is missing`,
-			);
+			throw new AuthMissingError('gitlab');
 		},
 	} satisfies InternalGitlabPlugin;
 }

--- a/packages/gmail/index.ts
+++ b/packages/gmail/index.ts
@@ -441,7 +441,7 @@ export function gmail<const T extends GmailPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new AuthMissingError('gmail');
+					throw new AuthMissingError('gmail', 'oauth_2');
 				}
 
 				const res = await ctx.keys.get_integration_credentials();
@@ -497,7 +497,7 @@ export function gmail<const T extends GmailPluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new AuthMissingError('gmail');
+			throw new AuthMissingError('gmail', 'oauth_2');
 		},
 		pluginWebhookMatcher: (request: RawWebhookRequest) => {
 			const headers = request.headers;

--- a/packages/gmail/index.ts
+++ b/packages/gmail/index.ts
@@ -12,6 +12,7 @@ import type {
 	RawWebhookRequest,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { getValidAccessToken } from './client';
 import type { GmailEndpointInputs, GmailEndpointOutputs } from './endpoints';
 import {
@@ -440,9 +441,7 @@ export function gmail<const T extends GmailPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new Error(
-						'[auth-missing:gmail:refresh_token]: Gmail refresh token is missing',
-					);
+					throw new AuthMissingError('gmail');
 				}
 
 				const res = await ctx.keys.get_integration_credentials();
@@ -498,7 +497,7 @@ export function gmail<const T extends GmailPluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new Error(`[auth-missing:gmail:${authType}]: Gmail key is missing`);
+			throw new AuthMissingError('gmail');
 		},
 		pluginWebhookMatcher: (request: RawWebhookRequest) => {
 			const headers = request.headers;

--- a/packages/googlecalendar/index.ts
+++ b/packages/googlecalendar/index.ts
@@ -239,7 +239,7 @@ export function googlecalendar<const T extends GoogleCalendarPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new AuthMissingError('googlecalendar');
+					throw new AuthMissingError('googlecalendar', 'oauth_2');
 				}
 
 				const res = await ctx.keys.get_integration_credentials();
@@ -290,7 +290,7 @@ export function googlecalendar<const T extends GoogleCalendarPluginOptions>(
 				}
 			}
 
-			throw new AuthMissingError('googlecalendar');
+			throw new AuthMissingError('googlecalendar', 'oauth_2');
 		},
 		pluginWebhookMatcher: (request: RawWebhookRequest) => {
 			const headers = request.headers;

--- a/packages/googlecalendar/index.ts
+++ b/packages/googlecalendar/index.ts
@@ -11,6 +11,7 @@ import type {
 	RawWebhookRequest,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { getValidAccessToken } from './client';
 import type {
 	GoogleCalendarEndpointInputs,
@@ -238,9 +239,7 @@ export function googlecalendar<const T extends GoogleCalendarPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new Error(
-						'[auth-missing:googlecalendar:refresh_token]: Google Calendar refresh token is missing',
-					);
+					throw new AuthMissingError('googlecalendar');
 				}
 
 				const res = await ctx.keys.get_integration_credentials();
@@ -291,9 +290,7 @@ export function googlecalendar<const T extends GoogleCalendarPluginOptions>(
 				}
 			}
 
-			throw new Error(
-				`[auth-missing:googlecalendar:${authType}]: Google Calendar key is missing`,
-			);
+			throw new AuthMissingError('googlecalendar');
 		},
 		pluginWebhookMatcher: (request: RawWebhookRequest) => {
 			const headers = request.headers;

--- a/packages/googledrive/index.ts
+++ b/packages/googledrive/index.ts
@@ -395,7 +395,7 @@ export function googledrive<const T extends GoogleDrivePluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new AuthMissingError('googledrive');
+					throw new AuthMissingError('googledrive', 'oauth_2');
 				}
 
 				const res = await ctx.keys.get_integration_credentials();
@@ -444,7 +444,7 @@ export function googledrive<const T extends GoogleDrivePluginOptions>(
 				}
 			}
 
-			throw new AuthMissingError('googledrive');
+			throw new AuthMissingError('googledrive', 'oauth_2');
 		},
 		pluginWebhookMatcher: (request: RawWebhookRequest) => {
 			const headers = request.headers;

--- a/packages/googledrive/index.ts
+++ b/packages/googledrive/index.ts
@@ -11,6 +11,7 @@ import type {
 	RawWebhookRequest,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { getValidAccessToken } from './client';
 import type {
 	GoogleDriveEndpointInputs,
@@ -394,9 +395,7 @@ export function googledrive<const T extends GoogleDrivePluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new Error(
-						'[auth-missing:googledrive:refresh_token]: Google Drive refresh token is missing',
-					);
+					throw new AuthMissingError('googledrive');
 				}
 
 				const res = await ctx.keys.get_integration_credentials();
@@ -445,9 +444,7 @@ export function googledrive<const T extends GoogleDrivePluginOptions>(
 				}
 			}
 
-			throw new Error(
-				`[auth-missing:googledrive:${authType}]: Google Drive key is missing`,
-			);
+			throw new AuthMissingError('googledrive');
 		},
 		pluginWebhookMatcher: (request: RawWebhookRequest) => {
 			const headers = request.headers;

--- a/packages/googlesheets/index.ts
+++ b/packages/googlesheets/index.ts
@@ -11,6 +11,7 @@ import type {
 	RawWebhookRequest,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { getValidAccessToken } from './client';
 import type {
 	GoogleSheetsEndpointInputs,
@@ -300,9 +301,7 @@ export function googlesheets<const T extends GoogleSheetsPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new Error(
-						'[auth-missing:googlesheets:refresh_token]: Google Sheets refresh token is missing',
-					);
+					throw new AuthMissingError('googlesheets');
 				}
 
 				const res = await ctx.keys.get_integration_credentials();
@@ -351,9 +350,7 @@ export function googlesheets<const T extends GoogleSheetsPluginOptions>(
 				}
 			}
 
-			throw new Error(
-				`[auth-missing:googlesheets:${authType}]: Google Sheets key is missing`,
-			);
+			throw new AuthMissingError('googlesheets');
 		},
 		pluginWebhookMatcher: (request: RawWebhookRequest) => {
 			const body = request.body as RangeUpdatedEvent;

--- a/packages/googlesheets/index.ts
+++ b/packages/googlesheets/index.ts
@@ -301,7 +301,7 @@ export function googlesheets<const T extends GoogleSheetsPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new AuthMissingError('googlesheets');
+					throw new AuthMissingError('googlesheets', 'oauth_2');
 				}
 
 				const res = await ctx.keys.get_integration_credentials();
@@ -350,7 +350,7 @@ export function googlesheets<const T extends GoogleSheetsPluginOptions>(
 				}
 			}
 
-			throw new AuthMissingError('googlesheets');
+			throw new AuthMissingError('googlesheets', 'oauth_2');
 		},
 		pluginWebhookMatcher: (request: RawWebhookRequest) => {
 			const body = request.body as RangeUpdatedEvent;

--- a/packages/grafana/index.ts
+++ b/packages/grafana/index.ts
@@ -12,6 +12,7 @@ import type {
 	RequiredPluginEndpointMeta,
 	RequiredPluginEndpointSchemas,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	Dashboards,
 	Health,
@@ -280,16 +281,12 @@ export function grafana<const T extends GrafanaPluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'api_key') {
 				const res = await ctx.keys.get_api_key();
 				if (!res) {
-					throw new Error(
-						'[auth-missing:grafana:api_key]: Grafana API Key is missing',
-					);
+					throw new AuthMissingError('grafana', 'api_key');
 				}
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:grafana:${authType}]: Grafana key is missing`,
-			);
+			throw new AuthMissingError('grafana', 'api_key');
 		},
 	} satisfies InternalGrafanaPlugin;
 }

--- a/packages/hubspot/index.ts
+++ b/packages/hubspot/index.ts
@@ -12,6 +12,7 @@ import type {
 	RawWebhookRequest,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { z } from 'zod';
 import type {
 	HubSpotEndpointInputs,
@@ -665,18 +666,14 @@ export function hubspot<const PluginOptions extends HubSpotPluginOptions>(
 					const res = await ctx.keys.get_access_token();
 
 					if (!res) {
-						throw new Error(
-							'[auth-missing:hubspot:oauth_2]: HubSpot access token is missing',
-						);
+						throw new AuthMissingError('hubspot');
 					}
 
 					return res;
 				}
 			}
 
-			throw new Error(
-				`[auth-missing:hubspot:${authType}]: HubSpot key is missing`,
-			);
+			throw new AuthMissingError('hubspot');
 		},
 	} satisfies InternalHubSpotPlugin;
 }

--- a/packages/hubspot/index.ts
+++ b/packages/hubspot/index.ts
@@ -656,9 +656,7 @@ export function hubspot<const PluginOptions extends HubSpotPluginOptions>(
 					const res = await ctx.keys.get_api_key();
 
 					if (!res) {
-						throw new Error(
-							'[auth-missing:hubspot:api_key]: HubSpot API Key is missing',
-						);
+						throw new AuthMissingError('hubspot', 'api_key');
 					}
 
 					return res;
@@ -666,14 +664,14 @@ export function hubspot<const PluginOptions extends HubSpotPluginOptions>(
 					const res = await ctx.keys.get_access_token();
 
 					if (!res) {
-						throw new AuthMissingError('hubspot');
+						throw new AuthMissingError('hubspot', 'oauth_2');
 					}
 
 					return res;
 				}
 			}
 
-			throw new AuthMissingError('hubspot');
+			throw new AuthMissingError('hubspot', 'oauth_2');
 		},
 	} satisfies InternalHubSpotPlugin;
 }

--- a/packages/intercom/index.ts
+++ b/packages/intercom/index.ts
@@ -13,6 +13,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	Admins,
 	Articles,
@@ -770,16 +771,12 @@ export function intercom<const T extends IntercomPluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'api_key') {
 				const res = await ctx.keys.get_api_key();
 				if (!res) {
-					throw new Error(
-						'[auth-missing:intercom:api_key]: Intercom API Key is missing',
-					);
+					throw new AuthMissingError('intercom', 'api_key');
 				}
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:intercom:${authType}]: Intercom key is missing`,
-			);
+			throw new AuthMissingError('intercom', 'api_key');
 		},
 	} satisfies InternalIntercomPlugin;
 }

--- a/packages/jira/index.ts
+++ b/packages/jira/index.ts
@@ -13,6 +13,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	Comments,
 	Groups,
@@ -548,14 +549,12 @@ export function jira<const T extends JiraPluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'api_key') {
 				const res = await ctx.keys.get_api_key();
 				if (!res) {
-					throw new Error(
-						'[auth-missing:jira:api_key]: Jira API Key is missing',
-					);
+					throw new AuthMissingError('jira', 'api_key');
 				}
 				return res;
 			}
 
-			throw new Error(`[auth-missing:jira:${authType}]: Jira key is missing`);
+			throw new AuthMissingError('jira', 'api_key');
 		},
 	} satisfies InternalJiraPlugin;
 }

--- a/packages/linear/index.ts
+++ b/packages/linear/index.ts
@@ -11,6 +11,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { getValidLinearAccessToken } from './client';
 import type { LinearEndpointInputs, LinearEndpointOutputs } from './endpoints';
 import { Comments, Issues, Projects, Teams, Users } from './endpoints';
@@ -450,9 +451,7 @@ export function linear<const T extends LinearPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new Error(
-						'[auth-missing:linear:refresh_token]: Linear refresh token is missing',
-					);
+					throw new AuthMissingError('linear');
 				}
 
 				const credentials = await ctx.keys.get_integration_credentials();
@@ -510,9 +509,7 @@ export function linear<const T extends LinearPluginOptions>(
 				return `Bearer ${result.accessToken}`;
 			}
 
-			throw new Error(
-				`[auth-missing:linear:${authType}]: Linear key is missing`,
-			);
+			throw new AuthMissingError('linear');
 		},
 	} satisfies InternalLinearPlugin;
 }

--- a/packages/linear/index.ts
+++ b/packages/linear/index.ts
@@ -435,9 +435,7 @@ export function linear<const T extends LinearPluginOptions>(
 				const res = await ctx.keys.get_api_key();
 
 				if (!res) {
-					throw new Error(
-						'[auth-missing:linear:api_key]: Linear API Key is missing',
-					);
+					throw new AuthMissingError('linear', 'api_key');
 				}
 
 				return res;
@@ -451,7 +449,7 @@ export function linear<const T extends LinearPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new AuthMissingError('linear');
+					throw new AuthMissingError('linear', 'oauth_2');
 				}
 
 				const credentials = await ctx.keys.get_integration_credentials();
@@ -509,7 +507,7 @@ export function linear<const T extends LinearPluginOptions>(
 				return `Bearer ${result.accessToken}`;
 			}
 
-			throw new AuthMissingError('linear');
+			throw new AuthMissingError('linear', 'oauth_2');
 		},
 	} satisfies InternalLinearPlugin;
 }

--- a/packages/monday/index.ts
+++ b/packages/monday/index.ts
@@ -13,6 +13,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	Boards,
 	Columns,
@@ -567,16 +568,12 @@ export function monday<const T extends MondayPluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'api_key') {
 				const res = await ctx.keys.get_api_key();
 				if (!res) {
-					throw new Error(
-						'[auth-missing:monday:api_key]: Monday API Key is missing',
-					);
+					throw new AuthMissingError('monday', 'api_key');
 				}
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:monday:${authType}]: Monday key is missing`,
-			);
+			throw new AuthMissingError('monday', 'api_key');
 		},
 	} satisfies InternalMondayPlugin;
 }

--- a/packages/notion/index.ts
+++ b/packages/notion/index.ts
@@ -13,6 +13,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { Blocks, DatabasePages, Databases, Pages, Users } from './endpoints';
 import type {
 	NotionEndpointInputs,
@@ -386,17 +387,13 @@ export function notion<const T extends NotionPluginOptions>(
 				const accessToken = await ctx.keys.get_access_token();
 
 				if (!accessToken) {
-					throw new Error(
-						'[auth-missing:notion:oauth_2]: Notion access token is missing',
-					);
+					throw new AuthMissingError('notion');
 				}
 
 				return accessToken;
 			}
 
-			throw new Error(
-				`[auth-missing:notion:${authType}]: Notion key is missing`,
-			);
+			throw new AuthMissingError('notion');
 		},
 	} satisfies InternalNotionPlugin;
 }

--- a/packages/notion/index.ts
+++ b/packages/notion/index.ts
@@ -375,9 +375,7 @@ export function notion<const T extends NotionPluginOptions>(
 				const res = await ctx.keys.get_api_key();
 
 				if (!res) {
-					throw new Error(
-						'[auth-missing:notion:api_key]: Notion API Key is missing',
-					);
+					throw new AuthMissingError('notion', 'api_key');
 				}
 
 				return res;
@@ -387,13 +385,13 @@ export function notion<const T extends NotionPluginOptions>(
 				const accessToken = await ctx.keys.get_access_token();
 
 				if (!accessToken) {
-					throw new AuthMissingError('notion');
+					throw new AuthMissingError('notion', 'oauth_2');
 				}
 
 				return accessToken;
 			}
 
-			throw new AuthMissingError('notion');
+			throw new AuthMissingError('notion', 'oauth_2');
 		},
 	} satisfies InternalNotionPlugin;
 }

--- a/packages/onedrive/index.ts
+++ b/packages/onedrive/index.ts
@@ -14,6 +14,7 @@ import type {
 	RequiredPluginEndpointSchemas,
 	RequiredPluginWebhookSchemas,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { getValidAccessToken } from './client';
 import {
 	Drive,
@@ -832,9 +833,7 @@ export function onedrive<const PluginOptions extends OnedrivePluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new Error(
-						'[auth-missing:onedrive:refresh_token]: OneDrive refresh token is missing',
-					);
+					throw new AuthMissingError('onedrive');
 				}
 
 				const creds = await ctx.keys.get_integration_credentials();
@@ -902,9 +901,7 @@ export function onedrive<const PluginOptions extends OnedrivePluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new Error(
-				`[auth-missing:onedrive:${authType}]: OneDrive key is missing`,
-			);
+			throw new AuthMissingError('onedrive');
 		},
 	} satisfies InternalOnedrivePlugin;
 }

--- a/packages/onedrive/index.ts
+++ b/packages/onedrive/index.ts
@@ -833,7 +833,7 @@ export function onedrive<const PluginOptions extends OnedrivePluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new AuthMissingError('onedrive');
+					throw new AuthMissingError('onedrive', 'oauth_2');
 				}
 
 				const creds = await ctx.keys.get_integration_credentials();
@@ -901,7 +901,7 @@ export function onedrive<const PluginOptions extends OnedrivePluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new AuthMissingError('onedrive');
+			throw new AuthMissingError('onedrive', 'oauth_2');
 		},
 	} satisfies InternalOnedrivePlugin;
 }

--- a/packages/openweathermap/index.ts
+++ b/packages/openweathermap/index.ts
@@ -12,6 +12,7 @@ import type {
 	RequiredPluginEndpointMeta,
 	RequiredPluginEndpointSchemas,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { History, Summary, Weather } from './endpoints';
 import type {
 	OpenWeatherMapEndpointInputs,
@@ -227,9 +228,7 @@ export function openweathermap<const T extends OpenWeatherMapPluginOptions>(
 				return res ?? '';
 			}
 
-			throw new Error(
-				`[auth-missing:openweathermap:${authType}]: OpenWeatherMap key is missing`,
-			);
+			throw new AuthMissingError('openweathermap', 'api_key');
 		},
 	} satisfies InternalOpenWeatherMapPlugin;
 }

--- a/packages/oura/index.ts
+++ b/packages/oura/index.ts
@@ -13,6 +13,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { Profile, Summary } from './endpoints';
 import type {
 	OuraEndpointInputs,
@@ -219,14 +220,12 @@ export function oura<const T extends OuraPluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'api_key') {
 				const res = await ctx.keys.get_api_key();
 				if (!res) {
-					throw new Error(
-						'[auth-missing:oura:api_key]: Oura API Key is missing',
-					);
+					throw new AuthMissingError('oura', 'api_key');
 				}
 				return res;
 			}
 
-			throw new Error(`[auth-missing:oura:${authType}]: Oura key is missing`);
+			throw new AuthMissingError('oura', 'api_key');
 		},
 	} satisfies InternalOuraPlugin;
 }

--- a/packages/outlook/index.ts
+++ b/packages/outlook/index.ts
@@ -642,7 +642,7 @@ export function outlook<const T extends OutlookPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new AuthMissingError('outlook');
+					throw new AuthMissingError('outlook', 'oauth_2');
 				}
 
 				const res = await ctx.keys.get_integration_credentials();
@@ -668,7 +668,7 @@ export function outlook<const T extends OutlookPluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new AuthMissingError('outlook');
+			throw new AuthMissingError('outlook', 'oauth_2');
 		},
 	} satisfies InternalOutlookPlugin;
 }

--- a/packages/outlook/index.ts
+++ b/packages/outlook/index.ts
@@ -16,6 +16,7 @@ import type {
 	RequiredPluginEndpointSchemas,
 	RequiredPluginWebhookSchemas,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { getValidAccessToken } from './client';
 import { Calendars, Contacts, Events, Folders, Messages } from './endpoints';
 import type {
@@ -641,7 +642,7 @@ export function outlook<const T extends OutlookPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new Error('No refresh token. Cannot get access token.');
+					throw new AuthMissingError('outlook');
 				}
 
 				const res = await ctx.keys.get_integration_credentials();
@@ -667,9 +668,7 @@ export function outlook<const T extends OutlookPluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new Error(
-				`[auth-missing:outlook:${authType}]: Outlook key is missing`,
-			);
+			throw new AuthMissingError('outlook');
 		},
 	} satisfies InternalOutlookPlugin;
 }

--- a/packages/pagerduty/index.ts
+++ b/packages/pagerduty/index.ts
@@ -12,6 +12,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { IncidentNotes, Incidents, LogEntries, Users } from './endpoints';
 import type {
 	PagerdutyEndpointInputs,
@@ -334,17 +335,13 @@ export function pagerduty<const T extends PagerdutyPluginOptions>(
 				const res = await ctx.keys.get_api_key();
 
 				if (!res) {
-					throw new Error(
-						'[auth-missing:pagerduty:api_key]: PagerDuty API Key is missing',
-					);
+					throw new AuthMissingError('pagerduty', 'api_key');
 				}
 
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:pagerduty:${authType}]: PagerDuty key is missing`,
-			);
+			throw new AuthMissingError('pagerduty', 'api_key');
 		},
 	} satisfies InternalPagerdutyPlugin;
 }

--- a/packages/posthog/index.ts
+++ b/packages/posthog/index.ts
@@ -11,6 +11,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { Events } from './endpoints';
 import type {
 	PostHogEndpointInputs,
@@ -231,17 +232,13 @@ export function posthog<const T extends PostHogPluginOptions>(
 				const res = await ctx.keys.get_api_key();
 
 				if (!res) {
-					throw new Error(
-						'[auth-missing:posthog:api_key]: PostHog API Key is missing',
-					);
+					throw new AuthMissingError('posthog', 'api_key');
 				}
 
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:posthog:${authType}]: PostHog key is missing`,
-			);
+			throw new AuthMissingError('posthog', 'api_key');
 		},
 	} satisfies InternalPostHogPlugin;
 }

--- a/packages/razorpay/index.ts
+++ b/packages/razorpay/index.ts
@@ -14,6 +14,7 @@ import type {
 	RequiredPluginEndpointSchemas,
 	RequiredPluginWebhookSchemas,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	Customers,
 	Orders,
@@ -517,9 +518,7 @@ export function razorpay<const T extends RazorpayPluginOptions>(
 				return res ?? '';
 			}
 
-			throw new Error(
-				`[auth-missing:razorpay:${authType}]: Razorpay key is missing`,
-			);
+			throw new AuthMissingError('razorpay', 'api_key');
 		},
 	} satisfies InternalRazorpayPlugin;
 }

--- a/packages/resend/index.ts
+++ b/packages/resend/index.ts
@@ -11,6 +11,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { Domains, Emails } from './endpoints';
 import type {
 	ResendEndpointInputs,
@@ -338,17 +339,13 @@ export function resend<const T extends ResendPluginOptions>(
 				const res = await ctx.keys.get_api_key();
 
 				if (!res) {
-					throw new Error(
-						'[auth-missing:resend:api_key]: Resend API Key is missing',
-					);
+					throw new AuthMissingError('resend', 'api_key');
 				}
 
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:resend:${authType}]: Resend key is missing`,
-			);
+			throw new AuthMissingError('resend', 'api_key');
 		},
 	} satisfies InternalResendPlugin;
 }

--- a/packages/sentry/index.ts
+++ b/packages/sentry/index.ts
@@ -12,6 +12,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import type { SentryEndpointInputs, SentryEndpointOutputs } from './endpoints';
 import {
 	Events,
@@ -529,17 +530,13 @@ export function sentry<const T extends SentryPluginOptions>(
 				const res = await ctx.keys.get_api_key();
 
 				if (!res) {
-					throw new Error(
-						'[auth-missing:sentry:api_key]: Sentry API Key is missing',
-					);
+					throw new AuthMissingError('sentry', 'api_key');
 				}
 
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:sentry:${authType}]: Sentry key is missing`,
-			);
+			throw new AuthMissingError('sentry', 'api_key');
 		},
 	} satisfies InternalSentryPlugin;
 }

--- a/packages/sharepoint/index.ts
+++ b/packages/sharepoint/index.ts
@@ -1384,7 +1384,7 @@ export function sharepoint<const T extends SharepointPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new AuthMissingError('sharepoint');
+					throw new AuthMissingError('sharepoint', 'oauth_2');
 				}
 
 				const creds = await ctx.keys.get_integration_credentials();
@@ -1447,7 +1447,7 @@ export function sharepoint<const T extends SharepointPluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new AuthMissingError('sharepoint');
+			throw new AuthMissingError('sharepoint', 'oauth_2');
 		},
 	} satisfies InternalSharepointPlugin;
 }

--- a/packages/sharepoint/index.ts
+++ b/packages/sharepoint/index.ts
@@ -13,6 +13,7 @@ import type {
 	RequiredPluginEndpointMeta,
 	RequiredPluginEndpointSchemas,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { getValidSharepointAccessToken } from './client';
 import {
 	ContentTypes,
@@ -1383,9 +1384,7 @@ export function sharepoint<const T extends SharepointPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new Error(
-						'[auth-missing:sharepoint:refresh_token]: SharePoint refresh token is missing',
-					);
+					throw new AuthMissingError('sharepoint');
 				}
 
 				const creds = await ctx.keys.get_integration_credentials();
@@ -1448,9 +1447,7 @@ export function sharepoint<const T extends SharepointPluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new Error(
-				`[auth-missing:sharepoint:${authType}]: SharePoint key is missing`,
-			);
+			throw new AuthMissingError('sharepoint');
 		},
 	} satisfies InternalSharepointPlugin;
 }

--- a/packages/slack/index.ts
+++ b/packages/slack/index.ts
@@ -767,9 +767,7 @@ export function slack<const PluginOptions extends SlackPluginOptions>(
 				const res = await ctx.keys.get_api_key();
 
 				if (!res) {
-					throw new Error(
-						'[auth-missing:slack:api_key]: Slack API Key is missing',
-					);
+					throw new AuthMissingError('slack', 'api_key');
 				}
 
 				return res;
@@ -777,13 +775,13 @@ export function slack<const PluginOptions extends SlackPluginOptions>(
 				const res = await ctx.keys.get_access_token();
 
 				if (!res) {
-					throw new AuthMissingError('slack');
+					throw new AuthMissingError('slack', 'oauth_2');
 				}
 
 				return res;
 			}
 
-			throw new AuthMissingError('slack');
+			throw new AuthMissingError('slack', 'oauth_2');
 		},
 	} satisfies InternalSlackPlugin;
 }

--- a/packages/slack/index.ts
+++ b/packages/slack/index.ts
@@ -12,6 +12,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import type { SlackEndpointInputs, SlackEndpointOutputs } from './endpoints';
 import {
 	Channels,
@@ -776,15 +777,13 @@ export function slack<const PluginOptions extends SlackPluginOptions>(
 				const res = await ctx.keys.get_access_token();
 
 				if (!res) {
-					throw new Error(
-						'[auth-missing:slack:oauth_2]: Slack access token is missing',
-					);
+					throw new AuthMissingError('slack');
 				}
 
 				return res;
 			}
 
-			throw new Error(`[auth-missing:slack:${authType}]: Slack key is missing`);
+			throw new AuthMissingError('slack');
 		},
 	} satisfies InternalSlackPlugin;
 }

--- a/packages/spotify/index.ts
+++ b/packages/spotify/index.ts
@@ -553,9 +553,7 @@ export function spotify<const T extends SpotifyPluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'api_key') {
 				const res = await ctx.keys.get_api_key();
 				if (!res) {
-					throw new Error(
-						'[auth-missing:spotify:api_key]: Spotify API Key is missing',
-					);
+					throw new AuthMissingError('spotify', 'api_key');
 				}
 				return res;
 			}
@@ -565,7 +563,7 @@ export function spotify<const T extends SpotifyPluginOptions>(
 				const refreshToken = await ctx.keys.get_refresh_token();
 
 				if (!refreshToken) {
-					throw new AuthMissingError('spotify');
+					throw new AuthMissingError('spotify', 'oauth_2');
 				}
 
 				const res = await ctx.keys.get_integration_credentials();
@@ -609,7 +607,7 @@ export function spotify<const T extends SpotifyPluginOptions>(
 				}
 			}
 
-			throw new AuthMissingError('spotify');
+			throw new AuthMissingError('spotify', 'oauth_2');
 		},
 	} satisfies InternalSpotifyPlugin;
 }

--- a/packages/spotify/index.ts
+++ b/packages/spotify/index.ts
@@ -12,6 +12,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { getValidAccessToken } from './client';
 import {
 	Albums,
@@ -564,9 +565,7 @@ export function spotify<const T extends SpotifyPluginOptions>(
 				const refreshToken = await ctx.keys.get_refresh_token();
 
 				if (!refreshToken) {
-					throw new Error(
-						'[auth-missing:spotify:refresh_token]: Spotify refresh token is missing',
-					);
+					throw new AuthMissingError('spotify');
 				}
 
 				const res = await ctx.keys.get_integration_credentials();
@@ -610,9 +609,7 @@ export function spotify<const T extends SpotifyPluginOptions>(
 				}
 			}
 
-			throw new Error(
-				`[auth-missing:spotify:${authType}]: Spotify key is missing`,
-			);
+			throw new AuthMissingError('spotify');
 		},
 	} satisfies InternalSpotifyPlugin;
 }

--- a/packages/strava/index.ts
+++ b/packages/strava/index.ts
@@ -434,13 +434,13 @@ export function strava<const T extends StravaPluginOptions>(
 				const res = await ctx.keys.get_access_token();
 
 				if (!res) {
-					throw new AuthMissingError('strava');
+					throw new AuthMissingError('strava', 'oauth_2');
 				}
 
 				return res;
 			}
 
-			throw new AuthMissingError('strava');
+			throw new AuthMissingError('strava', 'oauth_2');
 		},
 	} satisfies InternalStravaPlugin;
 }

--- a/packages/strava/index.ts
+++ b/packages/strava/index.ts
@@ -14,6 +14,7 @@ import type {
 	RequiredPluginEndpointSchemas,
 	RequiredPluginWebhookSchemas,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	Activities,
 	Athletes,
@@ -433,17 +434,13 @@ export function strava<const T extends StravaPluginOptions>(
 				const res = await ctx.keys.get_access_token();
 
 				if (!res) {
-					throw new Error(
-						'[auth-missing:strava:oauth_2]: Strava access token is missing',
-					);
+					throw new AuthMissingError('strava');
 				}
 
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:strava:${authType}]: Strava key is missing`,
-			);
+			throw new AuthMissingError('strava');
 		},
 	} satisfies InternalStravaPlugin;
 }

--- a/packages/stripe/index.ts
+++ b/packages/stripe/index.ts
@@ -13,6 +13,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { getValidStripeAccessToken } from './client';
 import {
 	Balance,
@@ -517,9 +518,7 @@ export function stripe<const T extends StripePluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new Error(
-						'[auth-missing:stripe:refresh_token]: Stripe refresh token is missing',
-					);
+					throw new AuthMissingError('stripe');
 				}
 
 				const creds = await ctx.keys.get_integration_credentials();
@@ -576,9 +575,7 @@ export function stripe<const T extends StripePluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new Error(
-				`[auth-missing:stripe:${authType}]: Stripe key is missing`,
-			);
+			throw new AuthMissingError('stripe');
 		},
 	} satisfies InternalStripePlugin;
 }

--- a/packages/stripe/index.ts
+++ b/packages/stripe/index.ts
@@ -502,9 +502,7 @@ export function stripe<const T extends StripePluginOptions>(
 				const res = await ctx.keys.get_api_key();
 
 				if (!res) {
-					throw new Error(
-						'[auth-missing:stripe:api_key]: Stripe API Key is missing',
-					);
+					throw new AuthMissingError('stripe', 'api_key');
 				}
 
 				return res;
@@ -518,7 +516,7 @@ export function stripe<const T extends StripePluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new AuthMissingError('stripe');
+					throw new AuthMissingError('stripe', 'oauth_2');
 				}
 
 				const creds = await ctx.keys.get_integration_credentials();
@@ -575,7 +573,7 @@ export function stripe<const T extends StripePluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new AuthMissingError('stripe');
+			throw new AuthMissingError('stripe', 'oauth_2');
 		},
 	} satisfies InternalStripePlugin;
 }

--- a/packages/tavily/index.ts
+++ b/packages/tavily/index.ts
@@ -11,6 +11,7 @@ import type {
 	RequiredPluginEndpointMeta,
 	RequiredPluginEndpointSchemas,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { Crawl, Extract, Map, Search } from './endpoints';
 import type {
 	TavilyEndpointInputs,
@@ -156,9 +157,7 @@ export function tavily<const T extends TavilyPluginOptions>(
 				return res ?? '';
 			}
 
-			throw new Error(
-				`[auth-missing:tavily:${authType}]: Tavily key is missing`,
-			);
+			throw new AuthMissingError('tavily', 'api_key');
 		},
 	} satisfies InternalTavilyPlugin;
 }

--- a/packages/teams/index.ts
+++ b/packages/teams/index.ts
@@ -14,6 +14,7 @@ import type {
 	RequiredPluginEndpointSchemas,
 	RequiredPluginWebhookSchemas,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { getValidAccessToken } from './client';
 import { Channels, Chats, Members, Messages, Teams } from './endpoints';
 import type {
@@ -484,7 +485,7 @@ export function teams<const T extends TeamsPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new Error('No refresh token. Cannot get access token.');
+					throw new AuthMissingError('teams');
 				}
 
 				const creds = await ctx.keys.get_integration_credentials();
@@ -509,7 +510,7 @@ export function teams<const T extends TeamsPluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new Error(`[auth-missing:teams:${authType}]: Teams key is missing`);
+			throw new AuthMissingError('teams');
 		},
 	} satisfies InternalTeamsPlugin;
 }

--- a/packages/teams/index.ts
+++ b/packages/teams/index.ts
@@ -485,7 +485,7 @@ export function teams<const T extends TeamsPluginOptions>(
 				]);
 
 				if (!refreshToken) {
-					throw new AuthMissingError('teams');
+					throw new AuthMissingError('teams', 'oauth_2');
 				}
 
 				const creds = await ctx.keys.get_integration_credentials();
@@ -510,7 +510,7 @@ export function teams<const T extends TeamsPluginOptions>(
 				return result.accessToken;
 			}
 
-			throw new AuthMissingError('teams');
+			throw new AuthMissingError('teams', 'oauth_2');
 		},
 	} satisfies InternalTeamsPlugin;
 }

--- a/packages/telegram/index.ts
+++ b/packages/telegram/index.ts
@@ -11,6 +11,7 @@ import type {
 	PickAuth,
 	PluginAuthConfig,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	Callback,
 	Chat,
@@ -305,9 +306,7 @@ export function telegram<const T extends TelegramPluginOptions>(
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:telegram:${authType}]: Telegram key is missing`,
-			);
+			throw new AuthMissingError('telegram', 'bot_token');
 		},
 	} satisfies InternalTelegramPlugin;
 }

--- a/packages/todoist/index.ts
+++ b/packages/todoist/index.ts
@@ -13,6 +13,7 @@ import type {
 	PluginEndpointMeta,
 	PluginPermissionsConfig,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	Comments,
 	Labels,
@@ -493,17 +494,13 @@ export function todoist<const T extends TodoistPluginOptions>(
 				const res = await ctx.keys.get_api_key();
 
 				if (!res) {
-					throw new Error(
-						'[auth-missing:todoist:api_key]: Todoist API Key is missing',
-					);
+					throw new AuthMissingError('todoist', 'api_key');
 				}
 
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:todoist:${authType}]: Todoist key is missing`,
-			);
+			throw new AuthMissingError('todoist', 'api_key');
 		},
 	} satisfies InternalTodoistPlugin;
 }

--- a/packages/trello/index.ts
+++ b/packages/trello/index.ts
@@ -12,6 +12,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { Boards, Cards, Checklists, Labels, Lists, Members } from './endpoints';
 import type {
 	TrelloEndpointInputs,
@@ -446,16 +447,12 @@ export function trello<const T extends TrelloPluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'api_key') {
 				const res = await ctx.keys.get_api_key();
 				if (!res) {
-					throw new Error(
-						'[auth-missing:trello:api_key]: Trello API Key is missing',
-					);
+					throw new AuthMissingError('trello', 'api_key');
 				}
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:trello:${authType}]: Trello key is missing`,
-			);
+			throw new AuthMissingError('trello', 'api_key');
 		},
 	} satisfies InternalTrelloPlugin;
 }

--- a/packages/twitter/index.ts
+++ b/packages/twitter/index.ts
@@ -11,6 +11,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	TweetsEndpoints,
 	TwitterEndpointInputSchemas,
@@ -178,16 +179,12 @@ export function twitter<const T extends TwitterPluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'oauth_2') {
 				const res = await ctx.keys.get_access_token();
 				if (!res) {
-					throw new Error(
-						'[auth-missing:twitter:oauth_2]: Twitter access token is missing',
-					);
+					throw new AuthMissingError('twitter');
 				}
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:twitter:${authType}]: Twitter key is missing`,
-			);
+			throw new AuthMissingError('twitter');
 		},
 	} satisfies InternalTwitterPlugin;
 }

--- a/packages/twitter/index.ts
+++ b/packages/twitter/index.ts
@@ -179,12 +179,12 @@ export function twitter<const T extends TwitterPluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'oauth_2') {
 				const res = await ctx.keys.get_access_token();
 				if (!res) {
-					throw new AuthMissingError('twitter');
+					throw new AuthMissingError('twitter', 'oauth_2');
 				}
 				return res;
 			}
 
-			throw new AuthMissingError('twitter');
+			throw new AuthMissingError('twitter', 'oauth_2');
 		},
 	} satisfies InternalTwitterPlugin;
 }

--- a/packages/twitterapiio/index.ts
+++ b/packages/twitterapiio/index.ts
@@ -13,6 +13,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	CommunitiesEndpoints,
 	ListsEndpoints,
@@ -731,9 +732,7 @@ export function twitterapiio<const T extends TwitterApiIOPluginOptions>(
 				return res ?? '';
 			}
 
-			throw new Error(
-				`[auth-missing:twitterapiio:${authType}]: Twitter API IO key is missing`,
-			);
+			throw new AuthMissingError('twitterapiio', 'api_key');
 		},
 	} satisfies InternalTwitterApiIOPlugin;
 }

--- a/packages/typeform/index.ts
+++ b/packages/typeform/index.ts
@@ -553,12 +553,12 @@ export function typeform<const T extends TypeformPluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'oauth_2') {
 				const res = await ctx.keys.get_access_token();
 				if (!res) {
-					throw new AuthMissingError('typeform');
+					throw new AuthMissingError('typeform', 'oauth_2');
 				}
 				return res;
 			}
 
-			throw new AuthMissingError('typeform');
+			throw new AuthMissingError('typeform', 'oauth_2');
 		},
 	} satisfies InternalTypeformPlugin;
 }

--- a/packages/typeform/index.ts
+++ b/packages/typeform/index.ts
@@ -13,6 +13,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	Forms,
 	Images,
@@ -552,16 +553,12 @@ export function typeform<const T extends TypeformPluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'oauth_2') {
 				const res = await ctx.keys.get_access_token();
 				if (!res) {
-					throw new Error(
-						'[auth-missing:typeform:oauth_2]: Typeform access token is missing',
-					);
+					throw new AuthMissingError('typeform');
 				}
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:typeform:${authType}]: Typeform key is missing`,
-			);
+			throw new AuthMissingError('typeform');
 		},
 	} satisfies InternalTypeformPlugin;
 }

--- a/packages/vapi/index.ts
+++ b/packages/vapi/index.ts
@@ -13,6 +13,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { z } from 'zod';
 import type { VapiEndpointInputs, VapiEndpointOutputs } from './endpoints';
 import {
@@ -616,14 +617,12 @@ export function vapi<const T extends VapiPluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'api_key') {
 				const res = await ctx.keys.get_api_key();
 				if (!res) {
-					throw new Error(
-						'[auth-missing:vapi:api_key]: Vapi API Key is missing',
-					);
+					throw new AuthMissingError('vapi', 'api_key');
 				}
 				return res;
 			}
 
-			throw new Error(`[auth-missing:vapi:${authType}]: Vapi key is missing`);
+			throw new AuthMissingError('vapi', 'api_key');
 		},
 	} satisfies InternalVapiPlugin;
 }

--- a/packages/xquik/index.ts
+++ b/packages/xquik/index.ts
@@ -15,6 +15,7 @@ import type {
 	RequiredPluginEndpointSchemas,
 	RequiredPluginWebhookSchemas,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	Media,
 	Trends,
@@ -449,9 +450,9 @@ export function xquik<const T extends XquikPluginOptions>(
 				return res ?? '';
 			}
 
-			throw new Error(
-				`[auth-missing:xquik:${ctx.authType}]: Xquik key is missing`,
-			);
+			throw new AuthMissingError('xquik', 'api_key');
+			throw new AuthMissingError('xquik', 'api_key');
+			throw new AuthMissingError('xquik', 'api_key');
 		},
 		options,
 		pluginWebhookMatcher: hasXquikSignature,

--- a/packages/xquik/index.ts
+++ b/packages/xquik/index.ts
@@ -451,8 +451,6 @@ export function xquik<const T extends XquikPluginOptions>(
 			}
 
 			throw new AuthMissingError('xquik', 'api_key');
-			throw new AuthMissingError('xquik', 'api_key');
-			throw new AuthMissingError('xquik', 'api_key');
 		},
 		options,
 		pluginWebhookMatcher: hasXquikSignature,

--- a/packages/youtube/index.ts
+++ b/packages/youtube/index.ts
@@ -14,6 +14,7 @@ import type {
 	RequiredPluginEndpointMeta,
 	RequiredPluginEndpointSchemas,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	CaptionsEndpoints,
 	ChannelsEndpoints,
@@ -721,16 +722,12 @@ export function youtube<const T extends YoutubePluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'oauth_2') {
 				const res = await ctx.keys.get_access_token();
 				if (!res) {
-					throw new Error(
-						'[auth-missing:youtube:oauth_2]: Youtube access token is missing',
-					);
+					throw new AuthMissingError('youtube');
 				}
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:youtube:${authType}]: Youtube key is missing`,
-			);
+			throw new AuthMissingError('youtube');
 		},
 	} satisfies InternalYoutubePlugin;
 }

--- a/packages/youtube/index.ts
+++ b/packages/youtube/index.ts
@@ -722,12 +722,12 @@ export function youtube<const T extends YoutubePluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'oauth_2') {
 				const res = await ctx.keys.get_access_token();
 				if (!res) {
-					throw new AuthMissingError('youtube');
+					throw new AuthMissingError('youtube', 'oauth_2');
 				}
 				return res;
 			}
 
-			throw new AuthMissingError('youtube');
+			throw new AuthMissingError('youtube', 'oauth_2');
 		},
 	} satisfies InternalYoutubePlugin;
 }

--- a/packages/zendesk/index.ts
+++ b/packages/zendesk/index.ts
@@ -15,6 +15,7 @@ import type {
 	RequiredPluginEndpointSchemas,
 	RequiredPluginWebhookSchemas,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { Comments, Tickets, Users } from './endpoints';
 import type {
 	ZendeskEndpointInputs,
@@ -292,16 +293,12 @@ export function zendesk<const T extends ZendeskPluginOptions>(
 			if (source === 'endpoint' && ctx.authType === 'api_key') {
 				const res = await ctx.keys.get_api_key();
 				if (!res) {
-					throw new Error(
-						'[auth-missing:zendesk:api_key]: Zendesk API Key is missing',
-					);
+					throw new AuthMissingError('zendesk', 'api_key');
 				}
 				return res;
 			}
 
-			throw new Error(
-				`[auth-missing:zendesk:${authType}]: Zendesk key is missing`,
-			);
+			throw new AuthMissingError('zendesk', 'api_key');
 		},
 	} satisfies InternalZendeskPlugin;
 }

--- a/packages/zoom/index.ts
+++ b/packages/zoom/index.ts
@@ -446,13 +446,13 @@ export function zoom<const PluginOptions extends ZoomPluginOptions>(
 				const res = await ctx.keys.get_access_token();
 
 				if (!res) {
-					throw new AuthMissingError('zoom');
+					throw new AuthMissingError('zoom', 'oauth_2');
 				}
 
 				return res;
 			}
 
-			throw new AuthMissingError('zoom');
+			throw new AuthMissingError('zoom', 'oauth_2');
 		},
 	} satisfies InternalZoomPlugin;
 }

--- a/packages/zoom/index.ts
+++ b/packages/zoom/index.ts
@@ -12,6 +12,7 @@ import type {
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import {
 	ArchiveFiles,
 	Devices,
@@ -445,15 +446,13 @@ export function zoom<const PluginOptions extends ZoomPluginOptions>(
 				const res = await ctx.keys.get_access_token();
 
 				if (!res) {
-					throw new Error(
-						'[auth-missing:zoom:oauth_2]: Zoom access token is missing',
-					);
+					throw new AuthMissingError('zoom');
 				}
 
 				return res;
 			}
 
-			throw new Error(`[auth-missing:zoom:${authType}]: Zoom key is missing`);
+			throw new AuthMissingError('zoom');
 		},
 	} satisfies InternalZoomPlugin;
 }


### PR DESCRIPTION
Closes #242

`AuthMissingError` now accepts `(pluginId, authType)` so `bind.ts` can gate connect-link generation on `err.authType === 'oauth_2'`. All 57 plugins switched to throw `AuthMissingError` with the correct auth type.

**Changes:**
- Added `authType` param to `AuthMissingError` constructor
- `bind.ts` only generates connect links for `oauth_2` errors
- All plugins (OAuth + api_key + bot_token) now use `AuthMissingError`

**Kept as plain `Error`:**
`webhook_signature`, `client_credentials`, `client_secret`, `[corsair:...]` operational errors