### PR TITLE
feat(www): add dark mode toggle for OSS page

### DIFF
--- a/www/src/app/integrations/layout.tsx
+++ b/www/src/app/integrations/layout.tsx
@@ -19,7 +19,7 @@ export default async function IntegrationsLayout({
 		: null;
 
 	return (
-		<div className="min-h-screen bg-[#f7f7f5] text-foreground">
+		<div className="min-h-screen bg-[#f7f7f5] text-foreground dark:bg-background">
 			<div className="mx-auto max-w-3xl">
 				<OssIntegrationsBar
 					session={session}

--- a/www/src/app/integrations/layout.tsx
+++ b/www/src/app/integrations/layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 
+import { ThemeScope } from '@/components/theme-scope';
 import { getSession } from '@/lib/auth-server';
 import { getApi } from '@/server/api/caller';
 import { getGithubUserAvatar } from '@/server/github-users';
@@ -19,15 +20,17 @@ export default async function IntegrationsLayout({
 		: null;
 
 	return (
-		<div className="min-h-screen bg-[#f7f7f5] text-foreground dark:bg-background">
-			<div className="mx-auto max-w-3xl">
-				<OssIntegrationsBar
-					session={session}
-					githubUsername={githubUsername}
-					githubAvatarUrl={githubAvatarUrl}
-				/>
-				{children}
+		<ThemeScope>
+			<div className="min-h-screen bg-[#f7f7f5] text-foreground dark:bg-background">
+				<div className="mx-auto max-w-3xl">
+					<OssIntegrationsBar
+						session={session}
+						githubUsername={githubUsername}
+						githubAvatarUrl={githubAvatarUrl}
+					/>
+					{children}
+				</div>
 			</div>
-		</div>
+		</ThemeScope>
 	);
 }

--- a/www/src/app/layout.tsx
+++ b/www/src/app/layout.tsx
@@ -121,7 +121,6 @@ export default function RootLayout({
 	return (
 		<html
 			lang="en"
-			suppressHydrationWarning
 			className={cn(
 				'scroll-smooth',
 				hostGrotesk.variable,
@@ -129,13 +128,6 @@ export default function RootLayout({
 				azeretMono.variable,
 			)}
 		>
-			<head>
-				<script
-					dangerouslySetInnerHTML={{
-						__html: `(function(){try{var t=localStorage.getItem("corsair-theme");if(t==="dark")document.documentElement.classList.add("dark")}catch(e){}})()`,
-					}}
-				/>
-			</head>
 			<body className="min-h-screen antialiased">
 				<script
 					type="application/ld+json"

--- a/www/src/app/layout.tsx
+++ b/www/src/app/layout.tsx
@@ -121,6 +121,7 @@ export default function RootLayout({
 	return (
 		<html
 			lang="en"
+			suppressHydrationWarning
 			className={cn(
 				'scroll-smooth',
 				hostGrotesk.variable,
@@ -128,6 +129,13 @@ export default function RootLayout({
 				azeretMono.variable,
 			)}
 		>
+			<head>
+				<script
+					dangerouslySetInnerHTML={{
+						__html: `(function(){try{var t=localStorage.getItem("corsair-theme");if(t==="dark")document.documentElement.classList.add("dark")}catch(e){}})()`,
+					}}
+				/>
+			</head>
 			<body className="min-h-screen antialiased">
 				<script
 					type="application/ld+json"

--- a/www/src/app/oss/layout.tsx
+++ b/www/src/app/oss/layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 
+import { ThemeScope } from '@/components/theme-scope';
 import { getSession } from '@/lib/auth-server';
 import { getApi } from '@/server/api/caller';
 import { getGithubUserAvatar } from '@/server/github-users';
@@ -19,15 +20,17 @@ export default async function OssIntegrationsLayout({
 		: null;
 
 	return (
-		<div className="min-h-screen bg-[#f7f7f5] text-foreground dark:bg-background">
-			<div className="mx-auto max-w-3xl">
-				<OssIntegrationsBar
-					session={session}
-					githubUsername={githubUsername}
-					githubAvatarUrl={githubAvatarUrl}
-				/>
-				{children}
+		<ThemeScope>
+			<div className="min-h-screen bg-[#f7f7f5] text-foreground dark:bg-background">
+				<div className="mx-auto max-w-3xl">
+					<OssIntegrationsBar
+						session={session}
+						githubUsername={githubUsername}
+						githubAvatarUrl={githubAvatarUrl}
+					/>
+					{children}
+				</div>
 			</div>
-		</div>
+		</ThemeScope>
 	);
 }

--- a/www/src/app/oss/layout.tsx
+++ b/www/src/app/oss/layout.tsx
@@ -19,7 +19,7 @@ export default async function OssIntegrationsLayout({
 		: null;
 
 	return (
-		<div className="min-h-screen bg-[#f7f7f5] text-foreground">
+		<div className="min-h-screen bg-[#f7f7f5] text-foreground dark:bg-background">
 			<div className="mx-auto max-w-3xl">
 				<OssIntegrationsBar
 					session={session}

--- a/www/src/app/oss/oss-integrations-bar.tsx
+++ b/www/src/app/oss/oss-integrations-bar.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
+import { ThemeToggle } from '@/components/theme-toggle';
 import { Badge } from '@/components/ui/badge';
 import type { getSession } from '@/lib/auth-server';
 
@@ -18,7 +19,7 @@ export function OssIntegrationsBar({
 	githubAvatarUrl: string | null;
 }) {
 	return (
-		<header className="sticky top-0 z-10 flex items-center justify-between gap-4 border-b border-border/60 bg-[#f7f7f5]/90 px-6 py-3 text-sm backdrop-blur-sm">
+		<header className="sticky top-0 z-10 flex items-center justify-between gap-4 border-b border-border/60 bg-[#f7f7f5]/90 px-6 py-3 text-sm backdrop-blur-sm dark:bg-background/90">
 			<Link
 				href="/"
 				aria-label="Corsair home"
@@ -36,6 +37,7 @@ export function OssIntegrationsBar({
 				</span>
 			</Link>
 			<div className="flex items-center gap-3">
+				<ThemeToggle />
 				{session?.user ? (
 					<>
 						<div className="hidden items-center gap-2 sm:flex">

--- a/www/src/app/oss/sign-in-banner.tsx
+++ b/www/src/app/oss/sign-in-banner.tsx
@@ -5,7 +5,7 @@ export function SignInBanner() {
 	return (
 		<div
 			role="alert"
-			className="mb-6 flex items-center justify-between gap-4 rounded-xl border border-amber-200/80 bg-amber-50 px-4 py-3 text-left text-xs text-amber-950"
+			className="mb-6 flex items-center justify-between gap-4 rounded-xl border border-amber-200/80 bg-amber-50 px-4 py-3 text-left text-xs text-amber-950 dark:border-amber-800/30 dark:bg-amber-950/20 dark:text-amber-300/90"
 		>
 			<div className="flex min-w-0 items-center gap-2">
 				<UserIcon className="size-4 shrink-0 text-current" />

--- a/www/src/components/theme-scope.tsx
+++ b/www/src/components/theme-scope.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+
+// Applies the saved theme to this wrapper only (never <html>), before paint,
+// so dark mode stays scoped to the routes that render <ThemeScope> and the
+// landing page can never inherit it.
+const themeInitScript = `(function(){try{var s=document.currentScript;if(s&&s.parentElement&&localStorage.getItem("corsair-theme")==="dark"){s.parentElement.classList.add("dark")}}catch(e){}})()`;
+
+export function ThemeScope({ children }: { children: ReactNode }) {
+	return (
+		<div data-theme-scope suppressHydrationWarning>
+			<script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+			{children}
+		</div>
+	);
+}

--- a/www/src/components/theme-toggle.tsx
+++ b/www/src/components/theme-toggle.tsx
@@ -34,23 +34,29 @@ function MoonIcon({ className }: { className?: string }) {
 
 const STORAGE_KEY = 'corsair-theme';
 
+function getScope() {
+	return document.querySelector('[data-theme-scope]');
+}
+
 export function ThemeToggle() {
 	const [dark, setDark] = useState(false);
 	const [mounted, setMounted] = useState(false);
 
 	useEffect(() => {
-		setDark(document.documentElement.classList.contains('dark'));
+		setDark(getScope()?.classList.contains('dark') ?? false);
 		setMounted(true);
 	}, []);
 
 	const toggle = useCallback(() => {
-		const next = !dark;
+		const scope = getScope();
+		if (!scope) return;
+		const next = !scope.classList.contains('dark');
+		scope.classList.toggle('dark', next);
 		setDark(next);
-		document.documentElement.classList.toggle('dark', next);
 		try {
 			localStorage.setItem(STORAGE_KEY, next ? 'dark' : 'light');
 		} catch {}
-	}, [dark]);
+	}, []);
 
 	if (!mounted) {
 		return <div className="size-7" />;

--- a/www/src/components/theme-toggle.tsx
+++ b/www/src/components/theme-toggle.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+function SunIcon({ className }: { className?: string }) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 20 20"
+			fill="currentColor"
+			className={className}
+		>
+			<path d="M10 2a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 10 2ZM10 15a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 10 15ZM10 7a3 3 0 1 0 0 6 3 3 0 0 0 0-6ZM15.657 5.404a.75.75 0 1 0-1.06-1.06l-1.061 1.06a.75.75 0 0 0 1.06 1.06l1.061-1.06ZM6.464 14.596a.75.75 0 1 0-1.06-1.06l-1.061 1.06a.75.75 0 0 0 1.06 1.06l1.061-1.06ZM18 10a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 18 10ZM5 10a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 5 10ZM14.596 15.657a.75.75 0 0 0 1.06-1.06l-1.06-1.061a.75.75 0 1 0-1.06 1.06l1.06 1.061ZM5.404 6.464a.75.75 0 0 0 1.06-1.06L5.404 4.343a.75.75 0 0 0-1.06 1.06l1.06 1.061Z" />
+		</svg>
+	);
+}
+
+function MoonIcon({ className }: { className?: string }) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 20 20"
+			fill="currentColor"
+			className={className}
+		>
+			<path
+				fillRule="evenodd"
+				d="M7.455 2.004a.75.75 0 0 1 .26.77 7 7 0 0 0 9.958 7.967.75.75 0 0 1 1.067.853A8.5 8.5 0 1 1 6.647 1.921a.75.75 0 0 1 .808.083Z"
+				clipRule="evenodd"
+			/>
+		</svg>
+	);
+}
+
+const STORAGE_KEY = 'corsair-theme';
+
+export function ThemeToggle() {
+	const [dark, setDark] = useState(false);
+	const [mounted, setMounted] = useState(false);
+
+	useEffect(() => {
+		setDark(document.documentElement.classList.contains('dark'));
+		setMounted(true);
+	}, []);
+
+	const toggle = useCallback(() => {
+		const next = !dark;
+		setDark(next);
+		document.documentElement.classList.toggle('dark', next);
+		try {
+			localStorage.setItem(STORAGE_KEY, next ? 'dark' : 'light');
+		} catch {}
+	}, [dark]);
+
+	if (!mounted) {
+		return <div className="size-7" />;
+	}
+
+	return (
+		<button
+			type="button"
+			onClick={toggle}
+			aria-label={dark ? 'Switch to light mode' : 'Switch to dark mode'}
+			className="inline-flex size-7 items-center justify-center rounded-lg border border-border/70 bg-card text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground"
+		>
+			{dark ? (
+				<SunIcon className="size-3.5" />
+			) : (
+				<MoonIcon className="size-3.5" />
+			)}
+		</button>
+	);
+}


### PR DESCRIPTION
## Summary

Adds a small dark mode toggle for the OSS page.

## Changes

* Added a theme toggle to the `/oss` page header.
* Persists the selected theme in `localStorage`.
* Added dark mode styles for the OSS page shell and sign-in banner.
* Kept the change scoped to the OSS/integration pages.

## Testing

* `cd www && pnpm build`
* Manually checked `/oss` in light and dark mode. 

## Screenshot 
<img width="1536" height="688" alt="image" src="https://github.com/user-attachments/assets/c30d7c93-539f-4bbe-b2a4-6ad2cf873336" />
