### PR TITLE
docs: add Management API section for #241

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -78,6 +78,16 @@
             ]
           },
           {
+            "group": "Management API",
+            "pages": [
+              "management/overview",
+              "management/handler",
+              "management/client",
+              "management/react",
+              "management/connect"
+            ]
+          },
+          {
             "group": "Production",
             "pages": [
               "production/oauth-process"

--- a/docs/management/client.mdx
+++ b/docs/management/client.mdx
@@ -1,0 +1,97 @@
+---
+title: Vanilla Client
+description: createCorsairClient is a typed fetch wrapper for the management API. No React, no framework, just types.
+---
+
+`createCorsairClient({ baseURL })` returns a typed client that mirrors every route on the [handler](/management/handler). Use it from a Node script, a CLI, a worker, or a non-React frontend.
+
+```ts client.ts
+import { createCorsairClient } from "corsair";
+
+const client = createCorsairClient({ baseURL: "/api/corsair" });
+```
+
+For React, prefer [`createCorsairReactClient`](/management/react) — it wraps this one and adds hooks.
+
+## Reading
+
+```ts reads.ts
+await client.tenants.list();                      // GET /tenants
+await client.tenants.get("acme");                 // GET /tenants/acme
+
+await client.plugins.list();                      // GET /plugins
+await client.plugins.get("github");               // GET /plugins/github
+
+await client.connectionStatus.get({               // GET /connection-status
+  tenantId: "acme",
+});
+
+await client.permissions.get("perm_123");         // GET /permissions/perm_123
+await client.permissions.getByToken("tok_abc");   // POST /permissions/lookup-by-token
+
+await client.ok();                                // GET /ok
+```
+
+Every method is typed against the route's response. Hovering `client.tenants.list()` in your editor shows `Promise<Tenant[]>`, and so on.
+
+`connectionStatus.get` returns a `Record<string, 'connected' | 'missing_credentials' | 'not_connected'>` keyed by plugin id:
+
+```ts
+const status = await client.connectionStatus.get({ tenantId: "acme" });
+// { github: 'connected', slack: 'not_connected', notion: 'missing_credentials' }
+```
+
+## Writing
+
+```ts writes.ts
+await client.tenants.create({ id: "acme" });      // POST /tenants
+```
+
+Connect/OAuth methods are documented on the [Connect page](/management/connect).
+
+## Options
+
+```ts
+createCorsairClient({
+  baseURL: "/api/corsair",     // required
+  fetch: customFetch,          // optional — override globalThis.fetch
+});
+```
+
+`baseURL` is the origin + base path the handler is mounted at, e.g. `https://app.example.com/api/corsair`. A trailing slash is tolerated.
+
+The `fetch` override is resolved lazily — if you omit it, `globalThis.fetch` is read on every call, not at construction. This makes the client work cleanly in test environments that inject `fetch` after module load (jsdom, Node's experimental fetch flag, etc.).
+
+Need auth headers, custom retry, or interceptors? Pass a wrapped `fetch`:
+
+```ts
+const client = createCorsairClient({
+  baseURL: "/api/corsair",
+  fetch: (input, init) =>
+    globalThis.fetch(input, {
+      ...init,
+      headers: { ...init?.headers, Authorization: `Bearer ${token()}` },
+    }),
+});
+```
+
+## Error handling
+
+Failed requests throw `CorsairClientError`:
+
+```ts
+import { CorsairClientError } from "corsair";
+
+try {
+  await client.tenants.get("does-not-exist");
+} catch (err) {
+  if (err instanceof CorsairClientError) {
+    err.status;   // number — HTTP status
+    err.code;     // string — e.g. "not_found"
+    err.message;  // string — human message from the server
+    err.extra;    // Record<string, unknown> — any additional fields the server returned
+  }
+}
+```
+
+Network failures (DNS, abort, no response) throw a plain `Error` — `CorsairClientError` is only used when the server responded with a non-2xx body.

--- a/docs/management/client.mdx
+++ b/docs/management/client.mdx
@@ -60,7 +60,7 @@ createCorsairClient({
 
 `baseURL` is the origin + base path the handler is mounted at, e.g. `https://app.example.com/api/corsair`. A trailing slash is tolerated.
 
-The `fetch` override is resolved lazily — if you omit it, `globalThis.fetch` is read on every call, not at construction. This makes the client work cleanly in test environments that inject `fetch` after module load (jsdom, Node's experimental fetch flag, etc.).
+`fetch` is optional — see [Custom fetch](#custom-fetch) below.
 
 Need auth headers, custom retry, or interceptors? Pass a wrapped `fetch`:
 
@@ -95,3 +95,25 @@ try {
 ```
 
 Network failures (DNS, abort, no response) throw a plain `Error` — `CorsairClientError` is only used when the server responded with a non-2xx body.
+
+## Custom fetch
+
+When you call `createCorsairClient`, the client picks its `fetch` function once — either the one you pass in, or `globalThis.fetch` at that moment. Every later call (`client.tenants.list()`, etc.) uses that same function; it does not re-read `globalThis.fetch` on each request.
+
+In a normal browser or Node 18+ app, this makes no practical difference. `fetch` is already available when you create the client, and it stays the same.
+
+It only matters in two cases:
+
+- **Tests** — your test runner or jsdom may install or replace `fetch` after your client module is imported. Pass an explicit `fetch` so the client uses the right one.
+- **Custom behavior** — auth headers, retries, or routing requests to an in-process handler instead of over HTTP.
+
+```ts
+// Test: wire the client directly to the handler, no TCP socket
+const handler = managementHandler(corsair);
+const client = createCorsairClient({
+  baseURL: "http://test.local/api/corsair",
+  fetch: (input, init) => handler(new Request(String(input), init)),
+});
+```
+
+If you create the client at module scope and later replace `globalThis.fetch`, the client will not pick up the change. Create the client after your environment is ready, or pass `fetch` explicitly.

--- a/docs/management/connect.mdx
+++ b/docs/management/connect.mdx
@@ -1,0 +1,131 @@
+---
+title: Connect / OAuth
+description: How users connect their own Slack, GitHub, Notion, etc. accounts to a tenant — signed connect links, OAuth redirect, callback.
+---
+
+When a user clicks "Connect GitHub" in your dashboard, three things happen:
+
+1. Your backend asks Corsair for a **signed connect link**.
+2. The user is redirected to the provider's OAuth screen.
+3. The provider redirects back, and your backend **exchanges the code** for tokens, which Corsair encrypts and stores.
+
+The management API exposes three routes for this. The vanilla and React clients wrap them.
+
+## Server setup
+
+Connect routes require `connect` config on your Corsair instance — without it the routes return `connect_not_configured` (500):
+
+```ts server.ts
+export const corsair = createCorsair({
+  plugins: [github(), slack()],
+  database,
+  kek,
+  connect: {
+    baseUrl: "https://app.example.com/connect", // where users land after clicking the link
+    redirectUri: "https://app.example.com/api/oauth/callback",
+  },
+});
+```
+
+## The three routes
+
+| Method | Path                                | Purpose                                          |
+| ------ | ----------------------------------- | ------------------------------------------------ |
+| POST   | `/connect/links`                    | Create a signed connect link                     |
+| GET    | `/connect/resolve?state=…`          | Verify the signed state, return the OAuth URL    |
+| POST   | `/connect/oauth/callback`           | Exchange the OAuth code for tokens               |
+
+The signed `state` is an HMAC over `{ plugin, tenantId, iat }` using the KEK. The `iat` gives the link an expiry, so a leaked link goes stale quickly.
+
+## Step 1 — Create the connect link
+
+```ts backend.ts
+const { connectUrl, state } = await client.connect.createLink({
+  plugin: "github",
+  tenantId: "acme", // optional — omit for single-tenant deployments
+});
+// redirect the user's browser to connectUrl
+```
+
+`connectUrl` already points at your `/connect/resolve` route. You don't have to build it.
+
+In React:
+
+```tsx connect-button.tsx
+function ConnectGithub({ tenantId }: { tenantId: string }) {
+  const { mutate, loading } = useCreateConnectLink();
+
+  return (
+    <button
+      disabled={loading}
+      onClick={async () => {
+        const link = await mutate({ plugin: "github", tenantId });
+        if (link) window.location.href = link.connectUrl;
+      }}
+    >
+      Connect GitHub
+    </button>
+  );
+}
+```
+
+## Step 2 — Resolve
+
+The browser hits `/connect/resolve?state=…`. The handler:
+
+- verifies the HMAC,
+- checks the `iat` against the link TTL,
+- looks up the plugin's OAuth config (client ID, scopes, redirect URI),
+- responds with the provider authorize URL plus the original `plugin`, `tenantId`, and `providerName`.
+
+You normally don't call this manually — `connectUrl` from step 1 already targets it. The route exists as its own step so a frontend can `fetch` the resolved URL instead of doing a full redirect, if that fits your UX better.
+
+## Step 3 — OAuth callback
+
+The provider redirects back to your app with `?code=…&state=…`. Your callback route forwards both to Corsair:
+
+```ts app/api/oauth/callback/route.ts
+import { corsair } from "@/server";
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const code = url.searchParams.get("code")!;
+  const state = url.searchParams.get("state")!;
+
+  await corsair.manage.connect.oauthCallback({ code, state });
+
+  return Response.redirect("/dashboard?connected=1");
+}
+```
+
+Or, from a frontend with the client:
+
+```ts
+await client.connect.oauthCallback({ code, state });
+```
+
+Corsair re-verifies the `state`, exchanges the `code` with the provider, encrypts the resulting tokens with the tenant DEK, and stores them. From this point on, `corsair.withTenant(tenantId).github.api.*` works against the connected account.
+
+## Checking connection status
+
+After a successful callback, `useConnectionStatus({ tenantId })` reflects the new state:
+
+```tsx status.tsx
+const { data, refetch } = useConnectionStatus({ tenantId: "acme" });
+// data: { github: 'connected', slack: 'not_connected', ... }
+```
+
+Call `refetch()` after the callback resolves to update the dashboard without a full reload.
+
+## Errors
+
+| Status | `error`                  | When                                                          |
+| ------ | ------------------------ | ------------------------------------------------------------- |
+| 500    | `connect_not_configured` | `connect` config wasn't passed to `createCorsair`             |
+| 500    | `database_not_configured`| `database` and `kek` are required to issue connect links      |
+| 500    | `connect_misconfigured`  | `connect.baseUrl` isn't a valid full URL                      |
+| 400    | `missing_credentials`    | Plugin OAuth client id / secret aren't configured             |
+| 500    | `resolve_failed`         | State invalid or expired                                      |
+| 502    | `oauth_callback_failed`  | Provider rejected the code — usually means it was already used |
+
+All come back as `CorsairClientError` with these `code` values, so you can branch on them in your UI.

--- a/docs/management/handler.mdx
+++ b/docs/management/handler.mdx
@@ -14,7 +14,7 @@ const handler = managementHandler(corsair, { basePath: "/api/corsair" });
 
 ## Routes
 
-The handler dispatches 9 read/write routes plus 3 connect routes (see [Connect / OAuth](/management/connect)).
+The handler dispatches 9 read/write routes. Connect/OAuth is covered separately on the [Connect page](/management/connect).
 
 | Method | Path                                | Purpose                                       |
 | ------ | ----------------------------------- | --------------------------------------------- |
@@ -39,7 +39,7 @@ managementHandler(corsair, {
 });
 ```
 
-`basePath` defaults to `""`. Set it to whatever prefix your framework mounts the handler under. The handler strips it before matching routes, so `/api/corsair/tenants` → `/tenants`.
+`basePath` defaults to `"/api/corsair"`. Set it to whatever prefix your framework mounts the handler under. The handler strips it before matching routes, so `/api/corsair/tenants` → `/tenants`.
 
 `onError` lets you log or rewrite errors. Return a `Response` to take over, or `undefined` to fall through to the default JSON error.
 
@@ -94,7 +94,7 @@ Sometimes you don't want HTTP — you want to call the same operations directly 
 await corsair.manage.tenants.list();
 await corsair.manage.tenants.create({ id: "acme" });
 await corsair.manage.plugins.get("github");
-await corsair.manage.connectionStatus.get("acme");
+await corsair.manage.connectionStatus.get({ tenantId: "acme" });
 ```
 
 Every route on the HTTP handler has a matching `manage.*` method with the same shape.
@@ -110,7 +110,7 @@ Errors come back as JSON in this flat shape:
 }
 ```
 
-The TypeScript class is `ManagementApiError` (exported from `corsair`). Common codes you'll see from the management routes:
+In-process `corsair.manage.*` calls throw errors with `status`, `code`, `message`, and `extra` fields — the same shape HTTP clients surface as [`CorsairClientError`](/management/client#error-handling). Common codes you'll see from the management routes:
 
 | Status | `error`                 | When                                              |
 | ------ | ----------------------- | ------------------------------------------------- |

--- a/docs/management/handler.mdx
+++ b/docs/management/handler.mdx
@@ -1,0 +1,120 @@
+---
+title: Handler
+description: managementHandler() turns a Corsair instance into a framework-agnostic fetch handler exposing the management routes.
+---
+
+`managementHandler(corsair, opts)` returns a single function: `(req: Request) => Promise<Response>`. Mount it anywhere that speaks the Fetch API. For Next.js, Express, and Hono there are one-line adapters.
+
+```ts
+import { managementHandler } from "corsair";
+
+const handler = managementHandler(corsair, { basePath: "/api/corsair" });
+// handler: (req: Request) => Promise<Response>
+```
+
+## Routes
+
+The handler dispatches 9 read/write routes plus 3 connect routes (see [Connect / OAuth](/management/connect)).
+
+| Method | Path                                | Purpose                                       |
+| ------ | ----------------------------------- | --------------------------------------------- |
+| GET    | `/ok`                               | Health check → `{ ok: true }`                 |
+| GET    | `/tenants`                          | List tenants                                  |
+| POST   | `/tenants`                          | Create a tenant                               |
+| GET    | `/tenants/:id`                      | Get one tenant                                |
+| GET    | `/plugins`                          | List plugins + whether each is configured     |
+| GET    | `/plugins/:id`                      | Get one plugin                                |
+| GET    | `/connection-status`                | Per-plugin OAuth status for a tenant          |
+| GET    | `/permissions/:id`                  | Get a permission record                       |
+| POST   | `/permissions/lookup-by-token`      | Resolve a permission by email-link token      |
+
+All routes return JSON. Errors return `{ error, message, …extra }` with a non-2xx status — see [Errors](#errors).
+
+## Options
+
+```ts
+managementHandler(corsair, {
+  basePath: "/api/corsair", // optional — stripped before route matching
+  onError: (err, req) => undefined, // optional — return a Response to override, or undefined to fall through
+});
+```
+
+`basePath` defaults to `""`. Set it to whatever prefix your framework mounts the handler under. The handler strips it before matching routes, so `/api/corsair/tenants` → `/tenants`.
+
+`onError` lets you log or rewrite errors. Return a `Response` to take over, or `undefined` to fall through to the default JSON error.
+
+## Framework adapters
+
+Each adapter is a thin wrapper around `managementHandler`. All three are exported from the `corsair` root.
+
+### Next.js
+
+```ts app/api/corsair/[...path]/route.ts
+import { toNextJsHandler } from "corsair";
+import { corsair } from "@/server";
+
+export const { GET, POST } = toNextJsHandler(corsair, {
+  basePath: "/api/corsair",
+});
+```
+
+Works in App Router. Both `GET` and `POST` exports point at the same handler.
+
+### Express
+
+```ts server.ts
+import express from "express";
+import { toExpressHandler } from "corsair";
+import { corsair } from "./corsair";
+
+const app = express();
+app.all("/api/corsair/*", toExpressHandler(corsair, { basePath: "/api/corsair" }));
+```
+
+The adapter bridges Express's `(req, res)` to a Fetch `Request` and back.
+
+### Hono
+
+```ts server.ts
+import { Hono } from "hono";
+import { toHonoHandler } from "corsair";
+import { corsair } from "./corsair";
+
+const app = new Hono();
+app.all("/api/corsair/*", toHonoHandler(corsair, { basePath: "/api/corsair" }));
+```
+
+The Hono context is mapped to the underlying `Request`/`Response`.
+
+## In-process API
+
+Sometimes you don't want HTTP — you want to call the same operations directly from server code (e.g. inside a server action, a job, or a CLI). The handler is built on top of `corsair.manage.*`, available without going through the handler:
+
+```ts in-process.ts
+await corsair.manage.tenants.list();
+await corsair.manage.tenants.create({ id: "acme" });
+await corsair.manage.plugins.get("github");
+await corsair.manage.connectionStatus.get("acme");
+```
+
+Every route on the HTTP handler has a matching `manage.*` method with the same shape.
+
+## Errors
+
+Errors come back as JSON in this flat shape:
+
+```json
+{
+  "error": "not_found",
+  "message": "No tenant with id acme"
+}
+```
+
+The TypeScript class is `ManagementApiError` (exported from `corsair`). Common codes you'll see from the management routes:
+
+| Status | `error`                 | When                                              |
+| ------ | ----------------------- | ------------------------------------------------- |
+| 400    | `bad_request`           | Missing or invalid request body / params          |
+| 404    | `not_found`             | Tenant / plugin / permission lookup misses        |
+
+Connect-route codes are documented on the [Connect page](/management/connect#errors).

--- a/docs/management/overview.mdx
+++ b/docs/management/overview.mdx
@@ -1,0 +1,104 @@
+---
+title: Overview
+description: Mount Corsair's management API in your own app — the same routes app.corsair.dev uses, available to self-hosted dashboards.
+---
+
+Corsair has two surfaces:
+
+- **Runtime** — `createCorsair()`. Agents call Slack, GitHub, and the rest through this.
+- **Management API** — the routes behind a dashboard: list tenants, connect OAuth accounts, check plugin status, look up permissions.
+
+If you self-host Corsair and want your own dashboard, the management API is what you mount. The shape mirrors [better-auth](https://better-auth.com):
+
+```ts mental-model.ts
+managementHandler(corsair)              // server instance → fetch handler
+toNextJsHandler(corsair)                // framework adapter
+createCorsairClient({ baseURL })        // typed vanilla client
+createCorsairReactClient({ baseURL })   // typed React hooks
+```
+
+All of these (except the React hooks) are exported from the `corsair` package root.
+
+## When to reach for it
+
+- You are building a dashboard, an internal tool, or any UI that needs to see Corsair state from outside the agent runtime.
+- You want a typed HTTP boundary between a frontend and your Corsair server instead of calling `corsair.*` directly.
+
+If you only run agents server-side, you don't need this — keep using `corsair.slack.api.*` and friends.
+
+## The pieces
+
+<CardGroup cols={2}>
+  <Card title="Handler" href="/management/handler">
+    Mount the 9 management routes on any HTTP framework. Ships with Next.js, Express, and Hono adapters.
+  </Card>
+  <Card title="Vanilla client" href="/management/client">
+    `createCorsairClient` — typed fetch wrapper. Works in any JS runtime.
+  </Card>
+  <Card title="React hooks" href="/management/react">
+    `createCorsairReactClient` — typed `useTenants`, `useConnectionStatus`, etc.
+  </Card>
+  <Card title="Connect / OAuth" href="/management/connect">
+    Signed connect links + OAuth callback. Lets users connect their own Slack, GitHub, etc.
+  </Card>
+</CardGroup>
+
+## End-to-end flow
+
+```ts server.ts
+// 1. Your existing Corsair instance
+import { createCorsair } from "corsair";
+import { github, slack } from "corsair/plugins";
+
+export const corsair = createCorsair({
+  plugins: [github(), slack()],
+  database,
+  kek,
+});
+```
+
+```ts app/api/corsair/[...path]/route.ts
+// 2. Mount the management API on your framework
+import { toNextJsHandler } from "corsair";
+import { corsair } from "@/server";
+
+export const { GET, POST } = toNextJsHandler(corsair, {
+  basePath: "/api/corsair",
+});
+```
+
+```tsx app/dashboard/page.tsx
+// 3. Use the typed React hooks in your dashboard
+"use client";
+import { createCorsairReactClient } from "corsair/client/react";
+
+const { useTenants } = createCorsairReactClient({
+  baseURL: "/api/corsair",
+});
+
+export function Dashboard() {
+  const { data: tenants, loading } = useTenants();
+  if (loading) return <p>Loading…</p>;
+  return <ul>{tenants?.map(t => <li key={t.id}>{t.id}</li>)}</ul>;
+}
+```
+
+That is the whole picture. The next pages cover each layer in detail.
+
+## Auth
+
+The management API has **no auth opinion**. Wire your own — NextAuth, Clerk, an API key check, whatever already protects the rest of your dashboard. Put it in front of the handler:
+
+```ts
+import { managementHandler } from "corsair";
+
+const corsairHandler = managementHandler(corsair);
+
+export async function GET(req: Request) {
+  const session = await getSession(req);
+  if (!session) return new Response("Unauthorized", { status: 401 });
+  return corsairHandler(req);
+}
+```
+
+Corsair will not block you, prompt you, or guess. That is intentional.

--- a/docs/management/react.mdx
+++ b/docs/management/react.mdx
@@ -1,0 +1,114 @@
+---
+title: React Hooks
+description: createCorsairReactClient returns typed React hooks over the management API — useTenants, useConnectionStatus, useOAuthCallback, and friends.
+---
+
+`createCorsairReactClient({ baseURL })` returns a bag of typed React hooks built on top of [`createCorsairClient`](/management/client). One factory call per app — use the returned hooks anywhere in your component tree.
+
+```tsx corsair-client.ts
+"use client";
+import { createCorsairReactClient } from "corsair/client/react";
+
+export const {
+  useTenants, useTenant, useCreateTenant,
+  usePlugins, usePlugin,
+  useConnectionStatus,
+  usePermission, usePermissionByToken,
+  useCreateConnectLink, useOAuthCallback,
+  client, // escape hatch — the underlying vanilla client
+} = createCorsairReactClient({ baseURL: "/api/corsair" });
+```
+
+React 18+ is a peer dependency. If you aren't on React, use the [vanilla client](/management/client).
+
+## Read hooks
+
+Read hooks follow the same shape:
+
+```tsx tenants-list.tsx
+const { data, loading, error, refetch } = useTenants();
+```
+
+| Field      | Type                          | Notes                                   |
+| ---------- | ----------------------------- | --------------------------------------- |
+| `data`     | the typed response, or `null` | populated on success                    |
+| `loading`  | `boolean`                     | `true` while a request is in flight     |
+| `error`    | `Error \| null`               | typed error if the call failed          |
+| `refetch`  | `() => Promise<void>`         | manual re-trigger                       |
+
+Read hooks re-fetch automatically when their argument changes:
+
+```tsx tenant-detail.tsx
+function TenantDetail({ id }: { id: string }) {
+  const { data, loading } = useTenant(id);
+  // changing `id` triggers a fresh fetch automatically
+  if (loading) return <Spinner />;
+  return <pre>{JSON.stringify(data, null, 2)}</pre>;
+}
+```
+
+Available read hooks: `useTenants`, `useTenant(id)`, `usePlugins`, `usePlugin(id)`, `useConnectionStatus({ tenantId })`, `usePermission(id)`, `usePermissionByToken(token)`.
+
+## Mutation hooks
+
+Mutations stay idle until you call `mutate(input)`:
+
+```tsx create-tenant.tsx
+function CreateTenant() {
+  const { mutate, loading, error, data } = useCreateTenant();
+
+  return (
+    <form onSubmit={async (e) => {
+      e.preventDefault();
+      const id = new FormData(e.currentTarget).get("id") as string;
+      await mutate({ id });
+    }}>
+      <input name="id" />
+      <button disabled={loading}>Create</button>
+      {error && <p>{error.message}</p>}
+      {data && <p>Created {data.id}</p>}
+    </form>
+  );
+}
+```
+
+Available mutation hooks: `useCreateTenant`, `useCreateConnectLink`, `useOAuthCallback`.
+
+## Connection status
+
+`useConnectionStatus` is the hook your dashboard probably opens with. The response is a `Record<string, 'connected' | 'missing_credentials' | 'not_connected'>` keyed by plugin id:
+
+```tsx connections.tsx
+function Connections({ tenantId }: { tenantId: string }) {
+  const { data } = useConnectionStatus({ tenantId });
+  if (!data) return null;
+  return (
+    <ul>
+      {Object.entries(data).map(([plugin, status]) => (
+        <li key={plugin}>
+          {plugin}: {status === "connected" ? "✓" : "Connect →"}
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+For wiring the actual connect-and-authorize flow, see the [Connect page](/management/connect).
+
+## Escape hatch
+
+If a hook doesn't fit (e.g. you need imperative access inside an event handler), reach for `client`:
+
+```tsx escape.tsx
+const handleClick = async () => {
+  const tenant = await client.tenants.create({ id: "acme" });
+  console.log(tenant);
+};
+```
+
+It is exactly the [vanilla client](/management/client), sharing the same `baseURL`.
+
+## What this is not
+
+These hooks are intentionally minimal: no cache, no deduplication, no request reuse. If you want React Query, SWR, or RTK semantics, build them on top of `client` — the hooks here exist to give you typed loading/error/data state without forcing a data-layer choice.


### PR DESCRIPTION
Closes the docs gap for #241. Five new pages document the self-hosted control-plane API added across #249 (handler + vanilla client), #250 (connect / OAuth), and #263 (React hooks).

## Summary
- New \"Management API\" group under the SDK tab in \`docs.json\`.
- \`management/overview\` — mental model (better-auth analogue), end-to-end flow, auth-is-yours note.
- \`management/handler\` — \`managementHandler\` + Next.js / Express / Hono adapters, route table, in-process \`corsair.manage.*\` API, error shape.
- \`management/client\` — \`createCorsairClient\` options, every method, \`fetch\` override pattern for auth headers, \`CorsairClientError\`.
- \`management/react\` — \`createCorsairReactClient\` read/mutation hook shapes, \`useConnectionStatus\` usage, escape hatch to the vanilla client.
- \`management/connect\` — server-side \`connect\` config requirement, the three routes, end-to-end React + Next.js example, full error-code table.

## Notes
- All imports verified against \`packages/corsair/package.json\` exports and \`packages/corsair/index.ts\` — everything except React hooks lives on the \`corsair\` root.
- Error codes and response shapes verified against \`core/management/errors.ts\` and \`core/management/operations.ts\`.

## Test plan
- [x] Imports, route paths, types, and error codes cross-checked against the source on \`feat/management-client-react\`
- [x] Sidebar entry added to \`docs.json\` under the SDK tab
- [x] Internal links between the 5 pages resolve