### PR TITLE
ci: enforce plugin validation and standardize jest testing across monorepo

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Validate Plugins
+        run: pnpm run validate:plugins
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,11 @@ Useful commands from the repo root:
 ```bash
 pnpm typecheck
 pnpm lint
+pnpm lint:fix
+pnpm format
+pnpm run validate:plugins
 pnpm build
+pnpm test
 ```
 
 If your change needs credentials or local environment setup, follow the package-specific docs or examples in the repo before running tests.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "generate:labeler-config": "node scripts/generate-labeler-config.mjs",
     "generate:docs": "tsx scripts/generate-plugin-docs.ts",
     "generate:docs:all": "tsx scripts/generate-plugin-docs.ts --all",
-    "build:explorer-catalog": "tsx scripts/build-explorer-catalog.ts"
+    "build:explorer-catalog": "tsx scripts/build-explorer-catalog.ts",
+    "validate:plugins": "tsx scripts/validate-plugins.ts"
   },
   "pnpm": {
     "overrides": {

--- a/packages/airtable/package.json
+++ b/packages/airtable/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/amplitude/package.json
+++ b/packages/amplitude/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/asana/package.json
+++ b/packages/asana/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/bitwarden/package.json
+++ b/packages/bitwarden/package.json
@@ -15,7 +15,8 @@
   },
   "scripts": {
     "build": "rm -rf dist && tsc --build --force && tsup",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
   },
   "peerDependencies": {
     "corsair": ">=0.1.0",
@@ -25,7 +26,9 @@
     "corsair": "workspace:*",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.14"
   },
   "keywords": [
     "corsair",

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/cal/package.json
+++ b/packages/cal/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/calendly/package.json
+++ b/packages/calendly/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/discord/package.json
+++ b/packages/discord/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/dodopayments/package.json
+++ b/packages/dodopayments/package.json
@@ -15,7 +15,8 @@
   },
   "scripts": {
     "build": "rm -rf dist && tsc --build --force && tsup",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
   },
   "peerDependencies": {
     "corsair": ">=0.1.0",
@@ -25,7 +26,9 @@
     "corsair": "workspace:*",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.14"
   },
   "keywords": [
     "corsair",

--- a/packages/dropbox/package.json
+++ b/packages/dropbox/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/exa/package.json
+++ b/packages/exa/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/figma/package.json
+++ b/packages/figma/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/firecrawl/package.json
+++ b/packages/firecrawl/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/fireflies/package.json
+++ b/packages/fireflies/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -32,7 +32,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -43,8 +44,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/gitlab/package.json
+++ b/packages/gitlab/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/gmail/package.json
+++ b/packages/gmail/package.json
@@ -32,7 +32,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -43,8 +44,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/googlecalendar/package.json
+++ b/packages/googlecalendar/package.json
@@ -32,7 +32,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -43,8 +44,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/googledrive/package.json
+++ b/packages/googledrive/package.json
@@ -32,7 +32,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -43,8 +44,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/googlesheets/package.json
+++ b/packages/googlesheets/package.json
@@ -32,7 +32,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -43,8 +44,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/grafana/package.json
+++ b/packages/grafana/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/hackernews/package.json
+++ b/packages/hackernews/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/hubspot/package.json
+++ b/packages/hubspot/package.json
@@ -32,7 +32,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -43,8 +44,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/jira/package.json
+++ b/packages/jira/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/linear/package.json
+++ b/packages/linear/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/monday/package.json
+++ b/packages/monday/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/notion/package.json
+++ b/packages/notion/package.json
@@ -29,7 +29,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -40,8 +41,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/onedrive/package.json
+++ b/packages/onedrive/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/openweathermap/package.json
+++ b/packages/openweathermap/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/oura/package.json
+++ b/packages/oura/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/outlook/package.json
+++ b/packages/outlook/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/pagerduty/package.json
+++ b/packages/pagerduty/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/posthog/package.json
+++ b/packages/posthog/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -41,7 +42,6 @@
     "dist"
   ],
   "dependencies": {
-    "jest": "^29.7.0",
     "uuid": "^13.0.0"
   }
 }

--- a/packages/resend/package.json
+++ b/packages/resend/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/sharepoint/package.json
+++ b/packages/sharepoint/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/spotify/package.json
+++ b/packages/spotify/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/tally/package.json
+++ b/packages/tally/package.json
@@ -22,16 +22,14 @@
     "corsair": ">=0.1.0",
     "zod": "^4.1.13"
   },
-  "dependencies": {
-    "jest": "^29.7.0"
-  },
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "corsair": "workspace:*",
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",

--- a/packages/teams/package.json
+++ b/packages/teams/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -40,8 +41,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/todoist/package.json
+++ b/packages/todoist/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/trello/package.json
+++ b/packages/trello/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/twitter/package.json
+++ b/packages/twitter/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/twitterapiio/package.json
+++ b/packages/twitterapiio/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/typeform/package.json
+++ b/packages/typeform/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/vapi/package.json
+++ b/packages/vapi/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/xquik/package.json
+++ b/packages/xquik/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/youtube/package.json
+++ b/packages/youtube/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/zendesk/package.json
+++ b/packages/zendesk/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/zohomail/package.json
+++ b/packages/zohomail/package.json
@@ -32,7 +32,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -45,8 +46,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/packages/zoom/package.json
+++ b/packages/zoom/package.json
@@ -28,7 +28,8 @@
     "ts-jest": "^29.4.9",
     "tsup": "^8.0.1",
     "typescript": "catalog:",
-    "zod": "^4.1.13"
+    "zod": "^4.1.13",
+    "jest": "^29.7.0"
   },
   "keywords": [
     "corsair",
@@ -39,8 +40,5 @@
   "license": "Apache-2.0",
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "jest": "^29.7.0"
-  }
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,10 +257,6 @@ importers:
         version: 5.9.3
 
   packages/airtable:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -268,6 +264,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -282,10 +281,6 @@ importers:
         version: 4.1.13
 
   packages/amplitude:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -293,6 +288,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -328,10 +326,6 @@ importers:
         version: 5.9.3
 
   packages/asana:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -339,6 +333,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -354,9 +351,15 @@ importers:
 
   packages/bitwarden:
     devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.1)
@@ -392,10 +395,6 @@ importers:
         version: 4.1.13
 
   packages/box:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -403,6 +402,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -417,10 +419,6 @@ importers:
         version: 4.1.13
 
   packages/cal:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -428,6 +426,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -442,10 +443,6 @@ importers:
         version: 4.1.13
 
   packages/calendly:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -453,6 +450,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -634,10 +634,6 @@ importers:
         version: 4.1.13
 
   packages/discord:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -645,6 +641,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -660,9 +659,15 @@ importers:
 
   packages/dodopayments:
     devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.8.1)
@@ -674,10 +679,6 @@ importers:
         version: 4.1.13
 
   packages/dropbox:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -685,6 +686,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -699,10 +703,6 @@ importers:
         version: 4.1.13
 
   packages/exa:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -710,6 +710,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -724,10 +727,6 @@ importers:
         version: 4.1.13
 
   packages/figma:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -735,6 +734,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -749,10 +751,6 @@ importers:
         version: 4.1.13
 
   packages/firecrawl:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -760,6 +758,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -774,10 +775,6 @@ importers:
         version: 4.1.13
 
   packages/fireflies:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -785,6 +782,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -799,10 +799,6 @@ importers:
         version: 4.1.13
 
   packages/github:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -810,6 +806,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -824,10 +823,6 @@ importers:
         version: 4.1.13
 
   packages/gitlab:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -835,6 +830,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -849,10 +847,6 @@ importers:
         version: 4.1.13
 
   packages/gmail:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -860,6 +854,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -874,10 +871,6 @@ importers:
         version: 4.1.13
 
   packages/googlecalendar:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -885,6 +878,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -899,10 +895,6 @@ importers:
         version: 4.1.13
 
   packages/googledrive:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -910,6 +902,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -924,10 +919,6 @@ importers:
         version: 4.1.13
 
   packages/googlesheets:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -935,6 +926,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -949,10 +943,6 @@ importers:
         version: 4.1.13
 
   packages/grafana:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -960,6 +950,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -974,10 +967,6 @@ importers:
         version: 4.1.13
 
   packages/hackernews:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -985,6 +974,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -999,10 +991,6 @@ importers:
         version: 4.1.13
 
   packages/hubspot:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1010,6 +998,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1024,10 +1015,6 @@ importers:
         version: 4.1.13
 
   packages/intercom:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1035,6 +1022,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1049,10 +1039,6 @@ importers:
         version: 4.1.13
 
   packages/jira:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1060,6 +1046,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1074,10 +1063,6 @@ importers:
         version: 4.1.13
 
   packages/linear:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1085,6 +1070,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1145,10 +1133,6 @@ importers:
         version: 5.9.3
 
   packages/monday:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1156,6 +1140,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1170,10 +1157,6 @@ importers:
         version: 4.1.13
 
   packages/notion:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1181,6 +1164,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1195,10 +1181,6 @@ importers:
         version: 4.1.13
 
   packages/onedrive:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1206,6 +1188,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1220,10 +1205,6 @@ importers:
         version: 4.1.13
 
   packages/openweathermap:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1231,6 +1212,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1245,10 +1229,6 @@ importers:
         version: 4.1.13
 
   packages/oura:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1256,6 +1236,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1270,10 +1253,6 @@ importers:
         version: 4.1.13
 
   packages/outlook:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1281,6 +1260,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1295,10 +1277,6 @@ importers:
         version: 4.1.13
 
   packages/pagerduty:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1306,6 +1284,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1321,9 +1302,6 @@ importers:
 
   packages/posthog:
     dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
@@ -1334,6 +1312,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1396,10 +1377,6 @@ importers:
         version: 4.1.13
 
   packages/resend:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1407,6 +1384,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1421,10 +1401,6 @@ importers:
         version: 4.1.13
 
   packages/sentry:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1432,6 +1408,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1446,10 +1425,6 @@ importers:
         version: 4.1.13
 
   packages/sharepoint:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1457,6 +1432,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1471,10 +1449,6 @@ importers:
         version: 4.1.13
 
   packages/slack:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1482,6 +1456,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1496,10 +1473,6 @@ importers:
         version: 4.1.13
 
   packages/spotify:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1507,6 +1480,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1545,10 +1521,6 @@ importers:
         version: 4.1.13
 
   packages/stripe:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1556,6 +1528,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1646,10 +1621,6 @@ importers:
         version: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.20.6)(yaml@2.8.1)
 
   packages/tally:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1657,6 +1628,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1695,10 +1669,6 @@ importers:
         version: 4.1.13
 
   packages/teams:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1706,6 +1676,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1720,10 +1693,6 @@ importers:
         version: 4.1.13
 
   packages/telegram:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1731,6 +1700,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1745,10 +1717,6 @@ importers:
         version: 4.1.13
 
   packages/todoist:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1756,6 +1724,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1770,10 +1741,6 @@ importers:
         version: 4.1.13
 
   packages/trello:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1781,6 +1748,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1819,10 +1789,6 @@ importers:
         version: 4.1.13
 
   packages/twitter:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1830,6 +1796,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1844,10 +1813,6 @@ importers:
         version: 4.1.13
 
   packages/twitterapiio:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1855,6 +1820,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1869,10 +1837,6 @@ importers:
         version: 4.1.13
 
   packages/typeform:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1880,6 +1844,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1925,10 +1892,6 @@ importers:
         version: 5.9.3
 
   packages/vapi:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1936,6 +1899,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1974,10 +1940,6 @@ importers:
         version: 4.1.13
 
   packages/xquik:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1985,6 +1947,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1999,10 +1964,6 @@ importers:
         version: 4.1.13
 
   packages/youtube:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -2010,6 +1971,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -2024,10 +1988,6 @@ importers:
         version: 4.1.13
 
   packages/zendesk:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -2035,6 +1995,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -2049,10 +2012,6 @@ importers:
         version: 4.1.13
 
   packages/zohomail:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -2060,6 +2019,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -2074,10 +2036,6 @@ importers:
         version: 4.1.13
 
   packages/zoom:
-    dependencies:
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -2085,6 +2043,9 @@ importers:
       corsair:
         specifier: workspace:*
         version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
         version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)

--- a/scripts/validate-plugins.ts
+++ b/scripts/validate-plugins.ts
@@ -1,0 +1,107 @@
+import fs from 'fs';
+import path from 'path';
+
+const PACKAGES_DIR = path.join(process.cwd(), 'packages');
+const IGNORED_PACKAGES = ['corsair', 'cli', 'mcp', 'studio', 'ui', 'app'];
+
+const plugins = fs
+	.readdirSync(PACKAGES_DIR, { withFileTypes: true })
+	.filter(
+		(dirent) => dirent.isDirectory() && !IGNORED_PACKAGES.includes(dirent.name),
+	)
+	.map((dirent) => dirent.name);
+
+let hasErrors = false;
+
+function logError(plugin: string, message: string) {
+	console.error(`[ERROR] [${plugin}] ${message}`);
+	hasErrors = true;
+}
+
+for (const plugin of plugins) {
+	const pluginPath = path.join(PACKAGES_DIR, plugin);
+
+	// 1. Check package.json
+	const packageJsonPath = path.join(pluginPath, 'package.json');
+	if (!fs.existsSync(packageJsonPath)) {
+		logError(plugin, 'Missing package.json');
+		continue;
+	}
+
+	// Using `any` because package.json has no guaranteed schema and we intentionally
+	// perform duck-typing checks on arbitrary fields below.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let pkg: any;
+	try {
+		pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+	} catch (e) {
+		logError(plugin, 'Invalid package.json JSON');
+		continue;
+	}
+
+	// 2. Validate package.json contents
+	if (!pkg.name?.startsWith('@corsair-dev/')) {
+		logError(plugin, 'Package name must start with @corsair-dev/');
+	}
+
+	if (!pkg.scripts?.test?.startsWith('jest')) {
+		logError(plugin, 'Must have a "test" script using jest in package.json');
+	}
+
+	if (!pkg.devDependencies?.jest) {
+		logError(plugin, 'Must have "jest" in devDependencies');
+	}
+
+	if (!pkg.devDependencies?.['@types/jest']) {
+		logError(plugin, 'Must have "@types/jest" in devDependencies');
+	}
+
+	// 3. Check for index.ts
+	if (!fs.existsSync(path.join(pluginPath, 'index.ts'))) {
+		logError(plugin, 'Missing index.ts');
+	}
+
+	// 4. Check for endpoints directory or endpoints.ts file
+	const hasEndpointsDir =
+		fs.existsSync(path.join(pluginPath, 'endpoints')) &&
+		fs.statSync(path.join(pluginPath, 'endpoints')).isDirectory();
+	const hasEndpointsFile = fs.existsSync(path.join(pluginPath, 'endpoints.ts'));
+
+	if (!hasEndpointsDir && !hasEndpointsFile) {
+		logError(plugin, 'Missing endpoints/ directory or endpoints.ts file');
+	}
+
+	// 5. Check for test files (must have api.test.ts, integration.test.ts, or be inside a tests/ dir)
+	const files = fs.readdirSync(pluginPath);
+	const hasTestFile = files.some((f) => f.endsWith('.test.ts'));
+	const hasTestsDir = fs.existsSync(path.join(pluginPath, 'tests'));
+
+	const PLUGINS_WITHOUT_TESTS_YET = ['bitwarden', 'dodopayments'];
+	if (
+		!hasTestFile &&
+		!hasTestsDir &&
+		!PLUGINS_WITHOUT_TESTS_YET.includes(plugin)
+	) {
+		logError(
+			plugin,
+			'Must have at least one test file (*.test.ts) or a tests/ directory',
+		);
+	}
+
+	// Ensure no forbidden manual test scripts
+	if (pkg.scripts?.['test:manual']) {
+		logError(
+			plugin,
+			'test:manual script is forbidden. All tests should be automated and run via the standard "test" script.',
+		);
+	}
+}
+
+if (hasErrors) {
+	console.error(
+		'\n[FAILED] Plugin validation failed. Please fix the errors above.',
+	);
+	process.exit(1);
+} else {
+	console.log('\n[SUCCESS] All plugins passed structural validation!');
+}

--- a/www/src/app/oss/oss-bar-auth.tsx
+++ b/www/src/app/oss/oss-bar-auth.tsx
@@ -23,8 +23,7 @@ export function OssBarAuth({
 	githubAvatarUrl: string | null;
 }) {
 	const pathname = usePathname();
-	const hideSignIn =
-		!session?.user && pathname.startsWith('/oss/waitlist');
+	const hideSignIn = !session?.user && pathname.startsWith('/oss/waitlist');
 
 	if (session?.user) {
 		return (

--- a/www/src/app/oss/waitlist/waitlist-profile-form.tsx
+++ b/www/src/app/oss/waitlist/waitlist-profile-form.tsx
@@ -112,9 +112,7 @@ export function WaitlistProfileForm({
 			setHasJoined(true);
 			router.refresh();
 		} catch (err) {
-			setError(
-				err instanceof Error ? err.message : 'Failed to join waitlist',
-			);
+			setError(err instanceof Error ? err.message : 'Failed to join waitlist');
 		} finally {
 			setSubmitLoading(false);
 		}
@@ -132,8 +130,8 @@ export function WaitlistProfileForm({
 					</h2>
 					<p className="mx-auto mt-3 max-w-md text-[14px] leading-[1.65] text-[#1c1c1c99]">
 						We&apos;ll email you at{' '}
-						<span className="font-medium text-[#1c1c1c]">{email}</span> when
-						the OSS hackathon opens.
+						<span className="font-medium text-[#1c1c1c]">{email}</span> when the
+						OSS hackathon opens.
 					</p>
 					<dl className="mx-auto mt-6 max-w-sm space-y-3 border-t border-[#1c1c1c1a] pt-6 text-left">
 						<div className="flex items-center justify-between gap-4 text-[13px]">
@@ -162,8 +160,8 @@ export function WaitlistProfileForm({
 				</h2>
 				<p className="mt-2 text-[13px] leading-[1.65] text-[#1c1c1c99]">
 					Signed in as{' '}
-					<span className="font-medium text-[#1c1c1c]">{email}</span>. Add
-					your GitHub handle, join Discord, then enter your Discord username.
+					<span className="font-medium text-[#1c1c1c]">{email}</span>. Add your
+					GitHub handle, join Discord, then enter your Discord username.
 				</p>
 
 				<div className="mt-6 space-y-5">


### PR DESCRIPTION
## 📝 Description

Add a plugin validation script and standardize jest as the test runner across all plugins.

**Changes:**
- **`scripts/validate-plugins.ts`**: Validation script that checks all plugin packages — ensures `@corsair-dev/` naming, `endpoints` structure, `jest` test script, and proper devDependencies.
- **CI Integration**: Added `validate:plugins` script to root `package.json` and a "Validate Plugins" step in `.github/workflows/pr-checks.yml`.
- **Standardized `jest`**: Added `"jest": "^29.7.0"` and `"@types/jest": "^29.5.14"` to `devDependencies` for all 55 plugins. Fixed plugins where `jest` was incorrectly in `dependencies` instead of `devDependencies`.
- **Docs**: Updated `CONTRIBUTING.md` with `pnpm lint:fix`, `pnpm run validate:plugins`, and `pnpm test` commands.

## ✅ Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## 📸 Screenshots / Demos (if applicable)

N/A — CI/CD and infrastructure changes only.

## 🛠️ Additional Notes

- New plugins must include a `test` script using `jest` and have `jest` + `@types/jest` in `devDependencies`. The CI pipeline will catch any structurally incomplete plugins automatically.
