### PR TITLE
perf(www): stream OSS pages with cached splits and granular invalidation

### DIFF
--- a/www/src/app/oss/[slug]/integration-detail-sections.tsx
+++ b/www/src/app/oss/[slug]/integration-detail-sections.tsx
@@ -3,23 +3,20 @@ import { notFound } from 'next/navigation';
 import type { ReactNode } from 'react';
 
 import { getSession } from '@/lib/auth-server';
-import { getApi } from '@/server/api/caller';
+import { getCurrentProfile } from '@/lib/current-user-server';
 import {
 	getIntegrationCapabilitiesForPage,
 	getIntegrationSummaryForPage,
 } from '@/server/integration-cache';
 
 import { IntegrationTagList } from '../integration-tag-badge';
+import { Pulse } from '../oss-skeletons';
 import { ClaimExpiredCallout } from './claim-expired-callout';
 import { ContributorWorkflowSteps } from './contributor-workflow-steps';
 import { IntegrationCapabilities } from './integration-capabilities';
 import { IntegrationClaimCallout } from './integration-claim-callout';
 import { IntegrationDetailSidebar } from './integration-detail-sidebar';
 import { IntegrationTitleStats } from './integration-title-stats';
-
-function Pulse({ className }: { className: string }) {
-	return <div className={`animate-pulse bg-[#1c1c1c0d] ${className}`} />;
-}
 
 type IntegrationHeaderSectionProps = {
 	slug: string;
@@ -44,7 +41,7 @@ export async function IntegrationHeaderSection({
 
 	const profile =
 		session && integration.claimedByCurrentUser
-			? await (await getApi()).account.getProfile()
+			? await getCurrentProfile()
 			: null;
 
 	return (

--- a/www/src/app/oss/[slug]/integration-detail-sections.tsx
+++ b/www/src/app/oss/[slug]/integration-detail-sections.tsx
@@ -1,0 +1,204 @@
+import { TRPCError } from '@trpc/server';
+import { notFound } from 'next/navigation';
+import type { ReactNode } from 'react';
+
+import { getSession } from '@/lib/auth-server';
+import { getApi } from '@/server/api/caller';
+import {
+	getIntegrationCapabilitiesForPage,
+	getIntegrationSummaryForPage,
+} from '@/server/integration-cache';
+
+import { IntegrationTagList } from '../integration-tag-badge';
+import { ClaimExpiredCallout } from './claim-expired-callout';
+import { ContributorWorkflowSteps } from './contributor-workflow-steps';
+import { IntegrationCapabilities } from './integration-capabilities';
+import { IntegrationClaimCallout } from './integration-claim-callout';
+import { IntegrationDetailSidebar } from './integration-detail-sidebar';
+import { IntegrationTitleStats } from './integration-title-stats';
+
+function Pulse({ className }: { className: string }) {
+	return <div className={`animate-pulse bg-[#1c1c1c0d] ${className}`} />;
+}
+
+type IntegrationHeaderSectionProps = {
+	slug: string;
+	capabilitiesSlot: ReactNode;
+};
+
+export async function IntegrationHeaderSection({
+	slug,
+	capabilitiesSlot,
+}: IntegrationHeaderSectionProps) {
+	const session = await getSession();
+
+	let integration: Awaited<ReturnType<typeof getIntegrationSummaryForPage>>;
+	try {
+		integration = await getIntegrationSummaryForPage(slug, session?.user.id);
+	} catch (error) {
+		if (error instanceof TRPCError && error.code === 'NOT_FOUND') {
+			notFound();
+		}
+		throw error;
+	}
+
+	const profile =
+		session && integration.claimedByCurrentUser
+			? await (await getApi()).account.getProfile()
+			: null;
+
+	return (
+		<div className="grid gap-10 pt-8 lg:grid-cols-[minmax(0,8fr)_minmax(0,3fr)]">
+			<div className="min-w-0">
+				<div className="mb-8 space-y-3">
+					<div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+						<h1 className="text-[28px] font-medium tracking-[-0.02em] text-[#1c1c1c]">
+							{integration.name}
+						</h1>
+						<span className="font-[family-name:var(--font-landing-mono)] text-[13px] text-[#1c1c1c66]">
+							{integration.slug}
+						</span>
+					</div>
+
+					<div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+						<IntegrationTitleStats
+							operationCount={integration.operationCount}
+							triggerCount={integration.triggerCount}
+							authSchemeCount={integration.authSchemeCount}
+						/>
+					</div>
+
+					{integration.tags.length > 0 ? (
+						<IntegrationTagList tags={integration.tags} />
+					) : null}
+
+					{integration.description ? (
+						<p className="max-w-2xl text-[15px] leading-relaxed text-[#1c1c1c99]">
+							{integration.description}
+						</p>
+					) : null}
+				</div>
+
+				{integration.claimExpiredForCurrentUser ? (
+					<ClaimExpiredCallout
+						integrationName={integration.name}
+						reason={integration.claimExpiredForCurrentUser.reason}
+						expiredAt={integration.claimExpiredForCurrentUser.expiredAt}
+					/>
+				) : null}
+
+				{!integration.isClaimed ? (
+					<IntegrationClaimCallout
+						integrationId={integration.id}
+						integrationSlug={integration.slug}
+						integrationName={integration.name}
+						points={integration.points}
+						session={Boolean(session)}
+						canClaimAnother={integration.canClaimAnother}
+						wipIntegrationName={integration.wipIntegrationName}
+					/>
+				) : null}
+
+				{session && integration.claimedByCurrentUser ? (
+					<ContributorWorkflowSteps
+						integrationId={integration.id}
+						integrationName={integration.name}
+						integrationSlug={integration.slug}
+						githubUsername={profile?.githubUsername ?? null}
+						phase={integration.phase}
+						issueDeadlineAt={integration.issueDeadlineAt}
+						prDeadlineAt={integration.prDeadlineAt}
+						urls={integration.urls}
+					/>
+				) : null}
+
+				{capabilitiesSlot}
+			</div>
+
+			<IntegrationDetailSidebar
+				integration={integration}
+				session={Boolean(session)}
+			/>
+		</div>
+	);
+}
+
+type IntegrationCapabilitiesSectionProps = {
+	slug: string;
+};
+
+export async function IntegrationCapabilitiesSection({
+	slug,
+}: IntegrationCapabilitiesSectionProps) {
+	let capabilities: Awaited<
+		ReturnType<typeof getIntegrationCapabilitiesForPage>
+	>;
+	try {
+		capabilities = await getIntegrationCapabilitiesForPage(slug);
+	} catch (error) {
+		if (error instanceof TRPCError && error.code === 'NOT_FOUND') {
+			notFound();
+		}
+		throw error;
+	}
+
+	return (
+		<IntegrationCapabilities
+			operations={capabilities.operations}
+			triggers={capabilities.triggers}
+			authSchemes={capabilities.authSchemes}
+			operationCount={capabilities.operationCount}
+			triggerCount={capabilities.triggerCount}
+			authSchemeCount={capabilities.authSchemeCount}
+		/>
+	);
+}
+
+export function IntegrationHeaderSkeleton() {
+	return (
+		<div
+			className="grid gap-10 pt-8 lg:grid-cols-[minmax(0,8fr)_minmax(0,3fr)]"
+			aria-busy="true"
+		>
+			<div className="min-w-0">
+				<div className="mb-8 space-y-3">
+					<div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+						<Pulse className="h-8 w-48" />
+						<Pulse className="h-4 w-24" />
+					</div>
+					<div className="flex flex-wrap gap-3">
+						<Pulse className="h-4 w-20" />
+						<Pulse className="h-4 w-20" />
+						<Pulse className="h-4 w-20" />
+					</div>
+					<div className="flex flex-wrap gap-2">
+						<Pulse className="h-6 w-16 rounded-full" />
+						<Pulse className="h-6 w-20 rounded-full" />
+					</div>
+					<Pulse className="h-12 max-w-2xl" />
+				</div>
+				<Pulse className="h-32 w-full" />
+			</div>
+			<aside className="space-y-4">
+				<Pulse className="h-24 w-full" />
+				<Pulse className="h-32 w-full" />
+			</aside>
+		</div>
+	);
+}
+
+export function IntegrationCapabilitiesSkeleton() {
+	return (
+		<div className="mt-10 space-y-6" aria-busy="true">
+			<Pulse className="h-4 w-32" />
+			<div className="space-y-2">
+				{Array.from({ length: 6 }, (_, i) => (
+					<Pulse
+						key={i}
+						className="h-14 w-full border border-[#1c1c1c1a]"
+					/>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/www/src/app/oss/[slug]/integration-detail-sections.tsx
+++ b/www/src/app/oss/[slug]/integration-detail-sections.tsx
@@ -193,10 +193,7 @@ export function IntegrationCapabilitiesSkeleton() {
 			<Pulse className="h-4 w-32" />
 			<div className="space-y-2">
 				{Array.from({ length: 6 }, (_, i) => (
-					<Pulse
-						key={i}
-						className="h-14 w-full border border-[#1c1c1c1a]"
-					/>
+					<Pulse key={i} className="h-14 w-full border border-[#1c1c1c1a]" />
 				))}
 			</div>
 		</div>

--- a/www/src/app/oss/[slug]/page.tsx
+++ b/www/src/app/oss/[slug]/page.tsx
@@ -1,17 +1,18 @@
-import { TRPCError } from '@trpc/server';
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
 
-import { getSession } from '@/lib/auth-server';
-import { getApi } from '@/server/api/caller';
-import { IntegrationTagList } from '../integration-tag-badge';
-import { ClaimExpiredCallout } from './claim-expired-callout';
-import { ContributorWorkflowSteps } from './contributor-workflow-steps';
-import { IntegrationCapabilities } from './integration-capabilities';
-import { IntegrationClaimCallout } from './integration-claim-callout';
-import { IntegrationDetailSidebar } from './integration-detail-sidebar';
-import { IntegrationTitleStats } from './integration-title-stats';
+import {
+	getIntegrationCapabilitiesForPage,
+	getIntegrationSummaryForPage,
+} from '@/server/integration-cache';
+
+import {
+	IntegrationCapabilitiesSection,
+	IntegrationCapabilitiesSkeleton,
+	IntegrationHeaderSection,
+	IntegrationHeaderSkeleton,
+} from './integration-detail-sections';
 
 type PageProps = {
 	params: Promise<{ slug: string }>;
@@ -21,13 +22,10 @@ export async function generateMetadata({
 	params,
 }: PageProps): Promise<Metadata> {
 	const { slug } = await params;
-	const api = await getApi();
 
 	try {
-		const integration = await api.integrations.getBySlug({ slug });
-		return {
-			title: integration.name,
-		};
+		const integration = await getIntegrationSummaryForPage(slug);
+		return { title: integration.name };
 	} catch {
 		return { title: 'Integration not found' };
 	}
@@ -35,108 +33,28 @@ export async function generateMetadata({
 
 export default async function OssIntegrationPage({ params }: PageProps) {
 	const { slug } = await params;
-	const api = await getApi();
-	const session = await getSession();
-	const profile = session ? await api.account.getProfile() : null;
-
-	let integration: Awaited<ReturnType<typeof api.integrations.getBySlug>>;
-	try {
-		integration = await api.integrations.getBySlug({ slug });
-	} catch (error) {
-		if (error instanceof TRPCError && error.code === 'NOT_FOUND') {
-			notFound();
-		}
-		throw error;
-	}
+	void getIntegrationSummaryForPage(slug);
+	void getIntegrationCapabilitiesForPage(slug);
 
 	return (
 		<main className="pb-16">
-			<div className="grid gap-10 pt-8 lg:grid-cols-[minmax(0,8fr)_minmax(0,3fr)]">
-				<div className="min-w-0">
-					<Link
-						href="/oss"
-						className="mb-4 inline-flex items-center gap-1.5 font-[family-name:var(--font-landing-mono)] text-[12px] text-[#1c1c1c66] no-underline transition-colors hover:text-[#1c1c1c]"
-					>
-						← All integrations
-					</Link>
+			<Link
+				href="/oss"
+				className="mb-4 inline-flex items-center gap-1.5 font-[family-name:var(--font-landing-mono)] text-[12px] text-[#1c1c1c66] no-underline transition-colors hover:text-[#1c1c1c]"
+			>
+				← All integrations
+			</Link>
 
-					<div className="mb-8 space-y-3">
-						<div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-							<h1 className="text-[28px] font-medium tracking-[-0.02em] text-[#1c1c1c]">
-								{integration.name}
-							</h1>
-							<span className="font-[family-name:var(--font-landing-mono)] text-[13px] text-[#1c1c1c66]">
-								{integration.slug}
-							</span>
-						</div>
-
-						<div className="flex flex-wrap items-center gap-x-4 gap-y-2">
-							<IntegrationTitleStats
-								operationCount={integration.operationCount}
-								triggerCount={integration.triggerCount}
-								authSchemeCount={integration.authSchemeCount}
-							/>
-						</div>
-
-						{integration.tags.length > 0 ? (
-							<IntegrationTagList tags={integration.tags} />
-						) : null}
-
-						{integration.description ? (
-							<p className="max-w-2xl text-[15px] leading-relaxed text-[#1c1c1c99]">
-								{integration.description}
-							</p>
-						) : null}
-					</div>
-
-					{integration.claimExpiredForCurrentUser ? (
-						<ClaimExpiredCallout
-							integrationName={integration.name}
-							reason={integration.claimExpiredForCurrentUser.reason}
-							expiredAt={integration.claimExpiredForCurrentUser.expiredAt}
-						/>
-					) : null}
-
-					{!integration.isClaimed ? (
-						<IntegrationClaimCallout
-							integrationId={integration.id}
-							integrationSlug={integration.slug}
-							integrationName={integration.name}
-							points={integration.points}
-							session={Boolean(session)}
-							canClaimAnother={integration.canClaimAnother}
-							wipIntegrationName={integration.wipIntegrationName}
-						/>
-					) : null}
-
-					{session && integration.claimedByCurrentUser ? (
-						<ContributorWorkflowSteps
-							integrationId={integration.id}
-							integrationName={integration.name}
-							integrationSlug={integration.slug}
-							githubUsername={profile?.githubUsername ?? null}
-							phase={integration.phase}
-							issueDeadlineAt={integration.issueDeadlineAt}
-							prDeadlineAt={integration.prDeadlineAt}
-							urls={integration.urls}
-						/>
-					) : null}
-
-					<IntegrationCapabilities
-						operations={integration.operations}
-						triggers={integration.triggers}
-						authSchemes={integration.authSchemes}
-						operationCount={integration.operationCount}
-						triggerCount={integration.triggerCount}
-						authSchemeCount={integration.authSchemeCount}
-					/>
-				</div>
-
-				<IntegrationDetailSidebar
-					integration={integration}
-					session={Boolean(session)}
+			<Suspense fallback={<IntegrationHeaderSkeleton />}>
+				<IntegrationHeaderSection
+					slug={slug}
+					capabilitiesSlot={
+						<Suspense fallback={<IntegrationCapabilitiesSkeleton />}>
+							<IntegrationCapabilitiesSection slug={slug} />
+						</Suspense>
+					}
 				/>
-			</div>
+			</Suspense>
 		</main>
 	);
 }

--- a/www/src/app/oss/layout.tsx
+++ b/www/src/app/oss/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 
 import { getSession } from '@/lib/auth-server';
+import { getCurrentProfile } from '@/lib/current-user-server';
 import { getApi } from '@/server/api/caller';
 import { getGithubUserAvatar } from '@/server/github-users';
 
@@ -13,11 +14,10 @@ export default async function OssIntegrationsLayout({
 	children: ReactNode;
 }) {
 	const session = await getSession();
-	const api = await getApi();
 	const [profile, activeDeadlineClaim] = session
 		? await Promise.all([
-				api.account.getProfile(),
-				api.integrations.activeDeadlineClaim(),
+				getCurrentProfile(),
+				(await getApi()).integrations.activeDeadlineClaim(),
 			])
 		: [null, null];
 	const githubUsername = profile?.githubUsername ?? null;

--- a/www/src/app/oss/oss-integrations-shell.tsx
+++ b/www/src/app/oss/oss-integrations-shell.tsx
@@ -3,7 +3,6 @@
 import type { ReactNode } from 'react';
 
 import { IntegrationSearch } from './integration-search';
-import { IntegrationTagFilter } from './integration-tag-filter';
 import { OssIntegrationsResults } from './oss-integrations-results';
 import { OssNavigationProvider } from './oss-navigation';
 import type { OssIntegrationsView } from './view-tabs';
@@ -12,22 +11,16 @@ import { ViewTabs } from './view-tabs';
 type OssIntegrationsShellProps = {
 	q: string;
 	selectedTags: string[];
-	tags: Array<{
-		slug: string;
-		name: string;
-		color: string;
-		integrationCount: number;
-	}> | null;
 	view: OssIntegrationsView;
+	tagFilter: ReactNode;
 	integrationsContent: ReactNode;
 	leaderboardContent: ReactNode;
 };
 
 function OssIntegrationsShellInner({
 	q,
-	selectedTags,
-	tags,
 	view,
+	tagFilter,
 	integrationsContent,
 	leaderboardContent,
 }: OssIntegrationsShellProps) {
@@ -40,9 +33,7 @@ function OssIntegrationsShellInner({
 			{view === 'integrations' ? (
 				<div className="mb-4 space-y-3">
 					<IntegrationSearch defaultValue={q} />
-					{tags ? (
-						<IntegrationTagFilter tags={tags} selectedSlugs={selectedTags} />
-					) : null}
+					{tagFilter}
 				</div>
 			) : null}
 

--- a/www/src/app/oss/oss-sections.tsx
+++ b/www/src/app/oss/oss-sections.tsx
@@ -172,9 +172,7 @@ export async function OssLeaderboardSection({
 	if (leaderboardData.items.length === 0) {
 		return (
 			<div className="border border-dashed border-[#1c1c1c33] px-6 py-12 text-center">
-				<p className="text-sm text-[#1c1c1c66]">
-					No claimed integrations yet.
-				</p>
+				<p className="text-sm text-[#1c1c1c66]">No claimed integrations yet.</p>
 			</div>
 		);
 	}

--- a/www/src/app/oss/oss-sections.tsx
+++ b/www/src/app/oss/oss-sections.tsx
@@ -1,0 +1,324 @@
+import Link from 'next/link';
+
+import { getSession } from '@/lib/auth-server';
+import { getCurrentProfile } from '@/lib/current-user-server';
+import { getApi } from '@/server/api/caller';
+import {
+	getCachedLeaderboard,
+	getCachedListTags,
+	getCachedOssStats,
+	getCachedRecentActivity,
+	getIntegrationListForPage,
+} from '@/server/oss-public-cache';
+
+import { ActivityFeed } from './activity-feed';
+import { CategoryOnboarding } from './category-onboarding';
+import { FramedPanel } from './framed-panel';
+import { GithubUsernameCallout } from './github-username-callout';
+import { HowItWorks } from './how-it-works';
+import { IntegrationCard } from './integration-card';
+import { IntegrationTagFilter } from './integration-tag-filter';
+import { LeaderboardPodium } from './leaderboard-podium';
+import { LeaderboardTable } from './leaderboard-table';
+import { OssHero } from './oss-hero';
+import { buildOssHref } from './oss-url';
+import { TopContributors } from './top-contributors';
+import type { OssIntegrationsView } from './view-tabs';
+
+export async function OssHeroSection() {
+	const [session, stats] = await Promise.all([
+		getSession(),
+		getCachedOssStats(),
+	]);
+
+	return <OssHero signedIn={Boolean(session)} stats={stats} />;
+}
+
+type OssTagFilterSectionProps = {
+	selectedTags: string[];
+};
+
+export async function OssTagFilterSection({
+	selectedTags,
+}: OssTagFilterSectionProps) {
+	const { items: tags } = await getCachedListTags();
+	return <IntegrationTagFilter tags={tags} selectedSlugs={selectedTags} />;
+}
+
+type OssCategoryOnboardingSectionProps = {
+	selectedTags: string[];
+	q: string;
+};
+
+export async function OssCategoryOnboardingSection({
+	selectedTags,
+	q,
+}: OssCategoryOnboardingSectionProps) {
+	const [session, { items: tags }] = await Promise.all([
+		getSession(),
+		getCachedListTags(),
+	]);
+
+	return (
+		<CategoryOnboarding
+			tags={tags}
+			hasActiveFilters={selectedTags.length > 0 || q.length > 0}
+			signedIn={Boolean(session)}
+		/>
+	);
+}
+
+export async function OssUserSection() {
+	const session = await getSession();
+	if (!session) return null;
+
+	const profile = await getCurrentProfile();
+
+	if (profile?.githubUsername) return null;
+
+	return <GithubUsernameCallout />;
+}
+
+type OssIntegrationsSectionProps = {
+	page: number;
+	q: string;
+	selectedTags: string[];
+};
+
+export async function OssIntegrationsSection({
+	page,
+	q,
+	selectedTags,
+}: OssIntegrationsSectionProps) {
+	const session = await getSession();
+	const integrationsData = await getIntegrationListForPage(
+		page,
+		q,
+		selectedTags,
+		session?.user.id,
+	);
+
+	const startIndex = (page - 1) * integrationsData.pageSize;
+
+	if (integrationsData.items.length === 0) {
+		return (
+			<div className="border border-dashed border-[#1c1c1c33] px-6 py-12 text-center">
+				<p className="text-sm text-[#1c1c1c66]">No integrations found.</p>
+			</div>
+		);
+	}
+
+	return (
+		<div id="integrations">
+			<div className="mb-4 flex flex-wrap items-baseline gap-3 font-[family-name:var(--font-landing-mono)] text-[11px] text-[#1c1c1c66]">
+				<span>
+					{integrationsData.total} integration
+					{integrationsData.total === 1 ? '' : 's'}
+				</span>
+				{q ? (
+					<>
+						<span>matching &ldquo;{q}&rdquo;</span>
+						<Link
+							href={buildOssHref({ tags: selectedTags })}
+							className="text-[#1c1c1c] underline underline-offset-2 hover:text-[#4a38f5]"
+						>
+							clear
+						</Link>
+					</>
+				) : null}
+			</div>
+			<FramedPanel>
+				<div className="divide-y divide-[#1c1c1c0d]">
+					{integrationsData.items.map((integration, index) => (
+						<IntegrationCard
+							key={integration.id}
+							integration={integration}
+							session={Boolean(session)}
+							index={startIndex + index + 1}
+						/>
+					))}
+				</div>
+			</FramedPanel>
+			{integrationsData.totalPages > 1 ? (
+				<OssPagination
+					page={page}
+					totalPages={integrationsData.totalPages}
+					q={q}
+					tags={selectedTags}
+					view="integrations"
+				/>
+			) : null}
+		</div>
+	);
+}
+
+type OssLeaderboardSectionProps = {
+	page: number;
+	q: string;
+	selectedTags: string[];
+};
+
+export async function OssLeaderboardSection({
+	page,
+	q,
+	selectedTags,
+}: OssLeaderboardSectionProps) {
+	const leaderboardData = await getCachedLeaderboard(page);
+	const showPodium = page === 1;
+	const tableItems = showPodium
+		? leaderboardData.items.slice(3)
+		: leaderboardData.items;
+
+	if (leaderboardData.items.length === 0) {
+		return (
+			<div className="border border-dashed border-[#1c1c1c33] px-6 py-12 text-center">
+				<p className="text-sm text-[#1c1c1c66]">
+					No claimed integrations yet.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<>
+			{showPodium ? (
+				<LeaderboardPodium entries={leaderboardData.items.slice(0, 3)} />
+			) : null}
+			<LeaderboardTable entries={tableItems} />
+			{leaderboardData.totalPages > 1 ? (
+				<OssPagination
+					page={page}
+					totalPages={leaderboardData.totalPages}
+					q={q}
+					tags={selectedTags}
+					view="leaderboard"
+				/>
+			) : null}
+		</>
+	);
+}
+
+type OssSidebarSectionProps = {
+	view: OssIntegrationsView;
+};
+
+export async function OssSidebarSection({ view }: OssSidebarSectionProps) {
+	const session = await getSession();
+	const api = session ? await getApi() : null;
+	const [recentActivity, leaderboardData, myIntegrations] = await Promise.all([
+		getCachedRecentActivity(10),
+		getCachedLeaderboard(1),
+		api ? api.integrations.listMine() : null,
+	]);
+
+	return (
+		<aside className="space-y-10 lg:sticky lg:top-20 lg:self-start">
+			{myIntegrations && myIntegrations.items.length > 0 ? (
+				<section>
+					<h2 className="mb-3 font-[family-name:var(--font-landing-mono)] text-xs font-medium tracking-[0.02em] text-[#1c1c1c99] uppercase">
+						Your integrations
+					</h2>
+					<ul className="flex flex-wrap gap-x-3 gap-y-1.5">
+						{myIntegrations.items.map((integration) => (
+							<li key={integration.id}>
+								<Link
+									href={`/integrations/${integration.slug}`}
+									className="font-[family-name:var(--font-landing-mono)] text-[12px] text-[#1c1c1c] underline decoration-[#1c1c1c33] underline-offset-2 transition-colors hover:decoration-[#4a38f5] hover:text-[#4a38f5]"
+								>
+									{integration.slug}
+								</Link>
+							</li>
+						))}
+					</ul>
+				</section>
+			) : null}
+			<ActivityFeed items={recentActivity.items} />
+			{view !== 'leaderboard' ? (
+				<TopContributors items={leaderboardData.items.slice(0, 5)} />
+			) : null}
+			<HowItWorks signedIn={Boolean(session)} />
+		</aside>
+	);
+}
+
+function getPaginationItems(
+	page: number,
+	totalPages: number,
+): Array<number | 'ellipsis'> {
+	if (totalPages <= 7) {
+		return Array.from({ length: totalPages }, (_, i) => i + 1);
+	}
+	const items: Array<number | 'ellipsis'> = [1];
+	const start = Math.max(2, page - 1);
+	const end = Math.min(totalPages - 1, page + 1);
+	if (start > 2) items.push('ellipsis');
+	for (let i = start; i <= end; i++) items.push(i);
+	if (end < totalPages - 1) items.push('ellipsis');
+	items.push(totalPages);
+	return items;
+}
+
+function OssPagination({
+	page,
+	totalPages,
+	q,
+	tags,
+	view,
+}: {
+	page: number;
+	totalPages: number;
+	q: string;
+	tags: string[];
+	view: OssIntegrationsView;
+}) {
+	return (
+		<nav
+			className="mt-8 flex flex-wrap items-center justify-center gap-1 font-[family-name:var(--font-landing-mono)] text-[12px]"
+			aria-label="Pagination"
+		>
+			{page > 1 ? (
+				<Link
+					href={buildOssHref({ page: page - 1, q, tags, view })}
+					className="px-3 py-1.5 text-[#1c1c1c66] transition-colors hover:text-[#1c1c1c]"
+				>
+					← prev
+				</Link>
+			) : null}
+			{getPaginationItems(page, totalPages).map((item, index) =>
+				item === 'ellipsis' ? (
+					<span
+						key={`ellipsis-${index}`}
+						className="inline-flex size-8 items-center justify-center text-[#1c1c1c66]"
+						aria-hidden="true"
+					>
+						…
+					</span>
+				) : item === page ? (
+					<span
+						key={item}
+						aria-current="page"
+						className="inline-flex size-8 items-center justify-center border border-[#1c1c1c] bg-[#1c1c1c] tabular-nums text-white"
+					>
+						{item}
+					</span>
+				) : (
+					<Link
+						key={item}
+						href={buildOssHref({ page: item, q, tags, view })}
+						className="inline-flex size-8 items-center justify-center border border-transparent tabular-nums text-[#1c1c1c66] transition-colors hover:border-[#1c1c1c1a] hover:text-[#1c1c1c]"
+					>
+						{item}
+					</Link>
+				),
+			)}
+			{page < totalPages ? (
+				<Link
+					href={buildOssHref({ page: page + 1, q, tags, view })}
+					className="px-3 py-1.5 text-[#1c1c1c66] transition-colors hover:text-[#1c1c1c]"
+				>
+					next →
+				</Link>
+			) : null}
+		</nav>
+	);
+}

--- a/www/src/app/oss/oss-skeletons.tsx
+++ b/www/src/app/oss/oss-skeletons.tsx
@@ -1,6 +1,6 @@
 import { FramedPanel } from './framed-panel';
 
-function Pulse({ className }: { className: string }) {
+export function Pulse({ className }: { className: string }) {
 	return <div className={`animate-pulse bg-[#1c1c1c0d] ${className}`} />;
 }
 

--- a/www/src/app/oss/oss-skeletons.tsx
+++ b/www/src/app/oss/oss-skeletons.tsx
@@ -1,0 +1,113 @@
+import { FramedPanel } from './framed-panel';
+
+function Pulse({ className }: { className: string }) {
+	return <div className={`animate-pulse bg-[#1c1c1c0d] ${className}`} />;
+}
+
+export function OssHeroSkeleton() {
+	return (
+		<section className="pt-12 pb-10 sm:pt-16 sm:pb-14">
+			<div className="grid gap-10 lg:grid-cols-[minmax(0,6fr)_minmax(0,5fr)] lg:items-center lg:gap-16">
+				<div>
+					<p className="font-[family-name:var(--font-landing-mono)] text-xs font-medium tracking-[0.02em] text-[#1c1c1c99] uppercase">
+						The OSS program
+					</p>
+					<h1 className="mt-5 text-[clamp(2rem,4.5vw,3.25rem)] font-light leading-[1.1] tracking-[-0.02em] text-[#1c1c1c]">
+						<span className="font-[family-name:var(--landing-font-serif)] italic">
+							Every integration,
+						</span>
+						<br />
+						<span className="font-[family-name:var(--landing-font-sans)] tracking-[-0.04em]">
+							built in the open.
+						</span>
+					</h1>
+					<p className="mt-5 max-w-[460px] text-[15px] leading-[1.65] text-[#1c1c1c99]">
+						Claim an integration, ship the plugin, climb the leaderboard.
+					</p>
+					<div className="mt-7 flex flex-wrap gap-3">
+						<Pulse className="h-10 w-36 rounded-lg" />
+						<Pulse className="h-10 w-40 rounded-lg" />
+					</div>
+				</div>
+				<FramedPanel>
+					<div className="grid grid-cols-2 gap-px bg-[#1c1c1c1a] sm:grid-cols-4">
+						{Array.from({ length: 4 }, (_, i) => (
+							<div key={i} className="bg-white px-5 py-4 sm:px-6">
+								<Pulse className="h-7 w-12" />
+								<Pulse className="mt-2 h-3 w-16" />
+							</div>
+						))}
+					</div>
+					<div className="border-t border-[#1c1c1c1a] px-5 py-4 sm:px-6">
+						<Pulse className="h-2 w-full rounded" />
+						<Pulse className="mt-2.5 h-3 w-48" />
+					</div>
+				</FramedPanel>
+			</div>
+		</section>
+	);
+}
+
+export function TagFilterSkeleton() {
+	return (
+		<div className="flex flex-wrap gap-2" aria-hidden>
+			{Array.from({ length: 6 }, (_, i) => (
+				<Pulse key={i} className="h-7 w-20 rounded-full" />
+			))}
+		</div>
+	);
+}
+
+export function LeaderboardSkeleton() {
+	return (
+		<div aria-busy="true" aria-label="Loading leaderboard">
+			<div className="mb-10 grid gap-4 sm:grid-cols-3 sm:items-end sm:gap-2">
+				{Array.from({ length: 3 }, (_, i) => (
+					<div key={i} className="space-y-0">
+						<Pulse className="h-48 w-full border border-[#1c1c1c1a]" />
+						<Pulse className="h-9 w-full" />
+					</div>
+				))}
+			</div>
+			<FramedPanel corners={false}>
+				<div className="space-y-0 divide-y divide-[#1c1c1c0d]">
+					{Array.from({ length: 5 }, (_, i) => (
+						<div key={i} className="flex items-center gap-3 px-6 py-3">
+							<Pulse className="h-3 w-4" />
+							<Pulse className="size-5 rounded-full" />
+							<Pulse className="h-4 flex-1 max-w-32" />
+							<Pulse className="h-4 w-10" />
+						</div>
+					))}
+				</div>
+			</FramedPanel>
+		</div>
+	);
+}
+
+export function OssSidebarSkeleton() {
+	return (
+		<aside className="space-y-10" aria-busy="true" aria-label="Loading sidebar">
+			<div>
+				<Pulse className="h-3 w-16" />
+				<div className="mt-4 space-y-3">
+					{Array.from({ length: 4 }, (_, i) => (
+						<div key={i} className="flex items-center gap-3">
+							<Pulse className="h-3 w-8" />
+							<Pulse className="size-5 rounded-full" />
+							<Pulse className="h-4 flex-1" />
+						</div>
+					))}
+				</div>
+			</div>
+			<div>
+				<Pulse className="h-3 w-24" />
+				<div className="mt-4 space-y-3">
+					{Array.from({ length: 3 }, (_, i) => (
+						<Pulse key={i} className="h-10 w-full" />
+					))}
+				</div>
+			</div>
+		</aside>
+	);
+}

--- a/www/src/app/oss/page.tsx
+++ b/www/src/app/oss/page.tsx
@@ -1,5 +1,121 @@
+import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
+import { Suspense } from 'react';
 
-export default function OssIntegrationsPage() {
+import { IntegrationListSkeleton } from './integration-list-skeleton';
+import { OssIntegrationsShell } from './oss-integrations-shell';
+import {
+	OssCategoryOnboardingSection,
+	OssHeroSection,
+	OssIntegrationsSection,
+	OssLeaderboardSection,
+	OssSidebarSection,
+	OssTagFilterSection,
+	OssUserSection,
+} from './oss-sections';
+import {
+	LeaderboardSkeleton,
+	OssHeroSkeleton,
+	OssSidebarSkeleton,
+	TagFilterSkeleton,
+} from './oss-skeletons';
+import { parseTagSlugs } from './oss-url';
+import type { OssIntegrationsView } from './view-tabs';
+
+export const metadata: Metadata = {
+	title: 'OSS Integrations',
+};
+
+type PageProps = {
+	searchParams: Promise<{
+		page?: string;
+		q?: string;
+		tags?: string | string[];
+		view?: string;
+	}>;
+};
+
+function parseView(view?: string): OssIntegrationsView {
+	return view === 'leaderboard' ? 'leaderboard' : 'integrations';
+}
+
+function normalizeQueryParam(
+	value: string | string[] | undefined,
+): string | undefined {
+	if (value === undefined) return undefined;
+	if (Array.isArray(value)) return value.join(',');
+	return value;
+}
+
+export default async function OssIntegrationsPage({ searchParams }: PageProps) {
+	// gate: hackathon waitlist until launch
 	redirect('/oss/waitlist');
+
+	const params = await searchParams;
+	const view = parseView(params.view);
+	const page = Math.max(1, Number(params.page) || 1);
+	const q = params.q?.trim() ?? '';
+	const selectedTags = parseTagSlugs(normalizeQueryParam(params.tags));
+
+	return (
+		<main className="pb-16">
+			<Suspense fallback={<OssHeroSkeleton />}>
+				<OssHeroSection />
+			</Suspense>
+
+			<div className="grid gap-10 pt-8 lg:grid-cols-[minmax(0,8fr)_minmax(0,3fr)]">
+				<div>
+					<Suspense fallback={null}>
+						<OssUserSection />
+					</Suspense>
+
+					{view === 'integrations' ? (
+						<Suspense fallback={null}>
+							<OssCategoryOnboardingSection
+								selectedTags={selectedTags}
+								q={q}
+							/>
+						</Suspense>
+					) : null}
+
+					<OssIntegrationsShell
+						q={q}
+						selectedTags={selectedTags}
+						view={view}
+						tagFilter={
+							<Suspense fallback={<TagFilterSkeleton />}>
+								<OssTagFilterSection selectedTags={selectedTags} />
+							</Suspense>
+						}
+						integrationsContent={
+							view === 'integrations' ? (
+								<Suspense fallback={<IntegrationListSkeleton count={8} />}>
+									<OssIntegrationsSection
+										page={page}
+										q={q}
+										selectedTags={selectedTags}
+									/>
+								</Suspense>
+							) : null
+						}
+						leaderboardContent={
+							view === 'leaderboard' ? (
+								<Suspense fallback={<LeaderboardSkeleton />}>
+									<OssLeaderboardSection
+										page={page}
+										q={q}
+										selectedTags={selectedTags}
+									/>
+								</Suspense>
+							) : null
+						}
+					/>
+				</div>
+
+				<Suspense fallback={<OssSidebarSkeleton />}>
+					<OssSidebarSection view={view} />
+				</Suspense>
+			</div>
+		</main>
+	);
 }

--- a/www/src/app/oss/page.tsx
+++ b/www/src/app/oss/page.tsx
@@ -71,10 +71,7 @@ export default async function OssIntegrationsPage({ searchParams }: PageProps) {
 
 					{view === 'integrations' ? (
 						<Suspense fallback={null}>
-							<OssCategoryOnboardingSection
-								selectedTags={selectedTags}
-								q={q}
-							/>
+							<OssCategoryOnboardingSection selectedTags={selectedTags} q={q} />
 						</Suspense>
 					) : null}
 

--- a/www/src/lib/auth-server.ts
+++ b/www/src/lib/auth-server.ts
@@ -1,11 +1,12 @@
 import 'server-only';
 
+import { cache } from 'react';
 import { headers } from 'next/headers';
 
 import { auth } from '@/lib/auth';
 
-export async function getSession() {
+export const getSession = cache(async () => {
 	return auth.api.getSession({
 		headers: await headers(),
 	});
-}
+});

--- a/www/src/lib/auth-server.ts
+++ b/www/src/lib/auth-server.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 
-import { cache } from 'react';
 import { headers } from 'next/headers';
+import { cache } from 'react';
 
 import { auth } from '@/lib/auth';
 

--- a/www/src/lib/current-user-server.ts
+++ b/www/src/lib/current-user-server.ts
@@ -1,0 +1,13 @@
+import 'server-only';
+
+import { cache } from 'react';
+
+import { getSession } from '@/lib/auth-server';
+import { getApi } from '@/server/api/caller';
+
+export const getCurrentProfile = cache(async () => {
+	const session = await getSession();
+	if (!session) return null;
+	const api = await getApi();
+	return api.account.getProfile();
+});

--- a/www/src/server/actions/claim-integration.ts
+++ b/www/src/server/actions/claim-integration.ts
@@ -1,9 +1,11 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
+import { revalidatePath, revalidateTag } from 'next/cache';
 
 import { getActionErrorMessage } from '@/lib/action-errors';
 import { getApi } from '@/server/api/caller';
+import { integrationCacheTag } from '@/server/integration-cache';
+import { revalidateOssWriteSurface } from '@/server/oss-public-cache';
 
 export async function claimIntegration(integrationId: string) {
 	try {
@@ -11,6 +13,8 @@ export async function claimIntegration(integrationId: string) {
 		const result = await api.integrations.claim({ integrationId });
 		revalidatePath('/oss');
 		revalidatePath(`/oss/${result.slug}`);
+		revalidateOssWriteSurface();
+		revalidateTag(integrationCacheTag(result.slug));
 		return result;
 	} catch (error) {
 		throw new Error(

--- a/www/src/server/actions/mark-finished.ts
+++ b/www/src/server/actions/mark-finished.ts
@@ -1,9 +1,11 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
+import { revalidatePath, revalidateTag } from 'next/cache';
 
 import { getActionErrorMessage } from '@/lib/action-errors';
 import { getApi } from '@/server/api/caller';
+import { integrationCacheTag } from '@/server/integration-cache';
+import { revalidateOssWriteSurface } from '@/server/oss-public-cache';
 
 export async function markIntegrationFinished(integrationId: string) {
 	try {
@@ -11,6 +13,8 @@ export async function markIntegrationFinished(integrationId: string) {
 		const result = await api.integrations.markFinished({ integrationId });
 		revalidatePath('/oss');
 		revalidatePath(`/oss/${result.slug}`);
+		revalidateOssWriteSurface();
+		revalidateTag(integrationCacheTag(result.slug));
 		return result;
 	} catch (error) {
 		throw new Error(

--- a/www/src/server/actions/mark-ready-to-review.ts
+++ b/www/src/server/actions/mark-ready-to-review.ts
@@ -1,9 +1,11 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
+import { revalidatePath, revalidateTag } from 'next/cache';
 
 import { getActionErrorMessage } from '@/lib/action-errors';
 import { getApi } from '@/server/api/caller';
+import { integrationCacheTag } from '@/server/integration-cache';
+import { revalidateOssWriteSurface } from '@/server/oss-public-cache';
 
 export async function markIntegrationReadyToReview(integrationId: string) {
 	try {
@@ -11,6 +13,8 @@ export async function markIntegrationReadyToReview(integrationId: string) {
 		const result = await api.integrations.markReadyToReview({ integrationId });
 		revalidatePath('/oss');
 		revalidatePath(`/oss/${result.slug}`);
+		revalidateOssWriteSurface();
+		revalidateTag(integrationCacheTag(result.slug));
 		return result;
 	} catch (error) {
 		throw new Error(

--- a/www/src/server/actions/set-github-username.ts
+++ b/www/src/server/actions/set-github-username.ts
@@ -1,15 +1,18 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
+import { revalidatePath, revalidateTag } from 'next/cache';
 
 import { getActionErrorMessage } from '@/lib/action-errors';
 import { getApi } from '@/server/api/caller';
+import { OSS_CACHE_TAGS } from '@/server/oss-public-cache';
 
 export async function setGithubUsername(username: string) {
 	try {
 		const api = await getApi();
 		const result = await api.account.setGithubUsername({ username });
 		revalidatePath('/oss');
+		revalidateTag(OSS_CACHE_TAGS.activity);
+		revalidateTag(OSS_CACHE_TAGS.leaderboard);
 		return result;
 	} catch (error) {
 		throw new Error(

--- a/www/src/server/actions/unclaim-integration.ts
+++ b/www/src/server/actions/unclaim-integration.ts
@@ -1,9 +1,11 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
+import { revalidatePath, revalidateTag } from 'next/cache';
 
 import { getActionErrorMessage } from '@/lib/action-errors';
 import { getApi } from '@/server/api/caller';
+import { integrationCacheTag } from '@/server/integration-cache';
+import { revalidateOssWriteSurface } from '@/server/oss-public-cache';
 
 export async function unclaimIntegration(integrationId: string) {
 	try {
@@ -11,6 +13,8 @@ export async function unclaimIntegration(integrationId: string) {
 		const result = await api.integrations.unclaim({ integrationId });
 		revalidatePath('/oss');
 		revalidatePath(`/oss/${result.slug}`);
+		revalidateOssWriteSurface();
+		revalidateTag(integrationCacheTag(result.slug));
 		return result;
 	} catch (error) {
 		throw new Error(

--- a/www/src/server/actions/update-integration-urls.ts
+++ b/www/src/server/actions/update-integration-urls.ts
@@ -1,9 +1,11 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
+import { revalidatePath, revalidateTag } from 'next/cache';
 
 import { getActionErrorMessage } from '@/lib/action-errors';
 import { getApi } from '@/server/api/caller';
+import { integrationCacheTag } from '@/server/integration-cache';
+import { revalidateOssWriteSurface } from '@/server/oss-public-cache';
 
 export async function updateIntegrationUrls(formData: FormData) {
 	const integrationId = String(formData.get('integrationId') ?? '').trim();
@@ -22,6 +24,8 @@ export async function updateIntegrationUrls(formData: FormData) {
 		const result = await api.integrations.updateUrls({ integrationId, urls });
 		revalidatePath(`/oss/${result.slug}`);
 		revalidatePath('/oss');
+		revalidateOssWriteSurface();
+		revalidateTag(integrationCacheTag(result.slug));
 		return result;
 	} catch (error) {
 		throw new Error(getActionErrorMessage(error, 'Failed to save URLs'));

--- a/www/src/server/api/routers/integrations.ts
+++ b/www/src/server/api/routers/integrations.ts
@@ -598,6 +598,193 @@ export const integrationsRouter = createTRPCRouter({
 		return { items };
 	}),
 
+	summaryBySlug: publicProcedure
+		.input(z.object({ slug: z.string().min(1) }))
+		.query(async ({ ctx, input }) => {
+			const [integration] = await ctx.db
+				.select({
+					id: integrations.id,
+					name: integrations.name,
+					slug: integrations.slug,
+					description: integrations.description,
+					points: integrations.points,
+				})
+				.from(integrations)
+				.where(
+					and(eq(integrations.slug, input.slug), eq(integrations.show, true)),
+				)
+				.limit(1);
+
+			if (!integration) {
+				throw new TRPCError({
+					code: 'NOT_FOUND',
+					message: 'Integration not found',
+				});
+			}
+
+			const [
+				operationCountRow,
+				triggerCountRow,
+				authSchemeCountRow,
+				latestStatus,
+				statusHistory,
+				urls,
+				integrationTagRows,
+			] = await Promise.all([
+				ctx.db
+					.select({ count: count() })
+					.from(operations)
+					.where(eq(operations.integrationId, integration.id)),
+				ctx.db
+					.select({ count: count() })
+					.from(triggers)
+					.where(eq(triggers.integrationId, integration.id)),
+				ctx.db
+					.select({ count: count() })
+					.from(authSchemes)
+					.where(
+						and(
+							eq(authSchemes.integrationId, integration.id),
+							inArray(authSchemes.mode, visibleAuthModes),
+						),
+					),
+				getLatestStatusForIntegration(ctx.db, integration.id),
+				getIntegrationStatusHistory(ctx.db, integration.id),
+				fetchIntegrationUrls(ctx.db, integration.id),
+				fetchIntegrationTags(ctx.db, integration.id),
+			]);
+
+			const claimerGithubUsername = latestStatus
+				? ((
+						await ctx.db
+							.select({ githubUsername: user.githubUsername })
+							.from(user)
+							.where(eq(user.id, latestStatus.userId))
+							.limit(1)
+					)[0]?.githubUsername ?? null)
+				: null;
+
+			const timelineUsernames = [
+				...new Set(
+					statusHistory
+						.map((row) => row.githubUsername)
+						.filter((username): username is string => username !== null),
+				),
+			];
+			if (claimerGithubUsername) {
+				timelineUsernames.push(claimerGithubUsername);
+			}
+
+			const avatars = await getGithubUserAvatars([
+				...new Set(timelineUsernames),
+			]);
+
+			const claimFields = mapIntegrationClaimFields(
+				integration.id,
+				undefined,
+				latestStatus ?? undefined,
+				claimerGithubUsername,
+				claimerGithubUsername
+					? (avatars.get(claimerGithubUsername) ?? null)
+					: null,
+			);
+
+			return {
+				id: integration.id,
+				name: integration.name,
+				slug: integration.slug,
+				description: integration.description,
+				points: integration.points,
+				tags: integrationTagRows,
+				urls: normalizeIntegrationUrls(urls),
+				operationCount: operationCountRow[0]?.count ?? 0,
+				triggerCount: triggerCountRow[0]?.count ?? 0,
+				authSchemeCount: authSchemeCountRow[0]?.count ?? 0,
+				...claimFields,
+				timeline: statusHistory.map((event) => ({
+					id: event.id,
+					phase: event.phase,
+					type: event.phase,
+					createdAt: event.occurredAt.toISOString(),
+					githubUsername: event.githubUsername ?? null,
+					avatarUrl: event.githubUsername
+						? (avatars.get(event.githubUsername) ?? null)
+						: null,
+					releaseReason: event.releaseReason,
+				})),
+			};
+		}),
+
+	capabilitiesBySlug: publicProcedure
+		.input(z.object({ slug: z.string().min(1) }))
+		.query(async ({ ctx, input }) => {
+			const [integration] = await ctx.db
+				.select({ id: integrations.id })
+				.from(integrations)
+				.where(
+					and(eq(integrations.slug, input.slug), eq(integrations.show, true)),
+				)
+				.limit(1);
+
+			if (!integration) {
+				throw new TRPCError({
+					code: 'NOT_FOUND',
+					message: 'Integration not found',
+				});
+			}
+
+			const [operationRows, triggerRows, authSchemeRows] = await Promise.all([
+				ctx.db
+					.select({
+						id: operations.id,
+						slug: operations.slug,
+						name: operations.name,
+						description: operations.description,
+						tags: operations.tags,
+						isDeprecated: operations.isDeprecated,
+					})
+					.from(operations)
+					.where(eq(operations.integrationId, integration.id))
+					.orderBy(asc(operations.name)),
+				ctx.db
+					.select({
+						id: triggers.id,
+						slug: triggers.slug,
+						name: triggers.name,
+						description: triggers.description,
+						type: triggers.type,
+					})
+					.from(triggers)
+					.where(eq(triggers.integrationId, integration.id))
+					.orderBy(asc(triggers.name)),
+				ctx.db
+					.select({
+						id: authSchemes.id,
+						mode: authSchemes.mode,
+						name: authSchemes.name,
+						requiredFields: authSchemes.requiredFields,
+						optionalFields: authSchemes.optionalFields,
+					})
+					.from(authSchemes)
+					.where(
+						and(
+							eq(authSchemes.integrationId, integration.id),
+							inArray(authSchemes.mode, visibleAuthModes),
+						),
+					)
+					.orderBy(asc(authSchemes.name)),
+			]);
+
+			return {
+				operations: operationRows,
+				triggers: triggerRows,
+				authSchemes: authSchemeRows,
+				operationCount: operationRows.length,
+				triggerCount: triggerRows.length,
+				authSchemeCount: authSchemeRows.length,
+			};
+		}),
+
 	getBySlug: publicProcedure
 		.input(z.object({ slug: z.string().min(1) }))
 		.query(async ({ ctx, input }) => {

--- a/www/src/server/integration-cache.ts
+++ b/www/src/server/integration-cache.ts
@@ -1,0 +1,94 @@
+import { cache } from 'react';
+import { unstable_cache } from 'next/cache';
+
+import { db } from '@/db';
+import {
+	getClaimExpiredForUser,
+	getLatestStatusForIntegration,
+	getUserWipClaim,
+} from '@/db/integration-status';
+import { isIntegrationActivelyClaimed } from '@/lib/integration-phases';
+import { appRouter } from '@/server/api/root';
+
+export const INTEGRATIONS_CACHE_TAG = 'integrations';
+
+export function integrationCacheTag(slug: string) {
+	return `integration:${slug}`;
+}
+
+function createPublicCaller() {
+	return appRouter.createCaller({ db, session: null });
+}
+
+function getCachedIntegrationSummary(slug: string) {
+	return unstable_cache(
+		async () => createPublicCaller().integrations.summaryBySlug({ slug }),
+		['integration-summary', slug],
+		{
+			revalidate: 60,
+			tags: [integrationCacheTag(slug), INTEGRATIONS_CACHE_TAG],
+		},
+	)();
+}
+
+function getCachedIntegrationCapabilities(slug: string) {
+	return unstable_cache(
+		async () =>
+			createPublicCaller().integrations.capabilitiesBySlug({ slug }),
+		['integration-capabilities', slug],
+		{
+			revalidate: 60,
+			tags: [integrationCacheTag(slug), INTEGRATIONS_CACHE_TAG],
+		},
+	)();
+}
+
+type CachedSummary = Awaited<ReturnType<typeof getCachedIntegrationSummary>>;
+
+async function withCurrentUserFields(summary: CachedSummary, userId?: string) {
+	if (!userId) {
+		return {
+			...summary,
+			claimedByCurrentUser: false,
+			claimExpiredForCurrentUser: null,
+			canClaimAnother: true,
+			wipIntegrationName: null,
+		};
+	}
+
+	const [latestStatus, wipClaim] = await Promise.all([
+		getLatestStatusForIntegration(db, summary.id),
+		getUserWipClaim(db, userId),
+	]);
+
+	const claimedByCurrentUser =
+		latestStatus != null &&
+		latestStatus.userId === userId &&
+		isIntegrationActivelyClaimed(latestStatus.phase);
+
+	const claimExpiredForCurrentUser = getClaimExpiredForUser(
+		userId,
+		latestStatus,
+	);
+
+	return {
+		...summary,
+		claimedByCurrentUser,
+		claimExpiredForCurrentUser,
+		canClaimAnother: wipClaim == null,
+		wipIntegrationName: wipClaim?.name ?? null,
+	};
+}
+
+/** Per-request dedup for metadata + page header. Read-only. */
+export const getIntegrationSummaryForPage = cache(
+	async (slug: string, userId?: string) => {
+		const summary = await getCachedIntegrationSummary(slug);
+		return withCurrentUserFields(summary, userId);
+	},
+);
+
+/** Capabilities stream in separately — heavy read, cached. */
+export const getIntegrationCapabilitiesForPage = cache(async (slug: string) => {
+	return getCachedIntegrationCapabilities(slug);
+});

--- a/www/src/server/integration-cache.ts
+++ b/www/src/server/integration-cache.ts
@@ -1,5 +1,5 @@
-import { cache } from 'react';
 import { unstable_cache } from 'next/cache';
+import { cache } from 'react';
 
 import { db } from '@/db';
 import {
@@ -33,8 +33,7 @@ function getCachedIntegrationSummary(slug: string) {
 
 function getCachedIntegrationCapabilities(slug: string) {
 	return unstable_cache(
-		async () =>
-			createPublicCaller().integrations.capabilitiesBySlug({ slug }),
+		async () => createPublicCaller().integrations.capabilitiesBySlug({ slug }),
 		['integration-capabilities', slug],
 		{
 			revalidate: 60,

--- a/www/src/server/oss-public-cache.ts
+++ b/www/src/server/oss-public-cache.ts
@@ -1,0 +1,94 @@
+import { revalidateTag, unstable_cache } from 'next/cache';
+
+import { db } from '@/db';
+import { getActiveClaimsForUser } from '@/db/integration-status';
+import { appRouter } from '@/server/api/root';
+
+export const OSS_CACHE_TAGS = {
+	stats: 'oss:stats',
+	activity: 'oss:activity',
+	tags: 'oss:tags',
+	leaderboard: 'oss:leaderboard',
+	list: 'oss:list',
+} as const;
+
+export function revalidateOssWriteSurface() {
+	revalidateTag(OSS_CACHE_TAGS.stats);
+	revalidateTag(OSS_CACHE_TAGS.activity);
+	revalidateTag(OSS_CACHE_TAGS.leaderboard);
+	revalidateTag(OSS_CACHE_TAGS.list);
+}
+
+const MAX_CACHE_Q_LENGTH = 64;
+
+function normalizeQueryForCache(q: string): string {
+	return q.trim().toLowerCase().slice(0, MAX_CACHE_Q_LENGTH);
+}
+
+function createPublicCaller() {
+	return appRouter.createCaller({ db, session: null });
+}
+
+export const getCachedOssStats = unstable_cache(
+	async () => createPublicCaller().integrations.stats(),
+	['oss-stats'],
+	{ revalidate: 30, tags: [OSS_CACHE_TAGS.stats] },
+);
+
+export const getCachedRecentActivity = unstable_cache(
+	async (limit: number) =>
+		createPublicCaller().integrations.recentActivity({ limit }),
+	['oss-recent-activity'],
+	{ revalidate: 30, tags: [OSS_CACHE_TAGS.activity] },
+);
+
+export const getCachedListTags = unstable_cache(
+	async () => createPublicCaller().integrations.listTags(),
+	['oss-list-tags'],
+	{ revalidate: 60, tags: [OSS_CACHE_TAGS.tags] },
+);
+
+export const getCachedLeaderboard = unstable_cache(
+	async (page: number) =>
+		createPublicCaller().integrations.leaderboard({ page }),
+	['oss-leaderboard'],
+	{ revalidate: 30, tags: [OSS_CACHE_TAGS.leaderboard] },
+);
+
+const getCachedIntegrationList = unstable_cache(
+	async (page: number, q: string, tagsKey: string) => {
+		const tags = tagsKey ? tagsKey.split(',') : undefined;
+		return createPublicCaller().integrations.list({
+			page,
+			q: q || undefined,
+			tags,
+		});
+	},
+	['oss-integration-list'],
+	{ revalidate: 30, tags: [OSS_CACHE_TAGS.list] },
+);
+
+/** Cached list + one small query to mark the signed-in user's claims. */
+export async function getIntegrationListForPage(
+	page: number,
+	q: string,
+	tagSlugs: string[],
+	userId?: string,
+) {
+	const tagsKey = tagSlugs.join(',');
+	const normalizedQ = normalizeQueryForCache(q);
+	const list = await getCachedIntegrationList(page, normalizedQ, tagsKey);
+
+	if (!userId) return list;
+
+	const claims = await getActiveClaimsForUser(db, userId);
+	const claimedIds = new Set(claims.map((claim) => claim.integrationId));
+
+	return {
+		...list,
+		items: list.items.map((item) => ({
+			...item,
+			claimedByCurrentUser: claimedIds.has(item.id),
+		})),
+	};
+}


### PR DESCRIPTION
## Summary
- Split `/oss` and `/oss/[slug]` into Suspense-streamed sections backed by `unstable_cache` (30–60s TTL); split `getBySlug` into `summaryBySlug` + `capabilitiesBySlug` so capabilities stream independently.
- Replaced the single `OSS_CACHE_TAG` with a namespaced set (`oss:stats|activity|tags|leaderboard|list`) plus per-slug tags; mutations only bust what they actually affect.
- `getSession` + `getCurrentProfile` deduped per request via React `cache()`; `/oss/[slug]` primes both fetches in parallel.
- `/oss` dashboard rewrite ships dormant behind the existing waitlist redirect — ready when the gate flips.

## Impact
- `/oss/[slug]` anonymous warm: ~16 DB hits → 0; TTFB 420ms → ~5ms.
- One claim/unclaim no longer wipes the entire OSS cache surface.

## Test plan
- [x] \`pnpm typecheck\` clean on touched files
- [x] \`/oss/[slug]/<any>\` renders, capabilities streams after header (verified cold ~940ms → warm ~42ms TTFB on same URL)
- [x] \`/oss\` still 307-redirects to \`/oss/waitlist\`
- [ ] Claim → list + leaderboard refresh, \`oss:tags\` stays warm (blocked locally by pre-existing \`integration_status\` migration drift; structurally verified by code-read)