### PR TITLE
feat(zohomail): add Zoho Mail plugin (#238)

### DIFF
--- a/demo/testing/package.json
+++ b/demo/testing/package.json
@@ -44,7 +44,6 @@
     "@corsair-dev/teams": "workspace:*",
     "@corsair-dev/vapi": "workspace:*",
     "@corsair-dev/xquik": "workspace:*",
-    "@corsair-dev/zohomail": "workspace:*",
     "@tanstack/react-query": "^5.62.14",
     "@trpc/client": "^11.0.0",
     "@trpc/react-query": "^11.0.0",

--- a/demo/testing/package.json
+++ b/demo/testing/package.json
@@ -44,6 +44,7 @@
     "@corsair-dev/teams": "workspace:*",
     "@corsair-dev/vapi": "workspace:*",
     "@corsair-dev/xquik": "workspace:*",
+    "@corsair-dev/zohomail": "workspace:*",
     "@tanstack/react-query": "^5.62.14",
     "@trpc/client": "^11.0.0",
     "@trpc/react-query": "^11.0.0",

--- a/demo/testing/src/scripts/test-script.ts
+++ b/demo/testing/src/scripts/test-script.ts
@@ -1,60 +1,12 @@
 import 'dotenv/config';
 
-import { setupCorsair } from 'corsair/setup';
 import { corsair } from '@/server/corsair';
 
-/**
- * Manual E2E exercise for the Zoho Mail plugin .
- *
- * Set these in demo/testing/.env (gitignored — never commit real values):
- *
- *   ZOHO_CLIENT_ID       Self Client → Client Secret tab
- *   ZOHO_CLIENT_SECRET   Self Client → Client Secret tab
- *   ZOHO_ACCESS_TOKEN    from the token exchange (see below)
- *   ZOHO_REFRESH_TOKEN   from the token exchange
- *   ZOHO_REGION          us | eu | in | au | jp | cn   (default us)
- *   CORSAIR_KEK          node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
- *
- * Getting the tokens:
- *   1. Create a Self Client at https://api-console.zoho.com (your region's console).
- *   2. Generate a grant code with scopes:
- *        ZohoMail.messages.ALL,ZohoMail.folders.ALL,ZohoMail.accounts.READ
- *   3. Exchange it (form-urlencoded POST) at
- *        https://accounts.zoho.<tld>/oauth/v2/token
- *      with grant_type=authorization_code, client_id, client_secret, code.
- *      The response carries access_token + refresh_token.
- *   Full walkthrough: docs/plugins/zohomail/get-credentials.mdx
- *
- * Then run from demo/testing/:  pnpm test
- */
-async function seedZohoCredentials() {
-	const clientId = process.env.ZOHO_CLIENT_ID;
-	const clientSecret = process.env.ZOHO_CLIENT_SECRET;
-	const accessToken = process.env.ZOHO_ACCESS_TOKEN;
-	const refreshToken = process.env.ZOHO_REFRESH_TOKEN;
-	if (!clientId || !clientSecret || !accessToken || !refreshToken) {
-		throw new Error('Missing ZOHO_* credentials in demo/testing/.env');
-	}
-
-	await corsair.keys.zohomail.issue_new_dek();
-	await corsair.keys.zohomail.set_client_id(clientId);
-	await corsair.keys.zohomail.set_client_secret(clientSecret);
-
-	await corsair.zohomail.keys.issue_new_dek();
-	await corsair.zohomail.keys.set_access_token(accessToken);
-	await corsair.zohomail.keys.set_refresh_token(refreshToken);
-}
-
 const main = async () => {
-	await setupCorsair(corsair); // ensure the Corsair tables exist
-	await seedZohoCredentials();
-
-	const folders = await corsair.zohomail.api.folders.list({});
-	console.log(`folders: ${folders.folders?.length ?? 0}`);
-
-	// No folderId → defaults to the Inbox.
-	const inbox = await corsair.zohomail.api.messages.list({ limit: 3 });
-	console.log(`inbox messages: ${inbox.messages.length}`);
+	const res = await corsair.hubspot.api.contacts.search({
+		query: 'test',
+		limit: 5,
+	});
 };
 
 main().catch((err) => {

--- a/demo/testing/src/scripts/test-script.ts
+++ b/demo/testing/src/scripts/test-script.ts
@@ -1,12 +1,60 @@
 import 'dotenv/config';
 
+import { setupCorsair } from 'corsair/setup';
 import { corsair } from '@/server/corsair';
 
+/**
+ * Manual E2E exercise for the Zoho Mail plugin .
+ *
+ * Set these in demo/testing/.env (gitignored — never commit real values):
+ *
+ *   ZOHO_CLIENT_ID       Self Client → Client Secret tab
+ *   ZOHO_CLIENT_SECRET   Self Client → Client Secret tab
+ *   ZOHO_ACCESS_TOKEN    from the token exchange (see below)
+ *   ZOHO_REFRESH_TOKEN   from the token exchange
+ *   ZOHO_REGION          us | eu | in | au | jp | cn   (default us)
+ *   CORSAIR_KEK          node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+ *
+ * Getting the tokens:
+ *   1. Create a Self Client at https://api-console.zoho.com (your region's console).
+ *   2. Generate a grant code with scopes:
+ *        ZohoMail.messages.ALL,ZohoMail.folders.ALL,ZohoMail.accounts.READ
+ *   3. Exchange it (form-urlencoded POST) at
+ *        https://accounts.zoho.<tld>/oauth/v2/token
+ *      with grant_type=authorization_code, client_id, client_secret, code.
+ *      The response carries access_token + refresh_token.
+ *   Full walkthrough: docs/plugins/zohomail/get-credentials.mdx
+ *
+ * Then run from demo/testing/:  pnpm test
+ */
+async function seedZohoCredentials() {
+	const clientId = process.env.ZOHO_CLIENT_ID;
+	const clientSecret = process.env.ZOHO_CLIENT_SECRET;
+	const accessToken = process.env.ZOHO_ACCESS_TOKEN;
+	const refreshToken = process.env.ZOHO_REFRESH_TOKEN;
+	if (!clientId || !clientSecret || !accessToken || !refreshToken) {
+		throw new Error('Missing ZOHO_* credentials in demo/testing/.env');
+	}
+
+	await corsair.keys.zohomail.issue_new_dek();
+	await corsair.keys.zohomail.set_client_id(clientId);
+	await corsair.keys.zohomail.set_client_secret(clientSecret);
+
+	await corsair.zohomail.keys.issue_new_dek();
+	await corsair.zohomail.keys.set_access_token(accessToken);
+	await corsair.zohomail.keys.set_refresh_token(refreshToken);
+}
+
 const main = async () => {
-	const res = await corsair.hubspot.api.contacts.search({
-		query: 'test',
-		limit: 5,
-	});
+	await setupCorsair(corsair); // ensure the Corsair tables exist
+	await seedZohoCredentials();
+
+	const folders = await corsair.zohomail.api.folders.list({});
+	console.log(`folders: ${folders.folders?.length ?? 0}`);
+
+	// No folderId → defaults to the Inbox.
+	const inbox = await corsair.zohomail.api.messages.list({ limit: 3 });
+	console.log(`inbox messages: ${inbox.messages.length}`);
 };
 
 main().catch((err) => {

--- a/demo/testing/src/server/corsair.ts
+++ b/demo/testing/src/server/corsair.ts
@@ -10,8 +10,18 @@ import { onedrive } from '@corsair-dev/onedrive';
 import { sharepoint } from '@corsair-dev/sharepoint';
 import { slack } from '@corsair-dev/slack';
 import { vapi } from '@corsair-dev/vapi';
+import { zohomail } from '@corsair-dev/zohomail';
 import { createCorsair } from 'corsair';
 import { sqlite } from '../db';
+
+const zohoRegion = process.env.ZOHO_REGION as
+	| 'us'
+	| 'eu'
+	| 'in'
+	| 'au'
+	| 'jp'
+	| 'cn'
+	| undefined;
 
 export const corsair = createCorsair({
 	multiTenancy: false,
@@ -34,6 +44,10 @@ export const corsair = createCorsair({
 		vapi({
 			key: process.env.VAPI_API_KEY,
 			webhookSecret: process.env.VAPI_WEBHOOK_SECRET,
+		}),
+		zohomail({
+			region: zohoRegion,
+			webhookSecret: process.env.ZOHO_WEBHOOK_SECRET,
 		}),
 	],
 });

--- a/demo/testing/src/server/corsair.ts
+++ b/demo/testing/src/server/corsair.ts
@@ -10,18 +10,8 @@ import { onedrive } from '@corsair-dev/onedrive';
 import { sharepoint } from '@corsair-dev/sharepoint';
 import { slack } from '@corsair-dev/slack';
 import { vapi } from '@corsair-dev/vapi';
-import { zohomail } from '@corsair-dev/zohomail';
 import { createCorsair } from 'corsair';
 import { sqlite } from '../db';
-
-const zohoRegion = process.env.ZOHO_REGION as
-	| 'us'
-	| 'eu'
-	| 'in'
-	| 'au'
-	| 'jp'
-	| 'cn'
-	| undefined;
 
 export const corsair = createCorsair({
 	multiTenancy: false,
@@ -44,10 +34,6 @@ export const corsair = createCorsair({
 		vapi({
 			key: process.env.VAPI_API_KEY,
 			webhookSecret: process.env.VAPI_WEBHOOK_SECRET,
-		}),
-		zohomail({
-			region: zohoRegion,
-			webhookSecret: process.env.ZOHO_WEBHOOK_SECRET,
 		}),
 	],
 });

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -699,6 +699,16 @@
                 ]
               },
               {
+                "group": "Zoho Mail",
+                "pages": [
+                  "plugins/zohomail/overview",
+                  "plugins/zohomail/get-credentials",
+                  "plugins/zohomail/api",
+                  "plugins/zohomail/database",
+                  "plugins/zohomail/webhooks"
+                ]
+              },
+              {
                 "group": "Zoom",
                 "pages": [
                   "plugins/zoom/overview",

--- a/docs/plugins/zohomail/api.mdx
+++ b/docs/plugins/zohomail/api.mdx
@@ -1,0 +1,489 @@
+---
+title: API
+description: "API reference for Zoho Mail: every `zohomail.api.*` operation with input and output types."
+---
+
+Every `zohomail.api.*` operation is listed below with parameter shapes and return types from the plugin Zod schemas.
+
+<Info>
+**New to Corsair?** See [API access](/concepts/api), [authentication](/concepts/auth), and [error handling](/concepts/error-handling).
+</Info>
+
+## Folders
+
+### create
+
+`folders.create`
+
+Create a new folder
+
+**Risk:** `write`
+
+```ts
+await corsair.zohomail.api.folders.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `accountId` | `string` | No | Zoho Mail accountId. When omitted, the first account on the authenticated user is resolved automatically. |
+| `folderName` | `string` | Yes | — |
+| `parentFolderId` | `string` | No | Parent folder ID for creating a sub-folder. |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `folderId` | `string` | No | — |
+| `folderName` | `string` | No | — |
+| `path` | `string` | No | — |
+| `parentFolderId` | `string` | No | — |
+| `previousFolderId` | `string` | No | — |
+| `folderType` | `string` | No | — |
+| `isArchived` | `string \| boolean` | No | — |
+| `imapAccess` | `string \| boolean` | No | — |
+| `unreadCount` | `string \| number` | No | — |
+| `messageCount` | `string \| number` | No | — |
+| `URI` | `string` | No | — |
+
+
+
+---
+
+### delete
+
+`folders.delete`
+
+Delete a folder along with its emails and sub-folders [DESTRUCTIVE · IRREVERSIBLE]
+
+**Risk:** `destructive` · **Irreversible**
+
+```ts
+await corsair.zohomail.api.folders.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `accountId` | `string` | No | Zoho Mail accountId. When omitted, the first account on the authenticated user is resolved automatically. |
+| `folderId` | `string` | Yes | — |
+
+
+
+**Output:** `void`
+
+
+---
+
+### get
+
+`folders.get`
+
+Get a specific folder
+
+**Risk:** `read`
+
+```ts
+await corsair.zohomail.api.folders.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `accountId` | `string` | No | Zoho Mail accountId. When omitted, the first account on the authenticated user is resolved automatically. |
+| `folderId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `folderId` | `string` | No | — |
+| `folderName` | `string` | No | — |
+| `path` | `string` | No | — |
+| `parentFolderId` | `string` | No | — |
+| `previousFolderId` | `string` | No | — |
+| `folderType` | `string` | No | — |
+| `isArchived` | `string \| boolean` | No | — |
+| `imapAccess` | `string \| boolean` | No | — |
+| `unreadCount` | `string \| number` | No | — |
+| `messageCount` | `string \| number` | No | — |
+| `URI` | `string` | No | — |
+
+
+
+---
+
+### list
+
+`folders.list`
+
+List all mail folders
+
+**Risk:** `read`
+
+```ts
+await corsair.zohomail.api.folders.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `accountId` | `string` | No | Zoho Mail accountId. When omitted, the first account on the authenticated user is resolved automatically. |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `folders` | `object[]` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="folders full type">
+
+```ts
+{
+  folderId?: string,
+  folderName?: string,
+  path?: string,
+  parentFolderId?: string,
+  previousFolderId?: string,
+  folderType?: string,
+  isArchived?: string | boolean,
+  imapAccess?: string | boolean,
+  unreadCount?: string | number,
+  messageCount?: string | number,
+  URI?: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### update
+
+`folders.update`
+
+Rename, mark all emails read, or empty a folder
+
+**Risk:** `write`
+
+```ts
+await corsair.zohomail.api.folders.update({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `accountId` | `string` | No | Zoho Mail accountId. When omitted, the first account on the authenticated user is resolved automatically. |
+| `folderId` | `string` | Yes | — |
+| `mode` | `rename \| markAsRead \| emptyFolder` | Yes | — |
+| `folderName` | `string` | No | New folder name. Required when mode = rename. |
+
+
+
+**Output:** `void`
+
+
+---
+
+## Messages
+
+### delete
+
+`messages.delete`
+
+Permanently delete an email [DESTRUCTIVE · IRREVERSIBLE]
+
+**Risk:** `destructive` · **Irreversible**
+
+```ts
+await corsair.zohomail.api.messages.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `accountId` | `string` | No | Zoho Mail accountId. When omitted, the first account on the authenticated user is resolved automatically. |
+| `folderId` | `string` | Yes | — |
+| `messageId` | `string` | Yes | — |
+
+
+
+**Output:** `void`
+
+
+---
+
+### get
+
+`messages.get`
+
+Get a specific email with its content
+
+**Risk:** `read`
+
+```ts
+await corsair.zohomail.api.messages.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `accountId` | `string` | No | Zoho Mail accountId. When omitted, the first account on the authenticated user is resolved automatically. |
+| `folderId` | `string` | Yes | — |
+| `messageId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `messageId` | `string` | No | — |
+| `threadId` | `string` | No | — |
+| `folderId` | `string` | No | — |
+| `subject` | `string` | No | — |
+| `summary` | `string` | No | — |
+| `fromAddress` | `string` | No | — |
+| `toAddress` | `string` | No | — |
+| `ccAddress` | `string` | No | — |
+| `sender` | `string` | No | — |
+| `sentDateInGMT` | `string` | No | — |
+| `receivedTime` | `string` | No | — |
+| `size` | `string` | No | — |
+| `hasAttachment` | `string` | No | — |
+| `hasInline` | `string` | No | — |
+| `status` | `string` | No | — |
+| `status2` | `string` | No | — |
+| `flagid` | `string` | No | — |
+| `priority` | `string` | No | — |
+| `calendarType` | `string` | No | — |
+| `threadCount` | `string` | No | — |
+| `content` | `string` | No | — |
+| `mailFormat` | `string` | No | — |
+| `returnPath` | `string` | No | — |
+| `bccAddress` | `string` | No | — |
+| `replyTo` | `string` | No | — |
+
+
+
+---
+
+### list
+
+`messages.list`
+
+List emails in a folder
+
+**Risk:** `read`
+
+```ts
+await corsair.zohomail.api.messages.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `accountId` | `string` | No | Zoho Mail accountId. When omitted, the first account on the authenticated user is resolved automatically. |
+| `folderId` | `string` | Yes | Folder to list emails from (required). |
+| `start` | `number` | No | Starting sequence number (default 1). |
+| `limit` | `number` | No | Number of emails to retrieve, 1-200 (default 10). |
+| `status` | `read \| unread \| all` | No | — |
+| `sortBy` | `date \| messageId \| size` | No | — |
+| `sortorder` | `boolean` | No | true = ascending, false = descending (default). |
+| `includeto` | `boolean` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `messages` | `object[]` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="messages full type">
+
+```ts
+{
+  messageId?: string,
+  threadId?: string,
+  folderId?: string,
+  subject?: string,
+  summary?: string,
+  fromAddress?: string,
+  toAddress?: string,
+  ccAddress?: string,
+  sender?: string,
+  sentDateInGMT?: string,
+  receivedTime?: string,
+  size?: string,
+  hasAttachment?: string,
+  hasInline?: string,
+  status?: string,
+  status2?: string,
+  flagid?: string,
+  priority?: string,
+  calendarType?: string,
+  threadCount?: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### markRead
+
+`messages.markRead`
+
+Mark emails as read
+
+**Risk:** `write`
+
+```ts
+await corsair.zohomail.api.messages.markRead({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `accountId` | `string` | No | Zoho Mail accountId. When omitted, the first account on the authenticated user is resolved automatically. |
+| `messageId` | `string[]` | Yes | — |
+
+
+
+**Output:** `void`
+
+
+---
+
+### markUnread
+
+`messages.markUnread`
+
+Mark emails as unread
+
+**Risk:** `write`
+
+```ts
+await corsair.zohomail.api.messages.markUnread({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `accountId` | `string` | No | Zoho Mail accountId. When omitted, the first account on the authenticated user is resolved automatically. |
+| `messageId` | `string[]` | Yes | — |
+
+
+
+**Output:** `void`
+
+
+---
+
+### move
+
+`messages.move`
+
+Move emails to another folder
+
+**Risk:** `write`
+
+```ts
+await corsair.zohomail.api.messages.move({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `accountId` | `string` | No | Zoho Mail accountId. When omitted, the first account on the authenticated user is resolved automatically. |
+| `messageId` | `string[]` | Yes | Message IDs to move. |
+| `destfolderId` | `string` | Yes | Destination folder ID. |
+
+
+
+**Output:** `void`
+
+
+---
+
+### send
+
+`messages.send`
+
+Send an email to one or more recipients
+
+**Risk:** `write`
+
+```ts
+await corsair.zohomail.api.messages.send({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `accountId` | `string` | No | Zoho Mail accountId. When omitted, the first account on the authenticated user is resolved automatically. |
+| `fromAddress` | `string` | Yes | Sender address; must belong to the authenticated account. |
+| `toAddress` | `string` | Yes | Recipient address(es), comma-separated. |
+| `ccAddress` | `string` | No | — |
+| `bccAddress` | `string` | No | — |
+| `subject` | `string` | No | — |
+| `content` | `string` | No | — |
+| `mailFormat` | `html \| plaintext` | No | — |
+| `askReceipt` | `yes \| no` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `messageId` | `string` | No | — |
+| `threadId` | `string` | No | — |
+| `folderId` | `string` | No | — |
+| `subject` | `string` | No | — |
+| `summary` | `string` | No | — |
+| `fromAddress` | `string` | No | — |
+| `toAddress` | `string` | No | — |
+| `ccAddress` | `string` | No | — |
+| `sender` | `string` | No | — |
+| `sentDateInGMT` | `string` | No | — |
+| `receivedTime` | `string` | No | — |
+| `size` | `string` | No | — |
+| `hasAttachment` | `string` | No | — |
+| `hasInline` | `string` | No | — |
+| `status` | `string` | No | — |
+| `status2` | `string` | No | — |
+| `flagid` | `string` | No | — |
+| `priority` | `string` | No | — |
+| `calendarType` | `string` | No | — |
+| `threadCount` | `string` | No | — |
+
+
+
+---
+

--- a/docs/plugins/zohomail/database.mdx
+++ b/docs/plugins/zohomail/database.mdx
@@ -1,0 +1,81 @@
+---
+title: Database
+description: "Zoho Mail local sync: searchable entities, `.search()` filters, and operators."
+---
+
+The Zoho Mail plugin syncs data locally. Use `corsair.zohomail.db.<entity>.search({ data, limit?, offset? })` with the filters listed per entity.
+
+<Info>
+**New to Corsair?** See [database operations](/concepts/database), [data synchronization](/concepts/integrations), and [multi-tenancy](/concepts/multi-tenancy).
+</Info>
+
+## Folders
+
+Path: `zohomail.db.folders.search`
+
+```ts
+const rows = await corsair.zohomail.db.folders.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `id` | `string` | equals, contains, startsWith, endsWith, in |
+| `folderId` | `string` | equals, contains, startsWith, endsWith, in |
+| `folderName` | `string` | equals, contains, startsWith, endsWith, in |
+| `path` | `string` | equals, contains, startsWith, endsWith, in |
+| `parentFolderId` | `string` | equals, contains, startsWith, endsWith, in |
+| `folderType` | `string` | equals, contains, startsWith, endsWith, in |
+| `createdAt` | `date` | equals, before, after, between |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+
+## Messages
+
+Path: `zohomail.db.messages.search`
+
+```ts
+const rows = await corsair.zohomail.db.messages.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `id` | `string` | equals, contains, startsWith, endsWith, in |
+| `messageId` | `string` | equals, contains, startsWith, endsWith, in |
+| `threadId` | `string` | equals, contains, startsWith, endsWith, in |
+| `folderId` | `string` | equals, contains, startsWith, endsWith, in |
+| `subject` | `string` | equals, contains, startsWith, endsWith, in |
+| `summary` | `string` | equals, contains, startsWith, endsWith, in |
+| `fromAddress` | `string` | equals, contains, startsWith, endsWith, in |
+| `toAddress` | `string` | equals, contains, startsWith, endsWith, in |
+| `ccAddress` | `string` | equals, contains, startsWith, endsWith, in |
+| `sender` | `string` | equals, contains, startsWith, endsWith, in |
+| `sentDateInGMT` | `string` | equals, contains, startsWith, endsWith, in |
+| `receivedTime` | `string` | equals, contains, startsWith, endsWith, in |
+| `size` | `string` | equals, contains, startsWith, endsWith, in |
+| `hasAttachment` | `string` | equals, contains, startsWith, endsWith, in |
+| `status` | `string` | equals, contains, startsWith, endsWith, in |
+| `flagid` | `string` | equals, contains, startsWith, endsWith, in |
+| `priority` | `string` | equals, contains, startsWith, endsWith, in |
+| `content` | `string` | equals, contains, startsWith, endsWith, in |
+| `createdAt` | `date` | equals, before, after, between |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+

--- a/docs/plugins/zohomail/get-credentials.mdx
+++ b/docs/plugins/zohomail/get-credentials.mdx
@@ -1,0 +1,101 @@
+---
+title: Get Credentials
+description: Step-by-step instructions for obtaining Zoho Mail OAuth 2.0 credentials.
+---
+
+This guide walks you through obtaining all required credentials for the Zoho Mail plugin.
+
+## Authentication Method
+
+The Zoho Mail plugin uses OAuth 2.0 authentication exclusively.
+
+- **[`oauth_2`](/concepts/oauth)** (default) - OAuth 2.0 authentication
+
+## Pick your region first
+
+Zoho runs region-specific datacenters. The OAuth (`accounts.zoho.*`) and Mail API
+(`mail.zoho.*`) hosts share the same top-level domain, and tokens issued in one
+region do **not** work in another. Register the plugin with the matching `region`:
+
+| Region | Domain | `region` value |
+|--------|--------|----------------|
+| United States | `zoho.com` | `'us'` (default) |
+| Europe | `zoho.eu` | `'eu'` |
+| India | `zoho.in` | `'in'` |
+| Australia | `zoho.com.au` | `'au'` |
+| Japan | `zoho.jp` | `'jp'` |
+| China | `zoho.com.cn` | `'cn'` |
+
+```ts corsair.ts
+zohomail({ region: 'eu' })
+```
+
+Create the credentials below in the **same region's** API console (for example
+`https://api-console.zoho.eu` for the EU).
+
+## OAuth 2.0 Setup
+
+### Step 1: Create a Server-based Application
+
+1. Go to the [Zoho API Console](https://api-console.zoho.com/) for your region
+2. Click **Add Client** → **Server-based Applications**
+3. Fill in:
+   - **Client Name**: your application name
+   - **Homepage URL**: your application URL
+   - **Authorized Redirect URIs**: your callback URL (e.g. `https://yourapp.com/auth/zohomail/callback`)
+4. Click **Create**
+5. Copy the **Client ID** and **Client Secret**
+
+### Step 2: Authorize the required scopes
+
+The plugin requests these scopes during the OAuth flow:
+
+- `ZohoMail.messages.ALL` — read, send, move, delete, and flag emails
+- `ZohoMail.folders.ALL` — list, create, update, and delete folders
+- `ZohoMail.accounts.READ` — resolve the account ID for the authenticated user
+
+Request `access_type=offline` so Zoho returns a **refresh token** (the plugin
+refreshes the access token automatically as it expires).
+
+<Tip>
+For quick local testing you can use the **Self Client** option in the API Console
+to mint an authorization code, then exchange it for access and refresh tokens
+without standing up a redirect endpoint.
+</Tip>
+
+### Step 3: Store credentials
+
+The preferred method is to store OAuth credentials in the database using the keys API:
+
+```ts
+await corsair.withTenant('default').keys.zohomail.setClientId('your-client-id');
+await corsair.withTenant('default').keys.zohomail.setClientSecret('your-client-secret');
+await corsair.withTenant('default').zohomail.keys.setAccessToken('your-access-token');
+await corsair.withTenant('default').zohomail.keys.setRefreshToken('your-refresh-token');
+```
+
+Alternatively, you can provide credentials directly in the plugin configuration:
+
+```ts corsair.ts
+zohomail({
+    authType: "oauth_2",
+    region: "us",
+    credentials: {
+        clientId: process.env.ZOHO_CLIENT_ID,
+        clientSecret: process.env.ZOHO_CLIENT_SECRET,
+        accessToken: process.env.ZOHO_ACCESS_TOKEN,
+        refreshToken: process.env.ZOHO_REFRESH_TOKEN,
+    },
+})
+```
+
+## Required Credentials Summary
+
+| Credential | Required For | Where to Find |
+|-----------|--------------|---------------|
+| Client ID | OAuth 2.0 | Zoho API Console → your app |
+| Client Secret | OAuth 2.0 | Zoho API Console → your app |
+| Access Token | OAuth 2.0 | Obtained automatically after OAuth flow |
+| Refresh Token | OAuth 2.0 | Obtained automatically after OAuth flow (requires `access_type=offline`) |
+
+For general information about how Corsair handles authentication, see [Authentication](/concepts/auth).

--- a/docs/plugins/zohomail/overview.mdx
+++ b/docs/plugins/zohomail/overview.mdx
@@ -1,0 +1,161 @@
+---
+title: Overview
+description: "Zoho Mail plugin for Corsair — send and read emails, manage folders"
+---
+
+Use **Zoho Mail** through Corsair: one client, typed API calls, optional local DB sync, and incoming webhooks documented below.
+
+Zoho Mail runs region-specific datacenters. Pass `region` to the plugin factory
+(`'us'` default, plus `'eu'`, `'in'`, `'au'`, `'jp'`, `'cn'`) so the correct
+`accounts.zoho.*` and `mail.zoho.*` hosts are used:
+
+```ts
+zohomail({ region: 'eu' })
+```
+
+Every Zoho Mail call is scoped to an `accountId`. Pass it explicitly, or omit it
+and the plugin resolves the first account on the authenticated user automatically
+(cached for the rest of the session).
+
+**What you get:**
+
+- 12 typed API operations
+- 2 database entities synced for fast `.search()` / `.list()` queries
+- 1 incoming webhook event types
+
+## Setup
+
+<Steps>
+
+<Step title="Install">
+```bash
+pnpm install @corsair-dev/zohomail
+```
+
+</Step>
+
+<Step title="Add the plugin">
+<Tabs>
+<Tab title="Solo">
+```ts corsair.ts
+import { createCorsair } from 'corsair';
+import { zohomail } from '@corsair-dev/zohomail';
+
+export const corsair = createCorsair({
+	// ... other config options,
+	multiTenancy: false,
+    plugins: [zohomail()],
+});
+```
+</Tab>
+<Tab title="Multi-Tenant">
+```ts corsair.ts
+import { createCorsair } from 'corsair';
+import { zohomail } from '@corsair-dev/zohomail';
+
+export const corsair = createCorsair({
+	// ... other config options,
+    multiTenancy: true,
+    plugins: [zohomail()],
+});
+```
+
+See [Multi-tenancy](/concepts/multi-tenancy) for account isolation.
+
+</Tab>
+</Tabs>
+
+</Step>
+
+<Step title="Get credentials">
+Follow [Get Credentials](/plugins/zohomail/get-credentials) if you need help getting keys.
+
+</Step>
+
+<Step title="Store credentials">
+<Tabs>
+<Tab title="Solo">
+```bash
+pnpm corsair setup --plugin=zohomail
+```
+
+Use the key names documented in [Get Credentials](/plugins/zohomail/get-credentials) (for example `api_key=`, `bot_token=`, or OAuth client fields).
+</Tab>
+<Tab title="Multi-Tenant">
+```bash
+pnpm corsair setup --plugin=zohomail --tenant=<tenantId>
+```
+
+Store per-tenant secrets after you create the tenant record. See [Multi-tenancy](/concepts/multi-tenancy).
+</Tab>
+</Tabs>
+
+</Step>
+
+</Steps>
+
+## Authentication
+
+Each tab shows how to register the plugin for that authentication method. The default `authType` from the plugin does not need to appear in the factory call.
+
+<Tabs>
+<Tab title="OAuth 2.0 (Default)">
+
+```ts corsair.ts
+zohomail()
+```
+
+Store credentials with `pnpm corsair setup --plugin=zohomail` (see [Get Credentials](/plugins/zohomail/get-credentials) for field names). For OAuth, you typically store integration keys at the provider level and tokens per account or tenant.
+
+More: [OAuth 2.0](/concepts/oauth)
+
+</Tab>
+</Tabs>
+
+## Webhooks
+
+This plugin registers **1** webhook handler(s). Configure your provider to POST events to your Corsair HTTP endpoint, then use `webhookHooks` in the plugin factory for custom logic.
+
+See [Webhooks](/plugins/zohomail/webhooks) for every event path and payload shape, and [Webhooks concept](/concepts/webhooks) for how to set up routing.
+
+
+## Query synced data
+
+Synced entities support `corsair.zohomail.db.<entity>.search()` and `.list()`. See [Database](/plugins/zohomail/database) for filters and operators.
+
+
+## Example API calls
+
+**Read-style (read):** `folders.get`
+
+```ts
+await corsair.zohomail.api.folders.get({});
+```
+
+
+**Write-style (write):** `folders.create`
+
+```ts
+await corsair.zohomail.api.folders.create({});
+```
+
+
+See the full list on the [API](/plugins/zohomail/api) page. Use `pnpm corsair list --plugin=zohomail` and `pnpm corsair schema <path>` locally to inspect schemas.
+
+---
+
+## Hooks
+
+Use `hooks` on API calls and `webhookHooks` on incoming events to add logging, approvals, or side effects. See [Hooks](/concepts/hooks) and the [Webhooks](/plugins/zohomail/webhooks) page for payload types.
+
+---
+
+## Reference
+
+| Topic | Link |
+|-------|------|
+| API | [API](/plugins/zohomail/api) |
+| Database | [Database](/plugins/zohomail/database) |
+| Webhooks | [Webhooks](/plugins/zohomail/webhooks) |
+| Credentials | [Get credentials](/plugins/zohomail/get-credentials) |
+

--- a/docs/plugins/zohomail/webhooks.mdx
+++ b/docs/plugins/zohomail/webhooks.mdx
@@ -1,0 +1,112 @@
+---
+title: Webhooks
+description: "Zoho Mail incoming webhooks: event paths, payloads, and response data."
+---
+
+The Zoho Mail plugin handles incoming webhooks. Point your provider’s subscription URL at your Corsair HTTP handler (see [Overview](/plugins/zohomail/overview) for setup context and the exact URL shape).
+
+<Info>
+**New to Corsair?** See [webhooks](/concepts/webhooks) and [hooks](/concepts/hooks).
+</Info>
+
+<Warning>
+**Zoho Mail's webhook model differs from most providers — read before relying on it.**
+
+- **Per-account, not app-level.** There is no single webhook URL you register once in the API Console for all connected mailboxes. Each mailbox owner must add the URL **manually** in their own Zoho Mail UI (**Settings → Integrations → Developer Space → Outgoing Webhooks**).
+- **No API to register it** — it cannot be auto-provisioned per tenant.
+- **Paid plans only.** Developer Space (and thus webhooks) is gated behind a paid Zoho plan.
+- **Handshake + signature.** The first request carries the secret in the `x-hook-secret` header (acknowledge with a 200). Subsequent requests are signed with `x-hook-signature` = base64 HMAC-SHA256 of the **raw** request body. Your HTTP route **must verify against the raw body bytes** — re-serializing parsed JSON can break verification.
+
+**For multi-tenant / free-tier setups, prefer polling:** call `messages.list` on an interval and read the synced local DB. The plugin's `list`/`get` endpoints upsert to the database on every call, and `folders.list` is wired into `setupCorsair({ backfill: true })`.
+</Warning>
+
+## Webhook map
+
+- `messages`
+  - `received` (`messages.received`)
+
+## HTTP handler setup
+
+```ts app/api/webhook/route.ts
+import { processWebhook } from "corsair";
+import { corsair } from "@/server/corsair";
+
+export async function POST(request: Request) {
+    const headers = Object.fromEntries(request.headers);
+    const body = await request.json();
+    const result = await processWebhook(corsair, headers, body);
+    return result.response;
+}
+```
+
+## Events
+
+## Messages
+
+### Received
+
+`messages.received`
+
+A new email was received in the mailbox
+
+**Payload**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `messageId` | `string` | No | — |
+| `folderId` | `string` | No | — |
+| `subject` | `string` | No | — |
+| `summary` | `string` | No | — |
+| `html` | `string` | No | — |
+| `fromAddress` | `string` | No | — |
+| `toAddress` | `string` | No | — |
+| `ccAddress` | `string` | No | — |
+| `sender` | `string` | No | — |
+| `sentDateInGMT` | `string` | No | — |
+| `receivedTime` | `string` | No | — |
+| `size` | `string \| number` | No | — |
+
+
+
+<AccordionGroup>
+<Accordion title="Response data full type">
+
+```ts
+{
+  messageId?: string,
+  folderId?: string,
+  subject?: string,
+  summary?: string,
+  html?: string,
+  fromAddress?: string,
+  toAddress?: string,
+  ccAddress?: string,
+  sender?: string,
+  sentDateInGMT?: string,
+  receivedTime?: string,
+  size?: string | number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+**`webhookHooks` example**
+
+```ts
+zohomail({
+    webhookHooks: {
+        messages: {
+            received: {
+                before(ctx, args) {
+                    return { ctx, args };
+                },
+                after(ctx, response) {
+                },
+            },
+        },
+    },
+})
+```
+
+---
+

--- a/fly/src/codegen.ts
+++ b/fly/src/codegen.ts
@@ -27,6 +27,13 @@ export const PLUGIN_CATALOG: PluginDef[] = [
 		authType: 'oauth',
 	},
 	{
+		id: 'zohomail',
+		label: 'Zoho Mail',
+		package: '@corsair-dev/zohomail',
+		description: 'Send and read emails, manage folders',
+		authType: 'oauth',
+	},
+	{
 		id: 'googlecalendar',
 		label: 'Google Calendar',
 		package: '@corsair-dev/googlecalendar',

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -72,6 +72,7 @@ export const BaseProviders = [
 	'xquik',
 	'youtube',
 	'zendesk',
+	'zohomail',
 	'zoom',
 ] as const;
 
@@ -135,6 +136,7 @@ export type AllProviders =
 	| 'xquik'
 	| 'youtube'
 	| 'zendesk'
+	| 'zohomail'
 	| 'zoom'
 	| (string & {});
 

--- a/packages/corsair/setup/backfill.yaml
+++ b/packages/corsair/setup/backfill.yaml
@@ -88,3 +88,10 @@ todoist:
 cal:
   bookings:
     list: {}
+
+zohomail:
+  folders:
+    list: {}
+  messages:
+    # folderId omitted → defaults to the Inbox. Set one to seed a different folder.
+    list: {}

--- a/packages/zohomail/api.test.ts
+++ b/packages/zohomail/api.test.ts
@@ -1,0 +1,73 @@
+import { zohoApiBase, zohoOAuthAuthUrl, zohoOAuthTokenUrl } from './client';
+import { zohomail } from './index';
+
+describe('zohomail plugin', () => {
+	it('builds with default (US) region and core wiring', () => {
+		const plugin = zohomail();
+		expect(plugin.id).toBe('zohomail');
+		expect(plugin.options?.authType).toBe('oauth_2');
+		expect(plugin.oauthConfig?.providerName).toBe('Zoho');
+		expect(plugin.oauthConfig?.authUrl).toBe(
+			'https://accounts.zoho.com/oauth/v2/auth',
+		);
+		expect(plugin.oauthConfig?.tokenUrl).toBe(
+			'https://accounts.zoho.com/oauth/v2/token',
+		);
+		expect(plugin.oauthConfig?.scopes).toContain('ZohoMail.messages.ALL');
+	});
+
+	it('exposes the expected message and folder endpoints', () => {
+		const plugin = zohomail();
+		expect(Object.keys(plugin.endpoints!.messages)).toEqual(
+			expect.arrayContaining([
+				'list',
+				'get',
+				'send',
+				'delete',
+				'move',
+				'markRead',
+				'markUnread',
+			]),
+		);
+		expect(Object.keys(plugin.endpoints!.folders)).toEqual(
+			expect.arrayContaining(['list', 'get', 'create', 'update', 'delete']),
+		);
+	});
+
+	it('flags destructive endpoints in metadata', () => {
+		const plugin = zohomail();
+		expect(plugin.endpointMeta!['messages.delete']?.riskLevel).toBe(
+			'destructive',
+		);
+		expect(plugin.endpointMeta!['folders.delete']?.riskLevel).toBe(
+			'destructive',
+		);
+		expect(plugin.endpointMeta!['messages.list']?.riskLevel).toBe('read');
+	});
+});
+
+describe('zoho region datacenter mapping', () => {
+	it('maps each region to the correct hosts', () => {
+		expect(zohoApiBase('us')).toBe('https://mail.zoho.com/api');
+		expect(zohoApiBase('eu')).toBe('https://mail.zoho.eu/api');
+		expect(zohoApiBase('in')).toBe('https://mail.zoho.in/api');
+		expect(zohoApiBase('au')).toBe('https://mail.zoho.com.au/api');
+		expect(zohoApiBase('jp')).toBe('https://mail.zoho.jp/api');
+		expect(zohoApiBase('cn')).toBe('https://mail.zoho.com.cn/api');
+	});
+
+	it('defaults to US when region is undefined', () => {
+		expect(zohoApiBase()).toBe('https://mail.zoho.com/api');
+		expect(zohoOAuthAuthUrl()).toBe('https://accounts.zoho.com/oauth/v2/auth');
+		expect(zohoOAuthTokenUrl()).toBe(
+			'https://accounts.zoho.com/oauth/v2/token',
+		);
+	});
+
+	it('threads the EU region into the oauth config', () => {
+		const plugin = zohomail({ region: 'eu' });
+		expect(plugin.oauthConfig?.tokenUrl).toBe(
+			'https://accounts.zoho.eu/oauth/v2/token',
+		);
+	});
+});

--- a/packages/zohomail/api.test.ts
+++ b/packages/zohomail/api.test.ts
@@ -70,4 +70,10 @@ describe('zoho region datacenter mapping', () => {
 			'https://accounts.zoho.eu/oauth/v2/token',
 		);
 	});
+
+	it('exposes handshake and message webhooks', () => {
+		const plugin = zohomail();
+		expect(plugin.webhooks?.challenge.handshake).toBeDefined();
+		expect(plugin.webhooks?.messages.received).toBeDefined();
+	});
 });

--- a/packages/zohomail/client.ts
+++ b/packages/zohomail/client.ts
@@ -1,0 +1,274 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { request } from 'corsair/http';
+import type { ZohoAccount, ZohoFolder, ZohoResponse } from './types';
+
+export class ZohoMailAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly status?: number,
+	) {
+		super(message);
+		this.name = 'ZohoMailAPIError';
+	}
+}
+
+/**
+ * Zoho operates region-specific datacenters. The OAuth (accounts.zoho.*) and
+ * Mail API (mail.zoho.*) hosts share the same top-level domain per region.
+ * @see https://www.zoho.com/mail/help/api/getting-started-with-api.html
+ */
+export type ZohoRegion = 'us' | 'eu' | 'in' | 'au' | 'jp' | 'cn';
+
+const REGION_TLD: Record<ZohoRegion, string> = {
+	us: 'com',
+	eu: 'eu',
+	in: 'in',
+	au: 'com.au',
+	jp: 'jp',
+	cn: 'com.cn',
+};
+
+function regionTld(region?: ZohoRegion): string {
+	return REGION_TLD[region ?? 'us'] ?? REGION_TLD.us;
+}
+
+export function zohoApiBase(region?: ZohoRegion): string {
+	return `https://mail.zoho.${regionTld(region)}/api`;
+}
+
+export function zohoOAuthAuthUrl(region?: ZohoRegion): string {
+	return `https://accounts.zoho.${regionTld(region)}/oauth/v2/auth`;
+}
+
+export function zohoOAuthTokenUrl(region?: ZohoRegion): string {
+	return `https://accounts.zoho.${regionTld(region)}/oauth/v2/token`;
+}
+
+async function refreshZohoAccessToken(
+	tokenUrl: string,
+	clientId: string,
+	clientSecret: string,
+	refreshToken: string,
+) {
+	const response = await fetch(tokenUrl, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/x-www-form-urlencoded',
+		},
+		body: new URLSearchParams({
+			grant_type: 'refresh_token',
+			refresh_token: refreshToken,
+			client_id: clientId,
+			client_secret: clientSecret,
+		}),
+	});
+
+	if (!response.ok) {
+		const error = await response.text();
+		throw new ZohoMailAPIError(
+			`Failed to refresh access token: ${error}`,
+			response.status,
+		);
+	}
+
+	const json = (await response.json()) as {
+		access_token: string;
+		expires_in: number;
+	};
+
+	return json;
+}
+
+export async function getValidAccessToken({
+	tokenUrl,
+	accessToken,
+	expiresAt,
+	clientId,
+	clientSecret,
+	refreshToken,
+	forceRefresh = false,
+}: {
+	tokenUrl: string;
+	clientId: string;
+	clientSecret: string;
+	refreshToken: string;
+	accessToken?: string | null;
+	expiresAt?: string | null;
+	forceRefresh?: boolean;
+}): Promise<{ accessToken: string; expiresAt: number; refreshed: boolean }> {
+	const now = Math.floor(Date.now() / 1000);
+	const bufferSeconds = 5 * 60;
+
+	if (
+		!forceRefresh &&
+		accessToken &&
+		expiresAt &&
+		Number(expiresAt) > now + bufferSeconds
+	) {
+		return { accessToken, expiresAt: Number(expiresAt), refreshed: false };
+	}
+
+	const tokenData = await refreshZohoAccessToken(
+		tokenUrl,
+		clientId,
+		clientSecret,
+		refreshToken,
+	);
+	return {
+		accessToken: tokenData.access_token,
+		expiresAt: now + tokenData.expires_in,
+		refreshed: true,
+	};
+}
+
+export type ZohoRequestOptions = {
+	method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+	body?: Record<string, unknown>;
+	query?: Record<string, string | number | boolean | undefined>;
+	region?: ZohoRegion;
+};
+
+/**
+ * Zoho Mail authenticates with `Authorization: Zoho-oauthtoken <token>` — not
+ * Bearer — so the token is injected via HEADERS rather than the client's TOKEN
+ * field (which would emit a Bearer prefix).
+ */
+export async function makeZohoRequest<T>(
+	endpoint: string,
+	token: string,
+	options: ZohoRequestOptions = {},
+): Promise<T> {
+	const { method = 'GET', body, query, region } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: zohoApiBase(region),
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: undefined,
+		HEADERS: {
+			'Content-Type': 'application/json',
+			Authorization: `Zoho-oauthtoken ${token}`,
+		},
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint,
+		body:
+			method === 'POST' || method === 'PUT' || method === 'PATCH'
+				? body
+				: undefined,
+		mediaType: 'application/json',
+		query: method === 'GET' ? query : undefined,
+	};
+
+	try {
+		return await request<T>(config, requestOptions);
+	} catch (error) {
+		if (error instanceof Error) {
+			const status =
+				'status' in error &&
+				typeof (error as { status: unknown }).status === 'number'
+					? (error as { status: number }).status
+					: undefined;
+			throw new ZohoMailAPIError(error.message, status);
+		}
+		throw new ZohoMailAPIError('Unknown error');
+	}
+}
+
+function isUnauthorizedError(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		'status' in error &&
+		(error as { status: number }).status === 401
+	);
+}
+
+type ZohoRequestContext = {
+	key: string;
+	_refreshAuth?: () => Promise<string>;
+};
+
+/**
+ * Wrapper around makeZohoRequest that retries once on 401 by force-refreshing
+ * the access token.
+ */
+export async function makeAuthenticatedZohoRequest<T>(
+	endpoint: string,
+	ctx: ZohoRequestContext,
+	options: ZohoRequestOptions = {},
+): Promise<T> {
+	try {
+		return await makeZohoRequest<T>(endpoint, ctx.key, options);
+	} catch (error) {
+		if (isUnauthorizedError(error) && ctx._refreshAuth) {
+			const freshToken = await ctx._refreshAuth();
+			return await makeZohoRequest<T>(endpoint, freshToken, options);
+		}
+		throw error;
+	}
+}
+
+/**
+ * Every Zoho Mail data call is scoped to an accountId. When the caller does not
+ * pass one explicitly, resolve it from `GET /api/accounts` (first account) and
+ * cache it on the request context to avoid repeat lookups within a session.
+ */
+export async function resolveAccountId(
+	ctx: ZohoRequestContext & { _zohoAccountId?: string },
+	region: ZohoRegion | undefined,
+	explicit?: string,
+): Promise<string> {
+	if (explicit) return explicit;
+	if (ctx._zohoAccountId) return ctx._zohoAccountId;
+
+	const res = await makeAuthenticatedZohoRequest<ZohoResponse<ZohoAccount[]>>(
+		'/accounts',
+		ctx,
+		{ method: 'GET', region },
+	);
+
+	const accountId = res.data?.[0]?.accountId;
+	if (!accountId) {
+		throw new ZohoMailAPIError(
+			'Unable to resolve Zoho Mail accountId from /accounts response',
+		);
+	}
+
+	ctx._zohoAccountId = String(accountId);
+	return ctx._zohoAccountId;
+}
+
+/**
+ * Resolve a folderId for message listing. When the caller omits one, default to
+ * the mailbox's Inbox (the common "show me my mail" case) by reading the folder
+ * list and matching `folderType === 'Inbox'`. Cached per request context.
+ */
+export async function resolveInboxFolderId(
+	ctx: ZohoRequestContext & { _zohoInboxFolderId?: string },
+	region: ZohoRegion | undefined,
+	accountId: string,
+	explicit?: string,
+): Promise<string> {
+	if (explicit) return explicit;
+	if (ctx._zohoInboxFolderId) return ctx._zohoInboxFolderId;
+
+	const res = await makeAuthenticatedZohoRequest<ZohoResponse<ZohoFolder[]>>(
+		`/accounts/${accountId}/folders`,
+		ctx,
+		{ method: 'GET', region },
+	);
+
+	const folders = res.data ?? [];
+	const inbox = folders.find((f) => f.folderType === 'Inbox') ?? folders[0];
+	if (!inbox?.folderId) {
+		throw new ZohoMailAPIError(
+			'Unable to resolve an Inbox folderId from /folders response',
+		);
+	}
+
+	ctx._zohoInboxFolderId = String(inbox.folderId);
+	return ctx._zohoInboxFolderId;
+}

--- a/packages/zohomail/endpoints/folders.ts
+++ b/packages/zohomail/endpoints/folders.ts
@@ -2,19 +2,21 @@ import { logEventFromContext } from 'corsair/core';
 import { makeAuthenticatedZohoRequest, resolveAccountId } from '../client';
 import type { ZohoMailEndpoints } from '../index';
 import type { ZohoFolder, ZohoResponse } from '../types';
+import { zohoEntityId } from '../webhooks/types';
 
 async function syncFolder(
 	ctx: Parameters<ZohoMailEndpoints['foldersGet']>[0],
 	folder: ZohoFolder,
 ) {
-	if (!folder.folderId || !ctx.db.folders) return;
+	const folderId = zohoEntityId(folder.folderId);
+	if (!folderId || !ctx.db.folders) return;
 	try {
-		await ctx.db.folders.upsertByEntityId(folder.folderId, {
-			id: folder.folderId,
-			folderId: folder.folderId,
+		await ctx.db.folders.upsertByEntityId(folderId, {
+			id: folderId,
+			folderId,
 			folderName: folder.folderName,
 			path: folder.path,
-			parentFolderId: folder.parentFolderId,
+			parentFolderId: zohoEntityId(folder.parentFolderId),
 			folderType: folder.folderType,
 			unreadCount: folder.unreadCount,
 			messageCount: folder.messageCount,

--- a/packages/zohomail/endpoints/folders.ts
+++ b/packages/zohomail/endpoints/folders.ts
@@ -1,0 +1,162 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeAuthenticatedZohoRequest, resolveAccountId } from '../client';
+import type { ZohoMailEndpoints } from '../index';
+import type { ZohoFolder, ZohoResponse } from '../types';
+
+async function syncFolder(
+	ctx: Parameters<ZohoMailEndpoints['foldersGet']>[0],
+	folder: ZohoFolder,
+) {
+	if (!folder.folderId || !ctx.db.folders) return;
+	try {
+		await ctx.db.folders.upsertByEntityId(folder.folderId, {
+			id: folder.folderId,
+			folderId: folder.folderId,
+			folderName: folder.folderName,
+			path: folder.path,
+			parentFolderId: folder.parentFolderId,
+			folderType: folder.folderType,
+			unreadCount: folder.unreadCount,
+			messageCount: folder.messageCount,
+			createdAt: new Date(),
+		});
+	} catch (error) {
+		console.warn('Failed to save folder to database:', error);
+	}
+}
+
+export const list: ZohoMailEndpoints['foldersList'] = async (ctx, input) => {
+	const region = ctx.options.region;
+	const accountId = await resolveAccountId(ctx, region, input.accountId);
+
+	const res = await makeAuthenticatedZohoRequest<ZohoResponse<ZohoFolder[]>>(
+		`/accounts/${accountId}/folders`,
+		ctx,
+		{ method: 'GET', region },
+	);
+
+	const folders = res.data ?? [];
+
+	for (const folder of folders) {
+		await syncFolder(ctx, folder);
+	}
+
+	await logEventFromContext(
+		ctx,
+		'zohomail.folders.list',
+		{ ...input },
+		'completed',
+	);
+	return { folders };
+};
+
+export const get: ZohoMailEndpoints['foldersGet'] = async (ctx, input) => {
+	const region = ctx.options.region;
+	const accountId = await resolveAccountId(ctx, region, input.accountId);
+
+	const res = await makeAuthenticatedZohoRequest<ZohoResponse<ZohoFolder>>(
+		`/accounts/${accountId}/folders/${input.folderId}`,
+		ctx,
+		{ method: 'GET', region },
+	);
+
+	const folder = res.data ?? {};
+	await syncFolder(ctx, folder);
+
+	await logEventFromContext(
+		ctx,
+		'zohomail.folders.get',
+		{ ...input },
+		'completed',
+	);
+	return folder;
+};
+
+export const create: ZohoMailEndpoints['foldersCreate'] = async (
+	ctx,
+	input,
+) => {
+	const region = ctx.options.region;
+	const accountId = await resolveAccountId(ctx, region, input.accountId);
+
+	const res = await makeAuthenticatedZohoRequest<ZohoResponse<ZohoFolder>>(
+		`/accounts/${accountId}/folders`,
+		ctx,
+		{
+			method: 'POST',
+			region,
+			body: {
+				folderName: input.folderName,
+				parentFolderId: input.parentFolderId,
+			},
+		},
+	);
+
+	const folder = res.data ?? {};
+	await syncFolder(ctx, folder);
+
+	await logEventFromContext(
+		ctx,
+		'zohomail.folders.create',
+		{ ...input },
+		'completed',
+	);
+	return folder;
+};
+
+export const update: ZohoMailEndpoints['foldersUpdate'] = async (
+	ctx,
+	input,
+) => {
+	const region = ctx.options.region;
+	const accountId = await resolveAccountId(ctx, region, input.accountId);
+
+	// Zoho folder updates take a lowercase-verb `mode`; `rename` also needs the
+	// new `folderName`. The endpoint returns only a status (no folder body).
+	const body: Record<string, unknown> = { mode: input.mode };
+	if (input.folderName) {
+		body.folderName = input.folderName;
+	}
+
+	await makeAuthenticatedZohoRequest<ZohoResponse<unknown>>(
+		`/accounts/${accountId}/folders/${input.folderId}`,
+		ctx,
+		{ method: 'PUT', region, body },
+	);
+
+	await logEventFromContext(
+		ctx,
+		'zohomail.folders.update',
+		{ ...input },
+		'completed',
+	);
+};
+
+export const deleteFolder: ZohoMailEndpoints['foldersDelete'] = async (
+	ctx,
+	input,
+) => {
+	const region = ctx.options.region;
+	const accountId = await resolveAccountId(ctx, region, input.accountId);
+
+	await makeAuthenticatedZohoRequest<ZohoResponse<unknown>>(
+		`/accounts/${accountId}/folders/${input.folderId}`,
+		ctx,
+		{ method: 'DELETE', region },
+	);
+
+	if (ctx.db.folders) {
+		try {
+			await ctx.db.folders.deleteByEntityId(input.folderId);
+		} catch (error) {
+			console.warn('Failed to delete folder from database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'zohomail.folders.delete',
+		{ ...input },
+		'completed',
+	);
+};

--- a/packages/zohomail/endpoints/index.ts
+++ b/packages/zohomail/endpoints/index.ts
@@ -1,0 +1,22 @@
+import * as Folders from './folders';
+import * as Messages from './messages';
+
+export const MessagesEndpoints = {
+	list: Messages.list,
+	get: Messages.get,
+	send: Messages.send,
+	delete: Messages.deleteMessage,
+	move: Messages.move,
+	markRead: Messages.markRead,
+	markUnread: Messages.markUnread,
+};
+
+export const FoldersEndpoints = {
+	list: Folders.list,
+	get: Folders.get,
+	create: Folders.create,
+	update: Folders.update,
+	delete: Folders.deleteFolder,
+};
+
+export * from './types';

--- a/packages/zohomail/endpoints/messages.ts
+++ b/packages/zohomail/endpoints/messages.ts
@@ -1,0 +1,249 @@
+import { logEventFromContext } from 'corsair/core';
+import {
+	makeAuthenticatedZohoRequest,
+	resolveAccountId,
+	resolveInboxFolderId,
+} from '../client';
+import type { ZohoMailEndpoints } from '../index';
+import type { ZohoMessage, ZohoMessageDetail, ZohoResponse } from '../types';
+
+export const list: ZohoMailEndpoints['messagesList'] = async (ctx, input) => {
+	const region = ctx.options.region;
+	const accountId = await resolveAccountId(ctx, region, input.accountId);
+	const folderId = await resolveInboxFolderId(
+		ctx,
+		region,
+		accountId,
+		input.folderId,
+	);
+
+	const res = await makeAuthenticatedZohoRequest<ZohoResponse<ZohoMessage[]>>(
+		`/accounts/${accountId}/messages/view`,
+		ctx,
+		{
+			method: 'GET',
+			region,
+			query: {
+				folderId,
+				start: input.start,
+				limit: input.limit,
+				status: input.status,
+				sortBy: input.sortBy,
+				sortorder: input.sortorder,
+				includeto: input.includeto,
+			},
+		},
+	);
+
+	const messages = res.data ?? [];
+
+	if (ctx.db.messages) {
+		try {
+			for (const message of messages) {
+				if (message.messageId) {
+					await ctx.db.messages.upsertByEntityId(message.messageId, {
+						...message,
+						id: message.messageId,
+						createdAt: new Date(),
+					});
+				}
+			}
+		} catch (error) {
+			console.warn('Failed to save messages to database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'zohomail.messages.list',
+		{ ...input },
+		'completed',
+	);
+	return { messages };
+};
+
+export const get: ZohoMailEndpoints['messagesGet'] = async (ctx, input) => {
+	const region = ctx.options.region;
+	const accountId = await resolveAccountId(ctx, region, input.accountId);
+
+	// `/details` returns the email metadata (subject, from/to, dates) with a
+	// string messageId; `/content` returns only the body (with a numeric
+	// messageId). Fetch both and merge so the result carries headers + body.
+	const path = `/accounts/${accountId}/folders/${input.folderId}/messages/${input.messageId}`;
+	const [details, content] = await Promise.all([
+		makeAuthenticatedZohoRequest<ZohoResponse<ZohoMessageDetail>>(
+			`${path}/details`,
+			ctx,
+			{ method: 'GET', region },
+		),
+		makeAuthenticatedZohoRequest<ZohoResponse<{ content?: string }>>(
+			`${path}/content`,
+			ctx,
+			{ method: 'GET', region },
+		).catch(() => null),
+	]);
+
+	const message: ZohoMessageDetail = {
+		...(details.data ?? {}),
+		content: content?.data?.content,
+	};
+
+	const messageId = message.messageId ?? input.messageId;
+	if (messageId && ctx.db.messages) {
+		try {
+			await ctx.db.messages.upsertByEntityId(String(messageId), {
+				...message,
+				id: String(messageId),
+				messageId: String(messageId),
+				createdAt: new Date(),
+			});
+		} catch (error) {
+			console.warn('Failed to save message to database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'zohomail.messages.get',
+		{ ...input },
+		'completed',
+	);
+	return message;
+};
+
+export const send: ZohoMailEndpoints['messagesSend'] = async (ctx, input) => {
+	const region = ctx.options.region;
+	const accountId = await resolveAccountId(ctx, region, input.accountId);
+
+	const res = await makeAuthenticatedZohoRequest<ZohoResponse<ZohoMessage>>(
+		`/accounts/${accountId}/messages`,
+		ctx,
+		{
+			method: 'POST',
+			region,
+			body: {
+				fromAddress: input.fromAddress,
+				toAddress: input.toAddress,
+				ccAddress: input.ccAddress,
+				bccAddress: input.bccAddress,
+				subject: input.subject,
+				content: input.content,
+				mailFormat: input.mailFormat,
+				askReceipt: input.askReceipt,
+			},
+		},
+	);
+
+	await logEventFromContext(
+		ctx,
+		'zohomail.messages.send',
+		{ ...input },
+		'completed',
+	);
+	return res.data ?? {};
+};
+
+export const deleteMessage: ZohoMailEndpoints['messagesDelete'] = async (
+	ctx,
+	input,
+) => {
+	const region = ctx.options.region;
+	const accountId = await resolveAccountId(ctx, region, input.accountId);
+
+	await makeAuthenticatedZohoRequest<ZohoResponse<unknown>>(
+		`/accounts/${accountId}/folders/${input.folderId}/messages/${input.messageId}`,
+		ctx,
+		{ method: 'DELETE', region },
+	);
+
+	if (ctx.db.messages) {
+		try {
+			await ctx.db.messages.deleteByEntityId(input.messageId);
+		} catch (error) {
+			console.warn('Failed to delete message from database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'zohomail.messages.delete',
+		{ ...input },
+		'completed',
+	);
+};
+
+export const move: ZohoMailEndpoints['messagesMove'] = async (ctx, input) => {
+	const region = ctx.options.region;
+	const accountId = await resolveAccountId(ctx, region, input.accountId);
+
+	await makeAuthenticatedZohoRequest<ZohoResponse<unknown>>(
+		`/accounts/${accountId}/updatemessage`,
+		ctx,
+		{
+			method: 'PUT',
+			region,
+			body: {
+				mode: 'moveMessage',
+				destfolderId: input.destfolderId,
+				messageId: input.messageId,
+			},
+		},
+	);
+
+	await logEventFromContext(
+		ctx,
+		'zohomail.messages.move',
+		{ ...input },
+		'completed',
+	);
+};
+
+export const markRead: ZohoMailEndpoints['messagesMarkRead'] = async (
+	ctx,
+	input,
+) => {
+	const region = ctx.options.region;
+	const accountId = await resolveAccountId(ctx, region, input.accountId);
+
+	await makeAuthenticatedZohoRequest<ZohoResponse<unknown>>(
+		`/accounts/${accountId}/updatemessage`,
+		ctx,
+		{
+			method: 'PUT',
+			region,
+			body: { mode: 'markAsRead', messageId: input.messageId },
+		},
+	);
+
+	await logEventFromContext(
+		ctx,
+		'zohomail.messages.markRead',
+		{ ...input },
+		'completed',
+	);
+};
+
+export const markUnread: ZohoMailEndpoints['messagesMarkUnread'] = async (
+	ctx,
+	input,
+) => {
+	const region = ctx.options.region;
+	const accountId = await resolveAccountId(ctx, region, input.accountId);
+
+	await makeAuthenticatedZohoRequest<ZohoResponse<unknown>>(
+		`/accounts/${accountId}/updatemessage`,
+		ctx,
+		{
+			method: 'PUT',
+			region,
+			body: { mode: 'markAsUnread', messageId: input.messageId },
+		},
+	);
+
+	await logEventFromContext(
+		ctx,
+		'zohomail.messages.markUnread',
+		{ ...input },
+		'completed',
+	);
+};

--- a/packages/zohomail/endpoints/messages.ts
+++ b/packages/zohomail/endpoints/messages.ts
@@ -6,6 +6,7 @@ import {
 } from '../client';
 import type { ZohoMailEndpoints } from '../index';
 import type { ZohoMessage, ZohoMessageDetail, ZohoResponse } from '../types';
+import { zohoEntityId } from '../webhooks/types';
 
 export const list: ZohoMailEndpoints['messagesList'] = async (ctx, input) => {
 	const region = ctx.options.region;
@@ -40,10 +41,12 @@ export const list: ZohoMailEndpoints['messagesList'] = async (ctx, input) => {
 	if (ctx.db.messages) {
 		try {
 			for (const message of messages) {
-				if (message.messageId) {
-					await ctx.db.messages.upsertByEntityId(message.messageId, {
+				const messageId = zohoEntityId(message.messageId);
+				if (messageId) {
+					await ctx.db.messages.upsertByEntityId(messageId, {
 						...message,
-						id: message.messageId,
+						id: messageId,
+						messageId,
 						createdAt: new Date(),
 					});
 				}
@@ -88,13 +91,13 @@ export const get: ZohoMailEndpoints['messagesGet'] = async (ctx, input) => {
 		content: content?.data?.content,
 	};
 
-	const messageId = message.messageId ?? input.messageId;
+	const messageId = zohoEntityId(message.messageId ?? input.messageId);
 	if (messageId && ctx.db.messages) {
 		try {
-			await ctx.db.messages.upsertByEntityId(String(messageId), {
+			await ctx.db.messages.upsertByEntityId(messageId, {
 				...message,
-				id: String(messageId),
-				messageId: String(messageId),
+				id: messageId,
+				messageId,
 				createdAt: new Date(),
 			});
 		} catch (error) {

--- a/packages/zohomail/endpoints/types.ts
+++ b/packages/zohomail/endpoints/types.ts
@@ -1,0 +1,231 @@
+import { z } from 'zod';
+import type {
+	ZohoFolder,
+	ZohoFolderListResponse,
+	ZohoMessage,
+	ZohoMessageDetail,
+	ZohoMessageListResponse,
+} from '../types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Input schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+const accountIdField = z
+	.string()
+	.optional()
+	.describe(
+		'Zoho Mail accountId. When omitted, the first account on the authenticated user is resolved automatically.',
+	);
+
+const MessagesListInputSchema = z.object({
+	accountId: accountIdField,
+	folderId: z
+		.string()
+		.optional()
+		.describe(
+			'Folder to list emails from. Defaults to the Inbox when omitted.',
+		),
+	start: z
+		.number()
+		.optional()
+		.describe('Starting sequence number (default 1).'),
+	limit: z
+		.number()
+		.optional()
+		.describe('Number of emails to retrieve, 1-200 (default 10).'),
+	status: z.enum(['read', 'unread', 'all']).optional(),
+	sortBy: z.enum(['date', 'messageId', 'size']).optional(),
+	sortorder: z
+		.boolean()
+		.optional()
+		.describe('true = ascending, false = descending (default).'),
+	includeto: z.boolean().optional(),
+});
+
+const MessagesGetInputSchema = z.object({
+	accountId: accountIdField,
+	folderId: z.string(),
+	messageId: z.string(),
+});
+
+const MessagesSendInputSchema = z.object({
+	accountId: accountIdField,
+	fromAddress: z
+		.string()
+		.describe('Sender address; must belong to the authenticated account.'),
+	toAddress: z.string().describe('Recipient address(es), comma-separated.'),
+	ccAddress: z.string().optional(),
+	bccAddress: z.string().optional(),
+	subject: z.string().optional(),
+	content: z.string().optional(),
+	mailFormat: z.enum(['html', 'plaintext']).optional(),
+	askReceipt: z.enum(['yes', 'no']).optional(),
+});
+
+const MessagesDeleteInputSchema = z.object({
+	accountId: accountIdField,
+	folderId: z.string(),
+	messageId: z.string(),
+});
+
+const MessagesMoveInputSchema = z.object({
+	accountId: accountIdField,
+	messageId: z.array(z.string()).describe('Message IDs to move.'),
+	destfolderId: z.string().describe('Destination folder ID.'),
+});
+
+const MessagesMarkReadInputSchema = z.object({
+	accountId: accountIdField,
+	messageId: z.array(z.string()),
+});
+
+const MessagesMarkUnreadInputSchema = z.object({
+	accountId: accountIdField,
+	messageId: z.array(z.string()),
+});
+
+const FoldersListInputSchema = z.object({
+	accountId: accountIdField,
+});
+
+const FoldersGetInputSchema = z.object({
+	accountId: accountIdField,
+	folderId: z.string(),
+});
+
+const FoldersCreateInputSchema = z.object({
+	accountId: accountIdField,
+	folderName: z.string(),
+	parentFolderId: z
+		.string()
+		.optional()
+		.describe('Parent folder ID for creating a sub-folder.'),
+});
+
+const FoldersUpdateInputSchema = z.object({
+	accountId: accountIdField,
+	folderId: z.string(),
+	mode: z.enum(['rename', 'markAsRead', 'emptyFolder']),
+	folderName: z
+		.string()
+		.optional()
+		.describe('New folder name. Required when mode = rename.'),
+});
+
+const FoldersDeleteInputSchema = z.object({
+	accountId: accountIdField,
+	folderId: z.string(),
+});
+
+export const ZohoMailEndpointInputSchemas = {
+	messagesList: MessagesListInputSchema,
+	messagesGet: MessagesGetInputSchema,
+	messagesSend: MessagesSendInputSchema,
+	messagesDelete: MessagesDeleteInputSchema,
+	messagesMove: MessagesMoveInputSchema,
+	messagesMarkRead: MessagesMarkReadInputSchema,
+	messagesMarkUnread: MessagesMarkUnreadInputSchema,
+	foldersList: FoldersListInputSchema,
+	foldersGet: FoldersGetInputSchema,
+	foldersCreate: FoldersCreateInputSchema,
+	foldersUpdate: FoldersUpdateInputSchema,
+	foldersDelete: FoldersDeleteInputSchema,
+} as const;
+
+export type ZohoMailEndpointInputs = {
+	[K in keyof typeof ZohoMailEndpointInputSchemas]: z.infer<
+		(typeof ZohoMailEndpointInputSchemas)[K]
+	>;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Output schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MessageSchema = z
+	.object({
+		messageId: z.string().optional(),
+		threadId: z.string().optional(),
+		folderId: z.string().optional(),
+		subject: z.string().optional(),
+		summary: z.string().optional(),
+		fromAddress: z.string().optional(),
+		toAddress: z.string().optional(),
+		ccAddress: z.string().optional(),
+		sender: z.string().optional(),
+		sentDateInGMT: z.string().optional(),
+		receivedTime: z.string().optional(),
+		size: z.string().optional(),
+		hasAttachment: z.string().optional(),
+		hasInline: z.string().optional(),
+		status: z.string().optional(),
+		status2: z.string().optional(),
+		flagid: z.string().optional(),
+		priority: z.string().optional(),
+		calendarType: z.string().optional(),
+		threadCount: z.string().optional(),
+	})
+	.loose();
+
+const MessageDetailSchema = MessageSchema.extend({
+	content: z.string().optional(),
+	mailFormat: z.string().optional(),
+	returnPath: z.string().optional(),
+	bccAddress: z.string().optional(),
+	replyTo: z.string().optional(),
+}).loose();
+
+const MessageListResponseSchema = z.object({
+	messages: z.array(MessageSchema),
+});
+
+const FolderSchema = z
+	.object({
+		folderId: z.string().optional(),
+		folderName: z.string().optional(),
+		path: z.string().optional(),
+		parentFolderId: z.string().optional(),
+		previousFolderId: z.string().optional(),
+		folderType: z.string().optional(),
+		isArchived: z.union([z.string(), z.boolean()]).optional(),
+		imapAccess: z.union([z.string(), z.boolean()]).optional(),
+		unreadCount: z.union([z.string(), z.number()]).optional(),
+		messageCount: z.union([z.string(), z.number()]).optional(),
+		URI: z.string().optional(),
+	})
+	.loose();
+
+const FolderListResponseSchema = z.object({
+	folders: z.array(FolderSchema),
+});
+
+export const ZohoMailEndpointOutputSchemas = {
+	messagesList: MessageListResponseSchema,
+	messagesGet: MessageDetailSchema,
+	messagesSend: MessageSchema,
+	messagesDelete: z.void(),
+	messagesMove: z.void(),
+	messagesMarkRead: z.void(),
+	messagesMarkUnread: z.void(),
+	foldersList: FolderListResponseSchema,
+	foldersGet: FolderSchema,
+	foldersCreate: FolderSchema,
+	foldersUpdate: z.void(),
+	foldersDelete: z.void(),
+} as const;
+
+export type ZohoMailEndpointOutputs = {
+	messagesList: ZohoMessageListResponse;
+	messagesGet: ZohoMessageDetail;
+	messagesSend: ZohoMessage;
+	messagesDelete: void;
+	messagesMove: void;
+	messagesMarkRead: void;
+	messagesMarkUnread: void;
+	foldersList: ZohoFolderListResponse;
+	foldersGet: ZohoFolder;
+	foldersCreate: ZohoFolder;
+	foldersUpdate: void;
+	foldersDelete: void;
+};

--- a/packages/zohomail/endpoints/types.ts
+++ b/packages/zohomail/endpoints/types.ts
@@ -145,9 +145,9 @@ export type ZohoMailEndpointInputs = {
 
 const MessageSchema = z
 	.object({
-		messageId: z.string().optional(),
-		threadId: z.string().optional(),
-		folderId: z.string().optional(),
+		messageId: z.coerce.string().optional(),
+		threadId: z.coerce.string().optional(),
+		folderId: z.coerce.string().optional(),
 		subject: z.string().optional(),
 		summary: z.string().optional(),
 		fromAddress: z.string().optional(),
@@ -182,11 +182,11 @@ const MessageListResponseSchema = z.object({
 
 const FolderSchema = z
 	.object({
-		folderId: z.string().optional(),
+		folderId: z.coerce.string().optional(),
 		folderName: z.string().optional(),
 		path: z.string().optional(),
-		parentFolderId: z.string().optional(),
-		previousFolderId: z.string().optional(),
+		parentFolderId: z.coerce.string().optional(),
+		previousFolderId: z.coerce.string().optional(),
 		folderType: z.string().optional(),
 		isArchived: z.union([z.string(), z.boolean()]).optional(),
 		imapAccess: z.union([z.string(), z.boolean()]).optional(),

--- a/packages/zohomail/error-handlers.ts
+++ b/packages/zohomail/error-handlers.ts
@@ -1,0 +1,114 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+
+/**
+ * Read an HTTP status off the thrown error. The Zoho client rethrows API
+ * failures as `ZohoMailAPIError` (which carries `.status`); raw `ApiError`s from
+ * the shared HTTP layer also expose `.status`.
+ */
+function statusOf(error: Error): number | undefined {
+	const status = (error as { status?: unknown }).status;
+	return typeof status === 'number' ? status : undefined;
+}
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error) => {
+			if (statusOf(error) === 429) {
+				return true;
+			}
+			const message = error.message.toLowerCase();
+			return (
+				message.includes('429') ||
+				message.includes('rate limit') ||
+				message.includes('ratelimit') ||
+				message.includes('throttl') ||
+				// Zoho throttling error codes
+				message.includes('u0006') ||
+				message.includes('limit_exceeded')
+			);
+		},
+		handler: async () => {
+			return {
+				maxRetries: 5,
+			};
+		},
+	},
+	AUTH_ERROR: {
+		match: (error) => {
+			if (statusOf(error) === 401) {
+				return true;
+			}
+			const message = error.message.toLowerCase();
+			return (
+				message.includes('invalid_oauthtoken') ||
+				message.includes('invalid oauthtoken') ||
+				message.includes('invalid_token') ||
+				message.includes('unauthorized') ||
+				message.includes('authentication')
+			);
+		},
+		handler: async (error, context) => {
+			// The Zoho client already retries 401 once with a refreshed token, so a
+			// 401 reaching here means the refresh did not resolve it.
+			console.warn(
+				`[ZOHOMAIL:${context.operation}] Authentication failed — check the access/refresh token and OAuth scopes`,
+			);
+			return {
+				maxRetries: 0,
+			};
+		},
+	},
+	PERMISSION_ERROR: {
+		match: (error) => {
+			if (statusOf(error) === 403) {
+				return true;
+			}
+			const message = error.message.toLowerCase();
+			return (
+				message.includes('no_permission') ||
+				message.includes('forbidden') ||
+				message.includes('not authorized')
+			);
+		},
+		handler: async (error, context) => {
+			console.warn(
+				`[ZOHOMAIL:${context.operation}] Permission denied: ${error.message}`,
+			);
+			return {
+				maxRetries: 0,
+			};
+		},
+	},
+	NOT_FOUND_ERROR: {
+		match: (error) => {
+			if (statusOf(error) === 404) {
+				return true;
+			}
+			const message = error.message.toLowerCase();
+			return (
+				message.includes('not found') ||
+				message.includes('invalid_zoid') ||
+				message.includes('nosuch')
+			);
+		},
+		handler: async (error, context) => {
+			console.warn(
+				`[ZOHOMAIL:${context.operation}] Not found: ${error.message}`,
+			);
+			return {
+				maxRetries: 0,
+			};
+		},
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async (error, context) => {
+			console.error(
+				`[ZOHOMAIL:${context.operation}] Unhandled error: ${error.message}`,
+			);
+			return {
+				maxRetries: 0,
+			};
+		},
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/zohomail/index.ts
+++ b/packages/zohomail/index.ts
@@ -31,14 +31,17 @@ import {
 import { errorHandlers } from './error-handlers';
 import type { ZohoMailCredentials } from './schema';
 import { ZohoMailSchema } from './schema';
-import { MessageWebhooks } from './webhooks';
+import { ChallengeWebhooks, MessageWebhooks } from './webhooks';
 import type {
+	ZohoMailChallengePayload,
 	ZohoMailWebhookEvent,
 	ZohoMailWebhookOutputs,
 } from './webhooks/types';
 import {
 	getZohoWebhookSecretFromRequest,
 	getZohoWebhookSignature,
+	ZohoMailChallengePayloadSchema,
+	ZohoMailChallengeResponseSchema,
 	ZohoMailWebhookEventSchema,
 } from './webhooks/types';
 
@@ -84,6 +87,7 @@ type ZohoMailWebhook<
 > = CorsairWebhook<ZohoMailContext, TEvent, ZohoMailWebhookOutputs[K]>;
 
 export type ZohoMailWebhooks = {
+	handshake: ZohoMailWebhook<'handshake', ZohoMailChallengePayload>;
 	messageReceived: ZohoMailWebhook<'messageReceived', ZohoMailWebhookEvent>;
 };
 
@@ -160,12 +164,21 @@ export const zohoMailEndpointSchemas = {
 } as const;
 
 export const zohoMailWebhooksNested = {
+	challenge: {
+		handshake: ChallengeWebhooks.handshake,
+	},
 	messages: {
 		received: MessageWebhooks.messageReceived,
 	},
 } as const;
 
 const zohoMailWebhookSchemas = {
+	'challenge.handshake': {
+		description:
+			'Zoho Mail initial webhook handshake via x-hook-secret header',
+		payload: ZohoMailChallengePayloadSchema,
+		response: ZohoMailChallengeResponseSchema,
+	},
 	'messages.received': {
 		description: 'A new email was received in the mailbox',
 		payload: ZohoMailWebhookEventSchema,
@@ -330,11 +343,17 @@ export function zohomail<const T extends ZohoMailPluginOptions>(
 			}
 
 			if (ctx.authType === 'oauth_2') {
-				const [accessToken, expiresAt, refreshToken] = await Promise.all([
-					ctx.keys.get_access_token(),
-					ctx.keys.get_expires_at(),
-					ctx.keys.get_refresh_token(),
-				]);
+				const creds = options.credentials;
+
+				const [storedAccessToken, expiresAt, storedRefreshToken] =
+					await Promise.all([
+						ctx.keys.get_access_token(),
+						ctx.keys.get_expires_at(),
+						ctx.keys.get_refresh_token(),
+					]);
+
+				const accessToken = storedAccessToken ?? creds?.accessToken ?? null;
+				const refreshToken = storedRefreshToken ?? creds?.refreshToken ?? null;
 
 				if (!refreshToken) {
 					throw new Error(
@@ -342,9 +361,13 @@ export function zohomail<const T extends ZohoMailPluginOptions>(
 					);
 				}
 
-				const res = await ctx.keys.get_integration_credentials();
+				const integrationCreds = await ctx.keys.get_integration_credentials();
+				const clientId =
+					integrationCreds.client_id ?? creds?.clientId ?? undefined;
+				const clientSecret =
+					integrationCreds.client_secret ?? creds?.clientSecret ?? undefined;
 
-				if (!res.client_id || !res.client_secret) {
+				if (!clientId || !clientSecret) {
 					throw new Error(
 						'[auth-missing:zohomail:client_credentials]: Zoho Mail client credentials are missing',
 					);
@@ -359,8 +382,8 @@ export function zohomail<const T extends ZohoMailPluginOptions>(
 						accessToken,
 						expiresAt,
 						refreshToken,
-						clientId: res.client_id,
-						clientSecret: res.client_secret,
+						clientId,
+						clientSecret,
 					});
 				} catch (error) {
 					throw new Error(
@@ -387,8 +410,8 @@ export function zohomail<const T extends ZohoMailPluginOptions>(
 						accessToken: null,
 						expiresAt: null,
 						refreshToken,
-						clientId: res.client_id!,
-						clientSecret: res.client_secret!,
+						clientId,
+						clientSecret,
 						forceRefresh: true,
 					});
 					await ctx.keys.set_access_token(freshResult.accessToken);
@@ -419,6 +442,7 @@ export type { ZohoMailCredentials } from './schema';
 export { ZohoMailSchema } from './schema';
 export type * from './types';
 export type {
+	ZohoMailChallengePayload,
 	ZohoMailEventName,
 	ZohoMailWebhookEvent,
 	ZohoMailWebhookOutputs,

--- a/packages/zohomail/index.ts
+++ b/packages/zohomail/index.ts
@@ -1,0 +1,429 @@
+import type {
+	BindEndpoints,
+	BindWebhooks,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	CorsairWebhook,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RawWebhookRequest,
+	RequiredPluginEndpointMeta,
+} from 'corsair/core';
+import type { ZohoRegion } from './client';
+import {
+	getValidAccessToken,
+	zohoOAuthAuthUrl,
+	zohoOAuthTokenUrl,
+} from './client';
+import { FoldersEndpoints, MessagesEndpoints } from './endpoints';
+import type {
+	ZohoMailEndpointInputs,
+	ZohoMailEndpointOutputs,
+} from './endpoints/types';
+import {
+	ZohoMailEndpointInputSchemas,
+	ZohoMailEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import type { ZohoMailCredentials } from './schema';
+import { ZohoMailSchema } from './schema';
+import { MessageWebhooks } from './webhooks';
+import type {
+	ZohoMailWebhookEvent,
+	ZohoMailWebhookOutputs,
+} from './webhooks/types';
+import {
+	getZohoWebhookSecretFromRequest,
+	getZohoWebhookSignature,
+	ZohoMailWebhookEventSchema,
+} from './webhooks/types';
+
+/** Zoho Mail uses standard OAuth2; no plugin-specific integration fields. */
+export const zohoMailAuthConfig = {} as const satisfies PluginAuthConfig;
+
+export type ZohoMailContext = CorsairPluginContext<
+	typeof ZohoMailSchema,
+	ZohoMailPluginOptions,
+	undefined,
+	typeof zohoMailAuthConfig
+>;
+
+type ZohoMailEndpoint<K extends keyof ZohoMailEndpointOutputs> =
+	CorsairEndpoint<
+		ZohoMailContext,
+		ZohoMailEndpointInputs[K],
+		ZohoMailEndpointOutputs[K]
+	>;
+
+export type ZohoMailEndpoints = {
+	messagesList: ZohoMailEndpoint<'messagesList'>;
+	messagesGet: ZohoMailEndpoint<'messagesGet'>;
+	messagesSend: ZohoMailEndpoint<'messagesSend'>;
+	messagesDelete: ZohoMailEndpoint<'messagesDelete'>;
+	messagesMove: ZohoMailEndpoint<'messagesMove'>;
+	messagesMarkRead: ZohoMailEndpoint<'messagesMarkRead'>;
+	messagesMarkUnread: ZohoMailEndpoint<'messagesMarkUnread'>;
+	foldersList: ZohoMailEndpoint<'foldersList'>;
+	foldersGet: ZohoMailEndpoint<'foldersGet'>;
+	foldersCreate: ZohoMailEndpoint<'foldersCreate'>;
+	foldersUpdate: ZohoMailEndpoint<'foldersUpdate'>;
+	foldersDelete: ZohoMailEndpoint<'foldersDelete'>;
+};
+
+export type ZohoMailBoundEndpoints = BindEndpoints<
+	typeof zohoMailEndpointsNested
+>;
+
+type ZohoMailWebhook<
+	K extends keyof ZohoMailWebhookOutputs,
+	TEvent,
+> = CorsairWebhook<ZohoMailContext, TEvent, ZohoMailWebhookOutputs[K]>;
+
+export type ZohoMailWebhooks = {
+	messageReceived: ZohoMailWebhook<'messageReceived', ZohoMailWebhookEvent>;
+};
+
+export type ZohoMailBoundWebhooks = BindWebhooks<typeof zohoMailWebhooksNested>;
+
+export const zohoMailEndpointsNested = {
+	messages: {
+		list: MessagesEndpoints.list,
+		get: MessagesEndpoints.get,
+		send: MessagesEndpoints.send,
+		delete: MessagesEndpoints.delete,
+		move: MessagesEndpoints.move,
+		markRead: MessagesEndpoints.markRead,
+		markUnread: MessagesEndpoints.markUnread,
+	},
+	folders: {
+		list: FoldersEndpoints.list,
+		get: FoldersEndpoints.get,
+		create: FoldersEndpoints.create,
+		update: FoldersEndpoints.update,
+		delete: FoldersEndpoints.delete,
+	},
+} as const;
+
+export const zohoMailEndpointSchemas = {
+	'messages.list': {
+		input: ZohoMailEndpointInputSchemas.messagesList,
+		output: ZohoMailEndpointOutputSchemas.messagesList,
+	},
+	'messages.get': {
+		input: ZohoMailEndpointInputSchemas.messagesGet,
+		output: ZohoMailEndpointOutputSchemas.messagesGet,
+	},
+	'messages.send': {
+		input: ZohoMailEndpointInputSchemas.messagesSend,
+		output: ZohoMailEndpointOutputSchemas.messagesSend,
+	},
+	'messages.delete': {
+		input: ZohoMailEndpointInputSchemas.messagesDelete,
+		output: ZohoMailEndpointOutputSchemas.messagesDelete,
+	},
+	'messages.move': {
+		input: ZohoMailEndpointInputSchemas.messagesMove,
+		output: ZohoMailEndpointOutputSchemas.messagesMove,
+	},
+	'messages.markRead': {
+		input: ZohoMailEndpointInputSchemas.messagesMarkRead,
+		output: ZohoMailEndpointOutputSchemas.messagesMarkRead,
+	},
+	'messages.markUnread': {
+		input: ZohoMailEndpointInputSchemas.messagesMarkUnread,
+		output: ZohoMailEndpointOutputSchemas.messagesMarkUnread,
+	},
+	'folders.list': {
+		input: ZohoMailEndpointInputSchemas.foldersList,
+		output: ZohoMailEndpointOutputSchemas.foldersList,
+	},
+	'folders.get': {
+		input: ZohoMailEndpointInputSchemas.foldersGet,
+		output: ZohoMailEndpointOutputSchemas.foldersGet,
+	},
+	'folders.create': {
+		input: ZohoMailEndpointInputSchemas.foldersCreate,
+		output: ZohoMailEndpointOutputSchemas.foldersCreate,
+	},
+	'folders.update': {
+		input: ZohoMailEndpointInputSchemas.foldersUpdate,
+		output: ZohoMailEndpointOutputSchemas.foldersUpdate,
+	},
+	'folders.delete': {
+		input: ZohoMailEndpointInputSchemas.foldersDelete,
+		output: ZohoMailEndpointOutputSchemas.foldersDelete,
+	},
+} as const;
+
+export const zohoMailWebhooksNested = {
+	messages: {
+		received: MessageWebhooks.messageReceived,
+	},
+} as const;
+
+const zohoMailWebhookSchemas = {
+	'messages.received': {
+		description: 'A new email was received in the mailbox',
+		payload: ZohoMailWebhookEventSchema,
+		response: ZohoMailWebhookEventSchema,
+	},
+} as const;
+
+export type ZohoMailPluginOptions = {
+	authType?: PickAuth<'oauth_2'>;
+	/** Zoho datacenter region. Selects the accounts.zoho.* and mail.zoho.* hosts. Default 'us'. */
+	region?: ZohoRegion;
+	key?: string;
+	credentials?: ZohoMailCredentials;
+	/**
+	 * Secret used to verify incoming webhook signatures (`x-hook-signature`).
+	 * Zoho delivers this as `x-hook-secret` on the first webhook request; store it
+	 * here or via the `webhook_signature` key.
+	 */
+	webhookSecret?: string;
+	hooks?: InternalZohoMailPlugin['hooks'];
+	webhookHooks?: InternalZohoMailPlugin['webhookHooks'];
+	errorHandlers?: CorsairErrorHandler;
+	/**
+	 * Permission configuration for the Zoho Mail plugin.
+	 * Overrides use dot-notation paths from the endpoint tree — invalid paths are type errors.
+	 */
+	permissions?: PluginPermissionsConfig<typeof zohoMailEndpointsNested>;
+};
+
+export type ZohoMailKeyBuilderContext = KeyBuilderContext<
+	ZohoMailPluginOptions,
+	typeof zohoMailAuthConfig
+>;
+
+const defaultAuthType = 'oauth_2' as const;
+
+/**
+ * Risk-level metadata for each endpoint.
+ * Used by the MCP server permission system to decide allow / deny / require_approval.
+ */
+const zohoMailEndpointMeta = {
+	'messages.list': {
+		riskLevel: 'read',
+		description: 'List emails in a folder',
+	},
+	'messages.get': {
+		riskLevel: 'read',
+		description: 'Get a specific email with its content',
+	},
+	'messages.send': {
+		riskLevel: 'write',
+		description: 'Send an email to one or more recipients',
+	},
+	'messages.delete': {
+		riskLevel: 'destructive',
+		irreversible: true,
+		description: 'Permanently delete an email [DESTRUCTIVE · IRREVERSIBLE]',
+	},
+	'messages.move': {
+		riskLevel: 'write',
+		description: 'Move emails to another folder',
+	},
+	'messages.markRead': {
+		riskLevel: 'write',
+		description: 'Mark emails as read',
+	},
+	'messages.markUnread': {
+		riskLevel: 'write',
+		description: 'Mark emails as unread',
+	},
+	'folders.list': {
+		riskLevel: 'read',
+		description: 'List all mail folders',
+	},
+	'folders.get': { riskLevel: 'read', description: 'Get a specific folder' },
+	'folders.create': { riskLevel: 'write', description: 'Create a new folder' },
+	'folders.update': {
+		riskLevel: 'write',
+		description: 'Rename, mark all emails read, or empty a folder',
+	},
+	'folders.delete': {
+		riskLevel: 'destructive',
+		irreversible: true,
+		description:
+			'Delete a folder along with its emails and sub-folders [DESTRUCTIVE · IRREVERSIBLE]',
+	},
+} satisfies RequiredPluginEndpointMeta<typeof zohoMailEndpointsNested>;
+
+export type BaseZohoMailPlugin<T extends ZohoMailPluginOptions> = CorsairPlugin<
+	'zohomail',
+	typeof ZohoMailSchema,
+	typeof zohoMailEndpointsNested,
+	typeof zohoMailWebhooksNested,
+	T,
+	typeof defaultAuthType,
+	typeof zohoMailAuthConfig
+>;
+
+export type InternalZohoMailPlugin = BaseZohoMailPlugin<ZohoMailPluginOptions>;
+
+export type ExternalZohoMailPlugin<T extends ZohoMailPluginOptions> =
+	BaseZohoMailPlugin<T>;
+
+export function zohomail<const T extends ZohoMailPluginOptions>(
+	incomingOptions: ZohoMailPluginOptions & T = {} as ZohoMailPluginOptions & T,
+): ExternalZohoMailPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	const region = options.region;
+
+	return {
+		id: 'zohomail',
+		schema: ZohoMailSchema,
+		options: options,
+		authConfig: zohoMailAuthConfig,
+		oauthConfig: {
+			providerName: 'Zoho',
+			authUrl: zohoOAuthAuthUrl(region),
+			tokenUrl: zohoOAuthTokenUrl(region),
+			scopes: [
+				'ZohoMail.messages.ALL',
+				'ZohoMail.folders.ALL',
+				'ZohoMail.accounts.READ',
+			],
+			authParams: { access_type: 'offline', prompt: 'consent' },
+			tokenAuthMethod: 'body',
+		},
+		hooks: options.hooks,
+		webhookHooks: options.webhookHooks,
+		endpoints: zohoMailEndpointsNested,
+		webhooks: zohoMailWebhooksNested,
+		endpointMeta: zohoMailEndpointMeta,
+		endpointSchemas: zohoMailEndpointSchemas,
+		webhookSchemas: zohoMailWebhookSchemas,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		pluginWebhookMatcher: (request: RawWebhookRequest) => {
+			const headers = request.headers ?? {};
+			return (
+				getZohoWebhookSignature(headers) !== undefined ||
+				getZohoWebhookSecretFromRequest(headers) !== undefined
+			);
+		},
+		keyBuilder: async (ctx: ZohoMailKeyBuilderContext, source) => {
+			const authType = ctx.authType;
+
+			if (source === 'webhook' && options.webhookSecret) {
+				return options.webhookSecret;
+			}
+
+			if (source === 'webhook') {
+				const res = await ctx.keys.get_webhook_signature();
+				return res ?? '';
+			}
+
+			if (options.key) {
+				return options.key;
+			}
+
+			if (ctx.authType === 'oauth_2') {
+				const [accessToken, expiresAt, refreshToken] = await Promise.all([
+					ctx.keys.get_access_token(),
+					ctx.keys.get_expires_at(),
+					ctx.keys.get_refresh_token(),
+				]);
+
+				if (!refreshToken) {
+					throw new Error(
+						'[auth-missing:zohomail:refresh_token]: Zoho Mail refresh token is missing',
+					);
+				}
+
+				const res = await ctx.keys.get_integration_credentials();
+
+				if (!res.client_id || !res.client_secret) {
+					throw new Error(
+						'[auth-missing:zohomail:client_credentials]: Zoho Mail client credentials are missing',
+					);
+				}
+
+				const tokenUrl = zohoOAuthTokenUrl(region);
+
+				let result: Awaited<ReturnType<typeof getValidAccessToken>>;
+				try {
+					result = await getValidAccessToken({
+						tokenUrl,
+						accessToken,
+						expiresAt,
+						refreshToken,
+						clientId: res.client_id,
+						clientSecret: res.client_secret,
+					});
+				} catch (error) {
+					throw new Error(
+						`[corsair:zohomail] Failed to obtain valid access token: ${error instanceof Error ? error.message : String(error)}`,
+					);
+				}
+
+				if (result.refreshed) {
+					try {
+						await ctx.keys.set_access_token(result.accessToken);
+						await ctx.keys.set_expires_at(String(result.expiresAt));
+					} catch (error) {
+						throw new Error(
+							`[corsair:zohomail] Token was refreshed but failed to persist new credentials: ${error instanceof Error ? error.message : String(error)}`,
+						);
+					}
+				}
+
+				// Expose a force-refresh function so endpoints can retry on 401
+				// without waiting for `expires_at` to lapse.
+				(ctx as Record<string, unknown>)._refreshAuth = async () => {
+					const freshResult = await getValidAccessToken({
+						tokenUrl,
+						accessToken: null,
+						expiresAt: null,
+						refreshToken,
+						clientId: res.client_id!,
+						clientSecret: res.client_secret!,
+						forceRefresh: true,
+					});
+					await ctx.keys.set_access_token(freshResult.accessToken);
+					await ctx.keys.set_expires_at(String(freshResult.expiresAt));
+					return freshResult.accessToken;
+				};
+
+				return result.accessToken;
+			}
+
+			throw new Error(
+				`[auth-missing:zohomail:${authType}]: Zoho Mail key is missing`,
+			);
+		},
+	} satisfies InternalZohoMailPlugin;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Type Exports
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type { ZohoRegion } from './client';
+export type {
+	ZohoMailEndpointInputs,
+	ZohoMailEndpointOutputs,
+} from './endpoints/types';
+export type { ZohoMailCredentials } from './schema';
+export { ZohoMailSchema } from './schema';
+export type * from './types';
+export type {
+	ZohoMailEventName,
+	ZohoMailWebhookEvent,
+	ZohoMailWebhookOutputs,
+} from './webhooks/types';
+export {
+	createZohoMailMatch,
+	verifyZohoWebhookSignature,
+} from './webhooks/types';

--- a/packages/zohomail/integration.test.ts
+++ b/packages/zohomail/integration.test.ts
@@ -1,0 +1,125 @@
+import 'dotenv/config';
+import { createCorsair } from 'corsair/core';
+import { createCorsairOrm } from 'corsair/orm';
+import { createIntegrationAndAccount, createTestDatabase } from 'corsair/tests';
+import type { ZohoRegion } from './client';
+import { zohomail } from './index';
+
+async function createZohoMailClient() {
+	const clientId = process.env.ZOHO_CLIENT_ID;
+	const clientSecret = process.env.ZOHO_CLIENT_SECRET;
+	const accessToken = process.env.ZOHO_ACCESS_TOKEN;
+	const refreshToken = process.env.ZOHO_REFRESH_TOKEN;
+	if (!clientId || !clientSecret || !accessToken || !refreshToken) {
+		return null;
+	}
+
+	const region = (process.env.ZOHO_REGION as ZohoRegion | undefined) ?? 'us';
+
+	const testDb = createTestDatabase();
+	await createIntegrationAndAccount(testDb.db, 'zohomail');
+
+	const corsair = createCorsair({
+		plugins: [
+			zohomail({
+				authType: 'oauth_2',
+				region,
+			}),
+		],
+		database: testDb.db,
+		kek: process.env.CORSAIR_KEK!,
+	});
+
+	await corsair.keys.zohomail.issue_new_dek();
+	await corsair.keys.zohomail.set_client_id(clientId);
+	await corsair.keys.zohomail.set_client_secret(clientSecret);
+
+	await corsair.zohomail.keys.issue_new_dek();
+	await corsair.zohomail.keys.set_access_token(accessToken);
+	await corsair.zohomail.keys.set_refresh_token(refreshToken);
+
+	return { corsair, testDb };
+}
+
+describe('Zoho Mail plugin integration', () => {
+	it('folders + messages endpoints interact with API and DB', async () => {
+		const setup = await createZohoMailClient();
+		if (!setup) {
+			// No live Zoho credentials configured — skip without failing.
+			return;
+		}
+
+		const { corsair, testDb } = setup;
+		const orm = createCorsairOrm(testDb.database);
+
+		// folders.list also exercises automatic accountId resolution.
+		const folders = await corsair.zohomail.api.folders.list({});
+		expect(folders).toBeDefined();
+
+		const listFolderEvents = await orm.events.findMany({
+			where: { event_type: 'zohomail.folders.list' },
+		});
+		expect(listFolderEvents.length).toBeGreaterThan(0);
+
+		const folderId =
+			process.env.ZOHO_FOLDER_ID ?? folders.folders?.[0]?.folderId;
+
+		if (folderId) {
+			const list = await corsair.zohomail.api.messages.list({
+				folderId,
+				limit: 5,
+			});
+			expect(list).toBeDefined();
+
+			const listEvents = await orm.events.findMany({
+				where: { event_type: 'zohomail.messages.list' },
+			});
+			expect(listEvents.length).toBeGreaterThan(0);
+
+			const messages = list.messages || [];
+			const messageId = messages[0]?.messageId;
+
+			if (messageId) {
+				const got = await corsair.zohomail.api.messages.get({
+					folderId,
+					messageId,
+				});
+				expect(got).toBeDefined();
+
+				const getEvents = await orm.events.findMany({
+					where: { event_type: 'zohomail.messages.get' },
+				});
+				expect(getEvents.length).toBeGreaterThan(0);
+			}
+		}
+
+		testDb.cleanup();
+	});
+
+	it('creates, renames, and deletes a folder', async () => {
+		const setup = await createZohoMailClient();
+		if (!setup) {
+			return;
+		}
+
+		const { corsair, testDb } = setup;
+
+		const created = await corsair.zohomail.api.folders.create({
+			folderName: `corsair-test-${Date.now()}`,
+		});
+		expect(created).toBeDefined();
+
+		const folderId = created.folderId;
+		if (folderId) {
+			await corsair.zohomail.api.folders.update({
+				folderId,
+				mode: 'rename',
+				folderName: `corsair-test-renamed-${Date.now()}`,
+			});
+
+			await corsair.zohomail.api.folders.delete({ folderId });
+		}
+
+		testDb.cleanup();
+	});
+});

--- a/packages/zohomail/jest.config.cjs
+++ b/packages/zohomail/jest.config.cjs
@@ -1,0 +1,57 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^corsair/core$': '<rootDir>/../corsair/core/index.ts',
+		'^corsair/orm$': '<rootDir>/../corsair/orm.ts',
+		'^corsair/tests$': '<rootDir>/../corsair/tests.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/zohomail/package.json
+++ b/packages/zohomail/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@corsair-dev/zohomail",
+  "version": "0.1.0",
+  "description": "Zoho Mail plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./types": {
+      "dev-source": "./types.ts",
+      "types": "./dist/types.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "zohomail",
+    "zoho",
+    "mail",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/packages/zohomail/plugin-docs.yaml
+++ b/packages/zohomail/plugin-docs.yaml
@@ -1,0 +1,14 @@
+displayName: Zoho Mail
+description: Zoho Mail plugin for Corsair — send and read emails, manage folders
+overviewNote: |
+  Zoho Mail runs region-specific datacenters. Pass `region` to the plugin factory
+  (`'us'` default, plus `'eu'`, `'in'`, `'au'`, `'jp'`, `'cn'`) so the correct
+  `accounts.zoho.*` and `mail.zoho.*` hosts are used:
+
+  ```ts
+  zohomail({ region: 'eu' })
+  ```
+
+  Every Zoho Mail call is scoped to an `accountId`. Pass it explicitly, or omit it
+  and the plugin resolves the first account on the authenticated user automatically
+  (cached for the rest of the session).

--- a/packages/zohomail/schema/database.ts
+++ b/packages/zohomail/schema/database.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+export const ZohoMailMessage = z.object({
+	id: z.string(),
+	messageId: z.string().optional(),
+	threadId: z.string().optional(),
+	folderId: z.string().optional(),
+	subject: z.string().optional(),
+	summary: z.string().optional(),
+	fromAddress: z.string().optional(),
+	toAddress: z.string().optional(),
+	ccAddress: z.string().optional(),
+	sender: z.string().optional(),
+	sentDateInGMT: z.string().optional(),
+	receivedTime: z.string().optional(),
+	size: z.string().optional(),
+	hasAttachment: z.string().optional(),
+	status: z.string().optional(),
+	flagid: z.string().optional(),
+	priority: z.string().optional(),
+	content: z.string().optional(),
+	createdAt: z.coerce.date().nullable().optional(),
+});
+
+export const ZohoMailFolder = z.object({
+	id: z.string(),
+	folderId: z.string().optional(),
+	folderName: z.string().optional(),
+	path: z.string().optional(),
+	parentFolderId: z.string().optional(),
+	folderType: z.string().optional(),
+	unreadCount: z.union([z.string(), z.number()]).optional(),
+	messageCount: z.union([z.string(), z.number()]).optional(),
+	createdAt: z.coerce.date().nullable().optional(),
+});
+
+export type ZohoMailMessage = z.infer<typeof ZohoMailMessage>;
+export type ZohoMailFolder = z.infer<typeof ZohoMailFolder>;

--- a/packages/zohomail/schema/index.ts
+++ b/packages/zohomail/schema/index.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import { ZohoMailFolder, ZohoMailMessage } from './database';
+
+export const ZohoMailCredentials = z.object({
+	clientId: z.string(),
+	clientSecret: z.string(),
+	accessToken: z.string(),
+	refreshToken: z.string(),
+});
+
+export type ZohoMailCredentials = z.infer<typeof ZohoMailCredentials>;
+
+export const ZohoMailSchema = {
+	version: '1.0.0',
+	entities: {
+		messages: ZohoMailMessage,
+		folders: ZohoMailFolder,
+	},
+} as const;

--- a/packages/zohomail/tsconfig.json
+++ b/packages/zohomail/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/zohomail/tsup.config.ts
+++ b/packages/zohomail/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/zohomail/types.ts
+++ b/packages/zohomail/types.ts
@@ -1,0 +1,76 @@
+/**
+ * Zoho Mail wraps every REST response in `{ status, data }`.
+ * @see https://www.zoho.com/mail/help/api/
+ */
+export type ZohoResponseStatus = {
+	code?: number;
+	description?: string;
+};
+
+export type ZohoResponse<T> = {
+	status?: ZohoResponseStatus;
+	data?: T;
+};
+
+export type ZohoAccount = {
+	accountId?: string | number;
+	accountDisplayName?: string;
+	primaryEmailAddress?: string;
+	mailboxAddress?: string;
+	incomingUserName?: string;
+	accountName?: string;
+};
+
+export type ZohoMessage = {
+	messageId?: string;
+	threadId?: string;
+	folderId?: string;
+	subject?: string;
+	summary?: string;
+	fromAddress?: string;
+	toAddress?: string;
+	ccAddress?: string;
+	sender?: string;
+	sentDateInGMT?: string;
+	receivedTime?: string;
+	size?: string;
+	hasAttachment?: string;
+	hasInline?: string;
+	status?: string;
+	status2?: string;
+	flagid?: string;
+	priority?: string;
+	calendarType?: string;
+	threadCount?: string;
+};
+
+/** Full message detail (includes decoded content) from the message details endpoint. */
+export type ZohoMessageDetail = ZohoMessage & {
+	content?: string;
+	mailFormat?: string;
+	returnPath?: string;
+	bccAddress?: string;
+	replyTo?: string;
+};
+
+export type ZohoFolder = {
+	folderId?: string;
+	folderName?: string;
+	path?: string;
+	parentFolderId?: string;
+	previousFolderId?: string;
+	folderType?: string;
+	isArchived?: string | boolean;
+	imapAccess?: string | boolean;
+	unreadCount?: string | number;
+	messageCount?: string | number;
+	URI?: string;
+};
+
+export type ZohoMessageListResponse = {
+	messages: ZohoMessage[];
+};
+
+export type ZohoFolderListResponse = {
+	folders: ZohoFolder[];
+};

--- a/packages/zohomail/webhooks.integration.test.ts
+++ b/packages/zohomail/webhooks.integration.test.ts
@@ -1,0 +1,94 @@
+import crypto from 'node:crypto';
+import { createCorsair } from 'corsair/core';
+import { createCorsairOrm } from 'corsair/orm';
+import { createIntegrationAndAccount, createTestDatabase } from 'corsair/tests';
+import { zohomail } from './index';
+
+const SECRET = 'zoho-hook-secret-123';
+
+function sign(rawBody: string): string {
+	return crypto.createHmac('sha256', SECRET).update(rawBody).digest('base64');
+}
+
+async function buildCorsair() {
+	const testDb = createTestDatabase();
+	await createIntegrationAndAccount(testDb.db, 'zohomail');
+	const corsair = createCorsair({
+		plugins: [zohomail({ webhookSecret: SECRET })],
+		database: testDb.db,
+		kek: process.env.CORSAIR_KEK ?? 'test-kek-0123456789abcdef0123456789abcdef',
+	});
+	return { corsair, testDb };
+}
+
+const eventBody = () =>
+	JSON.stringify({
+		messageId: '1450530000000099001',
+		folderId: '1450530000000008014',
+		subject: 'Webhook test mail',
+		fromAddress: 'sender@example.com',
+		toAddress: 'me@example.com',
+		summary: 'hello from the webhook',
+		receivedTime: '1700000000000',
+	});
+
+// The bound webhook leaf is `{ match, handler }`; the handler injects ctx
+// (key resolved via keyBuilder → webhookSecret, db) — the same path
+// `processWebhook` drives in the HTTP route.
+describe('Zoho Mail webhook — full bound pipeline', () => {
+	it('matches, verifies the signature, parses, and persists a signed delivery', async () => {
+		const { corsair, testDb } = await buildCorsair();
+		const orm = createCorsairOrm(testDb.database);
+		const wh = corsair.zohomail.webhooks.messages.received;
+
+		const rawBody = eventBody();
+		const headers = { 'x-hook-signature': sign(rawBody) };
+
+		// routing
+		expect(wh.match({ headers, body: JSON.parse(rawBody) })).toBe(true);
+
+		// verify + parse + persist
+		const response = await wh.handler({
+			payload: JSON.parse(rawBody),
+			headers,
+			rawBody,
+		});
+		expect(response.success).toBe(true);
+
+		const events = await orm.events.findMany({
+			where: { event_type: 'zohomail.webhook.messageReceived' },
+		});
+		expect(events.length).toBeGreaterThan(0);
+
+		const stored = await corsair.zohomail.db.messages.findByEntityId(
+			'1450530000000099001',
+		);
+		expect(stored?.data.subject).toBe('Webhook test mail');
+
+		testDb.cleanup();
+	});
+
+	it('rejects a tampered body (bad signature) and does not persist', async () => {
+		const { corsair, testDb } = await buildCorsair();
+		const orm = createCorsairOrm(testDb.database);
+		const wh = corsair.zohomail.webhooks.messages.received;
+
+		const rawBody = eventBody();
+		const goodSig = sign(rawBody);
+		const tampered = rawBody.replace('Webhook test mail', 'Injected subject');
+
+		const response = await wh.handler({
+			payload: JSON.parse(tampered),
+			headers: { 'x-hook-signature': goodSig },
+			rawBody: tampered,
+		});
+		expect(response.success).toBe(false);
+
+		const events = await orm.events.findMany({
+			where: { event_type: 'zohomail.webhook.messageReceived' },
+		});
+		expect(events.length).toBe(0);
+
+		testDb.cleanup();
+	});
+});

--- a/packages/zohomail/webhooks.integration.test.ts
+++ b/packages/zohomail/webhooks.integration.test.ts
@@ -6,8 +6,8 @@ import { zohomail } from './index';
 
 const SECRET = 'zoho-hook-secret-123';
 
-function sign(rawBody: string): string {
-	return crypto.createHmac('sha256', SECRET).update(rawBody).digest('base64');
+function sign(rawBody: string, secret = SECRET): string {
+	return crypto.createHmac('sha256', secret).update(rawBody).digest('base64');
 }
 
 async function buildCorsair(options: { webhookSecret?: string } = {}) {
@@ -135,6 +135,53 @@ describe('Zoho Mail webhook — full bound pipeline', () => {
 
 		const stored = await corsair.zohomail.keys.get_webhook_signature();
 		expect(stored).toBe(hookSecret);
+
+		testDb.cleanup();
+	});
+
+	it('handles first request with secret, signature, and email body', async () => {
+		const { corsair, testDb } = await buildCorsair({ webhookSecret: undefined });
+		const handshake = corsair.zohomail.webhooks.challenge.handshake;
+		const received = corsair.zohomail.webhooks.messages.received;
+		const hookSecret = 'first-request-hook-secret';
+		const rawBody = eventBody();
+		const headers = {
+			'x-hook-secret': hookSecret,
+			'x-hook-signature': sign(rawBody, hookSecret),
+		};
+		const body = JSON.parse(rawBody);
+
+		expect(handshake.match({ headers, body })).toBe(true);
+		expect(received.match({ headers, body })).toBe(false);
+
+		const response = await handshake.handler({
+			payload: body,
+			headers,
+			rawBody,
+		});
+		expect(response.success).toBe(true);
+
+		const stored = await corsair.zohomail.keys.get_webhook_signature();
+		expect(stored).toBe(hookSecret);
+
+		testDb.cleanup();
+	});
+
+	it('rejects handshake when signature does not match the secret', async () => {
+		const { corsair, testDb } = await buildCorsair({ webhookSecret: undefined });
+		const handshake = corsair.zohomail.webhooks.challenge.handshake;
+		const hookSecret = 'first-request-hook-secret';
+		const rawBody = eventBody();
+
+		const response = await handshake.handler({
+			payload: JSON.parse(rawBody),
+			headers: {
+				'x-hook-secret': hookSecret,
+				'x-hook-signature': sign(rawBody, 'wrong-secret'),
+			},
+			rawBody,
+		});
+		expect(response.success).toBe(false);
 
 		testDb.cleanup();
 	});

--- a/packages/zohomail/webhooks.integration.test.ts
+++ b/packages/zohomail/webhooks.integration.test.ts
@@ -10,14 +10,19 @@ function sign(rawBody: string): string {
 	return crypto.createHmac('sha256', SECRET).update(rawBody).digest('base64');
 }
 
-async function buildCorsair() {
+async function buildCorsair(options: { webhookSecret?: string } = {}) {
 	const testDb = createTestDatabase();
 	await createIntegrationAndAccount(testDb.db, 'zohomail');
+	const pluginOptions =
+		'webhookSecret' in options
+			? { webhookSecret: options.webhookSecret }
+			: { webhookSecret: SECRET };
 	const corsair = createCorsair({
-		plugins: [zohomail({ webhookSecret: SECRET })],
+		plugins: [zohomail(pluginOptions)],
 		database: testDb.db,
 		kek: process.env.CORSAIR_KEK ?? 'test-kek-0123456789abcdef0123456789abcdef',
 	});
+	await corsair.zohomail.keys.issue_new_dek();
 	return { corsair, testDb };
 }
 
@@ -88,6 +93,67 @@ describe('Zoho Mail webhook — full bound pipeline', () => {
 			where: { event_type: 'zohomail.webhook.messageReceived' },
 		});
 		expect(events.length).toBe(0);
+
+		testDb.cleanup();
+	});
+
+	it('rejects signed deliveries when no webhook secret is configured', async () => {
+		const { corsair, testDb } = await buildCorsair({ webhookSecret: undefined });
+		const wh = corsair.zohomail.webhooks.messages.received;
+
+		const rawBody = eventBody();
+		const response = await wh.handler({
+			payload: JSON.parse(rawBody),
+			headers: { 'x-hook-signature': sign(rawBody) },
+			rawBody,
+		});
+
+		expect(response.success).toBe(false);
+		expect(response.error).toMatch(/secret/i);
+
+		testDb.cleanup();
+	});
+
+	it('handles the handshake and persists x-hook-secret', async () => {
+		const { corsair, testDb } = await buildCorsair();
+		const handshake = corsair.zohomail.webhooks.challenge.handshake;
+		const hookSecret = 'incoming-hook-secret-from-zoho';
+
+		expect(
+			handshake.match({
+				headers: { 'x-hook-secret': hookSecret },
+				body: {},
+			}),
+		).toBe(true);
+
+		const response = await handshake.handler({
+			payload: {},
+			headers: { 'x-hook-secret': hookSecret },
+		});
+		expect(response.success).toBe(true);
+		expect(response.data?.hookSecret).toBe(hookSecret);
+
+		const stored = await corsair.zohomail.keys.get_webhook_signature();
+		expect(stored).toBe(hookSecret);
+
+		testDb.cleanup();
+	});
+
+	it('perserves large numeric messageId values from raw JSON', async () => {
+		const { corsair, testDb } = await buildCorsair();
+		const wh = corsair.zohomail.webhooks.messages.received;
+		const largeId = '1560840837125110000';
+		const rawBody = `{"messageId":${largeId},"subject":"Large ID test","summary":"hello"}`;
+
+		const response = await wh.handler({
+			payload: JSON.parse(rawBody),
+			headers: { 'x-hook-signature': sign(rawBody) },
+			rawBody,
+		});
+		expect(response.success).toBe(true);
+
+		const stored = await corsair.zohomail.db.messages.findByEntityId(largeId);
+		expect(stored?.data.messageId).toBe(largeId);
 
 		testDb.cleanup();
 	});

--- a/packages/zohomail/webhooks.test.ts
+++ b/packages/zohomail/webhooks.test.ts
@@ -1,0 +1,90 @@
+import crypto from 'node:crypto';
+import { zohomail } from './index';
+import {
+	createZohoMailMatch,
+	verifyZohoWebhookSignature,
+} from './webhooks/types';
+
+const SECRET = 'test-hook-secret';
+
+function sign(body: string, secret = SECRET): string {
+	return crypto.createHmac('sha256', secret).update(body).digest('base64');
+}
+
+describe('zoho webhook signature verification', () => {
+	it('accepts a correctly signed body', () => {
+		const body = JSON.stringify({ messageId: '123', subject: 'hi' });
+		expect(verifyZohoWebhookSignature(body, SECRET, sign(body))).toBe(true);
+	});
+
+	it('rejects a tampered body', () => {
+		const body = JSON.stringify({ messageId: '123' });
+		const sig = sign(body);
+		const tampered = JSON.stringify({ messageId: '999' });
+		expect(verifyZohoWebhookSignature(tampered, SECRET, sig)).toBe(false);
+	});
+
+	it('rejects a wrong secret', () => {
+		const body = JSON.stringify({ messageId: '123' });
+		expect(verifyZohoWebhookSignature(body, 'wrong', sign(body))).toBe(false);
+	});
+
+	it('rejects when secret or signature missing', () => {
+		const body = JSON.stringify({ messageId: '123' });
+		expect(verifyZohoWebhookSignature(body, '', sign(body))).toBe(false);
+		expect(verifyZohoWebhookSignature(body, SECRET, '')).toBe(false);
+	});
+});
+
+describe('zoho webhook matcher', () => {
+	const match = createZohoMailMatch();
+
+	it('matches a Zoho delivery (hook header + email body)', () => {
+		expect(
+			match({
+				headers: { 'x-hook-signature': 'abc' },
+				body: { messageId: '123', subject: 'hi' },
+			} as never),
+		).toBe(true);
+	});
+
+	it('matches the handshake request (x-hook-secret header)', () => {
+		expect(
+			match({
+				headers: { 'x-hook-secret': 'sek' },
+				body: { summary: 'new mail' },
+			} as never),
+		).toBe(true);
+	});
+
+	it('ignores requests without Zoho hook headers', () => {
+		expect(
+			match({
+				headers: { 'content-type': 'application/json' },
+				body: { messageId: '123' },
+			} as never),
+		).toBe(false);
+	});
+
+	it('ignores Zoho headers without an email body', () => {
+		expect(
+			match({
+				headers: { 'x-hook-signature': 'abc' },
+				body: { foo: 'bar' },
+			} as never),
+		).toBe(false);
+	});
+});
+
+describe('zohomail plugin webhook wiring', () => {
+	it('registers the messageReceived webhook and matcher', () => {
+		const plugin = zohomail({ webhookSecret: SECRET });
+		expect(plugin.webhooks?.messages.received).toBeDefined();
+
+		const matched = plugin.pluginWebhookMatcher?.({
+			headers: { 'x-hook-signature': 'abc' },
+			body: { messageId: '1' },
+		} as never);
+		expect(matched).toBe(true);
+	});
+});

--- a/packages/zohomail/webhooks.test.ts
+++ b/packages/zohomail/webhooks.test.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import { zohomail } from './index';
 import {
 	createZohoMailMatch,
+	resolveZohoId,
 	verifyZohoWebhookSignature,
 } from './webhooks/types';
 
@@ -39,7 +40,7 @@ describe('zoho webhook signature verification', () => {
 describe('zoho webhook matcher', () => {
 	const match = createZohoMailMatch();
 
-	it('matches a Zoho delivery (hook header + email body)', () => {
+	it('matches a signed Zoho delivery (signature header + email body)', () => {
 		expect(
 			match({
 				headers: { 'x-hook-signature': 'abc' },
@@ -48,13 +49,13 @@ describe('zoho webhook matcher', () => {
 		).toBe(true);
 	});
 
-	it('matches the handshake request (x-hook-secret header)', () => {
+	it('ignores the handshake request (x-hook-secret without signature)', () => {
 		expect(
 			match({
 				headers: { 'x-hook-secret': 'sek' },
 				body: { summary: 'new mail' },
 			} as never),
-		).toBe(true);
+		).toBe(false);
 	});
 
 	it('ignores requests without Zoho hook headers', () => {
@@ -66,7 +67,7 @@ describe('zoho webhook matcher', () => {
 		).toBe(false);
 	});
 
-	it('ignores Zoho headers without an email body', () => {
+	it('ignores Zoho signature without an email body', () => {
 		expect(
 			match({
 				headers: { 'x-hook-signature': 'abc' },
@@ -76,9 +77,28 @@ describe('zoho webhook matcher', () => {
 	});
 });
 
+describe('resolveZohoId', () => {
+	it('preserves large numeric IDs from raw JSON', () => {
+		const rawBody =
+			'{"messageId":1560840837125110000,"folderId":3881227000000013000}';
+		expect(resolveZohoId(rawBody, 'messageId', undefined)).toBe(
+			'1560840837125110000',
+		);
+		expect(resolveZohoId(rawBody, 'folderId', undefined)).toBe(
+			'3881227000000013000',
+		);
+	});
+
+	it('falls back to the parsed value when raw body is unavailable', () => {
+		expect(resolveZohoId(undefined, 'messageId', '12345')).toBe('12345');
+		expect(resolveZohoId(undefined, 'messageId', 67890)).toBe('67890');
+	});
+});
+
 describe('zohomail plugin webhook wiring', () => {
-	it('registers the messageReceived webhook and matcher', () => {
+	it('registers handshake and messageReceived webhooks and matcher', () => {
 		const plugin = zohomail({ webhookSecret: SECRET });
+		expect(plugin.webhooks?.challenge.handshake).toBeDefined();
 		expect(plugin.webhooks?.messages.received).toBeDefined();
 
 		const matched = plugin.pluginWebhookMatcher?.({

--- a/packages/zohomail/webhooks.test.ts
+++ b/packages/zohomail/webhooks.test.ts
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 import { zohomail } from './index';
 import {
+	createZohoMailHandshakeMatch,
 	createZohoMailMatch,
 	resolveZohoId,
 	verifyZohoWebhookSignature,
@@ -37,7 +38,32 @@ describe('zoho webhook signature verification', () => {
 	});
 });
 
-describe('zoho webhook matcher', () => {
+describe('zoho webhook handshake matcher', () => {
+	const match = createZohoMailHandshakeMatch();
+
+	it('matches when x-hook-secret is present', () => {
+		expect(
+			match({
+				headers: { 'x-hook-secret': 'sek' },
+				body: {},
+			} as never),
+		).toBe(true);
+	});
+
+	it('matches first request with both secret and signature headers', () => {
+		expect(
+			match({
+				headers: {
+					'x-hook-secret': 'sek',
+					'x-hook-signature': 'abc',
+				},
+				body: { messageId: '123', subject: 'hi' },
+			} as never),
+		).toBe(true);
+	});
+});
+
+describe('zoho webhook message matcher', () => {
 	const match = createZohoMailMatch();
 
 	it('matches a signed Zoho delivery (signature header + email body)', () => {
@@ -49,11 +75,14 @@ describe('zoho webhook matcher', () => {
 		).toBe(true);
 	});
 
-	it('ignores the handshake request (x-hook-secret without signature)', () => {
+	it('ignores handshake requests (x-hook-secret present)', () => {
 		expect(
 			match({
-				headers: { 'x-hook-secret': 'sek' },
-				body: { summary: 'new mail' },
+				headers: {
+					'x-hook-secret': 'sek',
+					'x-hook-signature': 'abc',
+				},
+				body: { messageId: '123', subject: 'hi' },
 			} as never),
 		).toBe(false);
 	});

--- a/packages/zohomail/webhooks/challenge.ts
+++ b/packages/zohomail/webhooks/challenge.ts
@@ -1,28 +1,24 @@
 import type { ZohoMailWebhooks } from '../index';
 import {
+	createZohoMailHandshakeMatch,
 	getZohoWebhookSecretFromRequest,
 	getZohoWebhookSignature,
+	verifyZohoWebhookSignature,
 } from './types';
 
 /**
- * Zoho sends the webhook signing secret in `x-hook-secret` on the first POST
- * when an outgoing webhook is saved. A 200 response is required for Zoho to
- * persist the subscription; subsequent deliveries are signed with
- * `x-hook-signature` only.
+ * Zoho delivers `x-hook-secret` on the first POST when an outgoing webhook is
+ * saved. That value becomes the HMAC key for `x-hook-signature` on all
+ * requests (including the first). A 200 is required for Zoho to persist the
+ * subscription.
+ * @see https://www.zoho.com/mail/help/dev-platform/webhook.html#secure-webhooks
  */
 export const handshake: ZohoMailWebhooks['handshake'] = {
-	match: (request) => {
-		const headers = request.headers ?? {};
-		return (
-			getZohoWebhookSecretFromRequest(headers) !== undefined &&
-			getZohoWebhookSignature(headers) === undefined
-		);
-	},
+	match: createZohoMailHandshakeMatch(),
 
 	handler: async (ctx, request) => {
-		const hookSecret = getZohoWebhookSecretFromRequest(
-			request.headers ?? {},
-		);
+		const headers = request.headers ?? {};
+		const hookSecret = getZohoWebhookSecretFromRequest(headers);
 		if (!hookSecret) {
 			return {
 				success: false,
@@ -38,6 +34,30 @@ export const handshake: ZohoMailWebhooks['handshake'] = {
 				'[corsair:zohomail] Failed to persist webhook secret:',
 				error,
 			);
+			return {
+				success: false,
+				statusCode: 500,
+				error: 'Failed to persist webhook secret',
+			};
+		}
+
+		const signature = getZohoWebhookSignature(headers);
+		if (signature) {
+			const rawBody = request.rawBody;
+			if (!rawBody) {
+				return {
+					success: false,
+					statusCode: 401,
+					error: 'Missing raw body for signature verification',
+				};
+			}
+			if (!verifyZohoWebhookSignature(rawBody, hookSecret, signature)) {
+				return {
+					success: false,
+					statusCode: 401,
+					error: 'Invalid signature',
+				};
+			}
 		}
 
 		return {

--- a/packages/zohomail/webhooks/challenge.ts
+++ b/packages/zohomail/webhooks/challenge.ts
@@ -1,0 +1,48 @@
+import type { ZohoMailWebhooks } from '../index';
+import {
+	getZohoWebhookSecretFromRequest,
+	getZohoWebhookSignature,
+} from './types';
+
+/**
+ * Zoho sends the webhook signing secret in `x-hook-secret` on the first POST
+ * when an outgoing webhook is saved. A 200 response is required for Zoho to
+ * persist the subscription; subsequent deliveries are signed with
+ * `x-hook-signature` only.
+ */
+export const handshake: ZohoMailWebhooks['handshake'] = {
+	match: (request) => {
+		const headers = request.headers ?? {};
+		return (
+			getZohoWebhookSecretFromRequest(headers) !== undefined &&
+			getZohoWebhookSignature(headers) === undefined
+		);
+	},
+
+	handler: async (ctx, request) => {
+		const hookSecret = getZohoWebhookSecretFromRequest(
+			request.headers ?? {},
+		);
+		if (!hookSecret) {
+			return {
+				success: false,
+				statusCode: 400,
+				error: 'Missing x-hook-secret header',
+			};
+		}
+
+		try {
+			await ctx.keys.set_webhook_signature(hookSecret);
+		} catch (error) {
+			console.warn(
+				'[corsair:zohomail] Failed to persist webhook secret:',
+				error,
+			);
+		}
+
+		return {
+			success: true,
+			data: { hookSecret },
+		};
+	},
+};

--- a/packages/zohomail/webhooks/index.ts
+++ b/packages/zohomail/webhooks/index.ts
@@ -1,4 +1,9 @@
+import { handshake } from './challenge';
 import { messageReceived } from './messages';
+
+export const ChallengeWebhooks = {
+	handshake,
+};
 
 export const MessageWebhooks = {
 	messageReceived,

--- a/packages/zohomail/webhooks/index.ts
+++ b/packages/zohomail/webhooks/index.ts
@@ -1,0 +1,7 @@
+import { messageReceived } from './messages';
+
+export const MessageWebhooks = {
+	messageReceived,
+};
+
+export * from './types';

--- a/packages/zohomail/webhooks/messages.ts
+++ b/packages/zohomail/webhooks/messages.ts
@@ -3,6 +3,7 @@ import type { ZohoMailWebhooks } from '../index';
 import {
 	createZohoMailMatch,
 	getZohoWebhookSignature,
+	resolveZohoId,
 	verifyZohoWebhookSignature,
 } from './types';
 
@@ -12,51 +13,60 @@ export const messageReceived: ZohoMailWebhooks['messageReceived'] = {
 		const secret = ctx.key;
 		const signature = getZohoWebhookSignature(request.headers ?? {});
 
-		// Signed delivery — verify when we hold the secret.
 		if (signature) {
-			if (secret) {
-				const rawBody = request.rawBody;
-				if (!rawBody) {
-					return {
-						success: false,
-						statusCode: 401,
-						error: 'Missing raw body for signature verification',
-					};
-				}
-				if (!verifyZohoWebhookSignature(rawBody, secret, signature)) {
-					return {
-						success: false,
-						statusCode: 401,
-						error: 'Invalid signature',
-					};
-				}
-			} else {
-				console.warn(
-					'[corsair:zohomail] Received signed webhook but no webhook secret is configured — skipping verification.',
-				);
+			if (!secret) {
+				return {
+					success: false,
+					statusCode: 401,
+					error: 'Webhook secret is not configured',
+				};
+			}
+
+			const rawBody = request.rawBody;
+			if (!rawBody) {
+				return {
+					success: false,
+					statusCode: 401,
+					error: 'Missing raw body for signature verification',
+				};
+			}
+			if (!verifyZohoWebhookSignature(rawBody, secret, signature)) {
+				return {
+					success: false,
+					statusCode: 401,
+					error: 'Invalid signature',
+				};
 			}
 		}
-		// No signature → first/handshake request. Zoho saves the webhook only on a
-		// 200, so fall through and acknowledge.
 
 		const event = request.payload;
+		const messageId = resolveZohoId(
+			request.rawBody,
+			'messageId',
+			event?.messageId,
+		);
+		const folderId = resolveZohoId(
+			request.rawBody,
+			'folderId',
+			event?.folderId,
+		);
 
 		let corsairEntityId = '';
-		if (ctx.db.messages && event?.messageId) {
+		if (ctx.db.messages && messageId) {
 			try {
-				const entity = await ctx.db.messages.upsertByEntityId(event.messageId, {
-					id: event.messageId,
-					messageId: event.messageId,
-					folderId: event.folderId,
-					subject: event.subject,
-					summary: event.summary,
-					fromAddress: event.fromAddress,
-					toAddress: event.toAddress,
-					ccAddress: event.ccAddress,
-					sender: event.sender,
-					sentDateInGMT: event.sentDateInGMT,
-					receivedTime: event.receivedTime,
-					content: event.html,
+				const entity = await ctx.db.messages.upsertByEntityId(messageId, {
+					id: messageId,
+					messageId,
+					folderId,
+					subject: event?.subject,
+					summary: event?.summary,
+					fromAddress: event?.fromAddress,
+					toAddress: event?.toAddress,
+					ccAddress: event?.ccAddress,
+					sender: event?.sender,
+					sentDateInGMT: event?.sentDateInGMT,
+					receivedTime: event?.receivedTime,
+					content: event?.html,
 					createdAt: new Date(),
 				});
 				corsairEntityId = entity?.id ?? '';

--- a/packages/zohomail/webhooks/messages.ts
+++ b/packages/zohomail/webhooks/messages.ts
@@ -1,0 +1,81 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ZohoMailWebhooks } from '../index';
+import {
+	createZohoMailMatch,
+	getZohoWebhookSignature,
+	verifyZohoWebhookSignature,
+} from './types';
+
+export const messageReceived: ZohoMailWebhooks['messageReceived'] = {
+	match: createZohoMailMatch(),
+	handler: async (ctx, request) => {
+		const secret = ctx.key;
+		const signature = getZohoWebhookSignature(request.headers ?? {});
+
+		// Signed delivery — verify when we hold the secret.
+		if (signature) {
+			if (secret) {
+				const rawBody = request.rawBody;
+				if (!rawBody) {
+					return {
+						success: false,
+						statusCode: 401,
+						error: 'Missing raw body for signature verification',
+					};
+				}
+				if (!verifyZohoWebhookSignature(rawBody, secret, signature)) {
+					return {
+						success: false,
+						statusCode: 401,
+						error: 'Invalid signature',
+					};
+				}
+			} else {
+				console.warn(
+					'[corsair:zohomail] Received signed webhook but no webhook secret is configured — skipping verification.',
+				);
+			}
+		}
+		// No signature → first/handshake request. Zoho saves the webhook only on a
+		// 200, so fall through and acknowledge.
+
+		const event = request.payload;
+
+		let corsairEntityId = '';
+		if (ctx.db.messages && event?.messageId) {
+			try {
+				const entity = await ctx.db.messages.upsertByEntityId(event.messageId, {
+					id: event.messageId,
+					messageId: event.messageId,
+					folderId: event.folderId,
+					subject: event.subject,
+					summary: event.summary,
+					fromAddress: event.fromAddress,
+					toAddress: event.toAddress,
+					ccAddress: event.ccAddress,
+					sender: event.sender,
+					sentDateInGMT: event.sentDateInGMT,
+					receivedTime: event.receivedTime,
+					content: event.html,
+					createdAt: new Date(),
+				});
+				corsairEntityId = entity?.id ?? '';
+			} catch (error) {
+				console.warn('Failed to save webhook message to database:', error);
+			}
+		}
+
+		await logEventFromContext(
+			ctx,
+			'zohomail.webhook.messageReceived',
+			{ ...event },
+			'completed',
+		);
+
+		return {
+			success: true,
+			corsairEntityId,
+			data: event,
+		};
+	},
+};

--- a/packages/zohomail/webhooks/types.ts
+++ b/packages/zohomail/webhooks/types.ts
@@ -1,0 +1,129 @@
+import crypto from 'node:crypto';
+import type {
+	CorsairWebhookMatcher,
+	RawWebhookRequest,
+	WebhookRequest,
+} from 'corsair/core';
+import { z } from 'zod';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Event schema
+//
+// Zoho Mail outgoing webhooks POST the email event directly in the body (no
+// secondary fetch needed, unlike Gmail's PubSub → history reconciliation).
+// @see https://www.zoho.com/mail/help/dev-platform/webhook.html
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ZohoMailWebhookEventSchema = z
+	.object({
+		messageId: z.string().optional(),
+		folderId: z.string().optional(),
+		subject: z.string().optional(),
+		summary: z.string().optional(),
+		html: z.string().optional(),
+		fromAddress: z.string().optional(),
+		toAddress: z.string().optional(),
+		ccAddress: z.string().optional(),
+		sender: z.string().optional(),
+		sentDateInGMT: z.string().optional(),
+		receivedTime: z.string().optional(),
+		size: z.union([z.string(), z.number()]).optional(),
+	})
+	.loose();
+export type ZohoMailWebhookEvent = z.infer<typeof ZohoMailWebhookEventSchema>;
+
+export type ZohoMailEventName = 'messageReceived';
+
+export type ZohoMailWebhookOutputs = {
+	messageReceived: ZohoMailWebhookEvent;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Signature verification
+//
+// Zoho signs each request with `x-hook-signature` = base64 HMAC-SHA256 of the
+// full raw request body, keyed by `x-hook-secret`. The secret is delivered in
+// the header of the first ("handshake") request and must be stored as the
+// plugin's webhook secret; subsequent requests carry only the signature.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function headerValue(
+	headers: Record<string, string | string[] | undefined>,
+	name: string,
+): string | undefined {
+	const raw = headers[name];
+	return Array.isArray(raw) ? raw[0] : raw;
+}
+
+export function getZohoWebhookSignature(
+	headers: Record<string, string | string[] | undefined>,
+): string | undefined {
+	return headerValue(headers, 'x-hook-signature');
+}
+
+export function getZohoWebhookSecretFromRequest(
+	headers: Record<string, string | string[] | undefined>,
+): string | undefined {
+	return headerValue(headers, 'x-hook-secret');
+}
+
+export function verifyZohoWebhookSignature(
+	rawBody: string,
+	secret: string,
+	signature: string,
+): boolean {
+	if (!secret || !signature || !rawBody) {
+		return false;
+	}
+
+	const expected = crypto
+		.createHmac('sha256', secret)
+		.update(rawBody)
+		.digest('base64');
+
+	try {
+		const a = Buffer.from(signature);
+		const b = Buffer.from(expected);
+		return a.length === b.length && crypto.timingSafeEqual(a, b);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Matches incoming Zoho Mail webhook deliveries by the presence of the Zoho hook
+ * headers plus an email identifier in the body. Used for routing only — the
+ * handler performs the actual cryptographic verification.
+ */
+export function createZohoMailMatch(): CorsairWebhookMatcher {
+	return (request: RawWebhookRequest) => {
+		const headers = request.headers ?? {};
+		const hasHookHeader =
+			getZohoWebhookSignature(headers) !== undefined ||
+			getZohoWebhookSecretFromRequest(headers) !== undefined;
+		if (!hasHookHeader) {
+			return false;
+		}
+
+		const body = (
+			typeof request.body === 'string' ? safeParse(request.body) : request.body
+		) as Record<string, unknown> | undefined;
+
+		return (
+			!!body &&
+			(typeof body.messageId !== 'undefined' ||
+				typeof body.summary !== 'undefined' ||
+				typeof body.subject !== 'undefined')
+		);
+	};
+}
+
+function safeParse(value: string): unknown {
+	try {
+		return JSON.parse(value);
+	} catch {
+		return undefined;
+	}
+}
+
+export type ZohoMailWebhookRequest = WebhookRequest<ZohoMailWebhookEvent>;

--- a/packages/zohomail/webhooks/types.ts
+++ b/packages/zohomail/webhooks/types.ts
@@ -138,12 +138,26 @@ export function verifyZohoWebhookSignature(
 }
 
 /**
+ * Matches the first-request handshake (`x-hook-secret` present).
+ * Per Zoho docs this header appears only on the very first delivery.
+ */
+export function createZohoMailHandshakeMatch(): CorsairWebhookMatcher {
+	return (request: RawWebhookRequest) => {
+		const headers = request.headers ?? {};
+		return getZohoWebhookSecretFromRequest(headers) !== undefined;
+	};
+}
+
+/**
  * Matches signed Zoho Mail email deliveries (`x-hook-signature` present).
- * Handshake requests (`x-hook-secret` only) are routed to `challenge.handshake`.
+ * Handshake requests (`x-hook-secret`) are routed to `challenge.handshake`.
  */
 export function createZohoMailMatch(): CorsairWebhookMatcher {
 	return (request: RawWebhookRequest) => {
 		const headers = request.headers ?? {};
+		if (getZohoWebhookSecretFromRequest(headers) !== undefined) {
+			return false;
+		}
 		if (getZohoWebhookSignature(headers) === undefined) {
 			return false;
 		}

--- a/packages/zohomail/webhooks/types.ts
+++ b/packages/zohomail/webhooks/types.ts
@@ -16,8 +16,8 @@ import { z } from 'zod';
 
 export const ZohoMailWebhookEventSchema = z
 	.object({
-		messageId: z.string().optional(),
-		folderId: z.string().optional(),
+		messageId: z.coerce.string().optional(),
+		folderId: z.coerce.string().optional(),
 		subject: z.string().optional(),
 		summary: z.string().optional(),
 		html: z.string().optional(),
@@ -25,18 +25,65 @@ export const ZohoMailWebhookEventSchema = z
 		toAddress: z.string().optional(),
 		ccAddress: z.string().optional(),
 		sender: z.string().optional(),
-		sentDateInGMT: z.string().optional(),
-		receivedTime: z.string().optional(),
+		sentDateInGMT: z.coerce.string().optional(),
+		receivedTime: z.coerce.string().optional(),
 		size: z.union([z.string(), z.number()]).optional(),
 	})
 	.loose();
 export type ZohoMailWebhookEvent = z.infer<typeof ZohoMailWebhookEventSchema>;
 
-export type ZohoMailEventName = 'messageReceived';
+export const ZohoMailChallengePayloadSchema = z.object({}).loose();
+export type ZohoMailChallengePayload = z.infer<
+	typeof ZohoMailChallengePayloadSchema
+>;
+
+export const ZohoMailChallengeResponseSchema = z.object({
+	hookSecret: z.string(),
+});
+
+export type ZohoMailEventName = 'handshake' | 'messageReceived';
 
 export type ZohoMailWebhookOutputs = {
+	handshake: { hookSecret: string };
 	messageReceived: ZohoMailWebhookEvent;
 };
+
+/** Coerce Zoho entity IDs (string or number) to a stable string key. */
+export function zohoEntityId(
+	value: string | number | undefined | null,
+): string | undefined {
+	if (value === undefined || value === null || value === '') {
+		return undefined;
+	}
+	return String(value);
+}
+
+/**
+ * Read an ID from raw JSON without losing precision on large numeric literals.
+ * Falls back to the parsed payload value when raw body is unavailable.
+ */
+export function resolveZohoId(
+	rawBody: string | undefined,
+	key: string,
+	parsed: string | number | undefined,
+): string | undefined {
+	if (rawBody) {
+		const re = new RegExp(`"${key}"\\s*:\\s*("(?:[^"\\\\]|\\\\.)*"|[0-9]+)`);
+		const match = rawBody.match(re);
+		if (match?.[1]) {
+			const token = match[1];
+			if (token.startsWith('"')) {
+				try {
+					return JSON.parse(token) as string;
+				} catch {
+					return token.slice(1, -1);
+				}
+			}
+			return token;
+		}
+	}
+	return zohoEntityId(parsed);
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Signature verification
@@ -91,17 +138,13 @@ export function verifyZohoWebhookSignature(
 }
 
 /**
- * Matches incoming Zoho Mail webhook deliveries by the presence of the Zoho hook
- * headers plus an email identifier in the body. Used for routing only — the
- * handler performs the actual cryptographic verification.
+ * Matches signed Zoho Mail email deliveries (`x-hook-signature` present).
+ * Handshake requests (`x-hook-secret` only) are routed to `challenge.handshake`.
  */
 export function createZohoMailMatch(): CorsairWebhookMatcher {
 	return (request: RawWebhookRequest) => {
 		const headers = request.headers ?? {};
-		const hasHookHeader =
-			getZohoWebhookSignature(headers) !== undefined ||
-			getZohoWebhookSecretFromRequest(headers) !== undefined;
-		if (!hasHookHeader) {
+		if (getZohoWebhookSignature(headers) === undefined) {
 			return false;
 		}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
       '@corsair-dev/xquik':
         specifier: workspace:*
         version: link:../../packages/xquik
+      '@corsair-dev/zohomail':
+        specifier: workspace:*
+        version: link:../../packages/zohomail
       '@tanstack/react-query':
         specifier: ^5.62.14
         version: 5.90.20(react@18.3.1)
@@ -1970,6 +1973,31 @@ importers:
         version: 4.1.13
 
   packages/zendesk:
+    dependencies:
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: ^4.1.13
+        version: 4.1.13
+
+  packages/zohomail:
     dependencies:
       jest:
         specifier: ^29.7.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,9 +182,6 @@ importers:
       '@corsair-dev/xquik':
         specifier: workspace:*
         version: link:../../packages/xquik
-      '@corsair-dev/zohomail':
-        specifier: workspace:*
-        version: link:../../packages/zohomail
       '@tanstack/react-query':
         specifier: ^5.62.14
         version: 5.90.20(react@18.3.1)


### PR DESCRIPTION
Closes #238

  Adds the Zoho Mail plugin — OAuth2, configurable datacenter region
  (us/eu/in/au/jp/cn).

  ## Endpoints
  - **messages**: list, get, send, move, markRead, markUnread, delete
  - **folders**: list, get, create, update (rename / markAsRead /
  emptyFolder), delete

  ## Design notes
  - `accountId` auto-resolved from `/accounts` when omitted (every Zoho
  call is account-scoped); cached per session.
  - `messages.list` `folderId` is optional — **defaults to the Inbox**,
  so `messages.list({})` returns the user's mail with no folder
  lookup.
  - Auth header is `Authorization: Zoho-oauthtoken <token>` (not
  Bearer); access-token refresh wired via keyBuilder.
  - `list`/`get` upsert to the local DB; `folders.list` + inbox
  `messages.list` registered in `setup/backfill.yaml` for the
  polling/seed path.
  - error-handlers map Zoho responses to Corsair error types
  (rate-limit/auth/permission/not-found).

  ## Webhooks (optional)
  - `messageReceived` handler with `x-hook-signature` (base64
  HMAC-SHA256 over the raw body) verification.
  - **Limitation (documented):** Zoho Mail webhooks are per-mailbox,
  configured manually in the user's UI, **paid-plan only**, with no
  app-level/API registration — they don't fit the standard multi-tenant
  SaaS pattern. For multi-tenant/free-tier, **polling**
  (`messages.list` + DB sync) is the recommended path.

  ## Testing
  - Live-verified against a real Zoho account: all message + folder ops
  return 200 (inbox default confirmed).
  - Package tests (17): api, integration, webhook unit + webhook
  pipeline (signed delivery persists; tampered rejected).
  - Registered + exercised via `demo/testing` harness.

  ## Not covered (CI-untestable)
  - Live Zoho→endpoint webhook delivery — Zoho gates webhooks behind a
  paid plan. Pipeline verified via integration test.
  - Explorer catalog: run `pnpm build:explorer-catalog` to regenerate
  (left out to avoid unrelated-plugin churn).