### PR TITLE
feat(core): add management handler and `createCorsairClient()`

### DIFF
--- a/packages/corsair/client/index.ts
+++ b/packages/corsair/client/index.ts
@@ -90,8 +90,10 @@ export function createCorsairClient(
 		},
 		permissions: {
 			get: (id) => getJson<PermissionRecord>(`/permissions/${enc(id)}`),
+			// POST + body keeps the token off the URL where reverse proxies and
+			// access logs would capture it.
 			getByToken: (token) =>
-				getJson<PermissionRecord>(`/permissions/by-token/${enc(token)}`),
+				postJson<PermissionRecord>('/permissions/lookup-by-token', { token }),
 		},
 	};
 }

--- a/packages/corsair/client/index.ts
+++ b/packages/corsair/client/index.ts
@@ -1,0 +1,103 @@
+import type {
+	ConnectionStatus,
+	ManagementOk,
+	PermissionRecord,
+	PluginInfo,
+	Tenant,
+} from '../core/management/types';
+import type {
+	CorsairClientOptions,
+	CorsairManagementClient,
+} from './types';
+import { CorsairClientError } from './types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// createCorsairClient — vanilla client for the management control plane.
+//
+// Phase 1a ships an explicit dispatch (9 routes). Phase 2 will swap this for
+// a recursive Proxy once routes become plugin-extensible. The public shape
+// stays the same: client.tenants.list(), client.plugins.get(id), etc.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function trimBase(base: string): string {
+	return base.endsWith('/') ? base.slice(0, -1) : base;
+}
+
+async function parseError(res: Response): Promise<CorsairClientError> {
+	let body: Record<string, unknown> = {};
+	try {
+		body = (await res.json()) as Record<string, unknown>;
+	} catch {
+		// non-JSON error body
+	}
+	const code = typeof body.error === 'string' ? body.error : 'request_failed';
+	const message =
+		typeof body.message === 'string'
+			? body.message
+			: `Request failed (${res.status})`;
+	const { error: _e, message: _m, ...extra } = body;
+	return new CorsairClientError(res.status, code, message, extra);
+}
+
+export function createCorsairClient(
+	opts: CorsairClientOptions,
+): CorsairManagementClient {
+	const baseURL = trimBase(opts.baseURL);
+	const fetchImpl = opts.fetch ?? globalThis.fetch.bind(globalThis);
+
+	async function getJson<T>(
+		path: string,
+		query?: Record<string, string>,
+	): Promise<T> {
+		const qs =
+			query && Object.keys(query).length
+				? `?${new URLSearchParams(query).toString()}`
+				: '';
+		const res = await fetchImpl(`${baseURL}${path}${qs}`, { method: 'GET' });
+		if (!res.ok) throw await parseError(res);
+		return (await res.json()) as T;
+	}
+
+	async function postJson<T>(path: string, body: unknown): Promise<T> {
+		const res = await fetchImpl(`${baseURL}${path}`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify(body),
+		});
+		if (!res.ok) throw await parseError(res);
+		return (await res.json()) as T;
+	}
+
+	const enc = encodeURIComponent;
+
+	return {
+		ok: () => getJson<ManagementOk>('/ok'),
+		tenants: {
+			list: () => getJson<Tenant[]>('/tenants'),
+			create: (input) => postJson<Tenant>('/tenants', input),
+			get: (id) => getJson<Tenant>(`/tenants/${enc(id)}`),
+		},
+		plugins: {
+			list: () => getJson<PluginInfo[]>('/plugins'),
+			get: (id) => getJson<PluginInfo>(`/plugins/${enc(id)}`),
+		},
+		connectionStatus: {
+			get: (q) => {
+				const query: Record<string, string> = {};
+				if (q?.tenantId) query.tenantId = q.tenantId;
+				return getJson<ConnectionStatus>('/connection-status', query);
+			},
+		},
+		permissions: {
+			get: (id) => getJson<PermissionRecord>(`/permissions/${enc(id)}`),
+			getByToken: (token) =>
+				getJson<PermissionRecord>(`/permissions/by-token/${enc(token)}`),
+		},
+	};
+}
+
+export { CorsairClientError } from './types';
+export type {
+	CorsairClientOptions,
+	CorsairManagementClient,
+} from './types';

--- a/packages/corsair/client/types.ts
+++ b/packages/corsair/client/types.ts
@@ -1,0 +1,60 @@
+import type {
+	ConnectionStatus,
+	CreateTenantInput,
+	ManagementOk,
+	PermissionRecord,
+	PluginInfo,
+	Tenant,
+} from '../core/management/types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Client types for the management control plane.
+// Phase 1a ships a static client shape. Plugin-extensible inference lands in
+// Phase 2 once routes vary per plugin.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type CorsairClientOptions = {
+	/** Origin + base path of the mounted handler, e.g. 'https://api.example.com/api/corsair'. */
+	baseURL: string;
+	/** Optional fetch override. Defaults to globalThis.fetch. */
+	fetch?: typeof fetch;
+};
+
+export type CorsairManagementClient = {
+	ok: () => Promise<ManagementOk>;
+	tenants: {
+		list: () => Promise<Tenant[]>;
+		create: (input: CreateTenantInput) => Promise<Tenant>;
+		get: (id: string) => Promise<Tenant>;
+	};
+	plugins: {
+		list: () => Promise<PluginInfo[]>;
+		get: (id: string) => Promise<PluginInfo>;
+	};
+	connectionStatus: {
+		get: (query?: { tenantId?: string }) => Promise<ConnectionStatus>;
+	};
+	permissions: {
+		get: (id: string) => Promise<PermissionRecord>;
+		getByToken: (token: string) => Promise<PermissionRecord>;
+	};
+};
+
+export class CorsairClientError extends Error {
+	readonly status: number;
+	readonly code: string;
+	readonly extra: Record<string, unknown>;
+
+	constructor(
+		status: number,
+		code: string,
+		message: string,
+		extra: Record<string, unknown> = {},
+	) {
+		super(message);
+		this.name = 'CorsairClientError';
+		this.status = status;
+		this.code = code;
+		this.extra = extra;
+	}
+}

--- a/packages/corsair/core/client/index.ts
+++ b/packages/corsair/core/client/index.ts
@@ -19,6 +19,7 @@ import type { AuthTypes } from '../constants';
 import type { BindEndpoints, EndpointTree } from '../endpoints';
 import { bindEndpointsRecursively } from '../endpoints/bind';
 import type { CorsairErrorHandler } from '../errors';
+import type { CorsairManageNamespace } from '../management';
 import type { CorsairPermissionsNamespace } from '../permissions';
 import type {
 	CorsairKeyBuilderBase,
@@ -208,6 +209,12 @@ export type CorsairTenantWrapper<Plugins extends readonly CorsairPlugin[]> = {
 	 * Available at the root regardless of multi-tenancy setting.
 	 */
 	permissions: CorsairPermissionsNamespace;
+	/**
+	 * Management control plane namespace — in-process equivalent of the HTTP
+	 * `managementHandler`. Lists tenants, plugins, connection status, and
+	 * permission records without going through HTTP.
+	 */
+	manage: CorsairManageNamespace;
 };
 
 /**
@@ -226,6 +233,12 @@ export type CorsairSingleTenantClient<
 	 * Available at the root regardless of multi-tenancy setting.
 	 */
 	permissions: CorsairPermissionsNamespace;
+	/**
+	 * Management control plane namespace — in-process equivalent of the HTTP
+	 * `managementHandler`. Lists tenants, plugins, connection status, and
+	 * permission records without going through HTTP.
+	 */
+	manage: CorsairManageNamespace;
 };
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/corsair/core/index.ts
+++ b/packages/corsair/core/index.ts
@@ -3,6 +3,8 @@ import { createCorsairDatabase } from '../db/kysely/database';
 import { createMissingConfigProxy } from './auth/errors';
 import type { CorsairSingleTenantClient, CorsairTenantWrapper } from './client';
 import { buildCorsairClient, buildIntegrationKeys } from './client';
+import type { CorsairManageNamespace } from './management';
+import { buildManagementNamespace } from './management';
 import { buildPermissionsNamespace } from './permissions';
 import type { CorsairIntegration, CorsairPlugin } from './plugins';
 
@@ -104,6 +106,7 @@ export function createCorsair<const Plugins extends readonly CorsairPlugin[]>(
 	};
 
 	const permissions = buildPermissionsNamespace(resolvedDatabase);
+	const manage = buildManagementNamespace(internalConfig);
 
 	if (config.multiTenancy) {
 		return Object.assign(
@@ -128,6 +131,7 @@ export function createCorsair<const Plugins extends readonly CorsairPlugin[]>(
 				},
 				keys: integrationKeys,
 				permissions,
+				manage,
 			},
 			{ [CORSAIR_INTERNAL]: internalConfig },
 		);
@@ -145,6 +149,7 @@ export function createCorsair<const Plugins extends readonly CorsairPlugin[]>(
 	return Object.assign({}, client, {
 		keys: integrationKeys,
 		permissions,
+		manage,
 		[CORSAIR_INTERNAL]: internalConfig,
 	}) as CorsairSingleTenantClient<Plugins>;
 }

--- a/packages/corsair/core/management/adapters/express.ts
+++ b/packages/corsair/core/management/adapters/express.ts
@@ -82,6 +82,9 @@ async function writeResponse(
 }
 
 export function toExpressHandler(
+	// `unknown` matches the managementHandler signature — see the justification
+	// there. The handler only reads the CORSAIR_INTERNAL symbol, so the public
+	// client shape isn't needed at this seam.
 	corsair: unknown,
 	opts?: ManagementHandlerOptions,
 ): ExpressHandler {

--- a/packages/corsair/core/management/adapters/express.ts
+++ b/packages/corsair/core/management/adapters/express.ts
@@ -1,0 +1,97 @@
+import type { ManagementHandlerOptions } from '../handler';
+import { managementHandler } from '../handler';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Express adapter.
+//
+// Mount as middleware:
+//
+//   import express from 'express';
+//   import { toExpressHandler } from 'corsair';
+//   import { corsair } from './lib/corsair';
+//   const app = express();
+//   app.use('/api/corsair', toExpressHandler(corsair));
+//
+// Express's `req.url` is path-only and `req.body` is already-parsed when
+// `express.json()` is mounted upstream. We reconstruct a fetch Request,
+// dispatch to the vanilla handler, then stream the Response back onto
+// Express's `res`.
+//
+// Types are declared structurally so we don't carry an `@types/express`
+// peer dep on the corsair package.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type ExpressLikeRequest = {
+	method: string;
+	originalUrl: string;
+	url: string;
+	headers: Record<string, string | string[] | undefined>;
+	body?: unknown;
+	protocol?: string;
+	get?: (name: string) => string | undefined;
+};
+
+type ExpressLikeResponse = {
+	status: (code: number) => ExpressLikeResponse;
+	setHeader: (name: string, value: string) => void;
+	send: (body: string | Buffer) => void;
+};
+
+type ExpressLikeNext = (err?: unknown) => void;
+
+export type ExpressHandler = (
+	req: ExpressLikeRequest,
+	res: ExpressLikeResponse,
+	next: ExpressLikeNext,
+) => Promise<void>;
+
+function buildFetchRequest(req: ExpressLikeRequest): Request {
+	const host = req.get?.('host') ?? 'localhost';
+	const proto = req.protocol ?? 'http';
+	const path = req.originalUrl ?? req.url;
+	const url = `${proto}://${host}${path}`;
+
+	const headers = new Headers();
+	for (const [k, v] of Object.entries(req.headers)) {
+		if (v == null) continue;
+		if (Array.isArray(v)) for (const vv of v) headers.append(k, vv);
+		else headers.set(k, v);
+	}
+
+	const hasBody = req.method !== 'GET' && req.method !== 'HEAD';
+	const init: RequestInit = { method: req.method, headers };
+	if (hasBody && req.body !== undefined) {
+		// `express.json()` parsed it; re-serialize.
+		init.body =
+			typeof req.body === 'string' ? req.body : JSON.stringify(req.body);
+		if (!headers.has('content-type')) {
+			headers.set('content-type', 'application/json');
+		}
+	}
+	return new Request(url, init);
+}
+
+async function writeResponse(
+	res: ExpressLikeResponse,
+	fetchRes: Response,
+): Promise<void> {
+	res.status(fetchRes.status);
+	fetchRes.headers.forEach((value, key) => res.setHeader(key, value));
+	const buf = Buffer.from(await fetchRes.arrayBuffer());
+	res.send(buf);
+}
+
+export function toExpressHandler(
+	corsair: unknown,
+	opts?: ManagementHandlerOptions,
+): ExpressHandler {
+	const handler = managementHandler(corsair, opts);
+	return async (req, res, next) => {
+		try {
+			const fetchRes = await handler(buildFetchRequest(req));
+			await writeResponse(res, fetchRes);
+		} catch (err) {
+			next(err);
+		}
+	};
+}

--- a/packages/corsair/core/management/adapters/hono.ts
+++ b/packages/corsair/core/management/adapters/hono.ts
@@ -26,6 +26,9 @@ export type HonoHandler = (
 ) => Response | Promise<Response>;
 
 export function toHonoHandler(
+	// `unknown` matches the managementHandler signature — see the justification
+	// there. The handler only reads the CORSAIR_INTERNAL symbol, so the public
+	// client shape isn't needed at this seam.
 	corsair: unknown,
 	opts?: ManagementHandlerOptions,
 ): HonoHandler {

--- a/packages/corsair/core/management/adapters/hono.ts
+++ b/packages/corsair/core/management/adapters/hono.ts
@@ -1,0 +1,34 @@
+import type { ManagementHandlerOptions } from '../handler';
+import { managementHandler } from '../handler';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hono adapter.
+//
+// Mount on any path pattern that matches your basePath:
+//
+//   import { Hono } from 'hono';
+//   import { toHonoHandler } from 'corsair';
+//   import { corsair } from './lib/corsair';
+//   const app = new Hono();
+//   app.all('/api/corsair/*', toHonoHandler(corsair));
+//
+// Hono already speaks the fetch API — `c.req.raw` is a Web Request. The
+// adapter is a one-line bridge. Context type is declared structurally to
+// avoid taking a `hono` peer dep.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type HonoLikeContext = {
+	req: { raw: Request };
+};
+
+export type HonoHandler = (
+	c: HonoLikeContext,
+) => Response | Promise<Response>;
+
+export function toHonoHandler(
+	corsair: unknown,
+	opts?: ManagementHandlerOptions,
+): HonoHandler {
+	const handler = managementHandler(corsair, opts);
+	return (c) => handler(c.req.raw);
+}

--- a/packages/corsair/core/management/adapters/index.ts
+++ b/packages/corsair/core/management/adapters/index.ts
@@ -1,0 +1,5 @@
+export type { ExpressHandler } from './express';
+export { toExpressHandler } from './express';
+export type { HonoHandler } from './hono';
+export { toHonoHandler } from './hono';
+export { toNextJsHandler } from './next';

--- a/packages/corsair/core/management/adapters/next.ts
+++ b/packages/corsair/core/management/adapters/next.ts
@@ -15,6 +15,9 @@ import { managementHandler } from '../handler';
 // ─────────────────────────────────────────────────────────────────────────────
 
 export function toNextJsHandler(
+	// `unknown` matches the managementHandler signature — see the justification
+	// there. The handler only reads the CORSAIR_INTERNAL symbol, so the public
+	// client shape isn't needed at this seam.
 	corsair: unknown,
 	opts?: ManagementHandlerOptions,
 ): {

--- a/packages/corsair/core/management/adapters/next.ts
+++ b/packages/corsair/core/management/adapters/next.ts
@@ -1,0 +1,26 @@
+import type { ManagementHandlerOptions } from '../handler';
+import { managementHandler } from '../handler';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Next.js App Router adapter.
+//
+// Mount in app/api/corsair/[...all]/route.ts:
+//
+//   import { toNextJsHandler } from 'corsair';
+//   import { corsair } from '@/lib/corsair';
+//   export const { GET, POST } = toNextJsHandler(corsair);
+//
+// Next's Route Handlers already speak the fetch API, so the adapter just
+// returns the handler twice — once per method we serve.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function toNextJsHandler(
+	corsair: unknown,
+	opts?: ManagementHandlerOptions,
+): {
+	GET: (req: Request) => Promise<Response>;
+	POST: (req: Request) => Promise<Response>;
+} {
+	const handler = managementHandler(corsair, opts);
+	return { GET: handler, POST: handler };
+}

--- a/packages/corsair/core/management/errors.ts
+++ b/packages/corsair/core/management/errors.ts
@@ -1,0 +1,48 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Management API error type and JSON response helpers.
+// Mirrors better-auth's APIError shape: { error, message?, ...extra } as the
+// response body. Errors thrown from operations are caught by the handler and
+// serialized via toResponse().
+// ─────────────────────────────────────────────────────────────────────────────
+
+export class ManagementApiError extends Error {
+	readonly status: number;
+	readonly code: string;
+	readonly extra: Record<string, unknown>;
+
+	constructor(
+		status: number,
+		code: string,
+		message?: string,
+		extra: Record<string, unknown> = {},
+	) {
+		super(message ?? code);
+		this.name = 'ManagementApiError';
+		this.status = status;
+		this.code = code;
+		this.extra = extra;
+	}
+}
+
+export function json(status: number, body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { 'content-type': 'application/json' },
+	});
+}
+
+export function errorResponse(err: ManagementApiError): Response {
+	const body = { error: err.code, message: err.message, ...err.extra };
+	return json(err.status, body);
+}
+
+export function notFound(message: string): ManagementApiError {
+	return new ManagementApiError(404, 'not_found', message);
+}
+
+export function badRequest(
+	message: string,
+	extra: Record<string, unknown> = {},
+): ManagementApiError {
+	return new ManagementApiError(400, 'bad_request', message, extra);
+}

--- a/packages/corsair/core/management/errors.ts
+++ b/packages/corsair/core/management/errors.ts
@@ -1,8 +1,7 @@
 // ─────────────────────────────────────────────────────────────────────────────
 // Management API error type and JSON response helpers.
-// Mirrors better-auth's APIError shape: { error, message?, ...extra } as the
-// response body. Errors thrown from operations are caught by the handler and
-// serialized via toResponse().
+// Response body shape: { error, message?, ...extra }. Errors thrown from
+// operations are caught by the handler and serialized via errorResponse().
 // ─────────────────────────────────────────────────────────────────────────────
 
 export class ManagementApiError extends Error {

--- a/packages/corsair/core/management/handler.ts
+++ b/packages/corsair/core/management/handler.ts
@@ -16,8 +16,8 @@ import {
 // ─────────────────────────────────────────────────────────────────────────────
 // Management HTTP handler — framework-agnostic (Request) => Promise<Response>.
 //
-// Mirrors better-auth's one-core-handler design. Framework adapters in Phase 1b
-// will be thin fan-outs over this single function.
+// One fetch-style core handler is the canonical entry point. Framework
+// adapters (Next.js, Express, Hono) are thin fan-outs over this function.
 // ─────────────────────────────────────────────────────────────────────────────
 
 export type ManagementHandlerOptions = {
@@ -44,6 +44,10 @@ type Route = {
 	handler: (ctx: RouteCtx) => Promise<Response>;
 };
 
+// Inline `body as { ... }` casts narrow the parsed-JSON `unknown` to a
+// structural shape for TypeScript only. Operation functions validate every
+// required field at runtime (e.g., `createTenant` rejects empty `id`), so the
+// cast never propagates unvalidated data.
 const ROUTES: Route[] = [
 	{
 		method: 'GET',
@@ -60,7 +64,7 @@ const ROUTES: Route[] = [
 		pattern: '/tenants',
 		handler: async ({ internal, body }) =>
 			json(
-				200,
+				201,
 				await createTenant(internal, body as { id: string }),
 			),
 	},
@@ -94,14 +98,26 @@ const ROUTES: Route[] = [
 			json(200, await getPermission(internal, params.id!)),
 	},
 	{
-		method: 'GET',
-		pattern: '/permissions/by-token/:token',
-		handler: async ({ internal, params }) =>
-			json(200, await getPermissionByToken(internal, params.token!)),
+		// POST + body, not GET + path. Tokens are short-lived authorization
+		// credentials; reverse proxies and access-log formatters routinely
+		// capture URL paths, so placing the token in the path leaks it.
+		method: 'POST',
+		pattern: '/permissions/lookup-by-token',
+		handler: async ({ internal, body }) => {
+			const token = (body as { token?: string } | undefined)?.token?.trim();
+			if (!token) {
+				return json(400, {
+					error: 'bad_request',
+					message: 'token is required',
+					missingFields: ['token'],
+				});
+			}
+			return json(200, await getPermissionByToken(internal, token));
+		},
 	},
 ];
 
-// ── pre-flight conflict check (better-auth pattern) ─────────────────────────
+// ── pre-flight route conflict check ─────────────────────────────────────────
 (() => {
 	const seen = new Set<string>();
 	for (const r of ROUTES) {
@@ -146,6 +162,10 @@ function stripBasePath(pathname: string, basePath: string): string {
 }
 
 function getInternal(corsair: unknown): CorsairInternalConfig {
+	// CORSAIR_INTERNAL is a private Symbol attached to every corsair instance
+	// by createCorsair(). TypeScript cannot represent symbol-keyed properties
+	// on `unknown`, so an `unknown → Record<symbol, unknown>` cast is required
+	// to access it. The presence check below guards the typed return.
 	const internal = (corsair as Record<symbol, unknown>)[CORSAIR_INTERNAL] as
 		| CorsairInternalConfig
 		| undefined;
@@ -173,6 +193,12 @@ async function parseBody(req: Request): Promise<unknown> {
 const DEFAULT_BASE_PATH = '/api/corsair';
 
 export function managementHandler(
+	// `corsair: unknown` is intentional: the handler accepts both
+	// CorsairSingleTenantClient and CorsairTenantWrapper, but it never reads
+	// public properties — only the CORSAIR_INTERNAL symbol via getInternal().
+	// Typing this as the union of both client shapes would require importing
+	// the generic Plugins type parameter at every call site and adds no
+	// safety, since the symbol read is dynamic.
 	corsair: unknown,
 	opts: ManagementHandlerOptions = {},
 ): (req: Request) => Promise<Response> {

--- a/packages/corsair/core/management/handler.ts
+++ b/packages/corsair/core/management/handler.ts
@@ -1,0 +1,209 @@
+import type { CorsairInternalConfig } from '..';
+import { CORSAIR_INTERNAL } from '..';
+import { errorResponse, json, ManagementApiError, notFound } from './errors';
+import {
+	createTenant,
+	getConnectionStatus,
+	getPermission,
+	getPermissionByToken,
+	getPlugin,
+	getTenant,
+	listPlugins,
+	listTenants,
+	ok,
+} from './operations';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Management HTTP handler — framework-agnostic (Request) => Promise<Response>.
+//
+// Mirrors better-auth's one-core-handler design. Framework adapters in Phase 1b
+// will be thin fan-outs over this single function.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type ManagementHandlerOptions = {
+	/** Path prefix the handler is mounted at, e.g. '/api/corsair'. Stripped before dispatch. */
+	basePath?: string;
+	/** Override the default error response. Return undefined to fall through. */
+	onError?: (
+		err: unknown,
+		req: Request,
+	) => Response | Promise<Response> | undefined;
+};
+
+type RouteCtx = {
+	internal: CorsairInternalConfig;
+	req: Request;
+	params: Record<string, string>;
+	query: Record<string, string>;
+	body: unknown;
+};
+
+type Route = {
+	method: 'GET' | 'POST';
+	pattern: string;
+	handler: (ctx: RouteCtx) => Promise<Response>;
+};
+
+const ROUTES: Route[] = [
+	{
+		method: 'GET',
+		pattern: '/ok',
+		handler: async () => json(200, ok()),
+	},
+	{
+		method: 'GET',
+		pattern: '/tenants',
+		handler: async ({ internal }) => json(200, await listTenants(internal)),
+	},
+	{
+		method: 'POST',
+		pattern: '/tenants',
+		handler: async ({ internal, body }) =>
+			json(
+				200,
+				await createTenant(internal, body as { id: string }),
+			),
+	},
+	{
+		method: 'GET',
+		pattern: '/tenants/:id',
+		handler: async ({ internal, params }) =>
+			json(200, await getTenant(internal, params.id!)),
+	},
+	{
+		method: 'GET',
+		pattern: '/plugins',
+		handler: async ({ internal }) => json(200, await listPlugins(internal)),
+	},
+	{
+		method: 'GET',
+		pattern: '/plugins/:id',
+		handler: async ({ internal, params }) =>
+			json(200, await getPlugin(internal, params.id!)),
+	},
+	{
+		method: 'GET',
+		pattern: '/connection-status',
+		handler: async ({ internal, query }) =>
+			json(200, await getConnectionStatus(internal, query.tenantId)),
+	},
+	{
+		method: 'GET',
+		pattern: '/permissions/:id',
+		handler: async ({ internal, params }) =>
+			json(200, await getPermission(internal, params.id!)),
+	},
+	{
+		method: 'GET',
+		pattern: '/permissions/by-token/:token',
+		handler: async ({ internal, params }) =>
+			json(200, await getPermissionByToken(internal, params.token!)),
+	},
+];
+
+// ── pre-flight conflict check (better-auth pattern) ─────────────────────────
+(() => {
+	const seen = new Set<string>();
+	for (const r of ROUTES) {
+		const key = `${r.method} ${r.pattern}`;
+		if (seen.has(key)) {
+			throw new Error(`Duplicate management route registered: ${key}`);
+		}
+		seen.add(key);
+	}
+})();
+
+function matchPattern(
+	pattern: string,
+	pathname: string,
+): Record<string, string> | null {
+	const pSegs = pattern.split('/').filter(Boolean);
+	const aSegs = pathname.split('/').filter(Boolean);
+	if (pSegs.length !== aSegs.length) return null;
+	const params: Record<string, string> = {};
+	for (let i = 0; i < pSegs.length; i++) {
+		const p = pSegs[i]!;
+		const a = aSegs[i]!;
+		if (p.startsWith(':')) {
+			params[p.slice(1)] = decodeURIComponent(a);
+		} else if (p !== a) {
+			return null;
+		}
+	}
+	return params;
+}
+
+function stripBasePath(pathname: string, basePath: string): string {
+	if (!basePath) return pathname;
+	const normalized = basePath.endsWith('/')
+		? basePath.slice(0, -1)
+		: basePath;
+	if (pathname === normalized) return '/';
+	if (pathname.startsWith(`${normalized}/`)) {
+		return pathname.slice(normalized.length);
+	}
+	return pathname;
+}
+
+function getInternal(corsair: unknown): CorsairInternalConfig {
+	const internal = (corsair as Record<symbol, unknown>)[CORSAIR_INTERNAL] as
+		| CorsairInternalConfig
+		| undefined;
+	if (!internal) {
+		throw new Error(
+			'managementHandler: invalid corsair instance (missing internal config)',
+		);
+	}
+	return internal;
+}
+
+async function parseBody(req: Request): Promise<unknown> {
+	if (req.method === 'GET' || req.method === 'HEAD') return undefined;
+	const ct = req.headers.get('content-type') ?? '';
+	if (!ct.includes('application/json')) return undefined;
+	try {
+		const text = await req.text();
+		if (!text) return undefined;
+		return JSON.parse(text);
+	} catch {
+		throw new ManagementApiError(400, 'invalid_json', 'Request body is not valid JSON');
+	}
+}
+
+const DEFAULT_BASE_PATH = '/api/corsair';
+
+export function managementHandler(
+	corsair: unknown,
+	opts: ManagementHandlerOptions = {},
+): (req: Request) => Promise<Response> {
+	const basePath = opts.basePath ?? DEFAULT_BASE_PATH;
+	const internal = getInternal(corsair);
+
+	return async (req: Request): Promise<Response> => {
+		try {
+			const url = new URL(req.url);
+			const pathname = stripBasePath(url.pathname, basePath);
+			const method = req.method.toUpperCase() as 'GET' | 'POST';
+			const query = Object.fromEntries(url.searchParams);
+
+			for (const route of ROUTES) {
+				if (route.method !== method) continue;
+				const params = matchPattern(route.pattern, pathname);
+				if (!params) continue;
+				const body = await parseBody(req);
+				return await route.handler({ internal, req, params, query, body });
+			}
+
+			throw notFound(`No route for ${method} ${pathname}`);
+		} catch (err) {
+			if (opts.onError) {
+				const overridden = await opts.onError(err, req);
+				if (overridden) return overridden;
+			}
+			if (err instanceof ManagementApiError) return errorResponse(err);
+			const message =
+				err instanceof Error ? err.message : 'Internal server error';
+			return json(500, { error: 'internal_error', message });
+		}
+	};
+}

--- a/packages/corsair/core/management/index.ts
+++ b/packages/corsair/core/management/index.ts
@@ -1,0 +1,82 @@
+import type { CorsairInternalConfig } from '..';
+import {
+	createTenant,
+	getConnectionStatus,
+	getPermission,
+	getPermissionByToken,
+	getPlugin,
+	getTenant,
+	listPlugins,
+	listTenants,
+	ok,
+} from './operations';
+import type {
+	ConnectionStatus,
+	CreateTenantInput,
+	ManagementOk,
+	PermissionRecord,
+	PluginInfo,
+	Tenant,
+} from './types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// `corsair.manage` namespace — in-process equivalent of the HTTP handler.
+// Same logic, no HTTP. Useful for tests and for callers who don't want to
+// hop through fetch.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type CorsairManageNamespace = {
+	ok: () => ManagementOk;
+	tenants: {
+		list: () => Promise<Tenant[]>;
+		create: (input: CreateTenantInput) => Promise<Tenant>;
+		get: (id: string) => Promise<Tenant>;
+	};
+	plugins: {
+		list: () => Promise<PluginInfo[]>;
+		get: (id: string) => Promise<PluginInfo>;
+	};
+	connectionStatus: {
+		get: (query?: { tenantId?: string }) => Promise<ConnectionStatus>;
+	};
+	permissions: {
+		get: (id: string) => Promise<PermissionRecord>;
+		getByToken: (token: string) => Promise<PermissionRecord>;
+	};
+};
+
+export function buildManagementNamespace(
+	internal: CorsairInternalConfig,
+): CorsairManageNamespace {
+	return {
+		ok,
+		tenants: {
+			list: () => listTenants(internal),
+			create: (input) => createTenant(internal, input),
+			get: (id) => getTenant(internal, id),
+		},
+		plugins: {
+			list: () => listPlugins(internal),
+			get: (id) => getPlugin(internal, id),
+		},
+		connectionStatus: {
+			get: (q) => getConnectionStatus(internal, q?.tenantId),
+		},
+		permissions: {
+			get: (id) => getPermission(internal, id),
+			getByToken: (token) => getPermissionByToken(internal, token),
+		},
+	};
+}
+
+export { managementHandler } from './handler';
+export type { ManagementHandlerOptions } from './handler';
+export type {
+	ConnectionStatus,
+	CreateTenantInput,
+	ManagementOk,
+	PermissionRecord,
+	PluginConnectionState,
+	PluginInfo,
+	Tenant,
+} from './types';

--- a/packages/corsair/core/management/index.ts
+++ b/packages/corsair/core/management/index.ts
@@ -69,6 +69,12 @@ export function buildManagementNamespace(
 	};
 }
 
+export type { ExpressHandler, HonoHandler } from './adapters';
+export {
+	toExpressHandler,
+	toHonoHandler,
+	toNextJsHandler,
+} from './adapters';
 export { managementHandler } from './handler';
 export type { ManagementHandlerOptions } from './handler';
 export type {

--- a/packages/corsair/core/management/operations.ts
+++ b/packages/corsair/core/management/operations.ts
@@ -1,0 +1,279 @@
+import type { CorsairInternalConfig } from '..';
+import { createIntegrationKeyManager } from '../auth/key-manager';
+import { BASE_AUTH_FIELDS } from '../auth/types';
+import type { AuthTypes } from '../constants';
+import type { CorsairPlugin, OAuthConfig } from '../plugins';
+import { badRequest, notFound } from './errors';
+import type {
+	ConnectionStatus,
+	CreateTenantInput,
+	ManagementOk,
+	PermissionRecord,
+	PluginConnectionState,
+	PluginInfo,
+	Tenant,
+} from './types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Core operations for the management control plane.
+//
+// These pure functions are the single source of truth. Both the HTTP handler
+// and the in-process `corsair.manage.*` namespace dispatch into the same ops,
+// so HTTP and in-process callers see identical behavior.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ── plugin describe ────────────────────────────────────────────────────────
+
+function findPlugin(
+	internal: CorsairInternalConfig,
+	pluginId: string,
+): CorsairPlugin {
+	const plugin = internal.plugins.find((p) => p.id === pluginId);
+	if (!plugin) throw notFound(`Plugin '${pluginId}' not found`);
+	return plugin;
+}
+
+type PluginCredState = {
+	configured: boolean;
+	missingFields: string[];
+};
+
+async function getIntegrationCredState(
+	plugin: CorsairPlugin,
+	internal: CorsairInternalConfig,
+): Promise<PluginCredState> {
+	const authType = (plugin.options as { authType?: AuthTypes } | undefined)
+		?.authType;
+	if (!authType || !internal.database || !internal.kek) {
+		return { configured: false, missingFields: [] };
+	}
+
+	const km = createIntegrationKeyManager({
+		authType,
+		integrationName: plugin.id,
+		kek: internal.kek,
+		database: internal.database,
+	});
+
+	const fieldNames = BASE_AUTH_FIELDS[authType].integration as readonly string[];
+	const kmAny = km as unknown as Record<
+		string,
+		() => Promise<string | null>
+	>;
+	// If the integration row or DEK hasn't been seeded yet (setupCorsair not
+	// run), the underlying getter throws. Treat that as "all fields missing"
+	// so /plugins and /connection-status stay 200 on a fresh install.
+	let values: Array<string | null>;
+	try {
+		values = await Promise.all(fieldNames.map((f) => kmAny[`get_${f}`]!()));
+	} catch {
+		values = fieldNames.map(() => null);
+	}
+	const missingFields = fieldNames.filter((_, i) => values[i] == null);
+
+	// For OAuth2, "configured" means client_id + client_secret are present.
+	// redirect_url is treated as optional. For non-OAuth types, configured
+	// means every required field is present.
+	let configured: boolean;
+	if (authType === 'oauth_2') {
+		configured =
+			!missingFields.includes('client_id') &&
+			!missingFields.includes('client_secret');
+	} else {
+		configured = missingFields.length === 0;
+	}
+
+	return { configured, missingFields };
+}
+
+export async function describePlugin(
+	plugin: CorsairPlugin,
+	internal: CorsairInternalConfig,
+): Promise<PluginInfo> {
+	const authType =
+		(plugin.options as { authType?: AuthTypes } | undefined)?.authType ?? null;
+	const oauthConfig = (plugin as { oauthConfig?: OAuthConfig }).oauthConfig;
+	const { configured, missingFields } = await getIntegrationCredState(
+		plugin,
+		internal,
+	);
+
+	return {
+		id: plugin.id,
+		authType,
+		configured,
+		missingFields,
+		oauth: oauthConfig
+			? {
+					providerName: oauthConfig.providerName,
+					scopes: oauthConfig.scopes,
+					requiresRegisteredRedirect: !!oauthConfig.requiresRegisteredRedirect,
+				}
+			: null,
+	};
+}
+
+// ── ok ─────────────────────────────────────────────────────────────────────
+
+export function ok(): ManagementOk {
+	return { ok: true };
+}
+
+// ── plugins ────────────────────────────────────────────────────────────────
+
+export async function listPlugins(
+	internal: CorsairInternalConfig,
+): Promise<PluginInfo[]> {
+	return Promise.all(internal.plugins.map((p) => describePlugin(p, internal)));
+}
+
+export async function getPlugin(
+	internal: CorsairInternalConfig,
+	pluginId: string,
+): Promise<PluginInfo> {
+	const plugin = findPlugin(internal, pluginId);
+	return describePlugin(plugin, internal);
+}
+
+// ── tenants ────────────────────────────────────────────────────────────────
+
+async function listAccountSummariesForTenant(
+	internal: CorsairInternalConfig,
+	tenantId: string,
+): Promise<Tenant['accounts']> {
+	if (!internal.database) return [];
+
+	const rows = await internal.database.db
+		.selectFrom('corsair_accounts as a')
+		.innerJoin('corsair_integrations as i', 'i.id', 'a.integration_id')
+		.select(['a.id as accountId', 'a.dek as dek', 'i.name as integrationName'])
+		.where('a.tenant_id', '=', tenantId)
+		.execute();
+
+	return rows.map((r) => ({
+		integrationName: r.integrationName,
+		hasCredentials: !!r.dek,
+	}));
+}
+
+export async function describeTenant(
+	internal: CorsairInternalConfig,
+	tenantId: string,
+): Promise<Tenant> {
+	const accounts = await listAccountSummariesForTenant(internal, tenantId);
+	const connectedPlugins = accounts
+		.filter((a) => a.hasCredentials)
+		.map((a) => a.integrationName);
+	return { id: tenantId, accounts, connectedPlugins };
+}
+
+export async function listTenants(
+	internal: CorsairInternalConfig,
+): Promise<Tenant[]> {
+	const ids = new Set<string>(['default']);
+
+	if (internal.database) {
+		const rows = await internal.database.db
+			.selectFrom('corsair_accounts')
+			.select('tenant_id')
+			.distinct()
+			.execute();
+		for (const r of rows) {
+			if (r.tenant_id) ids.add(r.tenant_id);
+		}
+	}
+
+	return Promise.all([...ids].map((id) => describeTenant(internal, id)));
+}
+
+export async function getTenant(
+	internal: CorsairInternalConfig,
+	id: string,
+): Promise<Tenant> {
+	if (!id) throw badRequest('Tenant id must be a non-empty string');
+	return describeTenant(internal, id);
+}
+
+export async function createTenant(
+	internal: CorsairInternalConfig,
+	input: CreateTenantInput,
+): Promise<Tenant> {
+	const id = input?.id?.trim();
+	if (!id) {
+		throw badRequest('Tenant id is required', {
+			missingFields: ['id'],
+		});
+	}
+	// Implicit tenant model: no row written. Materializes when first
+	// account is linked. We just describe and return.
+	return describeTenant(internal, id);
+}
+
+// ── connection status ──────────────────────────────────────────────────────
+
+export async function getConnectionStatus(
+	internal: CorsairInternalConfig,
+	tenantId: string | undefined,
+): Promise<ConnectionStatus> {
+	const effectiveTenantId = tenantId?.trim() || 'default';
+	const result: ConnectionStatus = {};
+
+	const accounts = internal.database
+		? await listAccountSummariesForTenant(internal, effectiveTenantId)
+		: [];
+	const accountsByPlugin = new Map(accounts.map((a) => [a.integrationName, a]));
+
+	for (const plugin of internal.plugins) {
+		const cred = await getIntegrationCredState(plugin, internal);
+		if (!cred.configured) {
+			result[plugin.id] = 'missing_credentials';
+			continue;
+		}
+		const account = accountsByPlugin.get(plugin.id);
+		let state: PluginConnectionState;
+		if (account && account.hasCredentials) {
+			state = 'connected';
+		} else {
+			state = 'not_connected';
+		}
+		result[plugin.id] = state;
+	}
+
+	return result;
+}
+
+// ── permissions ────────────────────────────────────────────────────────────
+
+export async function getPermission(
+	internal: CorsairInternalConfig,
+	id: string,
+): Promise<PermissionRecord> {
+	if (!internal.database) {
+		throw notFound(`Permission '${id}' not found`);
+	}
+	const record = await internal.database.db
+		.selectFrom('corsair_permissions')
+		.selectAll()
+		.where('id', '=', id)
+		.executeTakeFirst();
+	if (!record) throw notFound(`Permission '${id}' not found`);
+	return record;
+}
+
+export async function getPermissionByToken(
+	internal: CorsairInternalConfig,
+	token: string,
+): Promise<PermissionRecord> {
+	if (!internal.database) {
+		throw notFound(`Permission with token '${token}' not found`);
+	}
+	const record = await internal.database.db
+		.selectFrom('corsair_permissions')
+		.selectAll()
+		.where('token', '=', token)
+		.executeTakeFirst();
+	if (!record) {
+		throw notFound(`Permission with token '${token}' not found`);
+	}
+	return record;
+}

--- a/packages/corsair/core/management/operations.ts
+++ b/packages/corsair/core/management/operations.ts
@@ -56,6 +56,12 @@ async function getIntegrationCredState(
 	});
 
 	const fieldNames = BASE_AUTH_FIELDS[authType].integration as readonly string[];
+	// `IntegrationKeyManagerFor<AuthTypes>` is a public type whose accessors are
+	// generated per-auth-type via template literals; indexing it with a runtime
+	// `get_${field}` string isn't expressible in TS without a structural shim,
+	// and exposing a public `Record<string, ...>` interface would weaken the
+	// stricter type used elsewhere. The unknown→record double cast is local to
+	// this loop and bounded by `BASE_AUTH_FIELDS[authType].integration`.
 	const kmAny = km as unknown as Record<
 		string,
 		() => Promise<string | null>
@@ -170,20 +176,37 @@ export async function describeTenant(
 export async function listTenants(
 	internal: CorsairInternalConfig,
 ): Promise<Tenant[]> {
-	const ids = new Set<string>(['default']);
+	// Single grouped JOIN, assembled in memory. Previously this fanned out one
+	// `describeTenant` query per tenant, which N+1'd dashboards with many
+	// tenants (51 queries at 50 tenants). Now: one query, bounded cost.
+	const tenants = new Map<string, Tenant>();
+	tenants.set('default', { id: 'default', accounts: [], connectedPlugins: [] });
 
 	if (internal.database) {
 		const rows = await internal.database.db
-			.selectFrom('corsair_accounts')
-			.select('tenant_id')
-			.distinct()
+			.selectFrom('corsair_accounts as a')
+			.innerJoin('corsair_integrations as i', 'i.id', 'a.integration_id')
+			.select(['a.tenant_id', 'a.dek as dek', 'i.name as integrationName'])
 			.execute();
+
 		for (const r of rows) {
-			if (r.tenant_id) ids.add(r.tenant_id);
+			const tenantId = r.tenant_id;
+			if (!tenantId) continue;
+			let t = tenants.get(tenantId);
+			if (!t) {
+				t = { id: tenantId, accounts: [], connectedPlugins: [] };
+				tenants.set(tenantId, t);
+			}
+			const hasCredentials = !!r.dek;
+			t.accounts.push({
+				integrationName: r.integrationName,
+				hasCredentials,
+			});
+			if (hasCredentials) t.connectedPlugins.push(r.integrationName);
 		}
 	}
 
-	return Promise.all([...ids].map((id) => describeTenant(internal, id)));
+	return [...tenants.values()];
 }
 
 export async function getTenant(
@@ -264,8 +287,10 @@ export async function getPermissionByToken(
 	internal: CorsairInternalConfig,
 	token: string,
 ): Promise<PermissionRecord> {
+	// Token is a short-lived authorization credential — never echo it back in
+	// error messages or response bodies where it could end up in logs.
 	if (!internal.database) {
-		throw notFound(`Permission with token '${token}' not found`);
+		throw notFound('Permission not found');
 	}
 	const record = await internal.database.db
 		.selectFrom('corsair_permissions')
@@ -273,7 +298,7 @@ export async function getPermissionByToken(
 		.where('token', '=', token)
 		.executeTakeFirst();
 	if (!record) {
-		throw notFound(`Permission with token '${token}' not found`);
+		throw notFound('Permission not found');
 	}
 	return record;
 }

--- a/packages/corsair/core/management/types.ts
+++ b/packages/corsair/core/management/types.ts
@@ -1,0 +1,42 @@
+import type { CorsairPermission } from '../../db';
+import type { AuthTypes } from '../constants';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Response shapes for the management control plane
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type Tenant = {
+	id: string;
+	accounts: Array<{
+		integrationName: string;
+		hasCredentials: boolean;
+	}>;
+	connectedPlugins: string[];
+};
+
+export type CreateTenantInput = {
+	id: string;
+};
+
+export type PluginInfo = {
+	id: string;
+	authType: AuthTypes | null;
+	configured: boolean;
+	missingFields: string[];
+	oauth: {
+		providerName: string;
+		scopes: string[];
+		requiresRegisteredRedirect: boolean;
+	} | null;
+};
+
+export type PluginConnectionState =
+	| 'connected'
+	| 'missing_credentials'
+	| 'not_connected';
+
+export type ConnectionStatus = Record<string, PluginConnectionState>;
+
+export type ManagementOk = { ok: true };
+
+export type PermissionRecord = CorsairPermission;

--- a/packages/corsair/index.ts
+++ b/packages/corsair/index.ts
@@ -9,6 +9,8 @@ export type {
 	ConnectionStatus,
 	CorsairManageNamespace,
 	CreateTenantInput,
+	ExpressHandler,
+	HonoHandler,
 	ManagementHandlerOptions,
 	ManagementOk,
 	PermissionRecord,
@@ -16,7 +18,12 @@ export type {
 	PluginInfo,
 	Tenant,
 } from './core/management';
-export { managementHandler } from './core/management';
+export {
+	managementHandler,
+	toExpressHandler,
+	toHonoHandler,
+	toNextJsHandler,
+} from './core/management';
 export {
 	type AnyCorsairInstance,
 	type FormFieldSchema,

--- a/packages/corsair/index.ts
+++ b/packages/corsair/index.ts
@@ -1,5 +1,22 @@
+export type {
+	CorsairClientOptions,
+	CorsairManagementClient,
+} from './client';
+export { createCorsairClient, CorsairClientError } from './client';
 export type { ResolveConnectLinkResult } from './core';
 export { AuthMissingError, createCorsair, resolveConnectLink } from './core';
+export type {
+	ConnectionStatus,
+	CorsairManageNamespace,
+	CreateTenantInput,
+	ManagementHandlerOptions,
+	ManagementOk,
+	PermissionRecord,
+	PluginConnectionState,
+	PluginInfo,
+	Tenant,
+} from './core/management';
+export { managementHandler } from './core/management';
 export {
 	type AnyCorsairInstance,
 	type FormFieldSchema,

--- a/packages/corsair/tests/management-adapters.test.ts
+++ b/packages/corsair/tests/management-adapters.test.ts
@@ -57,7 +57,7 @@ describe('toNextJsHandler', () => {
 				body: JSON.stringify({ id: 'team-a' }),
 			}),
 		);
-		expect(created.status).toBe(200);
+		expect(created.status).toBe(201);
 		const body = await created.json();
 		expect(body.id).toBe('team-a');
 	});
@@ -159,7 +159,7 @@ describe('toExpressHandler', () => {
 		await handler(req, res, jest.fn());
 
 		const out = read();
-		expect(out.status).toBe(200);
+		expect(out.status).toBe(201);
 		expect(JSON.parse(out.body!).id).toBe('team-b');
 	});
 

--- a/packages/corsair/tests/management-adapters.test.ts
+++ b/packages/corsair/tests/management-adapters.test.ts
@@ -1,0 +1,185 @@
+import {
+	toExpressHandler,
+	toHonoHandler,
+	toNextJsHandler,
+} from '../core/management';
+import { createCorsair } from '../core';
+import type { CorsairPlugin } from '../core/plugins';
+import { createTestDatabase } from './setup-db';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Framework adapter tests. Each adapter is a thin bridge to the same vanilla
+// (Request) => Promise<Response> handler; we just confirm the bridge wires up
+// methods, paths, and bodies correctly. The handler's own semantics are
+// covered exhaustively in management-handler.test.ts.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const slack = {
+	id: 'slack',
+	options: { authType: 'oauth_2' as const },
+	oauthConfig: {
+		providerName: 'Slack',
+		authUrl: 'https://slack.com/oauth/v2/authorize',
+		tokenUrl: 'https://slack.com/api/oauth.v2.access',
+		scopes: ['chat:write'],
+	},
+} as unknown as CorsairPlugin;
+
+const KEK = 'test-kek-adapters';
+
+function makeCorsair(env: ReturnType<typeof createTestDatabase>) {
+	return createCorsair({
+		plugins: [slack],
+		database: env.db,
+		kek: KEK,
+	} as any);
+}
+
+describe('toNextJsHandler', () => {
+	let env: ReturnType<typeof createTestDatabase>;
+	afterEach(() => env?.cleanup?.());
+
+	it('exposes GET and POST that share the same handler', async () => {
+		env = createTestDatabase();
+		const corsair = makeCorsair(env);
+		const route = toNextJsHandler(corsair);
+
+		const ok = await route.GET(
+			new Request('http://x/api/corsair/ok', { method: 'GET' }),
+		);
+		expect(ok.status).toBe(200);
+		expect(await ok.json()).toEqual({ ok: true });
+
+		const created = await route.POST(
+			new Request('http://x/api/corsair/tenants', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ id: 'team-a' }),
+			}),
+		);
+		expect(created.status).toBe(200);
+		const body = await created.json();
+		expect(body.id).toBe('team-a');
+	});
+});
+
+describe('toHonoHandler', () => {
+	let env: ReturnType<typeof createTestDatabase>;
+	afterEach(() => env?.cleanup?.());
+
+	it('dispatches c.req.raw to the vanilla handler', async () => {
+		env = createTestDatabase();
+		const corsair = makeCorsair(env);
+		const honoHandler = toHonoHandler(corsair);
+
+		const c = {
+			req: {
+				raw: new Request('http://x/api/corsair/ok', { method: 'GET' }),
+			},
+		};
+		const res = await honoHandler(c);
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true });
+	});
+});
+
+describe('toExpressHandler', () => {
+	let env: ReturnType<typeof createTestDatabase>;
+	afterEach(() => env?.cleanup?.());
+
+	function makeRes() {
+		let statusCode = 200;
+		const headers: Record<string, string> = {};
+		let body: Buffer | string | undefined;
+		const res: any = {
+			status: (code: number) => {
+				statusCode = code;
+				return res;
+			},
+			setHeader: (name: string, value: string) => {
+				headers[name.toLowerCase()] = value;
+			},
+			send: (b: Buffer | string) => {
+				body = b;
+			},
+		};
+		return {
+			res,
+			read: () => ({
+				status: statusCode,
+				headers,
+				body:
+					typeof body === 'string' ? body : body?.toString('utf-8'),
+			}),
+		};
+	}
+
+	it('bridges Express req → fetch Request, writes the Response back', async () => {
+		env = createTestDatabase();
+		const corsair = makeCorsair(env);
+		const handler = toExpressHandler(corsair);
+
+		const req: any = {
+			method: 'GET',
+			originalUrl: '/api/corsair/ok',
+			url: '/api/corsair/ok',
+			headers: { host: 'example.com' },
+			protocol: 'https',
+			get: (name: string) =>
+				name.toLowerCase() === 'host' ? 'example.com' : undefined,
+		};
+		const { res, read } = makeRes();
+		const next = jest.fn();
+
+		await handler(req, res, next);
+
+		const out = read();
+		expect(out.status).toBe(200);
+		expect(out.headers['content-type']).toContain('application/json');
+		expect(JSON.parse(out.body!)).toEqual({ ok: true });
+		expect(next).not.toHaveBeenCalled();
+	});
+
+	it('re-serializes a parsed JSON body for POST', async () => {
+		env = createTestDatabase();
+		const corsair = makeCorsair(env);
+		const handler = toExpressHandler(corsair);
+
+		const req: any = {
+			method: 'POST',
+			originalUrl: '/api/corsair/tenants',
+			url: '/api/corsair/tenants',
+			headers: { host: 'example.com', 'content-type': 'application/json' },
+			protocol: 'http',
+			body: { id: 'team-b' },
+			get: (name: string) =>
+				name.toLowerCase() === 'host' ? 'example.com' : undefined,
+		};
+		const { res, read } = makeRes();
+		await handler(req, res, jest.fn());
+
+		const out = read();
+		expect(out.status).toBe(200);
+		expect(JSON.parse(out.body!).id).toBe('team-b');
+	});
+
+	it('forwards adapter-level errors to next()', async () => {
+		env = createTestDatabase();
+		const corsair = makeCorsair(env);
+		const handler = toExpressHandler(corsair);
+
+		const req: any = {
+			method: 'GET',
+			// missing originalUrl + url triggers buildFetchRequest to construct an
+			// invalid URL — Request() throws synchronously inside the try.
+			originalUrl: 'not a url',
+			url: 'not a url',
+			headers: {},
+			get: () => undefined,
+		};
+		const { res } = makeRes();
+		const next = jest.fn();
+		await handler(req, res, next);
+		expect(next).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/corsair/tests/management-client.test.ts
+++ b/packages/corsair/tests/management-client.test.ts
@@ -1,0 +1,136 @@
+import { createCorsairClient, CorsairClientError } from '../client';
+import { createCorsair } from '../core';
+import { managementHandler } from '../core/management';
+import type { CorsairPlugin } from '../core/plugins';
+import { createTestDatabase } from './setup-db';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Client/handler integration. We don't spin up a TCP server — instead we wire
+// the client's `fetch` to invoke the handler directly with a Request. That
+// exercises the full URL building, body serialization, and error parsing path
+// without the cost of an HTTP socket.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const slackOAuth = {
+	id: 'slack',
+	options: { authType: 'oauth_2' as const },
+	oauthConfig: {
+		providerName: 'Slack',
+		authUrl: 'https://slack.com/oauth/v2/authorize',
+		tokenUrl: 'https://slack.com/api/oauth.v2.access',
+		scopes: ['chat:write'],
+	},
+} as unknown as CorsairPlugin;
+
+const KEK = 'test-kek-management-client';
+const BASE = 'http://test.local/api/corsair';
+
+function makeClient(corsair: unknown) {
+	const handler = managementHandler(corsair);
+	const fetchImpl: typeof fetch = async (input, init) => {
+		const req = new Request(
+			input instanceof Request ? input.url : String(input),
+			init,
+		);
+		return handler(req);
+	};
+	return createCorsairClient({ baseURL: BASE, fetch: fetchImpl });
+}
+
+describe('createCorsairClient — round-trip', () => {
+	let env: ReturnType<typeof createTestDatabase>;
+	afterEach(() => env?.cleanup?.());
+
+	it('ok() returns { ok: true }', async () => {
+		env = createTestDatabase();
+		const corsair = createCorsair({
+			plugins: [slackOAuth],
+			database: env.db,
+			kek: KEK,
+		} as any);
+		const client = makeClient(corsair);
+		expect(await client.ok()).toEqual({ ok: true });
+	});
+
+	it('plugins.list and plugins.get pass through', async () => {
+		env = createTestDatabase();
+		const corsair = createCorsair({
+			plugins: [slackOAuth],
+			database: env.db,
+			kek: KEK,
+		} as any);
+		const client = makeClient(corsair);
+
+		const list = await client.plugins.list();
+		expect(list).toHaveLength(1);
+		expect(list[0]!.id).toBe('slack');
+
+		const one = await client.plugins.get('slack');
+		expect(one.id).toBe('slack');
+	});
+
+	it('tenants.create + tenants.list + tenants.get', async () => {
+		env = createTestDatabase();
+		const corsair = createCorsair({
+			plugins: [slackOAuth],
+			database: env.db,
+			kek: KEK,
+		} as any);
+		const client = makeClient(corsair);
+
+		const created = await client.tenants.create({ id: 'team-a' });
+		expect(created.id).toBe('team-a');
+
+		const list = await client.tenants.list();
+		expect(list.map((t) => t.id)).toContain('default');
+
+		const got = await client.tenants.get('team-a');
+		expect(got.id).toBe('team-a');
+	});
+
+	it('throws CorsairClientError on bad request, preserving missingFields', async () => {
+		env = createTestDatabase();
+		const corsair = createCorsair({
+			plugins: [slackOAuth],
+			database: env.db,
+			kek: KEK,
+		} as any);
+		const client = makeClient(corsair);
+
+		await expect(client.tenants.create({ id: '' })).rejects.toMatchObject({
+			name: 'CorsairClientError',
+			status: 400,
+			code: 'bad_request',
+			extra: { missingFields: ['id'] },
+		});
+	});
+
+	it('connectionStatus.get sends tenantId as a query param', async () => {
+		env = createTestDatabase();
+		const corsair = createCorsair({
+			plugins: [slackOAuth],
+			database: env.db,
+			kek: KEK,
+		} as any);
+		const client = makeClient(corsair);
+		const status = await client.connectionStatus.get({ tenantId: 'team-a' });
+		expect(status.slack).toBe('missing_credentials');
+	});
+
+	it('permissions.get 404 surfaces as a CorsairClientError', async () => {
+		env = createTestDatabase();
+		const corsair = createCorsair({
+			plugins: [slackOAuth],
+			database: env.db,
+			kek: KEK,
+		} as any);
+
+		// permissions table doesn't exist in setup-db; the operation should still
+		// 404 because the underlying lookup throws ManagementApiError(404) when
+		// the DB call fails. We verify the client surfaces it cleanly.
+		const client = makeClient(corsair);
+		await expect(client.permissions.get('nope')).rejects.toBeInstanceOf(
+			CorsairClientError,
+		);
+	});
+});

--- a/packages/corsair/tests/management-handler.test.ts
+++ b/packages/corsair/tests/management-handler.test.ts
@@ -1,0 +1,434 @@
+import { createCorsair } from '../core';
+import { managementHandler } from '../core/management';
+import type { CorsairPlugin } from '../core/plugins';
+import { setupCorsair } from '../setup';
+import { createTestDatabase } from './setup-db';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test fixtures — minimal plugin stand-ins. 
+// The management handler reads .id, .options.authType, and .oauthConfig; 
+// ─────────────────────────────────────────────────────────────────────────────
+
+const slackOAuth = {
+	id: 'slack',
+	options: { authType: 'oauth_2' as const },
+	oauthConfig: {
+		providerName: 'Slack',
+		authUrl: 'https://slack.com/oauth/v2/authorize',
+		tokenUrl: 'https://slack.com/api/oauth.v2.access',
+		scopes: ['chat:write'],
+	},
+} as unknown as CorsairPlugin;
+
+const gmailOAuth = {
+	id: 'gmail',
+	options: { authType: 'oauth_2' as const },
+	oauthConfig: {
+		providerName: 'Google',
+		authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+		tokenUrl: 'https://oauth2.googleapis.com/token',
+		scopes: ['https://www.googleapis.com/auth/gmail.send'],
+		requiresRegisteredRedirect: true,
+	},
+} as unknown as CorsairPlugin;
+
+const noAuthPlugin = {
+	id: 'static',
+	options: {},
+} as unknown as CorsairPlugin;
+
+const KEK = 'test-kek-management-handler';
+
+function makeEnv() {
+	return createTestDatabase();
+}
+
+async function ensurePermissionsTable(db: ReturnType<typeof createTestDatabase>['db']) {
+	// SqliteDialect underlying connection — execute raw SQL via Kysely's schema
+	await db.schema
+		.createTable('corsair_permissions')
+		.ifNotExists()
+		.addColumn('id', 'text', (c) => c.primaryKey())
+		.addColumn('created_at', 'integer', (c) => c.notNull())
+		.addColumn('updated_at', 'integer', (c) => c.notNull())
+		.addColumn('token', 'text', (c) => c.notNull())
+		.addColumn('plugin', 'text', (c) => c.notNull())
+		.addColumn('endpoint', 'text', (c) => c.notNull())
+		.addColumn('args', 'text', (c) => c.notNull())
+		.addColumn('tenant_id', 'text', (c) => c.notNull())
+		.addColumn('status', 'text', (c) => c.notNull())
+		.addColumn('expires_at', 'text', (c) => c.notNull())
+		.addColumn('error', 'text')
+		.execute();
+}
+
+async function readJson<T>(res: Response): Promise<T> {
+	return (await res.json()) as T;
+}
+
+describe('managementHandler — /ok', () => {
+	let env: ReturnType<typeof makeEnv>;
+	afterEach(() => env?.cleanup?.());
+
+	it('returns { ok: true }', async () => {
+		env = makeEnv();
+		const corsair = createCorsair({
+			plugins: [slackOAuth],
+			database: env.db,
+			kek: KEK,
+		} as any);
+		const handler = managementHandler(corsair);
+
+		const res = await handler(
+			new Request('http://x/api/corsair/ok', { method: 'GET' }),
+		);
+		expect(res.status).toBe(200);
+		expect(await readJson(res)).toEqual({ ok: true });
+	});
+
+	it('honors a custom basePath', async () => {
+		env = makeEnv();
+		const corsair = createCorsair({
+			plugins: [slackOAuth],
+			database: env.db,
+			kek: KEK,
+		} as any);
+		const handler = managementHandler(corsair, { basePath: '/v1/corsair' });
+
+		const res = await handler(
+			new Request('http://x/v1/corsair/ok', { method: 'GET' }),
+		);
+		expect(res.status).toBe(200);
+	});
+
+	it('returns 404 for an unknown path', async () => {
+		env = makeEnv();
+		const corsair = createCorsair({
+			plugins: [slackOAuth],
+			database: env.db,
+			kek: KEK,
+		} as any);
+		const handler = managementHandler(corsair);
+
+		const res = await handler(
+			new Request('http://x/api/corsair/nope', { method: 'GET' }),
+		);
+		expect(res.status).toBe(404);
+		const body = await readJson<{ error: string }>(res);
+		expect(body.error).toBe('not_found');
+	});
+});
+
+describe('managementHandler — /plugins', () => {
+	let env: ReturnType<typeof makeEnv>;
+	afterEach(() => env?.cleanup?.());
+
+	it('lists all plugins with auth + oauth metadata', async () => {
+		env = makeEnv();
+		const corsair = createCorsair({
+			plugins: [slackOAuth, noAuthPlugin],
+			database: env.db,
+			kek: KEK,
+		} as any);
+		const handler = managementHandler(corsair);
+
+		const res = await handler(
+			new Request('http://x/api/corsair/plugins', { method: 'GET' }),
+		);
+		expect(res.status).toBe(200);
+		const body = await readJson<
+			Array<{
+				id: string;
+				authType: string | null;
+				configured: boolean;
+				missingFields: string[];
+				oauth: unknown;
+			}>
+		>(res);
+
+		expect(body).toHaveLength(2);
+		const slack = body.find((p) => p.id === 'slack')!;
+		expect(slack.authType).toBe('oauth_2');
+		expect(slack.configured).toBe(false);
+		expect(slack.missingFields).toEqual(
+			expect.arrayContaining(['client_id', 'client_secret']),
+		);
+		expect(slack.oauth).toEqual({
+			providerName: 'Slack',
+			scopes: ['chat:write'],
+			requiresRegisteredRedirect: false,
+		});
+
+		const stat = body.find((p) => p.id === 'static')!;
+		expect(stat.authType).toBeNull();
+		expect(stat.oauth).toBeNull();
+	});
+
+	it('reports configured=true once client_id and client_secret are set', async () => {
+		env = makeEnv();
+		const corsair = createCorsair({
+			plugins: [slackOAuth],
+			database: env.db,
+			kek: KEK,
+		} as any);
+		await setupCorsair(corsair);
+		await (corsair as any).keys.slack.set_client_id('cid');
+		await (corsair as any).keys.slack.set_client_secret('csec');
+
+		const handler = managementHandler(corsair);
+		const res = await handler(
+			new Request('http://x/api/corsair/plugins/slack', { method: 'GET' }),
+		);
+		const body = await readJson<{ configured: boolean; missingFields: string[] }>(res);
+		expect(body.configured).toBe(true);
+		expect(body.missingFields).toEqual(['redirect_url']);
+	});
+
+	it('404s when plugin id does not exist', async () => {
+		env = makeEnv();
+		const corsair = createCorsair({
+			plugins: [slackOAuth],
+			database: env.db,
+			kek: KEK,
+		} as any);
+		const handler = managementHandler(corsair);
+		const res = await handler(
+			new Request('http://x/api/corsair/plugins/unknown', { method: 'GET' }),
+		);
+		expect(res.status).toBe(404);
+	});
+});
+
+describe('managementHandler — /tenants', () => {
+	let env: ReturnType<typeof makeEnv>;
+	afterEach(() => env?.cleanup?.());
+
+	it('returns [default] when DB has no accounts', async () => {
+		env = makeEnv();
+		const corsair = createCorsair({
+			plugins: [slackOAuth],
+			database: env.db,
+			kek: KEK,
+		} as any);
+		const handler = managementHandler(corsair);
+
+		const res = await handler(
+			new Request('http://x/api/corsair/tenants', { method: 'GET' }),
+		);
+		const body = await readJson<Array<{ id: string }>>(res);
+		expect(body.map((t) => t.id)).toEqual(['default']);
+	});
+
+	it('lists distinct tenant ids from accounts (always including default)', async () => {
+		env = makeEnv();
+		const corsair = createCorsair({
+			plugins: [slackOAuth],
+			database: env.db,
+			kek: KEK,
+			multiTenancy: true,
+		} as any);
+
+		const now = new Date();
+		await env.db
+			.insertInto('corsair_integrations')
+			.values({
+				id: 'i1',
+				created_at: now,
+				updated_at: now,
+				name: 'slack',
+				config: {} as any,
+			} as any)
+			.execute();
+		await env.db
+			.insertInto('corsair_accounts')
+			.values({
+				id: 'a1',
+				created_at: now,
+				updated_at: now,
+				tenant_id: 'acme',
+				integration_id: 'i1',
+				config: {} as any,
+				dek: 'somedek',
+			} as any)
+			.execute();
+
+		const handler = managementHandler(corsair);
+		const res = await handler(
+			new Request('http://x/api/corsair/tenants', { method: 'GET' }),
+		);
+		const body = await readJson<
+			Array<{ id: string; connectedPlugins: string[] }>
+		>(res);
+		const ids = body.map((t) => t.id).sort();
+		expect(ids).toEqual(['acme', 'default']);
+		const acme = body.find((t) => t.id === 'acme')!;
+		expect(acme.connectedPlugins).toEqual(['slack']);
+	});
+
+	it('POST /tenants returns the implicit tenant; rejects empty id', async () => {
+		env = makeEnv();
+		const corsair = createCorsair({
+			plugins: [slackOAuth],
+			database: env.db,
+			kek: KEK,
+		} as any);
+		const handler = managementHandler(corsair);
+
+		const ok = await handler(
+			new Request('http://x/api/corsair/tenants', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ id: 'new-tenant' }),
+			}),
+		);
+		expect(ok.status).toBe(200);
+		const body = await readJson<{ id: string; accounts: unknown[] }>(ok);
+		expect(body.id).toBe('new-tenant');
+		expect(body.accounts).toEqual([]);
+
+		const bad = await handler(
+			new Request('http://x/api/corsair/tenants', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ id: '' }),
+			}),
+		);
+		expect(bad.status).toBe(400);
+		const badBody = await readJson<{ error: string; missingFields?: string[] }>(bad);
+		expect(badBody.error).toBe('bad_request');
+		expect(badBody.missingFields).toEqual(['id']);
+	});
+
+	it('GET /tenants/:id returns derived shape (no 404 for empty tenant)', async () => {
+		env = makeEnv();
+		const corsair = createCorsair({
+			plugins: [slackOAuth],
+			database: env.db,
+			kek: KEK,
+		} as any);
+		const handler = managementHandler(corsair);
+
+		const res = await handler(
+			new Request('http://x/api/corsair/tenants/anything', { method: 'GET' }),
+		);
+		expect(res.status).toBe(200);
+		const body = await readJson<{ id: string; accounts: unknown[] }>(res);
+		expect(body).toEqual({
+			id: 'anything',
+			accounts: [],
+			connectedPlugins: [],
+		});
+	});
+});
+
+describe('managementHandler — /connection-status', () => {
+	let env: ReturnType<typeof makeEnv>;
+	afterEach(() => env?.cleanup?.());
+
+	it('reports missing_credentials when integration creds are unset', async () => {
+		env = makeEnv();
+		const corsair = createCorsair({
+			plugins: [slackOAuth, gmailOAuth],
+			database: env.db,
+			kek: KEK,
+		} as any);
+		const handler = managementHandler(corsair);
+
+		const res = await handler(
+			new Request('http://x/api/corsair/connection-status', { method: 'GET' }),
+		);
+		const body = await readJson<Record<string, string>>(res);
+		expect(body.slack).toBe('missing_credentials');
+		expect(body.gmail).toBe('missing_credentials');
+	});
+
+	it('reports not_connected when creds present but no account for tenant', async () => {
+		env = makeEnv();
+		const corsair = createCorsair({
+			plugins: [slackOAuth],
+			database: env.db,
+			kek: KEK,
+			multiTenancy: true,
+		} as any);
+		await setupCorsair(corsair);
+		await (corsair as any).keys.slack.set_client_id('cid');
+		await (corsair as any).keys.slack.set_client_secret('csec');
+
+		const handler = managementHandler(corsair);
+		const res = await handler(
+			new Request('http://x/api/corsair/connection-status?tenantId=default', {
+				method: 'GET',
+			}),
+		);
+		const body = await readJson<Record<string, string>>(res);
+		expect(body.slack).toBe('not_connected');
+	});
+
+	it('defaults to tenantId=default when query is absent', async () => {
+		env = makeEnv();
+		const corsair = createCorsair({
+			plugins: [slackOAuth],
+			database: env.db,
+			kek: KEK,
+		} as any);
+		const handler = managementHandler(corsair);
+		const res = await handler(
+			new Request('http://x/api/corsair/connection-status', { method: 'GET' }),
+		);
+		expect(res.status).toBe(200);
+	});
+});
+
+describe('managementHandler — /permissions', () => {
+	let env: ReturnType<typeof makeEnv>;
+	afterEach(() => env?.cleanup?.());
+
+	it('returns permission by id and by token, 404s on unknown', async () => {
+		env = makeEnv();
+		await ensurePermissionsTable(env.db);
+		const corsair = createCorsair({
+			plugins: [slackOAuth],
+			database: env.db,
+			kek: KEK,
+		} as any);
+
+		const now = new Date();
+		await env.db
+			.insertInto('corsair_permissions')
+			.values({
+				id: 'perm-1',
+				created_at: now,
+				updated_at: now,
+				token: 'tok-abc',
+				plugin: 'slack',
+				endpoint: 'sendMessage',
+				args: '{}',
+				tenant_id: 'default',
+				status: 'pending',
+				expires_at: new Date(Date.now() + 60000).toISOString(),
+			} as any)
+			.execute();
+
+		const handler = managementHandler(corsair);
+
+		const byId = await handler(
+			new Request('http://x/api/corsair/permissions/perm-1', { method: 'GET' }),
+		);
+		expect(byId.status).toBe(200);
+		const idBody = await readJson<{ id: string; token: string }>(byId);
+		expect(idBody.id).toBe('perm-1');
+		expect(idBody.token).toBe('tok-abc');
+
+		const byTok = await handler(
+			new Request('http://x/api/corsair/permissions/by-token/tok-abc', {
+				method: 'GET',
+			}),
+		);
+		expect(byTok.status).toBe(200);
+
+		const missing = await handler(
+			new Request('http://x/api/corsair/permissions/nope', { method: 'GET' }),
+		);
+		expect(missing.status).toBe(404);
+	});
+});

--- a/packages/corsair/tests/management-handler.test.ts
+++ b/packages/corsair/tests/management-handler.test.ts
@@ -281,7 +281,7 @@ describe('managementHandler — /tenants', () => {
 				body: JSON.stringify({ id: 'new-tenant' }),
 			}),
 		);
-		expect(ok.status).toBe(200);
+		expect(ok.status).toBe(201);
 		const body = await readJson<{ id: string; accounts: unknown[] }>(ok);
 		expect(body.id).toBe('new-tenant');
 		expect(body.accounts).toEqual([]);
@@ -420,15 +420,43 @@ describe('managementHandler — /permissions', () => {
 		expect(idBody.token).toBe('tok-abc');
 
 		const byTok = await handler(
-			new Request('http://x/api/corsair/permissions/by-token/tok-abc', {
-				method: 'GET',
+			new Request('http://x/api/corsair/permissions/lookup-by-token', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ token: 'tok-abc' }),
 			}),
 		);
 		expect(byTok.status).toBe(200);
+		const byTokBody = await readJson<{ id: string }>(byTok);
+		expect(byTokBody.id).toBe('perm-1');
 
 		const missing = await handler(
 			new Request('http://x/api/corsair/permissions/nope', { method: 'GET' }),
 		);
 		expect(missing.status).toBe(404);
+
+		const missingTok = await handler(
+			new Request('http://x/api/corsair/permissions/lookup-by-token', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ token: 'does-not-exist' }),
+			}),
+		);
+		expect(missingTok.status).toBe(404);
+		// The error must not echo the token back into the message body —
+		// tokens are short-lived credentials.
+		const missingBody = await readJson<{ message: string }>(missingTok);
+		expect(missingBody.message ?? '').not.toContain('does-not-exist');
+
+		const noToken = await handler(
+			new Request('http://x/api/corsair/permissions/lookup-by-token', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({}),
+			}),
+		);
+		expect(noToken.status).toBe(400);
+		const noTokenBody = await readJson<{ missingFields?: string[] }>(noToken);
+		expect(noTokenBody.missingFields).toEqual(['token']);
 	});
 });


### PR DESCRIPTION
## Summary                                                                                                
                                                                                                            
  Phase 1 of #241. Adds a reusable management control plane for Corsair so anyone can build their own       
  dashboard. Pattern follows better-auth: one core fetch handler, an in-process namespace, a typed client,  
  and thin framework adapters.                                                                                    
                                                                                                            
  - `managementHandler(corsair, opts?)` — framework-agnostic `(Request) => Promise<Response>`               
  - `corsair.manage.*` — same operations in-process, no HTTP hop
  - `createCorsairClient({ baseURL })` — typed vanilla client                                               
  - `toNextJsHandler`, `toExpressHandler`, `toHonoHandler` — mount the handler in ~3 lines per framework
                                                                                                            
  ## Routes (Phase 1a)
                                                                                                            
  | Method | Path                              | Purpose                              |                     
  |--------|-----------------------------------|--------------------------------------|                   
  | GET    | `/ok`                             | Health check                         |                     
  | GET    | `/tenants`                        | List tenants                         |                     
  | POST   | `/tenants`                        | Create tenant (implicit)             |                   
  | GET    | `/tenants/:id`                    | Tenant + connected plugins           |                     
  | GET    | `/plugins`                        | Plugin catalog                       |                     
  | GET    | `/plugins/:id`                    | Single plugin                        |                     
  | GET    | `/connection-status`              | Per-plugin status for a tenant       |                     
  | GET    | `/permissions/:id`                | Permission record by id              |                     
  | GET    | `/permissions/by-token/:token`    | Permission record by token           |                   
                                                                                                            
  ## Design calls                                           
                                                                                                            
  **Tenants are implicit.** No new `corsair_tenants` table. `GET /tenants` runs `DISTINCT tenant_id` over   
  `corsair_accounts` and always returns `'default'` so a fresh install isn't empty. `POST /tenants` is a  
  no-op create; the tenant materializes when the first account row gets written.                            
                                                            
  **Missing OAuth creds surface as data.** When integration rows aren't seeded yet, `/plugins` and          
  `/connection-status` report `missingFields: ['client_id', ...]` instead of 500ing. Matches the contract in
   #241.                                                                                                    
                                                            
  **One operations layer.** HTTP routes and `corsair.manage.*` both dispatch into                           
  `core/management/operations.ts`. The two surfaces can't drift because they share the same code path.
                                                                                                            
  **Adapters carry no peer deps.** Express and Hono context types are declared structurally, so the package 
  doesn't pull in `@types/express` or `hono` for users who don't need them.                               
                                                                                                            
  **Pre-flight route conflict check.** Module load fails loudly if two routes share method + pattern.
                                                                                                          
  ## Out of scope

  Phase 2 (connect/OAuth routes) and Phase 3 (React hooks + Nuxt) ship as separate PRs.                     
   
  ## Test plan                                                                                              
                                                            
  - [x] `npm test` from `packages/corsair/` — 25 management tests green                                     
  - [x] Mount `toNextJsHandler` in a Next.js app, hit `/ok`
  - [x] Mount `toExpressHandler` behind `express.json()`, POST `/tenants`                                   
  - [x] Mount `toHonoHandler` with `app.all('/api/corsair/*', ...)`                                         
  - [x] Confirm `corsair.manage.tenants.list()` works in-process    