### PR TITLE
fix(googlecalendar): add missing fields to EventSchema

### DIFF
--- a/packages/googlecalendar/endpoints/types.ts
+++ b/packages/googlecalendar/endpoints/types.ts
@@ -257,6 +257,26 @@ const EventSchema = z.object({
 	guestsCanSeeOtherGuests: z.boolean().optional(),
 	privateCopy: z.boolean().optional(),
 	locked: z.boolean().optional(),
+	conferenceData: z.any().optional(),
+	attachments: z.array(z.any()).optional(),
+	source: z
+		.object({
+			url: z.string().optional(),
+			title: z.string().optional(),
+		})
+		.optional(),
+	gadget: z
+		.object({
+			type: z.string().optional(),
+			title: z.string().optional(),
+			link: z.string().optional(),
+			iconLink: z.string().optional(),
+			width: z.number().optional(),
+			height: z.number().optional(),
+			display: z.string().optional(),
+			preferences: z.record(z.string(), z.string()).optional(),
+		})
+		.optional(),
 	eventType: z
 		.enum([
 			'default',

--- a/packages/googlecalendar/endpoints/types.ts
+++ b/packages/googlecalendar/endpoints/types.ts
@@ -62,6 +62,48 @@ const EventRemindersSchema = z.object({
 });
 
 // Writable event fields used for create / update requests
+const AttachmentSchema = z.object({
+	fileUrl: z.string().optional(),
+	title: z.string().optional(),
+	mimeType: z.string().optional(),
+	iconLink: z.string().optional(),
+	fileId: z.string().optional(),
+});
+
+const ConferenceDataSchema = z.object({
+	createRequest: z
+		.object({
+			requestId: z.string().optional(),
+			conferenceSolutionKey: z.object({ type: z.string().optional() }).optional(),
+			status: z.object({ statusCode: z.string().optional() }).optional(),
+		})
+		.optional(),
+	entryPoints: z
+		.array(
+			z.object({
+				entryPointType: z.string().optional(),
+				uri: z.string().optional(),
+				label: z.string().optional(),
+				pin: z.string().optional(),
+				accessCode: z.string().optional(),
+				meetingCode: z.string().optional(),
+				passcode: z.string().optional(),
+				password: z.string().optional(),
+			}),
+		)
+		.optional(),
+	conferenceSolution: z
+		.object({
+			key: z.object({ type: z.string().optional() }).optional(),
+			name: z.string().optional(),
+			iconUri: z.string().optional(),
+		})
+		.optional(),
+	conferenceId: z.string().optional(),
+	signature: z.string().optional(),
+	notes: z.string().optional(),
+});
+
 const EventInputSchema = z.object({
 	summary: z.string().optional().describe('Title of the event'),
 	description: z
@@ -257,8 +299,8 @@ const EventSchema = z.object({
 	guestsCanSeeOtherGuests: z.boolean().optional(),
 	privateCopy: z.boolean().optional(),
 	locked: z.boolean().optional(),
-	conferenceData: z.any().optional(),
-	attachments: z.array(z.any()).optional(),
+	conferenceData: ConferenceDataSchema.optional(),
+	attachments: z.array(AttachmentSchema).optional(),
 	source: z
 		.object({
 			url: z.string().optional(),

--- a/packages/googlecalendar/endpoints/types.ts
+++ b/packages/googlecalendar/endpoints/types.ts
@@ -74,7 +74,9 @@ const ConferenceDataSchema = z.object({
 	createRequest: z
 		.object({
 			requestId: z.string().optional(),
-			conferenceSolutionKey: z.object({ type: z.string().optional() }).optional(),
+			conferenceSolutionKey: z
+				.object({ type: z.string().optional() })
+				.optional(),
 			status: z.object({ statusCode: z.string().optional() }).optional(),
 		})
 		.optional(),

--- a/packages/googlecalendar/package.json
+++ b/packages/googlecalendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/googlecalendar",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Google calendar plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION

## 📝 Description
conferenceData, attachments, source, and gadget are defined in the TS Event type but were missing from the Zod EventSchema. Since Zod strips unknown fields by default, these were silently dropped from Google Calendar API responses so things like Google Meet links and attachments were never making it through.

Builds on top of da62635 which fixed the eventType enum for birthdays.

## ✅ Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [ ] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## 📸 Screenshots / Demos (if applicable)
N/A
## 🛠️ Additional Notes

No breaking changes. Just additive fields to the output schema to match what's already in the TS type.