### PR TITLE
feat: Add Webhook Tenant Matcher for all Plugins

### DIFF
--- a/packages/airtable/index.ts
+++ b/packages/airtable/index.ts
@@ -194,7 +194,7 @@ const airtableEndpointMeta = {
 
 export const airtableAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['base_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -221,6 +221,7 @@ export function airtable<const T extends AirtablePluginOptions>(
 	};
 	return {
 		id: 'airtable',
+		authConfig: airtableAuthConfig,
 		oauthConfig: {
 			providerName: 'Airtable',
 			authUrl: 'https://airtable.com/oauth2/v1/authorize',

--- a/packages/airtable/index.ts
+++ b/packages/airtable/index.ts
@@ -26,6 +26,7 @@ import {
 import { errorHandlers } from './error-handlers';
 import { AirtableSchema } from './schema';
 import { EventWebhooks } from './webhooks';
+import { matchAirtableTenantWebhook } from './webhooks/tenant-matcher';
 import type { AirtableEvent, AirtableWebhookOutputs } from './webhooks/types';
 import {
 	AirtableEventPayloadSchema,
@@ -241,6 +242,7 @@ export function airtable<const T extends AirtablePluginOptions>(
 			const hasMac = 'x-airtable-content-mac' in headers;
 			return hasMac;
 		},
+		pluginTenantWebhookMatcher: matchAirtableTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/airtable/webhooks/tenant-matcher.ts
+++ b/packages/airtable/webhooks/tenant-matcher.ts
@@ -1,0 +1,17 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// Airtable webhook notification pings include the base id; full change payloads
+// are fetched separately via the Webhooks API.
+// See https://airtable.com/developers/web/api/webhooks-overview
+export function matchAirtableTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const baseId = firstString([asRecord(body.base)?.id]);
+	if (!baseId) return null;
+
+	return { linkType: 'base_id', externalId: baseId };
+}

--- a/packages/amplitude/index.ts
+++ b/packages/amplitude/index.ts
@@ -40,6 +40,7 @@ import {
 	ExperimentWebhooks,
 	MonitorWebhooks,
 } from './webhooks';
+import { matchAmplitudeTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	AmplitudeAnnotationCreatedEvent,
 	AmplitudeAnnotationUpdatedEvent,
@@ -423,6 +424,7 @@ export function amplitude<const T extends AmplitudePluginOptions>(
 			const headers = request.headers;
 			return 'x-amplitude-signature' in headers;
 		},
+		pluginTenantWebhookMatcher: matchAmplitudeTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/amplitude/index.ts
+++ b/packages/amplitude/index.ts
@@ -380,9 +380,7 @@ const amplitudeWebhookSchemas = {
 const defaultAuthType: AuthTypes = 'api_key' as const;
 
 export const amplitudeAuthConfig = {
-	api_key: {
-		account: ['one'] as const,
-	},
+	api_key: {},
 } as const satisfies PluginAuthConfig;
 
 export type BaseAmplitudePlugin<T extends AmplitudePluginOptions> =
@@ -411,6 +409,7 @@ export function amplitude<const T extends AmplitudePluginOptions>(
 	};
 	return {
 		id: 'amplitude',
+		authConfig: amplitudeAuthConfig,
 		schema: AmplitudeSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/amplitude/webhooks/tenant-matcher.ts
+++ b/packages/amplitude/webhooks/tenant-matcher.ts
@@ -1,0 +1,11 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+
+// Amplitude destination webhooks are scoped to a single configured URL and
+// authenticated via x-amplitude-signature (HMAC over the raw body). Payloads are
+// customizable via FreeMarker templates and do not include a stable org/account
+// identifier — see https://amplitude.com/docs/data/destination-catalog/webhooks
+export function matchAmplitudeTenantWebhook(
+	_request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	return null;
+}

--- a/packages/asana/index.ts
+++ b/packages/asana/index.ts
@@ -48,6 +48,7 @@ import {
 	AsanaWebhookEventSchema,
 } from './webhooks/types';
 import { matchAsanaTenantWebhook } from './webhooks/tenant-matcher';
+import { resolveAsanaOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
 
 export type AsanaEndpoints = {
 	// Tasks
@@ -892,7 +893,10 @@ const defaultAuthType = 'api_key' as const;
 
 export const asanaAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['workspace_gid'] as const,
+	},
+	oauth_2: {
+		account: ['workspace_gid'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -994,6 +998,7 @@ export function asana<const PluginOptions extends AsanaPluginOptions>(
 			return 'x-hook-signature' in headers || 'x-hook-secret' in headers;
 		},
 		pluginTenantWebhookMatcher: matchAsanaTenantWebhook,
+		oauthWebhookTenantLinkResolver: resolveAsanaOAuthWebhookTenantLink,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/asana/index.ts
+++ b/packages/asana/index.ts
@@ -47,6 +47,7 @@ import {
 	AsanaTaskWebhookPayloadSchema,
 	AsanaWebhookEventSchema,
 } from './webhooks/types';
+import { matchAsanaTenantWebhook } from './webhooks/tenant-matcher';
 
 export type AsanaEndpoints = {
 	// Tasks
@@ -992,6 +993,7 @@ export function asana<const PluginOptions extends AsanaPluginOptions>(
 			const headers = request.headers;
 			return 'x-hook-signature' in headers || 'x-hook-secret' in headers;
 		},
+		pluginTenantWebhookMatcher: matchAsanaTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/asana/index.ts
+++ b/packages/asana/index.ts
@@ -893,10 +893,10 @@ const defaultAuthType = 'api_key' as const;
 
 export const asanaAuthConfig = {
 	api_key: {
-		account: ['workspace_gid'] as const,
+		account: ['workspace_gid', 'project_gid'] as const,
 	},
 	oauth_2: {
-		account: ['workspace_gid'] as const,
+		account: ['workspace_gid', 'project_gid'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 

--- a/packages/asana/jest.config.cjs
+++ b/packages/asana/jest.config.cjs
@@ -44,6 +44,7 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',
 	},

--- a/packages/asana/webhooks/oauth-tenant-link.ts
+++ b/packages/asana/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,25 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { toExternalId } from 'corsair/core';
+
+export async function resolveAsanaOAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): Promise<WebhookTenantMatch | null> {
+	const accessToken = tokens.access_token;
+	if (!accessToken) return null;
+
+	const response = await fetch(
+		'https://app.asana.com/api/1.0/users/me?opt_fields=workspaces.gid',
+		{
+			headers: { Authorization: `Bearer ${accessToken}` },
+		},
+	);
+	if (!response.ok) return null;
+
+	const payload = (await response.json()) as {
+		data?: { workspaces?: Array<{ gid?: string }> };
+	};
+	const workspaceGid = toExternalId(payload.data?.workspaces?.[0]?.gid);
+	return workspaceGid
+		? { linkType: 'workspace_gid', externalId: workspaceGid }
+		: null;
+}

--- a/packages/asana/webhooks/tenant-matcher.test.ts
+++ b/packages/asana/webhooks/tenant-matcher.test.ts
@@ -1,0 +1,106 @@
+import type { RawWebhookRequest } from 'corsair/core';
+import { matchAsanaTenantWebhook } from './tenant-matcher';
+
+describe('matchAsanaTenantWebhook', () => {
+	it('returns project_gid when a task event parent is a project', () => {
+		const request: RawWebhookRequest = {
+			headers: {},
+			body: {
+				events: [
+					{
+						resource: {
+							gid: 'task-1',
+							resource_type: 'task',
+						},
+						parent: {
+							gid: 'project-99',
+							resource_type: 'project',
+						},
+					},
+				],
+			},
+		};
+
+		expect(matchAsanaTenantWebhook(request)).toEqual({
+			linkType: 'project_gid',
+			externalId: 'project-99',
+		});
+	});
+
+	it('returns project_gid when the event resource is a project', () => {
+		const request: RawWebhookRequest = {
+			headers: {},
+			body: {
+				events: [
+					{
+						resource: {
+							gid: 'project-42',
+							resource_type: 'project',
+						},
+						parent: {
+							gid: 'workspace-1',
+							resource_type: 'workspace',
+						},
+					},
+				],
+			},
+		};
+
+		expect(matchAsanaTenantWebhook(request)).toEqual({
+			linkType: 'project_gid',
+			externalId: 'project-42',
+		});
+	});
+
+	it('returns workspace_gid for workspace membership events', () => {
+		const request: RawWebhookRequest = {
+			headers: {},
+			body: {
+				events: [
+					{
+						resource: {
+							gid: 'membership-1',
+							resource_type: 'workspace_membership',
+						},
+						parent: {
+							gid: 'workspace-7',
+							resource_type: 'workspace',
+						},
+					},
+				],
+			},
+		};
+
+		expect(matchAsanaTenantWebhook(request)).toEqual({
+			linkType: 'workspace_gid',
+			externalId: 'workspace-7',
+		});
+	});
+
+	it('returns null for handshake requests with X-Hook-Secret', () => {
+		const request: RawWebhookRequest = {
+			headers: { 'x-hook-secret': 'secret' },
+			body: { events: [] },
+		};
+
+		expect(matchAsanaTenantWebhook(request)).toBeNull();
+	});
+
+	it('returns null when events carry no project or workspace gid', () => {
+		const request: RawWebhookRequest = {
+			headers: {},
+			body: {
+				events: [
+					{
+						resource: {
+							gid: 'story-1',
+							resource_type: 'story',
+						},
+					},
+				],
+			},
+		};
+
+		expect(matchAsanaTenantWebhook(request)).toBeNull();
+	});
+});

--- a/packages/asana/webhooks/tenant-matcher.ts
+++ b/packages/asana/webhooks/tenant-matcher.ts
@@ -1,0 +1,48 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import {
+	asRecord,
+	getHeader,
+	readBodyRecord,
+	toExternalId,
+} from 'corsair/core';
+
+function workspaceGidFromEvents(events: unknown[]): string | undefined {
+	for (const event of events) {
+		const eventRecord = asRecord(event);
+		if (!eventRecord) continue;
+
+		const resource = asRecord(eventRecord.resource);
+		if (resource?.resource_type === 'workspace') {
+			const workspaceGid = toExternalId(resource.gid);
+			if (workspaceGid) return workspaceGid;
+		}
+
+		const parent = asRecord(eventRecord.parent);
+		if (parent?.resource_type === 'workspace') {
+			const workspaceGid = toExternalId(parent.gid);
+			if (workspaceGid) return workspaceGid;
+		}
+	}
+
+	return undefined;
+}
+
+// Asana handshake (X-Hook-Secret) and heartbeat deliveries (empty events) carry no tenant id.
+// Workspace-scoped events include resource.resource_type === 'workspace'.
+// See https://developers.asana.com/docs/webhooks-guide
+export function matchAsanaTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	if (getHeader(request.headers, 'x-hook-secret')) return null;
+
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const events = body.events;
+	if (!Array.isArray(events) || events.length === 0) return null;
+
+	const workspaceGid = workspaceGidFromEvents(events);
+	if (!workspaceGid) return null;
+
+	return { linkType: 'workspace_gid', externalId: workspaceGid };
+}

--- a/packages/asana/webhooks/tenant-matcher.ts
+++ b/packages/asana/webhooks/tenant-matcher.ts
@@ -6,6 +6,27 @@ import {
 	toExternalId,
 } from 'corsair/core';
 
+function projectGidFromEvents(events: unknown[]): string | undefined {
+	for (const event of events) {
+		const eventRecord = asRecord(event);
+		if (!eventRecord) continue;
+
+		const resource = asRecord(eventRecord.resource);
+		if (resource?.resource_type === 'project') {
+			const projectGid = toExternalId(resource.gid);
+			if (projectGid) return projectGid;
+		}
+
+		const parent = asRecord(eventRecord.parent);
+		if (parent?.resource_type === 'project') {
+			const projectGid = toExternalId(parent.gid);
+			if (projectGid) return projectGid;
+		}
+	}
+
+	return undefined;
+}
+
 function workspaceGidFromEvents(events: unknown[]): string | undefined {
 	for (const event of events) {
 		const eventRecord = asRecord(event);
@@ -28,7 +49,7 @@ function workspaceGidFromEvents(events: unknown[]): string | undefined {
 }
 
 // Asana handshake (X-Hook-Secret) and heartbeat deliveries (empty events) carry no tenant id.
-// Workspace-scoped events include resource.resource_type === 'workspace'.
+// Project/task webhooks include a project parent; workspace webhooks include workspace resources.
 // See https://developers.asana.com/docs/webhooks-guide
 export function matchAsanaTenantWebhook(
 	request: RawWebhookRequest,
@@ -41,8 +62,15 @@ export function matchAsanaTenantWebhook(
 	const events = body.events;
 	if (!Array.isArray(events) || events.length === 0) return null;
 
-	const workspaceGid = workspaceGidFromEvents(events);
-	if (!workspaceGid) return null;
+	const projectGid = projectGidFromEvents(events);
+	if (projectGid) {
+		return { linkType: 'project_gid', externalId: projectGid };
+	}
 
-	return { linkType: 'workspace_gid', externalId: workspaceGid };
+	const workspaceGid = workspaceGidFromEvents(events);
+	if (workspaceGid) {
+		return { linkType: 'workspace_gid', externalId: workspaceGid };
+	}
+
+	return null;
 }

--- a/packages/bluesky/index.ts
+++ b/packages/bluesky/index.ts
@@ -24,6 +24,7 @@ import type {
 } from './endpoints/types';
 import { errorHandlers } from './error-handlers';
 import { BlueskySchema } from './schema';
+import { matchBlueskyTenantWebhook } from './webhooks/tenant-matcher';
 
 // ── Auth Config ───────────────────────────────────────────────────────────────
 
@@ -196,6 +197,7 @@ export function bluesky<const T extends BlueskyPluginOptions>(
 			// Webhooks not supported on Bluesky
 			return false;
 		},
+		pluginTenantWebhookMatcher: matchBlueskyTenantWebhook,
 		keyBuilder: async (ctx: BlueskyKeyBuilderContext, source) => {
 			const authType = ctx.authType;
 

--- a/packages/bluesky/index.ts
+++ b/packages/bluesky/index.ts
@@ -30,7 +30,7 @@ import { matchBlueskyTenantWebhook } from './webhooks/tenant-matcher';
 
 export const blueskyAuthConfig = {
 	api_key: {
-		account: ['handle'] as const,
+		account: ['handle', 'did'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 

--- a/packages/bluesky/webhooks/tenant-matcher.ts
+++ b/packages/bluesky/webhooks/tenant-matcher.ts
@@ -1,0 +1,18 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// AT Protocol has no native webhooks; relay services forward repo events with a repo DID.
+// See https://atproto.com/specs/sync#firehose
+export function matchBlueskyTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const commit = asRecord(body.commit);
+
+	const did = firstString([body.did, body.repo, commit?.repo]);
+	if (!did) return null;
+
+	return { linkType: 'did', externalId: did };
+}

--- a/packages/box/index.ts
+++ b/packages/box/index.ts
@@ -506,8 +506,8 @@ const boxWebhookSchemas = {
 const defaultAuthType = 'oauth_2' as const;
 
 export const boxAuthConfig = {
-	oauth_2: {
-		account: ['one'] as const,
+	api_key: {
+		account: ['webhook_id', 'user_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -533,6 +533,7 @@ export function box<const T extends BoxPluginOptions>(
 	};
 	return {
 		id: 'box',
+		authConfig: boxAuthConfig,
 		schema: BoxSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/box/index.ts
+++ b/packages/box/index.ts
@@ -29,6 +29,7 @@ import {
 	MetadataWebhooks,
 	SharedLinkWebhooks,
 } from './webhooks';
+import { matchBoxTenantWebhook } from './webhooks/tenant-matcher';
 import type { BoxWebhookOutputs, BoxWebhookPayload } from './webhooks/types';
 import {
 	CollaborationAcceptedPayloadSchema,
@@ -546,6 +547,7 @@ export function box<const T extends BoxPluginOptions>(
 			const hasTimestamp = 'box-delivery-timestamp' in headers;
 			return hasTimestamp;
 		},
+		pluginTenantWebhookMatcher: matchBoxTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/box/webhooks/tenant-matcher.ts
+++ b/packages/box/webhooks/tenant-matcher.ts
@@ -1,0 +1,25 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// Box webhook events identify the acting user on created_by and the
+// subscribed webhook registration on webhook.id.
+// See https://developer.box.com/guides/webhooks/v2/
+export function matchBoxTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const webhookId = firstString([asRecord(body.webhook)?.id]);
+	if (webhookId) {
+		return { linkType: 'webhook_id', externalId: webhookId };
+	}
+
+	const userId = firstString([
+		asRecord(body.created_by)?.id,
+		asRecord(asRecord(body.source)?.owned_by)?.id,
+	]);
+	if (!userId) return null;
+
+	return { linkType: 'user_id', externalId: userId };
+}

--- a/packages/cal/index.ts
+++ b/packages/cal/index.ts
@@ -23,6 +23,7 @@ import {
 import { errorHandlers } from './error-handlers';
 import { CalSchema } from './schema';
 import { BookingWebhooks, PingWebhooks } from './webhooks';
+import { matchCalTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	BookingCancelledEvent,
 	BookingCreatedEvent,
@@ -262,8 +263,8 @@ export function cal<const T extends CalPluginOptions>(
 			const headers = request.headers;
 			const hasSignature = 'x-cal-signature-256' in headers;
 			return hasSignature;
-			return hasSignature;
 		},
+		pluginTenantWebhookMatcher: matchCalTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/cal/index.ts
+++ b/packages/cal/index.ts
@@ -224,7 +224,7 @@ const calWebhookSchemas = {
 
 export const calAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['organization_id', 'user_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -250,6 +250,7 @@ export function cal<const T extends CalPluginOptions>(
 	};
 	return {
 		id: 'cal',
+		authConfig: calAuthConfig,
 		schema: CalSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/cal/webhooks/tenant-matcher.ts
+++ b/packages/cal/webhooks/tenant-matcher.ts
@@ -1,0 +1,32 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// Cal.com booking webhooks nest data under payload; MEETING_STARTED uses a flat
+// envelope with top-level userId and organizationId.
+// See https://cal.com/docs/developing/guides/automation/webhooks
+export function matchCalTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const payload = asRecord(body.payload) ?? body;
+
+	const organizationId = firstString([
+		body.organizationId,
+		payload.organizationId,
+	]);
+	if (organizationId) {
+		return { linkType: 'organization_id', externalId: organizationId };
+	}
+
+	const userId = firstString([
+		body.userId,
+		payload.userId,
+		asRecord(payload.organizer)?.id,
+		asRecord(payload.user)?.id,
+	]);
+	if (!userId) return null;
+
+	return { linkType: 'user_id', externalId: userId };
+}

--- a/packages/calendly/index.ts
+++ b/packages/calendly/index.ts
@@ -680,7 +680,7 @@ const calendlyEndpointMeta = {
 
 export const calendlyAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['organization', 'user_uri'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -741,6 +741,7 @@ export function calendly<const T extends CalendlyPluginOptions>(
 	};
 	return {
 		id: 'calendly',
+		authConfig: calendlyAuthConfig,
 		schema: CalendlySchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/calendly/index.ts
+++ b/packages/calendly/index.ts
@@ -42,6 +42,7 @@ import {
 	RoutingFormWebhooks,
 	UserWebhooks,
 } from './webhooks';
+import { matchCalendlyTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	CalendlyWebhookOutputs,
 	EventTypeUpdatedPayload,
@@ -753,6 +754,7 @@ export function calendly<const T extends CalendlyPluginOptions>(
 			const headers = request.headers;
 			return 'calendly-webhook-signature' in headers;
 		},
+		pluginTenantWebhookMatcher: matchCalendlyTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/calendly/webhooks/tenant-matcher.ts
+++ b/packages/calendly/webhooks/tenant-matcher.ts
@@ -4,15 +4,21 @@ import { asRecord, firstString, readBodyRecord } from 'corsair/core';
 const CALENDLY_ORGANIZATION_URI =
 	/^https:\/\/api\.calendly\.com\/organizations\/[^/]+$/;
 const CALENDLY_USER_URI = /^https:\/\/api\.calendly\.com\/users\/[^/]+$/;
+const MAX_TRAVERSAL_DEPTH = 32;
 
-function findCalendlyOrganizationUri(value: unknown): string | undefined {
+function findCalendlyOrganizationUri(
+	value: unknown,
+	depth = 0,
+): string | undefined {
+	if (depth > MAX_TRAVERSAL_DEPTH) return undefined;
+
 	if (typeof value === 'string' && CALENDLY_ORGANIZATION_URI.test(value)) {
 		return value;
 	}
 
 	if (Array.isArray(value)) {
 		for (const item of value) {
-			const organizationUri = findCalendlyOrganizationUri(item);
+			const organizationUri = findCalendlyOrganizationUri(item, depth + 1);
 			if (organizationUri) return organizationUri;
 		}
 		return undefined;
@@ -30,21 +36,23 @@ function findCalendlyOrganizationUri(value: unknown): string | undefined {
 	}
 
 	for (const nested of Object.values(record)) {
-		const organizationUri = findCalendlyOrganizationUri(nested);
+		const organizationUri = findCalendlyOrganizationUri(nested, depth + 1);
 		if (organizationUri) return organizationUri;
 	}
 
 	return undefined;
 }
 
-function findCalendlyUserUri(value: unknown): string | undefined {
+function findCalendlyUserUri(value: unknown, depth = 0): string | undefined {
+	if (depth > MAX_TRAVERSAL_DEPTH) return undefined;
+
 	if (typeof value === 'string' && CALENDLY_USER_URI.test(value)) {
 		return value;
 	}
 
 	if (Array.isArray(value)) {
 		for (const item of value) {
-			const userUri = findCalendlyUserUri(item);
+			const userUri = findCalendlyUserUri(item, depth + 1);
 			if (userUri) return userUri;
 		}
 		return undefined;
@@ -54,7 +62,7 @@ function findCalendlyUserUri(value: unknown): string | undefined {
 	if (!record) return undefined;
 
 	for (const nested of Object.values(record)) {
-		const userUri = findCalendlyUserUri(nested);
+		const userUri = findCalendlyUserUri(nested, depth + 1);
 		if (userUri) return userUri;
 	}
 

--- a/packages/calendly/webhooks/tenant-matcher.ts
+++ b/packages/calendly/webhooks/tenant-matcher.ts
@@ -1,0 +1,82 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+const CALENDLY_ORGANIZATION_URI =
+	/^https:\/\/api\.calendly\.com\/organizations\/[^/]+$/;
+const CALENDLY_USER_URI = /^https:\/\/api\.calendly\.com\/users\/[^/]+$/;
+
+function findCalendlyOrganizationUri(value: unknown): string | undefined {
+	if (typeof value === 'string' && CALENDLY_ORGANIZATION_URI.test(value)) {
+		return value;
+	}
+
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			const organizationUri = findCalendlyOrganizationUri(item);
+			if (organizationUri) return organizationUri;
+		}
+		return undefined;
+	}
+
+	const record = asRecord(value);
+	if (!record) return undefined;
+
+	const directOrganization = firstString([record.organization]);
+	if (
+		directOrganization &&
+		CALENDLY_ORGANIZATION_URI.test(directOrganization)
+	) {
+		return directOrganization;
+	}
+
+	for (const nested of Object.values(record)) {
+		const organizationUri = findCalendlyOrganizationUri(nested);
+		if (organizationUri) return organizationUri;
+	}
+
+	return undefined;
+}
+
+function findCalendlyUserUri(value: unknown): string | undefined {
+	if (typeof value === 'string' && CALENDLY_USER_URI.test(value)) {
+		return value;
+	}
+
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			const userUri = findCalendlyUserUri(item);
+			if (userUri) return userUri;
+		}
+		return undefined;
+	}
+
+	const record = asRecord(value);
+	if (!record) return undefined;
+
+	for (const nested of Object.values(record)) {
+		const userUri = findCalendlyUserUri(nested);
+		if (userUri) return userUri;
+	}
+
+	return undefined;
+}
+
+// Calendly v2 webhook payloads use organization and user URIs throughout the
+// nested payload object. Subscriptions are scoped by organization.
+// See https://developer.calendly.com/api-docs/69c58a784aabc-webhook-payload
+export function matchCalendlyTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const organizationUri = findCalendlyOrganizationUri(body.payload ?? body);
+	if (organizationUri) {
+		return { linkType: 'organization', externalId: organizationUri };
+	}
+
+	const userUri = findCalendlyUserUri(body.payload ?? body);
+	if (!userUri) return null;
+
+	return { linkType: 'user_uri', externalId: userUri };
+}

--- a/packages/cli/src/lib/google/calendar.ts
+++ b/packages/cli/src/lib/google/calendar.ts
@@ -7,7 +7,7 @@ export async function setupCalendarWatch(
 	accessToken: string,
 	webhookUrl: string,
 	calendarId: string,
-): Promise<void> {
+): Promise<{ channelId: string }> {
 	const watchSpin = p.spinner();
 	watchSpin.start('Starting Calendar watch...');
 
@@ -49,4 +49,6 @@ export async function setupCalendarWatch(
 		`Channel ID: ${channelId}\nResource ID: ${data.resourceId}\nExpiration: ${new Date(Number(data.expiration)).toISOString()}`,
 		'Watch Response',
 	);
+
+	return { channelId };
 }

--- a/packages/cli/src/lib/google/drive.ts
+++ b/packages/cli/src/lib/google/drive.ts
@@ -6,7 +6,7 @@ const DRIVE_API_BASE = 'https://www.googleapis.com/drive/v3';
 export async function setupDriveWatch(
 	accessToken: string,
 	webhookUrl: string,
-): Promise<void> {
+): Promise<{ channelId: string }> {
 	const watchSpin = p.spinner();
 	watchSpin.start('Getting start page token...');
 
@@ -69,4 +69,6 @@ export async function setupDriveWatch(
 		`Channel ID: ${channelId}\nResource ID: ${data.resourceId}\nStart Page Token: ${startPageTokenData.startPageToken}\nExpiration: ${new Date(Number(data.expiration)).toISOString()}`,
 		'Watch Response',
 	);
+
+	return { channelId };
 }

--- a/packages/cli/src/lib/google/gmail.ts
+++ b/packages/cli/src/lib/google/gmail.ts
@@ -5,7 +5,7 @@ const GMAIL_API_BASE = 'https://gmail.googleapis.com/gmail/v1';
 export async function setupGmailWatch(
 	accessToken: string,
 	topicName: string,
-): Promise<void> {
+): Promise<{ emailAddress: string | null }> {
 	const watchSpin = p.spinner();
 	watchSpin.start('Starting Gmail watch...');
 
@@ -36,8 +36,20 @@ export async function setupGmailWatch(
 
 	watchSpin.stop('Watch started.');
 
+	const profileResponse = await fetch(
+		`${GMAIL_API_BASE}/users/me/profile`,
+		{
+			headers: { Authorization: `Bearer ${accessToken}` },
+		},
+	);
+	const profile = profileResponse.ok
+		? ((await profileResponse.json()) as { emailAddress?: string })
+		: null;
+
 	p.note(
-		`History ID: ${data.historyId}\nExpiration: ${new Date(Number(data.expiration)).toISOString()}`,
+		`History ID: ${data.historyId}\nExpiration: ${new Date(Number(data.expiration)).toISOString()}${profile?.emailAddress ? `\nEmail: ${profile.emailAddress}` : ''}`,
 		'Watch Response',
 	);
+
+	return { emailAddress: profile?.emailAddress ?? null };
 }

--- a/packages/cli/src/lib/google/index.ts
+++ b/packages/cli/src/lib/google/index.ts
@@ -1,5 +1,6 @@
 import * as p from '@clack/prompts';
 import type { CorsairInternalConfig } from 'corsair/core';
+import { setWebhookTenantLink } from 'corsair';
 import {
 	CORSAIR_INTERNAL,
 	createAccountKeyManager,
@@ -165,6 +166,23 @@ export async function runGoogleSubscribe({
 
 		credSpin.stop('Credentials loaded.');
 
+		const saveGoogleTenantLink = async (link: {
+			linkType: string;
+			externalId: string;
+		}) => {
+			await setWebhookTenantLink({
+				database,
+				kek,
+				pluginId: pluginType,
+				tenantId,
+				link: {
+					linkType: link.linkType,
+					externalId: link.externalId,
+				},
+				authType: 'oauth_2',
+			});
+		};
+
 		if (pluginType === 'gmail') {
 			const topicName = await p.text({
 				message: 'Enter Pub/Sub topic name:',
@@ -177,7 +195,16 @@ export async function runGoogleSubscribe({
 				p.cancel('Operation cancelled.');
 				process.exit(0);
 			}
-			await setupGmailWatch(accessToken, topicName as string);
+			const gmailWatch = await setupGmailWatch(
+				accessToken,
+				topicName as string,
+			);
+			if (gmailWatch.emailAddress) {
+				await saveGoogleTenantLink({
+					linkType: 'email_address',
+					externalId: gmailWatch.emailAddress,
+				});
+			}
 		} else if (pluginType === 'googledrive') {
 			const webhookUrl = await p.text({
 				message: 'Enter webhook URL:',
@@ -190,7 +217,14 @@ export async function runGoogleSubscribe({
 				p.cancel('Operation cancelled.');
 				process.exit(0);
 			}
-			await setupDriveWatch(accessToken, webhookUrl as string);
+			const driveWatch = await setupDriveWatch(
+				accessToken,
+				webhookUrl as string,
+			);
+			await saveGoogleTenantLink({
+				linkType: 'channel_id',
+				externalId: driveWatch.channelId,
+			});
 		} else if (pluginType === 'googlecalendar') {
 			const webhookUrl = await p.text({
 				message: 'Enter webhook URL:',
@@ -212,11 +246,15 @@ export async function runGoogleSubscribe({
 				p.cancel('Operation cancelled.');
 				process.exit(0);
 			}
-			await setupCalendarWatch(
+			const calendarWatch = await setupCalendarWatch(
 				accessToken,
 				webhookUrl as string,
 				calendarId as string,
 			);
+			await saveGoogleTenantLink({
+				linkType: 'channel_id',
+				externalId: calendarWatch.channelId,
+			});
 		} else {
 			p.log.error(`Unsupported Google plugin: ${pluginType}`);
 			process.exit(1);

--- a/packages/cli/src/lib/microsoft/credentials.ts
+++ b/packages/cli/src/lib/microsoft/credentials.ts
@@ -4,6 +4,7 @@ import {
 	createAccountKeyManager,
 	createIntegrationKeyManager,
 } from 'corsair/core';
+import { setWebhookTenantLink } from 'corsair';
 
 const MICROSOFT_TOKEN_URL =
 	'https://login.microsoftonline.com/common/oauth2/v2.0/token';
@@ -149,9 +150,48 @@ export async function resolveAccessToken(
 export async function saveWebhookSignature(
 	accountKm: { set_webhook_signature(sig: string): Promise<void> },
 	clientState: string,
+	options?: {
+		pluginId: string;
+		tenantId: string;
+		internal: CorsairInternalConfig;
+	},
 ): Promise<void> {
 	const saveSpin = p.spinner();
 	saveSpin.start('Saving webhook secret...');
 	await accountKm.set_webhook_signature(clientState);
 	saveSpin.stop('Webhook secret saved.');
+
+	if (options?.internal.database) {
+		const linkSpin = p.spinner();
+		linkSpin.start('Saving webhook tenant link...');
+		await setWebhookTenantLink({
+			database: options.internal.database,
+			kek: options.internal.kek,
+			pluginId: options.pluginId,
+			tenantId: options.tenantId,
+			link: { linkType: 'client_state', externalId: clientState },
+			authType: 'oauth_2',
+		});
+		linkSpin.stop('Webhook tenant link saved.');
+	}
+}
+
+export async function saveSubscriptionTenantLink(
+	options: {
+		pluginId: string;
+		tenantId: string;
+		internal: CorsairInternalConfig;
+	},
+	subscriptionId: string,
+): Promise<void> {
+	if (!options.internal.database) return;
+
+	await setWebhookTenantLink({
+		database: options.internal.database,
+		kek: options.internal.kek,
+		pluginId: options.pluginId,
+		tenantId: options.tenantId,
+		link: { linkType: 'subscription_id', externalId: subscriptionId },
+		authType: 'oauth_2',
+	});
 }

--- a/packages/cli/src/lib/microsoft/onedrive.ts
+++ b/packages/cli/src/lib/microsoft/onedrive.ts
@@ -5,7 +5,7 @@ import {
 	promptTenantId,
 	promptWebhookUrl,
 } from '../../utils/prompts';
-import { resolveAccessToken, saveWebhookSignature } from './credentials';
+import { resolveAccessToken, saveSubscriptionTenantLink, saveWebhookSignature } from './credentials';
 import { createGraphSubscription } from './graph';
 
 // Microsoft Graph max subscription lifetime for drive resources (minutes)
@@ -145,6 +145,10 @@ export async function runOnedriveSubscribe({
 			results.push(
 				`${resourceType}\n  Resource: ${resource}\n  ID: ${subscription.id}\n  Expires: ${subscription.expirationDateTime}`,
 			);
+			await saveSubscriptionTenantLink(
+				{ pluginId: 'onedrive', tenantId, internal },
+				subscription.id,
+			);
 		} catch (error) {
 			subSpin.stop(`Failed: ${resourceType}`);
 			p.log.error(error instanceof Error ? error.message : String(error));
@@ -156,7 +160,11 @@ export async function runOnedriveSubscribe({
 		p.note(results.join('\n\n'), 'Subscriptions created');
 	}
 
-	await saveWebhookSignature(accountKm, clientState);
+	await saveWebhookSignature(accountKm, clientState, {
+		pluginId: 'onedrive',
+		tenantId,
+		internal,
+	});
 
 	if (!hasError) {
 		p.log.success('OneDrive webhook subscriptions set up successfully.');

--- a/packages/cli/src/lib/microsoft/outlook.ts
+++ b/packages/cli/src/lib/microsoft/outlook.ts
@@ -5,7 +5,7 @@ import {
 	promptTenantId,
 	promptWebhookUrl,
 } from '../../utils/prompts';
-import { resolveAccessToken, saveWebhookSignature } from './credentials';
+import { resolveAccessToken, saveSubscriptionTenantLink, saveWebhookSignature } from './credentials';
 import { createGraphSubscription } from './graph';
 
 type OutlookResourceType =
@@ -112,6 +112,10 @@ export async function runOutlookSubscribe({
 			results.push(
 				`${cfg.label}\n  ID: ${subscription.id}\n  Expires: ${subscription.expirationDateTime}`,
 			);
+			await saveSubscriptionTenantLink(
+				{ pluginId: 'outlook', tenantId, internal },
+				subscription.id,
+			);
 		} catch (error) {
 			subSpin.stop(`Failed: ${cfg.label}`);
 			p.log.error(error instanceof Error ? error.message : String(error));
@@ -123,7 +127,11 @@ export async function runOutlookSubscribe({
 		p.note(results.join('\n\n'), 'Subscriptions created');
 	}
 
-	await saveWebhookSignature(accountKm, clientState);
+	await saveWebhookSignature(accountKm, clientState, {
+		pluginId: 'outlook',
+		tenantId,
+		internal,
+	});
 
 	if (!hasError) {
 		p.log.success('Outlook webhook subscriptions set up successfully.');

--- a/packages/cli/src/lib/microsoft/sharepoint.ts
+++ b/packages/cli/src/lib/microsoft/sharepoint.ts
@@ -5,7 +5,7 @@ import {
 	promptTenantId,
 	promptWebhookUrl,
 } from '../../utils/prompts';
-import { resolveAccessToken, saveWebhookSignature } from './credentials';
+import { resolveAccessToken, saveSubscriptionTenantLink, saveWebhookSignature } from './credentials';
 import { GRAPH_API_BASE } from './graph';
 
 const SHAREPOINT_MAX_EXPIRY_DAYS = 180;
@@ -183,7 +183,16 @@ export async function runSharepointSubscribe({
 
 	subSpin.stop('Subscription created.');
 
-	await saveWebhookSignature(accountKm, clientState);
+	await saveSubscriptionTenantLink(
+		{ pluginId: sharepointPlugin.id, tenantId, internal },
+		subscription.id,
+	);
+
+	await saveWebhookSignature(accountKm, clientState, {
+		pluginId: sharepointPlugin.id,
+		tenantId,
+		internal,
+	});
 
 	p.note(
 		`Subscription ID:  ${subscription.id}\nSite ID:          ${siteId}\nList ID:          ${listId}\nExpires:          ${subscription.expirationDateTime}\nClientState:      ${clientState}\nWebhook URL:      ${webhookUrl}\n\nNote: SharePoint subscriptions expire after ${SHAREPOINT_MAX_EXPIRY_DAYS} days max. Re-run this command to renew.`,

--- a/packages/cli/src/lib/microsoft/teams.ts
+++ b/packages/cli/src/lib/microsoft/teams.ts
@@ -5,7 +5,7 @@ import {
 	promptTenantId,
 	promptWebhookUrl,
 } from '../../utils/prompts';
-import { resolveAccessToken, saveWebhookSignature } from './credentials';
+import { resolveAccessToken, saveSubscriptionTenantLink, saveWebhookSignature } from './credentials';
 import { createGraphSubscription, GRAPH_API_BASE } from './graph';
 
 async function fetchJoinedTeams(
@@ -319,6 +319,10 @@ export async function runTeamsSubscribe({
 			results.push(
 				`${resourceType}\n  Resource: ${resource}\n  ID: ${subscription.id}\n  Expires: ${subscription.expirationDateTime}`,
 			);
+			await saveSubscriptionTenantLink(
+				{ pluginId: 'teams', tenantId, internal },
+				subscription.id,
+			);
 		} catch (error) {
 			subSpin.stop(`Failed: ${resourceType}`);
 			p.log.error(error instanceof Error ? error.message : String(error));
@@ -330,7 +334,11 @@ export async function runTeamsSubscribe({
 		p.note(results.join('\n\n'), 'Subscriptions created');
 	}
 
-	await saveWebhookSignature(accountKm, clientState);
+	await saveWebhookSignature(accountKm, clientState, {
+		pluginId: 'teams',
+		tenantId,
+		internal,
+	});
 
 	if (!hasError) {
 		p.log.success('Teams webhook subscriptions set up successfully.');

--- a/packages/cloudflare/index.ts
+++ b/packages/cloudflare/index.ts
@@ -28,6 +28,7 @@ import {
 } from './endpoints/types';
 import { errorHandlers } from './error-handlers';
 import { CloudflareSchema } from './schema';
+import { matchCloudflareTenantWebhook } from './webhooks/tenant-matcher';
 
 export type CloudflarePluginOptions = {
 	authType?: PickAuth<'api_key'>;
@@ -335,6 +336,7 @@ export function cloudflare<const T extends CloudflarePluginOptions>(
 		endpointMeta: cloudflareEndpointMeta,
 		endpointSchemas: cloudflareEndpointSchemas,
 		pluginWebhookMatcher: () => false,
+		pluginTenantWebhookMatcher: matchCloudflareTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/cloudflare/index.ts
+++ b/packages/cloudflare/index.ts
@@ -298,7 +298,7 @@ const cloudflareEndpointMeta = {
 
 export const cloudflareAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['account_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -328,6 +328,7 @@ export function cloudflare<const T extends CloudflarePluginOptions>(
 	};
 	return {
 		id: 'cloudflare',
+		authConfig: cloudflareAuthConfig,
 		schema: CloudflareSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/cloudflare/webhooks/tenant-matcher.ts
+++ b/packages/cloudflare/webhooks/tenant-matcher.ts
@@ -1,0 +1,25 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// Cloudflare notification policies include account_id; SaaS webhooks nest it under metadata.account.id.
+// See https://developers.cloudflare.com/notifications/reference/webhook-payload-schema/
+export function matchCloudflareTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const metadata = asRecord(body.metadata);
+	const account = asRecord(metadata?.account);
+	const data = asRecord(body.data);
+
+	const accountId = firstString([
+		body.account_id,
+		account?.id,
+		asRecord(data?.account)?.id,
+	]);
+
+	if (!accountId) return null;
+
+	return { linkType: 'account_id', externalId: accountId };
+}

--- a/packages/corsair/core/auth/exchange.ts
+++ b/packages/corsair/core/auth/exchange.ts
@@ -7,6 +7,7 @@ export type TokenResponse = {
 	refresh_token?: string;
 	expires_in?: number;
 	token_type?: string;
+	[key: string]: unknown;
 };
 
 /**

--- a/packages/corsair/core/auth/exchange.ts
+++ b/packages/corsair/core/auth/exchange.ts
@@ -7,6 +7,8 @@ export type TokenResponse = {
 	refresh_token?: string;
 	expires_in?: number;
 	token_type?: string;
+	// Providers return extra fields (team_id, installation, hub_id, etc.) used by
+	// oauthWebhookTenantLinkResolver to populate webhook tenant routing keys.
 	[key: string]: unknown;
 };
 

--- a/packages/corsair/core/client/index.ts
+++ b/packages/corsair/core/client/index.ts
@@ -29,7 +29,12 @@ import type {
 	PermissionMode,
 	PermissionPolicy,
 } from '../plugins';
-import type { BindWebhooks, RawWebhookRequest, WebhookTree } from '../webhooks';
+import type {
+	BindWebhooks,
+	CorsairWebhookTenantMatcher,
+	RawWebhookRequest,
+	WebhookTree,
+} from '../webhooks';
 import { bindWebhooksRecursively } from '../webhooks/bind';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -139,6 +144,11 @@ type InferPluginNamespace<P extends CorsairPlugin> = P extends CorsairPlugin<
 							 * Use this as a first-level filter before checking individual webhook matchers.
 							 */
 							pluginWebhookMatcher?: (request: RawWebhookRequest) => boolean;
+							/**
+							 * Extracts the external tenant lookup key for this plugin's webhook.
+							 * Only present if the plugin defines `pluginTenantWebhookMatcher`.
+							 */
+							pluginTenantWebhookMatcher?: CorsairWebhookTenantMatcher;
 						}
 					: {}) &
 				// Account-level keys (per-tenant secrets like bot_token, api_key, access_token)
@@ -556,6 +566,10 @@ export function buildCorsairClient<
 			if (plugin.pluginWebhookMatcher) {
 				apiUnsafe[plugin.id]!.pluginWebhookMatcher =
 					plugin.pluginWebhookMatcher;
+			}
+			if (plugin.pluginTenantWebhookMatcher) {
+				apiUnsafe[plugin.id]!.pluginTenantWebhookMatcher =
+					plugin.pluginTenantWebhookMatcher;
 			}
 		}
 	}

--- a/packages/corsair/core/index.ts
+++ b/packages/corsair/core/index.ts
@@ -276,9 +276,25 @@ export type {
 	CorsairWebhook,
 	CorsairWebhookHandler,
 	CorsairWebhookMatcher,
+	CorsairWebhookTenantMatcher,
 	RawWebhookRequest,
 	WebhookPathsOf,
 	WebhookRequest,
 	WebhookResponse,
+	WebhookTenantMatch,
 	WebhookTree,
 } from './webhooks';
+export {
+	matchWebhookPlugin,
+	matchWebhookPluginAndTenant,
+	type PluginWebhookMatchers,
+	type WebhookPluginTenantMatch,
+} from './webhooks/tenant-match';
+export {
+	asRecord,
+	decodePubSubData,
+	firstString,
+	getHeader,
+	readBodyRecord,
+	toExternalId,
+} from './webhooks/tenant-match-utils';

--- a/packages/corsair/core/index.ts
+++ b/packages/corsair/core/index.ts
@@ -295,8 +295,11 @@ export {
 export {
 	asRecord,
 	decodePubSubData,
+	extractMicrosoftGraphValidationToken,
 	firstString,
 	getHeader,
+	isMicrosoftGraphValidationHandshake,
 	readBodyRecord,
+	readQueryParam,
 	toExternalId,
 } from './webhooks/tenant-match-utils';

--- a/packages/corsair/core/index.ts
+++ b/packages/corsair/core/index.ts
@@ -276,6 +276,7 @@ export type {
 	CorsairWebhook,
 	CorsairWebhookHandler,
 	CorsairWebhookMatcher,
+	CorsairOAuthWebhookTenantLinkResolver,
 	CorsairWebhookTenantMatcher,
 	RawWebhookRequest,
 	WebhookPathsOf,
@@ -287,6 +288,7 @@ export type {
 export {
 	matchWebhookPlugin,
 	matchWebhookPluginAndTenant,
+	collectPluginWebhookMatchers,
 	type PluginWebhookMatchers,
 	type WebhookPluginTenantMatch,
 } from './webhooks/tenant-match';

--- a/packages/corsair/core/plugins/index.ts
+++ b/packages/corsair/core/plugins/index.ts
@@ -17,6 +17,7 @@ import type {
 	CorsairWebhook,
 	CorsairWebhookHandler,
 	CorsairWebhookMatcher,
+	CorsairOAuthWebhookTenantLinkResolver,
 	CorsairWebhookTenantMatcher,
 	WebhookPathsOf,
 	WebhookRequest,
@@ -471,6 +472,11 @@ export type CorsairPlugin<
 	 * the request cannot be mapped to a tenant.
 	 */
 	pluginTenantWebhookMatcher?: CorsairWebhookTenantMatcher;
+	/**
+	 * Resolves the external id to store on the account after OAuth so incoming
+	 * webhooks can be routed to the correct tenant. Return null when unavailable.
+	 */
+	oauthWebhookTenantLinkResolver?: CorsairOAuthWebhookTenantLinkResolver;
 	/** Plugin-specific error handlers */
 	errorHandlers?: CorsairErrorHandler;
 	/**

--- a/packages/corsair/core/plugins/index.ts
+++ b/packages/corsair/core/plugins/index.ts
@@ -17,6 +17,7 @@ import type {
 	CorsairWebhook,
 	CorsairWebhookHandler,
 	CorsairWebhookMatcher,
+	CorsairWebhookTenantMatcher,
 	WebhookPathsOf,
 	WebhookRequest,
 	WebhookResponse,
@@ -464,6 +465,12 @@ export type CorsairPlugin<
 	 * should handle an incoming request. Acts as a first-level filter.
 	 */
 	pluginWebhookMatcher?: CorsairWebhookMatcher;
+	/**
+	 * Extracts the external identifier used to resolve a tenant for this webhook
+	 * (for example Slack `team_id`, GitHub `installation.id`). Return null when
+	 * the request cannot be mapped to a tenant.
+	 */
+	pluginTenantWebhookMatcher?: CorsairWebhookTenantMatcher;
 	/** Plugin-specific error handlers */
 	errorHandlers?: CorsairErrorHandler;
 	/**

--- a/packages/corsair/core/webhooks/index.ts
+++ b/packages/corsair/core/webhooks/index.ts
@@ -63,6 +63,25 @@ export type WebhookResponse<TData = unknown> = {
 export type CorsairWebhookMatcher = (request: RawWebhookRequest) => boolean;
 
 /**
+ * Identifies which external credential key should be used to resolve a tenant
+ * for an incoming webhook. The `linkType` names the field stored on
+ * `corsair_accounts` (for example `team_id`, `installation_id`).
+ */
+export type WebhookTenantMatch = {
+	linkType: string;
+	externalId: string;
+};
+
+/**
+ * Extracts the tenant lookup key from a webhook after the plugin has been
+ * identified. Return null when the payload does not contain a resolvable id
+ * (for example URL verification challenges).
+ */
+export type CorsairWebhookTenantMatcher = (
+	request: RawWebhookRequest,
+) => WebhookTenantMatch | null;
+
+/**
  * Bivariance hack for webhook function types to ensure proper type inference.
  * @template Args - The function arguments
  * @template R - The function return type

--- a/packages/corsair/core/webhooks/index.ts
+++ b/packages/corsair/core/webhooks/index.ts
@@ -13,6 +13,8 @@ export type RawWebhookRequest = {
 	headers: Record<string, string | string[] | undefined>;
 	/** Raw request body (string or already parsed object) */
 	body: unknown;
+	/** Query string parameters when available (e.g. Microsoft Graph validationToken). */
+	query?: Record<string, string | string[] | undefined>;
 };
 
 /**
@@ -27,6 +29,8 @@ export type WebhookRequest<TPayload = unknown> = {
 	headers: Record<string, string | string[] | undefined>;
 	/** Raw request body string (for signature verification) */
 	rawBody?: string;
+	/** Query string parameters when available. */
+	query?: Record<string, string | string[] | undefined>;
 };
 
 /**

--- a/packages/corsair/core/webhooks/index.ts
+++ b/packages/corsair/core/webhooks/index.ts
@@ -82,6 +82,14 @@ export type CorsairWebhookTenantMatcher = (
 ) => WebhookTenantMatch | null;
 
 /**
+ * Resolves the webhook tenant link field after OAuth completes.
+ * Return null when the provider does not expose a stable external id.
+ */
+export type CorsairOAuthWebhookTenantLinkResolver = (
+	tokens: import('../auth/exchange').TokenResponse,
+) => WebhookTenantMatch | null | Promise<WebhookTenantMatch | null>;
+
+/**
  * Bivariance hack for webhook function types to ensure proper type inference.
  * @template Args - The function arguments
  * @template R - The function return type

--- a/packages/corsair/core/webhooks/tenant-match-utils.ts
+++ b/packages/corsair/core/webhooks/tenant-match-utils.ts
@@ -30,6 +30,108 @@ export function readBodyRecord(request: RawWebhookRequest) {
 	return asRecord(request.body);
 }
 
+export function readQueryParam(
+	request: {
+		query?: Record<string, string | string[] | undefined>;
+	},
+	name: string,
+): string | undefined {
+	const query = request.query;
+	if (!query) return undefined;
+
+	const value = query[name] ?? query[name.toLowerCase()];
+	return firstString(Array.isArray(value) ? value : [value]);
+}
+
+type MicrosoftGraphValidationRequest = {
+	headers?: Record<string, string | string[] | undefined>;
+	body?: unknown;
+	payload?: unknown;
+	query?: Record<string, string | string[] | undefined>;
+};
+
+// Microsoft Graph and SharePoint subscription validation sends validationToken as a
+// query param, header, forwarded URI, or JSON body field during registration.
+export function extractMicrosoftGraphValidationToken(
+	request: MicrosoftGraphValidationRequest,
+): string | null {
+	const headers = request.headers ?? {};
+	const headerCandidates = [
+		headers.validationtoken,
+		headers.validationToken,
+		headers['validation-token'],
+		headers['ms-validation-token'],
+	];
+	for (const candidate of headerCandidates) {
+		const value = firstString(Array.isArray(candidate) ? candidate : [candidate]);
+		if (value) return decodeURIComponent(value);
+	}
+
+	const queryToken = readQueryParam(
+		{ query: request.query },
+		'validationToken',
+	);
+	if (queryToken) return queryToken;
+
+	const pathLikeHeaderKeys = [
+		'x-forwarded-uri',
+		'x-original-uri',
+		'x-rewrite-url',
+		'x-envoy-original-path',
+		'referer',
+	];
+	for (const key of pathLikeHeaderKeys) {
+		const headerValue = headers[key];
+		const asString = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+		if (!asString || typeof asString !== 'string') continue;
+		try {
+			const fullUrl = asString.startsWith('http')
+				? new URL(asString)
+				: new URL(
+						`https://example.invalid${asString.startsWith('/') ? asString : `/${asString}`}`,
+					);
+			const uriToken = fullUrl.searchParams.get('validationToken');
+			if (uriToken?.trim()) return uriToken.trim();
+		} catch {
+			continue;
+		}
+	}
+
+	const bodySource =
+		request.payload !== undefined
+			? request.payload
+			: request.body !== undefined
+				? request.body
+				: undefined;
+	const body = asRecord(
+		typeof bodySource === 'string'
+			? (() => {
+					try {
+						return JSON.parse(bodySource) as unknown;
+					} catch {
+						return bodySource;
+					}
+				})()
+			: bodySource,
+	);
+	const bodyToken = firstString([body?.validationToken]);
+	return bodyToken ?? null;
+}
+
+export function isMicrosoftGraphValidationHandshake(
+	request: MicrosoftGraphValidationRequest,
+): boolean {
+	if (extractMicrosoftGraphValidationToken(request)) return true;
+
+	const body = asRecord(request.body ?? request.payload);
+	const contentType = getHeader(request.headers ?? {}, 'content-type');
+	if (contentType?.includes('text/plain')) {
+		return !body || Object.keys(body).length === 0;
+	}
+
+	return false;
+}
+
 export function firstString(values: unknown[]): string | undefined {
 	for (const value of values) {
 		const externalId = toExternalId(value);

--- a/packages/corsair/core/webhooks/tenant-match-utils.ts
+++ b/packages/corsair/core/webhooks/tenant-match-utils.ts
@@ -1,0 +1,50 @@
+import type { RawWebhookRequest } from './index';
+
+export function getHeader(
+	headers: Record<string, string | string[] | undefined>,
+	name: string,
+): string | undefined {
+	const normalizedName = name.toLowerCase();
+	const value = headers[normalizedName] ?? headers[name];
+	if (Array.isArray(value)) return value[0];
+	return typeof value === 'string' ? value : undefined;
+}
+
+export function toExternalId(value: unknown): string | undefined {
+	if (typeof value === 'string') {
+		const trimmed = value.trim();
+		return trimmed.length > 0 ? trimmed : undefined;
+	}
+	if (typeof value === 'number' && Number.isFinite(value)) {
+		return String(value);
+	}
+	return undefined;
+}
+
+export function asRecord(value: unknown): Record<string, unknown> | null {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+	return value as Record<string, unknown>;
+}
+
+export function readBodyRecord(request: RawWebhookRequest) {
+	return asRecord(request.body);
+}
+
+export function firstString(values: unknown[]): string | undefined {
+	for (const value of values) {
+		const externalId = toExternalId(value);
+		if (externalId) return externalId;
+	}
+	return undefined;
+}
+
+export function decodePubSubData(body: Record<string, unknown>): unknown {
+	const message = asRecord(body.message);
+	const data = message?.data;
+	if (typeof data !== 'string') return null;
+	try {
+		return JSON.parse(Buffer.from(data, 'base64').toString('utf8'));
+	} catch {
+		return null;
+	}
+}

--- a/packages/corsair/core/webhooks/tenant-match.ts
+++ b/packages/corsair/core/webhooks/tenant-match.ts
@@ -1,0 +1,50 @@
+import type { AllProviders } from '../constants';
+import type {
+	CorsairWebhookMatcher,
+	CorsairWebhookTenantMatcher,
+	RawWebhookRequest,
+	WebhookTenantMatch,
+} from './index';
+
+export type PluginWebhookMatchers = {
+	pluginWebhookMatcher?: CorsairWebhookMatcher;
+	pluginTenantWebhookMatcher?: CorsairWebhookTenantMatcher;
+};
+
+export type WebhookPluginTenantMatch = {
+	plugin: AllProviders | (string & {});
+	tenantMatch: WebhookTenantMatch;
+};
+
+/**
+ * Identifies which plugin an incoming webhook belongs to.
+ */
+export function matchWebhookPlugin(
+	plugins: Record<string, PluginWebhookMatchers | undefined>,
+	request: RawWebhookRequest,
+): string | null {
+	for (const [pluginId, plugin] of Object.entries(plugins)) {
+		if (!plugin?.pluginWebhookMatcher) continue;
+		if (plugin.pluginWebhookMatcher(request)) return pluginId;
+	}
+	return null;
+}
+
+/**
+ * Runs plugin identification, then extracts the tenant lookup key for that plugin.
+ */
+export function matchWebhookPluginAndTenant(
+	plugins: Record<string, PluginWebhookMatchers | undefined>,
+	request: RawWebhookRequest,
+): WebhookPluginTenantMatch | null {
+	const pluginId = matchWebhookPlugin(plugins, request);
+	if (!pluginId) return null;
+
+	const plugin = plugins[pluginId];
+	if (!plugin?.pluginTenantWebhookMatcher) return null;
+
+	const tenantMatch = plugin.pluginTenantWebhookMatcher(request);
+	if (!tenantMatch) return null;
+
+	return { plugin: pluginId, tenantMatch };
+}

--- a/packages/corsair/core/webhooks/tenant-match.ts
+++ b/packages/corsair/core/webhooks/tenant-match.ts
@@ -1,4 +1,5 @@
 import type { AllProviders } from '../constants';
+import type { CorsairPlugin } from '../plugins';
 import type {
 	CorsairWebhookMatcher,
 	CorsairWebhookTenantMatcher,
@@ -47,4 +48,26 @@ export function matchWebhookPluginAndTenant(
 	if (!tenantMatch) return null;
 
 	return { plugin: pluginId, tenantMatch };
+}
+
+/**
+ * Collects plugin-level webhook matchers from a corsair plugin list.
+ */
+export function collectPluginWebhookMatchers(
+	plugins: readonly CorsairPlugin[],
+): Record<string, PluginWebhookMatchers> {
+	const result: Record<string, PluginWebhookMatchers> = {};
+
+	for (const plugin of plugins) {
+		if (!plugin.pluginWebhookMatcher && !plugin.pluginTenantWebhookMatcher) {
+			continue;
+		}
+
+		result[plugin.id] = {
+			pluginWebhookMatcher: plugin.pluginWebhookMatcher,
+			pluginTenantWebhookMatcher: plugin.pluginTenantWebhookMatcher,
+		};
+	}
+
+	return result;
 }

--- a/packages/corsair/index.ts
+++ b/packages/corsair/index.ts
@@ -43,6 +43,25 @@ export { executePermission } from './permissions';
 export { type SetupCorsairOptions, setupCorsair } from './setup/index';
 export { processWebhook } from './webhooks';
 export {
+	setWebhookTenantLink,
+	resolveAccountFromWebhookLink,
+	resolveTenantIdFromWebhookLink,
+	resolveTenantFromWebhookLink,
+	type ResolveAccountFromWebhookLinkInput,
+	type WebhookTenantLink,
+} from './webhooks/tenant-links';
+export {
+	processCorsair,
+	type OAuthCallbackTunnelPayload,
+	type ProcessCorsairOptions,
+	type ProcessCorsairRequest,
+	type TunnelAck,
+	type TunnelEnvelope,
+	type TunnelType,
+	type WebhookTunnelPayload,
+} from './tunnel';
+export {
+	collectPluginWebhookMatchers,
 	matchWebhookPlugin,
 	matchWebhookPluginAndTenant,
 	type PluginWebhookMatchers,

--- a/packages/corsair/index.ts
+++ b/packages/corsair/index.ts
@@ -42,3 +42,17 @@ export type { PermissionExecuteResult } from './permissions';
 export { executePermission } from './permissions';
 export { type SetupCorsairOptions, setupCorsair } from './setup/index';
 export { processWebhook } from './webhooks';
+export {
+	matchWebhookPlugin,
+	matchWebhookPluginAndTenant,
+	type PluginWebhookMatchers,
+	type WebhookPluginTenantMatch,
+} from './core/webhooks/tenant-match';
+export {
+	asRecord,
+	decodePubSubData,
+	firstString,
+	getHeader,
+	readBodyRecord,
+	toExternalId,
+} from './core/webhooks/tenant-match-utils';

--- a/packages/corsair/oauth/index.ts
+++ b/packages/corsair/oauth/index.ts
@@ -295,22 +295,36 @@ export async function processOAuthCallback(
 		);
 	}
 
-	const tenantLink = await resolveOAuthWebhookTenantLink(
-		internal.plugins,
-		pluginId,
-		tokens,
-	);
-	if (tenantLink) {
-		const extraAccountFields = plugin.authConfig?.oauth_2?.account ?? [];
-		await setWebhookTenantLink({
-			database: internal.database,
-			kek: internal.kek,
+	try {
+		const tenantLink = await resolveOAuthWebhookTenantLink(
+			internal.plugins,
 			pluginId,
-			tenantId,
-			link: tenantLink,
-			authType: 'oauth_2',
-			extraAccountFields,
-		});
+			tokens,
+		);
+		if (tenantLink) {
+			try {
+				const extraAccountFields = plugin.authConfig?.oauth_2?.account ?? [];
+				await setWebhookTenantLink({
+					database: internal.database,
+					kek: internal.kek,
+					pluginId,
+					tenantId,
+					link: tenantLink,
+					authType: 'oauth_2',
+					extraAccountFields,
+				});
+			} catch (error) {
+				console.warn(
+					`[corsair:oauth] Failed to persist webhook tenant link for '${pluginId}' tenant '${tenantId}':`,
+					error,
+				);
+			}
+		}
+	} catch (error) {
+		console.warn(
+			`[corsair:oauth] Failed to resolve webhook tenant link for '${pluginId}' tenant '${tenantId}':`,
+			error,
+		);
 	}
 
 	return { plugin: pluginId, tenantId };

--- a/packages/corsair/oauth/index.ts
+++ b/packages/corsair/oauth/index.ts
@@ -18,6 +18,8 @@ import {
 	verifyAndDecodeState,
 } from '../core/auth/state';
 import { createCorsairOrm } from '../db/orm';
+import { resolveOAuthWebhookTenantLink } from '../webhooks/resolve-oauth-tenant-link';
+import { setWebhookTenantLink } from '../webhooks/tenant-links';
 
 // Re-export state utilities for backward compatibility (barrel oauth.ts re-exports these)
 export { decodeOAuthState, encodeOAuthState } from '../core/auth/state';
@@ -291,6 +293,24 @@ export async function processOAuthCallback(
 		await accountKm.set_expires_at(
 			String(Math.floor(Date.now() / 1000) + tokens.expires_in),
 		);
+	}
+
+	const tenantLink = await resolveOAuthWebhookTenantLink(
+		internal.plugins,
+		pluginId,
+		tokens,
+	);
+	if (tenantLink) {
+		const extraAccountFields = plugin.authConfig?.oauth_2?.account ?? [];
+		await setWebhookTenantLink({
+			database: internal.database,
+			kek: internal.kek,
+			pluginId,
+			tenantId,
+			link: tenantLink,
+			authType: 'oauth_2',
+			extraAccountFields,
+		});
 	}
 
 	return { plugin: pluginId, tenantId };

--- a/packages/corsair/package.json
+++ b/packages/corsair/package.json
@@ -42,6 +42,11 @@
       "types": "./dist/oauth.d.ts",
       "default": "./dist/oauth.js"
     },
+    "./tunnel": {
+      "dev-source": "./tunnel.ts",
+      "types": "./dist/tunnel.d.ts",
+      "default": "./dist/tunnel.js"
+    },
     "./tests": {
       "dev-source": "./tests.ts",
       "types": "./dist/tests.d.ts",

--- a/packages/corsair/tests/tenant-links.test.ts
+++ b/packages/corsair/tests/tenant-links.test.ts
@@ -1,0 +1,155 @@
+import { encryptConfig, encryptDEK, generateDEK } from '../core/auth/encryption';
+import {
+	resolveAccountFromWebhookLink,
+	resolveTenantFromWebhookLink,
+	resolveTenantIdFromWebhookLink,
+	setWebhookTenantLink,
+} from '../webhooks/tenant-links';
+
+const KEK = 'test-kek-with-at-least-32-characters!!';
+
+function createTestDatabase() {
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	const Database = require('better-sqlite3') as typeof import('better-sqlite3');
+	const { Kysely, SqliteDialect } = require('kysely') as typeof import('kysely');
+	const { SqliteDatePlugin } = require('../db/kysely/sqlite-date-plugin.js') as {
+		SqliteDatePlugin: new () => import('kysely').KyselyPlugin;
+	};
+
+	const sqlite = new Database(':memory:');
+	sqlite.exec(`
+		CREATE TABLE corsair_integrations (
+			id TEXT PRIMARY KEY,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			name TEXT NOT NULL,
+			config TEXT NOT NULL,
+			dek TEXT NULL
+		);
+		CREATE TABLE corsair_accounts (
+			id TEXT PRIMARY KEY,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			tenant_id TEXT NOT NULL,
+			integration_id TEXT NOT NULL,
+			config TEXT NOT NULL,
+			dek TEXT NULL
+		);
+	`);
+
+	const db = new Kysely({
+		dialect: new SqliteDialect({ database: sqlite }),
+		plugins: [new SqliteDatePlugin()],
+	});
+
+	return {
+		database: { db },
+		destroy: async () => {
+			await db.destroy();
+			sqlite.close();
+		},
+	};
+}
+
+async function seedSlackIntegration(
+	database: ReturnType<typeof createTestDatabase>['database'],
+) {
+	const now = new Date();
+	const integrationId = 'slack-integration';
+	const dek = generateDEK();
+	const encryptedDek = await encryptDEK(dek, KEK);
+
+	await database.db
+		.insertInto('corsair_integrations')
+		.values({
+			id: integrationId,
+			created_at: now,
+			updated_at: now,
+			name: 'slack',
+			config: {},
+			dek: encryptedDek,
+		})
+		.execute();
+
+	return { integrationId, dek };
+}
+
+async function seedSlackAccount(
+	database: ReturnType<typeof createTestDatabase>['database'],
+	tenantId: string,
+	integrationId: string,
+	dek: string,
+) {
+	const now = new Date();
+	const accountId = `account-${tenantId}`;
+	const encryptedDek = await encryptDEK(dek, KEK);
+
+	await database.db
+		.insertInto('corsair_accounts')
+		.values({
+			id: accountId,
+			created_at: now,
+			updated_at: now,
+			tenant_id: tenantId,
+			integration_id: integrationId,
+			config: encryptConfig({}, dek),
+			dek: encryptedDek,
+		})
+		.execute();
+}
+
+describe('webhook tenant links', () => {
+	it('resolves tenant by decrypting the plugin link field on corsair_accounts', async () => {
+		const { database, destroy } = createTestDatabase();
+		try {
+			const { integrationId, dek } = await seedSlackIntegration(database);
+			await seedSlackAccount(database, 'tenant_a', integrationId, dek);
+			await seedSlackAccount(database, 'tenant_b', integrationId, dek);
+
+			await setWebhookTenantLink({
+				database,
+				kek: KEK,
+				pluginId: 'slack',
+				tenantId: 'tenant_a',
+				link: { linkType: 'team_id', externalId: 'T111' },
+			});
+			await setWebhookTenantLink({
+				database,
+				kek: KEK,
+				pluginId: 'slack',
+				tenantId: 'tenant_b',
+				link: { linkType: 'team_id', externalId: 'T222' },
+			});
+
+			const resolved = await resolveTenantIdFromWebhookLink({
+				database,
+				kek: KEK,
+				pluginId: 'slack',
+				linkType: 'team_id',
+				externalId: 'T222',
+			});
+
+			expect(resolved).toBe('tenant_b');
+
+			const account = await resolveAccountFromWebhookLink({
+				database,
+				kek: KEK,
+				pluginId: 'slack',
+				linkType: 'team_id',
+				externalId: 'T111',
+			});
+			expect(account?.tenant_id).toBe('tenant_a');
+			expect(account?.id).toBe('account-tenant_a');
+
+			const viaMatch = await resolveTenantFromWebhookLink({
+				database,
+				kek: KEK,
+				pluginId: 'slack',
+				match: { linkType: 'team_id', externalId: 'T111' },
+			});
+			expect(viaMatch).toBe('tenant_a');
+		} finally {
+			await destroy();
+		}
+	});
+});

--- a/packages/corsair/tests/tunnel.test.ts
+++ b/packages/corsair/tests/tunnel.test.ts
@@ -1,0 +1,70 @@
+import { createHmac } from 'node:crypto';
+import { CORSAIR_INTERNAL } from '../core';
+import { processCorsair } from '../tunnel/index';
+
+function createMockCorsair() {
+	return {
+		[CORSAIR_INTERNAL]: {
+			plugins: [],
+			kek: 'test-kek-with-at-least-32-characters!!',
+		},
+	};
+}
+
+function signBody(body: string, secret: string): string {
+	return createHmac('sha256', secret).update(body).digest('hex');
+}
+
+describe('processCorsair', () => {
+	it('rejects unsigned tunnel requests by default', async () => {
+		const body = JSON.stringify({
+			type: 'webhook',
+			payload: { headers: {}, body: '{}' },
+		});
+
+		const ack = await processCorsair(
+			createMockCorsair(),
+			{ headers: {}, body },
+			{},
+		);
+
+		expect(ack.status).toBe('failed');
+		expect(ack.error).toBe('Tunnel signing secret is required');
+	});
+
+	it('accepts signed tunnel requests when signingSecret is provided', async () => {
+		const secret = 'tunnel-signing-secret';
+		const body = JSON.stringify({
+			type: 'webhook',
+			payload: { headers: {}, body: '{}' },
+		});
+		const signature = signBody(body, secret);
+
+		const ack = await processCorsair(
+			createMockCorsair(),
+			{
+				headers: { 'x-corsair-signature': `sha256=${signature}` },
+				body,
+			},
+			{ signingSecret: secret },
+		);
+
+		expect(ack.error).not.toBe('Tunnel signing secret is required');
+		expect(ack.error).not.toBe('Invalid tunnel signature');
+	});
+
+	it('allows unsigned requests when allowUnsignedTunnel is enabled', async () => {
+		const body = JSON.stringify({
+			type: 'webhook',
+			payload: { headers: {}, body: '{}' },
+		});
+
+		const ack = await processCorsair(
+			createMockCorsair(),
+			{ headers: {}, body },
+			{ allowUnsignedTunnel: true },
+		);
+
+		expect(ack.error).not.toBe('Tunnel signing secret is required');
+	});
+});

--- a/packages/corsair/tsup.config.ts
+++ b/packages/corsair/tsup.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
 		'db.ts',
 		'mcp.ts',
 		'oauth.ts',
+		'tunnel.ts',
 		'orm.ts',
 		'setup.ts',
 		'http.ts',

--- a/packages/corsair/tunnel.ts
+++ b/packages/corsair/tunnel.ts
@@ -1,0 +1,14 @@
+export {
+	processCorsair,
+	resolveAccountFromWebhookLink,
+	resolveTenantFromWebhookLink,
+	resolveTenantIdFromWebhookLink,
+	setWebhookTenantLink,
+	type OAuthCallbackTunnelPayload,
+	type ProcessCorsairOptions,
+	type ProcessCorsairRequest,
+	type TunnelAck,
+	type TunnelEnvelope,
+	type TunnelType,
+	type WebhookTunnelPayload,
+} from './tunnel/index';

--- a/packages/corsair/tunnel/index.ts
+++ b/packages/corsair/tunnel/index.ts
@@ -206,7 +206,10 @@ async function handleOAuthCallbackTunnel(
 }
 
 export type ProcessCorsairOptions = {
+	/** HMAC signing secret shared with the tunnel relay. Required unless allowUnsignedTunnel is true. */
 	signingSecret?: string;
+	/** Local development only. Skips signature verification when signingSecret is omitted. */
+	allowUnsignedTunnel?: boolean;
 };
 
 export async function processCorsair(
@@ -219,7 +222,15 @@ export async function processCorsair(
 		normalizeHeader(request.headers, 'x-corsair-signature'),
 	);
 
-	if (options.signingSecret) {
+	if (!options.signingSecret) {
+		if (!options.allowUnsignedTunnel) {
+			return {
+				status: 'failed',
+				retryable: false,
+				error: 'Tunnel signing secret is required',
+			};
+		}
+	} else {
 		const valid = verifyTunnelSignature(
 			request.body,
 			signature,

--- a/packages/corsair/tunnel/index.ts
+++ b/packages/corsair/tunnel/index.ts
@@ -183,9 +183,16 @@ async function handleWebhookTunnel(
 		};
 	}
 
-	const responseBody = result.response?.returnToSender
-		? result.response.returnToSender
-		: result.response?.data ?? result.response;
+	const returnToSender = result.response?.returnToSender;
+	const responseBody =
+		returnToSender &&
+		typeof returnToSender === 'object' &&
+		typeof returnToSender.validationToken === 'string' &&
+		Object.keys(returnToSender).length === 1
+			? returnToSender.validationToken
+			: returnToSender
+				? returnToSender
+				: (result.response?.data ?? result.response);
 
 	return {
 		status: 'ok',

--- a/packages/corsair/tunnel/index.ts
+++ b/packages/corsair/tunnel/index.ts
@@ -1,0 +1,267 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { CorsairInternalConfig } from '../core';
+import { CORSAIR_INTERNAL } from '../core';
+import { processOAuthCallback } from '../oauth';
+import { processWebhook } from '../webhooks';
+import {
+	resolveAccountFromWebhookLink,
+	resolveTenantFromWebhookLink,
+	resolveTenantIdFromWebhookLink,
+	setWebhookTenantLink,
+} from '../webhooks/tenant-links';
+
+export {
+	resolveAccountFromWebhookLink,
+	resolveTenantFromWebhookLink,
+	resolveTenantIdFromWebhookLink,
+	setWebhookTenantLink,
+};
+
+export type TunnelType =
+	| 'oauth.callback'
+	| 'webhook'
+	| 'permission.approve'
+	| 'permission.deny'
+	| 'auth.credentials'
+	| 'run';
+
+export type TunnelEnvelope<TPayload = unknown> = {
+	type: TunnelType;
+	payload: TPayload;
+};
+
+export type TunnelAck = {
+	status: 'ok' | 'failed';
+	retryable?: boolean;
+	error?: string;
+	webhookResponse?: {
+		status?: number;
+		body?: unknown;
+		headers?: Record<string, string>;
+	};
+};
+
+export type WebhookTunnelPayload = {
+	headers: Record<string, string>;
+	body: string;
+	bodyBase64?: string;
+	bodyEncoding?: string;
+	query?: Record<string, string | string[] | undefined>;
+	plugin?: string;
+	linkType?: string;
+	externalId?: string;
+	tenantId?: string;
+};
+
+export type OAuthCallbackTunnelPayload = {
+	code: string;
+	state: string;
+	redirectUri: string;
+};
+
+export type ProcessCorsairRequest = {
+	headers: Headers | Record<string, string | string[] | undefined>;
+	body: string;
+};
+
+function getInternal(corsair: unknown): CorsairInternalConfig {
+	const internal = (corsair as Record<symbol, unknown>)[CORSAIR_INTERNAL] as
+		| CorsairInternalConfig
+		| undefined;
+	if (!internal) {
+		throw new Error('Invalid corsair instance');
+	}
+	return internal;
+}
+
+function normalizeHeader(
+	headers: ProcessCorsairRequest['headers'],
+	name: string,
+): string | undefined {
+	if (headers instanceof Headers) {
+		return headers.get(name) ?? undefined;
+	}
+	const value = headers[name] ?? headers[name.toLowerCase()];
+	if (Array.isArray(value)) return value[0];
+	return typeof value === 'string' ? value : undefined;
+}
+
+function parseSignatureHeader(value: string | undefined): string | undefined {
+	if (!value) return undefined;
+	return value.startsWith('sha256=') ? value.slice('sha256='.length) : value;
+}
+
+function verifyTunnelSignature(
+	body: string,
+	signature: string | undefined,
+	signingSecret: string,
+): boolean {
+	if (!signature) return false;
+
+	const expected = createHmac('sha256', signingSecret)
+		.update(body)
+		.digest('hex');
+
+	try {
+		return timingSafeEqual(
+			Buffer.from(expected, 'utf8'),
+			Buffer.from(signature, 'utf8'),
+		);
+	} catch {
+		return false;
+	}
+}
+
+async function resolveWebhookTenantId(
+	corsair: unknown,
+	internal: CorsairInternalConfig,
+	payload: WebhookTunnelPayload,
+): Promise<string | undefined> {
+	const explicitTenantId =
+		typeof payload.tenantId === 'string'
+			? payload.tenantId
+			: typeof payload.query?.tenantId === 'string'
+				? payload.query.tenantId
+				: undefined;
+
+	if (explicitTenantId) return explicitTenantId;
+
+	if (
+		!internal.database ||
+		!payload.plugin ||
+		!payload.linkType ||
+		!payload.externalId
+	) {
+		return undefined;
+	}
+
+	const resolved = await resolveTenantIdFromWebhookLink({
+		database: internal.database,
+		kek: internal.kek,
+		pluginId: payload.plugin,
+		linkType: payload.linkType,
+		externalId: payload.externalId,
+	});
+
+	return resolved ?? undefined;
+}
+
+async function handleWebhookTunnel(
+	corsair: unknown,
+	internal: CorsairInternalConfig,
+	payload: WebhookTunnelPayload,
+): Promise<TunnelAck> {
+	const tenantId = await resolveWebhookTenantId(corsair, internal, payload);
+	const query = {
+		...(payload.query ?? {}),
+		...(tenantId ? { tenantId } : {}),
+	};
+
+	const result = await processWebhook(
+		corsair as Parameters<typeof processWebhook>[0],
+		payload.headers,
+		payload.body,
+		query,
+	);
+
+	if (!result.plugin) {
+		return {
+			status: 'failed',
+			retryable: false,
+			error: 'No matching webhook handler found',
+		};
+	}
+
+	if (result.response && result.response.success === false) {
+		return {
+			status: 'failed',
+			retryable: false,
+			error:
+				typeof result.response.error === 'string'
+					? result.response.error
+					: 'Webhook handler failed',
+		};
+	}
+
+	const responseBody = result.response?.returnToSender
+		? result.response.returnToSender
+		: result.response?.data ?? result.response;
+
+	return {
+		status: 'ok',
+		webhookResponse: {
+			status: result.response?.statusCode ?? 200,
+			body: responseBody,
+			headers: result.responseHeaders,
+		},
+	};
+}
+
+async function handleOAuthCallbackTunnel(
+	corsair: unknown,
+	payload: OAuthCallbackTunnelPayload,
+): Promise<TunnelAck> {
+	await processOAuthCallback(corsair, payload);
+	return { status: 'ok' };
+}
+
+export type ProcessCorsairOptions = {
+	signingSecret?: string;
+};
+
+export async function processCorsair(
+	corsair: unknown,
+	request: ProcessCorsairRequest,
+	options: ProcessCorsairOptions = {},
+): Promise<TunnelAck> {
+	const internal = getInternal(corsair);
+	const signature = parseSignatureHeader(
+		normalizeHeader(request.headers, 'x-corsair-signature'),
+	);
+
+	if (options.signingSecret) {
+		const valid = verifyTunnelSignature(
+			request.body,
+			signature,
+			options.signingSecret,
+		);
+		if (!valid) {
+			return {
+				status: 'failed',
+				retryable: false,
+				error: 'Invalid tunnel signature',
+			};
+		}
+	}
+
+	let envelope: TunnelEnvelope;
+	try {
+		envelope = JSON.parse(request.body) as TunnelEnvelope;
+	} catch {
+		return {
+			status: 'failed',
+			retryable: false,
+			error: 'Invalid tunnel envelope JSON',
+		};
+	}
+
+	switch (envelope.type) {
+		case 'webhook':
+			return handleWebhookTunnel(
+				corsair,
+				internal,
+				envelope.payload as WebhookTunnelPayload,
+			);
+		case 'oauth.callback':
+			return handleOAuthCallbackTunnel(
+				corsair,
+				envelope.payload as OAuthCallbackTunnelPayload,
+			);
+		default:
+			return {
+				status: 'failed',
+				retryable: false,
+				error: `Unsupported tunnel type: ${envelope.type}`,
+			};
+	}
+}

--- a/packages/corsair/webhooks/index.ts
+++ b/packages/corsair/webhooks/index.ts
@@ -2,8 +2,10 @@ import { BaseProviders } from '../core/constants';
 import type {
 	BoundWebhook,
 	BoundWebhookTree,
+	CorsairWebhookTenantMatcher,
 	RawWebhookRequest,
 	WebhookResponse,
+	WebhookTenantMatch,
 } from '../core/webhooks';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -38,6 +40,8 @@ type PluginWithWebhooks = {
 	webhooks?: BoundWebhookTree;
 	/** Plugin-level matcher to quickly check if a webhook is for this plugin */
 	pluginWebhookMatcher?: (request: RawWebhookRequest) => boolean;
+	/** Extracts the external tenant lookup key for this plugin's webhook */
+	pluginTenantWebhookMatcher?: CorsairWebhookTenantMatcher;
 };
 
 /**

--- a/packages/corsair/webhooks/index.ts
+++ b/packages/corsair/webhooks/index.ts
@@ -202,6 +202,7 @@ export async function processWebhook(
 	const rawRequest = {
 		headers: normalizedHeaders,
 		body: parsedBody,
+		...(query ? { query } : {}),
 	} satisfies RawWebhookRequest;
 
 	const tenantId = query?.tenantId || 'default';
@@ -242,6 +243,7 @@ export async function processWebhook(
 			payload: parsedBody,
 			headers: normalizedHeaders,
 			rawBody: typeof body === 'string' ? body : JSON.stringify(body),
+			...(query ? { query } : {}),
 		};
 
 		try {

--- a/packages/corsair/webhooks/resolve-oauth-tenant-link.ts
+++ b/packages/corsair/webhooks/resolve-oauth-tenant-link.ts
@@ -1,0 +1,23 @@
+import type { CorsairPlugin } from '../core';
+import type { TokenResponse } from '../core/auth/exchange';
+import type { WebhookTenantLink } from './tenant-links';
+
+/**
+ * Calls the matching plugin's oauthWebhookTenantLinkResolver after OAuth.
+ */
+export async function resolveOAuthWebhookTenantLink(
+	plugins: readonly CorsairPlugin[],
+	pluginId: string,
+	tokens: TokenResponse,
+): Promise<WebhookTenantLink | null> {
+	for (const plugin of plugins) {
+		if (plugin.id !== pluginId) continue;
+
+		const resolver = plugin.oauthWebhookTenantLinkResolver;
+		if (!resolver) return null;
+
+		return resolver(tokens);
+	}
+
+	return null;
+}

--- a/packages/corsair/webhooks/tenant-links.ts
+++ b/packages/corsair/webhooks/tenant-links.ts
@@ -1,0 +1,234 @@
+import type { AuthTypes } from '../core/constants';
+import { createAccountKeyManager } from '../core/auth/key-manager';
+import {
+	decryptConfig,
+	decryptDEK,
+	decryptWithDEK,
+	encryptConfig,
+} from '../core/auth/encryption';
+import type { CorsairAccount } from '../db';
+import type { CorsairDatabase } from '../db/kysely/database';
+import type { WebhookTenantMatch } from '../core/webhooks';
+
+const parseConfig = (config: unknown): Record<string, unknown> => {
+	if (!config) return {};
+	if (typeof config === 'string') {
+		try {
+			return JSON.parse(config) as Record<string, unknown>;
+		} catch {
+			return {};
+		}
+	}
+	return config as Record<string, unknown>;
+};
+
+export type WebhookTenantLink = WebhookTenantMatch;
+
+type ResolvedAccount = {
+	integrationId: string;
+	accountId: string;
+};
+
+async function resolveAccountForTenant(options: {
+	database: CorsairDatabase;
+	pluginId: string;
+	tenantId: string;
+}): Promise<ResolvedAccount> {
+	const integration = await options.database.db
+		.selectFrom('corsair_integrations')
+		.selectAll()
+		.where('name', '=', options.pluginId)
+		.executeTakeFirst();
+
+	if (!integration) {
+		throw new Error(
+			`Integration '${options.pluginId}' not found. Run setupCorsair before registering webhook tenant links.`,
+		);
+	}
+
+	const account = await options.database.db
+		.selectFrom('corsair_accounts')
+		.selectAll()
+		.where('tenant_id', '=', options.tenantId)
+		.where('integration_id', '=', integration.id)
+		.executeTakeFirst();
+
+	if (!account) {
+		throw new Error(
+			`Account not found for tenant '${options.tenantId}' and integration '${options.pluginId}'.`,
+		);
+	}
+
+	return {
+		integrationId: integration.id,
+		accountId: account.id,
+	};
+}
+
+async function writeEncryptedAccountLinkField(options: {
+	database: CorsairDatabase;
+	kek: string;
+	accountId: string;
+	link: WebhookTenantLink;
+}): Promise<void> {
+	const account = await options.database.db
+		.selectFrom('corsair_accounts')
+		.selectAll()
+		.where('id', '=', options.accountId)
+		.executeTakeFirst();
+
+	if (!account?.dek) {
+		throw new Error(`Account '${options.accountId}' has no DEK.`);
+	}
+
+	const dek = await decryptDEK(account.dek, options.kek);
+	const storedConfig = parseConfig(account.config) as Record<string, string>;
+	let decryptedConfig: Record<string, string> = {};
+
+	if (Object.keys(storedConfig).length > 0) {
+		decryptedConfig = decryptConfig(storedConfig, dek);
+	}
+
+	decryptedConfig[options.link.linkType] = options.link.externalId;
+	const encryptedConfig = encryptConfig(decryptedConfig, dek);
+
+	await options.database.db
+		.updateTable('corsair_accounts')
+		.set({
+			config: encryptedConfig,
+			updated_at: new Date(),
+		})
+		.where('id', '=', account.id)
+		.execute();
+}
+
+export async function setWebhookTenantLink(options: {
+	database: CorsairDatabase;
+	kek: string;
+	pluginId: string;
+	tenantId: string;
+	link: WebhookTenantLink;
+	authType?: AuthTypes;
+	extraAccountFields?: readonly string[];
+}): Promise<void> {
+	const {
+		database,
+		kek,
+		pluginId,
+		tenantId,
+		link,
+		authType,
+		extraAccountFields = [],
+	} = options;
+
+	const { accountId } = await resolveAccountForTenant({
+		database,
+		pluginId,
+		tenantId,
+	});
+
+	let wroteViaKeyManager = false;
+
+	if (authType) {
+		const accountKeyManager = createAccountKeyManager({
+			authType,
+			integrationName: pluginId,
+			tenantId,
+			kek,
+			database,
+			extraAccountFields,
+		});
+		const setterName = `set_${link.linkType}`;
+		const setter = (accountKeyManager as Record<string, unknown>)[setterName];
+		if (typeof setter === 'function') {
+			await (setter as (value: string) => Promise<void>)(link.externalId);
+			wroteViaKeyManager = true;
+		}
+	}
+
+	if (!wroteViaKeyManager) {
+		await writeEncryptedAccountLinkField({
+			database,
+			kek,
+			accountId,
+			link,
+		});
+	}
+}
+
+export type ResolveAccountFromWebhookLinkInput = {
+	database: CorsairDatabase;
+	kek: string;
+	pluginId: string;
+	linkType: string;
+	externalId: string;
+};
+
+/**
+ * Resolves the matching corsair_accounts row for a webhook tenant link.
+ *
+ * Runs one SQL query scoped to the plugin, then decrypts only the requested
+ * link field per account using the account DEK and KEK.
+ */
+export async function resolveAccountFromWebhookLink(
+	options: ResolveAccountFromWebhookLinkInput,
+): Promise<CorsairAccount | null> {
+	const { database, kek, pluginId, linkType, externalId } = options;
+
+	const accounts = await database.db
+		.selectFrom('corsair_accounts as accounts')
+		.innerJoin(
+			'corsair_integrations as integrations',
+			'integrations.id',
+			'accounts.integration_id',
+		)
+		.selectAll('accounts')
+		.where('integrations.name', '=', pluginId)
+		.execute();
+
+	for (const account of accounts) {
+		if (!account.dek) continue;
+
+		try {
+			const dek = await decryptDEK(account.dek, kek);
+			const storedConfig = parseConfig(account.config) as Record<string, string>;
+			const encryptedValue = storedConfig[linkType];
+			if (!encryptedValue) continue;
+
+			const decryptedValue = decryptWithDEK(encryptedValue, dek);
+			if (decryptedValue === externalId) {
+				return account;
+			}
+		} catch {
+			continue;
+		}
+	}
+
+	return null;
+}
+
+export async function resolveTenantIdFromWebhookLink(options: {
+	database: CorsairDatabase;
+	kek: string;
+	pluginId: string;
+	linkType: string;
+	externalId: string;
+}): Promise<string | null> {
+	const account = await resolveAccountFromWebhookLink(options);
+	return account?.tenant_id ?? null;
+}
+
+export async function resolveTenantFromWebhookLink(options: {
+	database: CorsairDatabase;
+	kek: string;
+	pluginId: string;
+	match: WebhookTenantMatch;
+}): Promise<string | null> {
+	return resolveTenantIdFromWebhookLink({
+		database: options.database,
+		kek: options.kek,
+		pluginId: options.pluginId,
+		linkType: options.match.linkType,
+		externalId: options.match.externalId,
+	});
+}

--- a/packages/cursor/index.ts
+++ b/packages/cursor/index.ts
@@ -150,9 +150,7 @@ const cursorEndpointMeta = {
 } satisfies RequiredPluginEndpointMeta<typeof cursorEndpointsNested>;
 
 export const cursorAuthConfig = {
-	api_key: {
-		account: ['one'] as const,
-	},
+	api_key: {},
 } as const satisfies PluginAuthConfig;
 
 export type BaseCursorPlugin<T extends CursorPluginOptions> = CorsairPlugin<
@@ -178,6 +176,7 @@ export function cursor<const T extends CursorPluginOptions>(
 	};
 	return {
 		id: 'cursor',
+		authConfig: cursorAuthConfig,
 		schema: CursorSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/cursor/index.ts
+++ b/packages/cursor/index.ts
@@ -29,6 +29,7 @@ import {
 } from './endpoints/types';
 import { errorHandlers } from './error-handlers';
 import { CursorSchema } from './schema';
+import { matchCursorTenantWebhook } from './webhooks/tenant-matcher';
 
 export type CursorPluginOptions = {
 	authType?: PickAuth<'api_key'>;
@@ -187,6 +188,7 @@ export function cursor<const T extends CursorPluginOptions>(
 		endpointSchemas: cursorEndpointSchemas,
 		// Cursor defines no webhook triggers; always returns false.
 		pluginWebhookMatcher: (_request) => false,
+		pluginTenantWebhookMatcher: matchCursorTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/cursor/webhooks/tenant-matcher.ts
+++ b/packages/cursor/webhooks/tenant-matcher.ts
@@ -1,0 +1,8 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+
+// The Cursor API does not define incoming webhook triggers for this integration.
+export function matchCursorTenantWebhook(
+	_request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	return null;
+}

--- a/packages/discord/index.ts
+++ b/packages/discord/index.ts
@@ -365,7 +365,7 @@ const discordEndpointMeta = {
 
 export const discordAuthConfig = {
 	api_key: {
-		account: ['guild_id', 'application_id'] as const,
+		account: ['guild_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 

--- a/packages/discord/index.ts
+++ b/packages/discord/index.ts
@@ -363,7 +363,11 @@ const discordEndpointMeta = {
 	},
 } satisfies RequiredPluginEndpointMeta<typeof discordEndpointsNested>;
 
-export const discordAuthConfig = {} as const satisfies PluginAuthConfig;
+export const discordAuthConfig = {
+	api_key: {
+		account: ['guild_id', 'application_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
 
 // ── Plugin Type Hierarchy ──────────────────────────────────────────────────────
 
@@ -393,6 +397,7 @@ export function discord<const T extends DiscordPluginOptions>(
 
 	return {
 		id: 'discord',
+		authConfig: discordAuthConfig,
 		schema: DiscordSchema,
 		options,
 		hooks: options.hooks,

--- a/packages/discord/index.ts
+++ b/packages/discord/index.ts
@@ -48,6 +48,7 @@ import {
 import { errorHandlers } from './error-handlers';
 import { DiscordSchema } from './schema';
 import { InteractionWebhooks } from './webhooks';
+import { matchDiscordTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	DiscordApplicationCommandInteraction,
 	DiscordMessageComponentInteraction,
@@ -436,6 +437,7 @@ export function discord<const T extends DiscordPluginOptions>(
 				return false;
 			}
 		},
+		pluginTenantWebhookMatcher: matchDiscordTenantWebhook,
 
 		errorHandlers: {
 			...errorHandlers,

--- a/packages/discord/jest.config.cjs
+++ b/packages/discord/jest.config.cjs
@@ -44,6 +44,7 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',
 	},

--- a/packages/discord/webhooks/tenant-matcher.test.ts
+++ b/packages/discord/webhooks/tenant-matcher.test.ts
@@ -1,0 +1,45 @@
+import type { RawWebhookRequest } from 'corsair/core';
+import { DiscordInteractionType } from './types';
+import { matchDiscordTenantWebhook } from './tenant-matcher';
+
+describe('matchDiscordTenantWebhook', () => {
+	it('returns guild_id for server interactions', () => {
+		const request: RawWebhookRequest = {
+			headers: {},
+			body: {
+				type: DiscordInteractionType.APPLICATION_COMMAND,
+				application_id: 'app-123',
+				guild_id: 'guild-456',
+			},
+		};
+
+		expect(matchDiscordTenantWebhook(request)).toEqual({
+			linkType: 'guild_id',
+			externalId: 'guild-456',
+		});
+	});
+
+	it('returns null for DM interactions without guild_id', () => {
+		const request: RawWebhookRequest = {
+			headers: {},
+			body: {
+				type: DiscordInteractionType.APPLICATION_COMMAND,
+				application_id: 'app-123',
+			},
+		};
+
+		expect(matchDiscordTenantWebhook(request)).toBeNull();
+	});
+
+	it('returns null for PING verification handshakes', () => {
+		const request: RawWebhookRequest = {
+			headers: {},
+			body: {
+				type: DiscordInteractionType.PING,
+				application_id: 'app-123',
+			},
+		};
+
+		expect(matchDiscordTenantWebhook(request)).toBeNull();
+	});
+});

--- a/packages/discord/webhooks/tenant-matcher.ts
+++ b/packages/discord/webhooks/tenant-matcher.ts
@@ -2,7 +2,9 @@ import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
 import { firstString, readBodyRecord } from 'corsair/core';
 import { DiscordInteractionType } from './types';
 
-// Discord interactions include application_id on every payload; guild_id when in a server.
+// Discord interactions include guild_id when routed from a server context.
+// DMs and other global contexts omit guild_id — application_id is the bot's own
+// id and is identical across tenants, so it must not be used for tenant routing.
 // PING (type 1) is an endpoint verification handshake with no tenant context.
 // See https://discord.com/developers/docs/interactions/receiving-and-responding
 export function matchDiscordTenantWebhook(
@@ -14,12 +16,7 @@ export function matchDiscordTenantWebhook(
 	if (body.type === DiscordInteractionType.PING) return null;
 
 	const guildId = firstString([body.guild_id]);
-	if (guildId) {
-		return { linkType: 'guild_id', externalId: guildId };
-	}
+	if (!guildId) return null;
 
-	const applicationId = firstString([body.application_id]);
-	if (!applicationId) return null;
-
-	return { linkType: 'application_id', externalId: applicationId };
+	return { linkType: 'guild_id', externalId: guildId };
 }

--- a/packages/discord/webhooks/tenant-matcher.ts
+++ b/packages/discord/webhooks/tenant-matcher.ts
@@ -1,0 +1,25 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { firstString, readBodyRecord } from 'corsair/core';
+import { DiscordInteractionType } from './types';
+
+// Discord interactions include application_id on every payload; guild_id when in a server.
+// PING (type 1) is an endpoint verification handshake with no tenant context.
+// See https://discord.com/developers/docs/interactions/receiving-and-responding
+export function matchDiscordTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	if (body.type === DiscordInteractionType.PING) return null;
+
+	const guildId = firstString([body.guild_id]);
+	if (guildId) {
+		return { linkType: 'guild_id', externalId: guildId };
+	}
+
+	const applicationId = firstString([body.application_id]);
+	if (!applicationId) return null;
+
+	return { linkType: 'application_id', externalId: applicationId };
+}

--- a/packages/dodopayments/index.ts
+++ b/packages/dodopayments/index.ts
@@ -9,6 +9,7 @@ import type {
 	CorsairWebhook,
 	KeyBuilderContext,
 	PickAuth,
+	PluginAuthConfig,
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 	RequiredPluginEndpointSchemas,
@@ -286,9 +287,9 @@ const dodoPaymentsEndpointMeta = {
 
 export const dodoPaymentsAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['business_id'] as const,
 	},
-} as const;
+} as const satisfies PluginAuthConfig;
 
 export type BaseDodoPaymentsPlugin<T extends DodoPaymentsPluginOptions> =
 	CorsairPlugin<
@@ -316,6 +317,7 @@ export function dodopayments<const T extends DodoPaymentsPluginOptions>(
 	};
 	return {
 		id: 'dodopayments',
+		authConfig: dodoPaymentsAuthConfig,
 		schema: DodoPaymentsSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/dodopayments/index.ts
+++ b/packages/dodopayments/index.ts
@@ -39,6 +39,7 @@ import {
 	RefundWebhooks,
 	SubscriptionWebhooks,
 } from './webhooks';
+import { matchDodoPaymentsTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	DodoPaymentFailedEvent,
 	DodoPaymentSucceededEvent,
@@ -353,6 +354,7 @@ export function dodopayments<const T extends DodoPaymentsPluginOptions>(
 				typeof body.timestamp === 'string'
 			);
 		},
+		pluginTenantWebhookMatcher: matchDodoPaymentsTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/dodopayments/webhooks/tenant-matcher.ts
+++ b/packages/dodopayments/webhooks/tenant-matcher.ts
@@ -1,0 +1,16 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { firstString, readBodyRecord } from 'corsair/core';
+
+// Dodo Payments webhooks include business_id at the top level of the JSON body.
+// See https://docs.dodopayments.com/developer-resources/webhooks
+export function matchDodoPaymentsTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const businessId = firstString([body.business_id]);
+	if (!businessId) return null;
+
+	return { linkType: 'business_id', externalId: businessId };
+}

--- a/packages/dropbox/index.ts
+++ b/packages/dropbox/index.ts
@@ -25,6 +25,7 @@ import {
 import { errorHandlers } from './error-handlers';
 import { DropboxSchema } from './schema';
 import { FileSystemWebhooks } from './webhooks';
+import { matchDropboxTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	DropboxFileSystemChangedEvent,
 	DropboxWebhookOutputs,
@@ -274,6 +275,7 @@ export function dropbox<const T extends DropboxPluginOptions>(
 			const headers = request.headers;
 			return 'x-dropbox-signature' in headers;
 		},
+		pluginTenantWebhookMatcher: matchDropboxTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/dropbox/index.ts
+++ b/packages/dropbox/index.ts
@@ -8,6 +8,7 @@ import type {
 	CorsairWebhook,
 	KeyBuilderContext,
 	PickAuth,
+	PluginAuthConfig,
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
@@ -26,6 +27,7 @@ import { errorHandlers } from './error-handlers';
 import { DropboxSchema } from './schema';
 import { FileSystemWebhooks } from './webhooks';
 import { matchDropboxTenantWebhook } from './webhooks/tenant-matcher';
+import { resolveDropboxOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
 import type {
 	DropboxFileSystemChangedEvent,
 	DropboxWebhookOutputs,
@@ -224,6 +226,12 @@ type DropboxWebhook<
 
 export type DropboxBoundWebhooks = BindWebhooks<DropboxWebhooks>;
 
+export const dropboxAuthConfig = {
+	oauth_2: {
+		account: ['account_id', 'user_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
 export type BaseDropboxPlugin<T extends DropboxPluginOptions> = CorsairPlugin<
 	'dropbox',
 	typeof DropboxSchema,
@@ -247,6 +255,7 @@ export function dropbox<const T extends DropboxPluginOptions>(
 	};
 	return {
 		id: 'dropbox',
+		authConfig: dropboxAuthConfig,
 		schema: DropboxSchema,
 		options: options,
 		// https://developers.dropbox.com/oauth-guide — authorize & token endpoints.
@@ -276,6 +285,7 @@ export function dropbox<const T extends DropboxPluginOptions>(
 			return 'x-dropbox-signature' in headers;
 		},
 		pluginTenantWebhookMatcher: matchDropboxTenantWebhook,
+		oauthWebhookTenantLinkResolver: resolveDropboxOAuthWebhookTenantLink,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/dropbox/webhooks/oauth-tenant-link.ts
+++ b/packages/dropbox/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,33 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { toExternalId } from 'corsair/core';
+
+export async function resolveDropboxOAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): Promise<WebhookTenantMatch | null> {
+	const accountId = toExternalId(tokens.uid ?? tokens.account_id);
+	if (accountId) {
+		return { linkType: 'account_id', externalId: accountId };
+	}
+
+	const accessToken = tokens.access_token;
+	if (!accessToken) return null;
+
+	const response = await fetch(
+		'https://api.dropboxapi.com/2/users/get_current_account',
+		{
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				'Content-Type': 'application/json',
+			},
+			body: 'null',
+		},
+	);
+	if (!response.ok) return null;
+
+	const payload = (await response.json()) as { account_id?: string };
+	const fetchedAccountId = toExternalId(payload.account_id);
+	return fetchedAccountId
+		? { linkType: 'account_id', externalId: fetchedAccountId }
+		: null;
+}

--- a/packages/dropbox/webhooks/tenant-matcher.ts
+++ b/packages/dropbox/webhooks/tenant-matcher.ts
@@ -1,0 +1,24 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// Dropbox change notifications identify accounts in list_folder.accounts
+// (preferred) or delta.users for legacy payloads.
+// See https://www.dropbox.com/developers/reference/webhooks
+export function matchDropboxTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const listFolder = asRecord(body.list_folder);
+	const accountId = firstString([listFolder?.accounts?.[0]]);
+	if (accountId) {
+		return { linkType: 'account_id', externalId: accountId };
+	}
+
+	const delta = asRecord(body.delta);
+	const userId = firstString([delta?.users?.[0]]);
+	if (!userId) return null;
+
+	return { linkType: 'user_id', externalId: userId };
+}

--- a/packages/exa/index.ts
+++ b/packages/exa/index.ts
@@ -31,6 +31,7 @@ import {
 import { errorHandlers } from './error-handlers';
 import { ExaSchema } from './schema';
 import { ContentWebhooks, SearchWebhooks, WebsetWebhooks } from './webhooks';
+import { matchExaTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	ContentIndexedEvent,
 	ExaWebhookOutputs,
@@ -342,6 +343,7 @@ export function exa<const T extends ExaPluginOptions>(
 			const headers = request.headers;
 			return 'x-exa-signature' in headers;
 		},
+		pluginTenantWebhookMatcher: matchExaTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/exa/index.ts
+++ b/packages/exa/index.ts
@@ -270,9 +270,7 @@ const exaEndpointMeta = {
 } satisfies RequiredPluginEndpointMeta<typeof exaEndpointsNested>;
 
 export const exaAuthConfig = {
-	api_key: {
-		account: ['one'] as const,
-	},
+	api_key: {},
 } as const satisfies PluginAuthConfig;
 
 export type ExaBoundEndpoints = BindEndpoints<typeof exaEndpointsNested>;
@@ -330,6 +328,7 @@ export function exa<const T extends ExaPluginOptions>(
 	};
 	return {
 		id: 'exa',
+		authConfig: exaAuthConfig,
 		schema: ExaSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/exa/webhooks/tenant-matcher.ts
+++ b/packages/exa/webhooks/tenant-matcher.ts
@@ -1,0 +1,11 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+
+// Exa webhooks are authenticated per endpoint via Exa-Signature / x-exa-signature
+// (HMAC-SHA256). Payloads describe events (websets, monitors, etc.) but do not
+// include an account or org identifier — see
+// https://exa.ai/docs/websets/api/webhooks/verifying-signatures
+export function matchExaTenantWebhook(
+	_request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	return null;
+}

--- a/packages/figma/index.ts
+++ b/packages/figma/index.ts
@@ -706,8 +706,8 @@ const figmaWebhookSchemas = {
 } as const;
 
 export const figmaAuthConfig = {
-	api_key: {
-		account: ['one'] as const,
+	oauth_2: {
+		account: ['webhook_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -735,6 +735,7 @@ export function figma<const T extends FigmaPluginOptions>(
 	};
 	return {
 		id: 'figma',
+		authConfig: figmaAuthConfig,
 		schema: FigmaSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/figma/index.ts
+++ b/packages/figma/index.ts
@@ -47,6 +47,7 @@ import {
 	LibraryPublishWebhooks,
 	PingWebhooks,
 } from './webhooks';
+import { matchFigmaTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	FigmaFileCommentEvent,
 	FigmaFileDeleteEvent,
@@ -747,6 +748,7 @@ export function figma<const T extends FigmaPluginOptions>(
 			const hasSignature = 'x-figma-signature' in headers;
 			return hasSignature;
 		},
+		pluginTenantWebhookMatcher: matchFigmaTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/figma/webhooks/tenant-matcher.ts
+++ b/packages/figma/webhooks/tenant-matcher.ts
@@ -1,0 +1,16 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { firstString, readBodyRecord } from 'corsair/core';
+
+// Figma webhook payloads include webhook_id on every event (including PING).
+// See https://developers.figma.com/docs/rest-api/webhooks-events/
+export function matchFigmaTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const webhookId = firstString([body.webhook_id]);
+	if (!webhookId) return null;
+
+	return { linkType: 'webhook_id', externalId: webhookId };
+}

--- a/packages/firecrawl/index.ts
+++ b/packages/firecrawl/index.ts
@@ -29,6 +29,7 @@ import { errorHandlers as defaultErrorHandlers } from './error-handlers';
 import type { FirecrawlContext } from './plugin-context';
 import { FirecrawlSchema } from './schema';
 import * as Wh from './webhooks';
+import { matchFirecrawlTenantWebhook } from './webhooks/tenant-matcher';
 import {
 	AgentActionEventSchema,
 	AgentCancelledEventSchema,
@@ -329,6 +330,7 @@ export function firecrawl<const T extends FirecrawlPluginOptions>(
 				'x-firecrawl-signature' in headers || 'X-Firecrawl-Signature' in headers
 			);
 		},
+		pluginTenantWebhookMatcher: matchFirecrawlTenantWebhook,
 		errorHandlers: {
 			...defaultErrorHandlers,
 			...options.errorHandlers,

--- a/packages/firecrawl/webhooks/tenant-matcher.ts
+++ b/packages/firecrawl/webhooks/tenant-matcher.ts
@@ -1,0 +1,11 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+
+// Firecrawl webhooks are authenticated per account via X-Firecrawl-Signature
+// (HMAC-SHA256 of the raw body). Payloads carry job id and optional user-supplied
+// metadata but no built-in account/org identifier — see
+// https://docs.firecrawl.dev/webhooks/events
+export function matchFirecrawlTenantWebhook(
+	_request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	return null;
+}

--- a/packages/fireflies/index.ts
+++ b/packages/fireflies/index.ts
@@ -29,6 +29,7 @@ import {
 import { errorHandlers } from './error-handlers';
 import { FirefliesSchema } from './schema';
 import { MeetingWebhooks, TranscriptionWebhooks } from './webhooks';
+import { matchFirefliesTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	FirefliesWebhookOutputs,
 	InMeetingEvent,
@@ -397,6 +398,7 @@ export function fireflies<const T extends FirefliesPluginOptions>(
 			const headers = request.headers;
 			return 'x-fireflies-signature' in headers;
 		},
+		pluginTenantWebhookMatcher: matchFirefliesTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/fireflies/index.ts
+++ b/packages/fireflies/index.ts
@@ -330,9 +330,7 @@ type FirefliesWebhook<
 const defaultAuthType = 'api_key' as const;
 
 export const firefliesAuthConfig = {
-	api_key: {
-		account: ['one'] as const,
-	},
+	api_key: {},
 } as const satisfies PluginAuthConfig;
 
 export type FirefliesBoundEndpoints = BindEndpoints<
@@ -385,6 +383,7 @@ export function fireflies<const T extends FirefliesPluginOptions>(
 	};
 	return {
 		id: 'fireflies',
+		authConfig: firefliesAuthConfig,
 		schema: FirefliesSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/fireflies/webhooks/tenant-matcher.ts
+++ b/packages/fireflies/webhooks/tenant-matcher.ts
@@ -1,0 +1,11 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+
+// Fireflies webhooks are scoped to the meeting owner and authenticated via
+// X-Hub-Signature / x-fireflies-signature. Payloads include meetingId (V1) or
+// meeting_id (V2) but no organization or account identifier — see
+// https://docs.fireflies.ai/graphql-api/webhooks
+export function matchFirefliesTenantWebhook(
+	_request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	return null;
+}

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -267,6 +267,7 @@ import {
 	WorkflowRunInProgressEventSchema,
 	WorkflowRunRequestedEventSchema,
 } from './webhooks/types';
+import { matchGithubTenantWebhook } from './webhooks/tenant-matcher';
 
 export {
 	createGithubEventMatch,
@@ -1744,6 +1745,7 @@ export function github<const PluginOptions extends GithubPluginOptions>(
 			const hasGithubSignature = headers['x-hub-signature-256'] !== undefined;
 			return hasGithubEvent && hasGithubSignature;
 		},
+		pluginTenantWebhookMatcher: matchGithubTenantWebhook,
 		keyBuilder: async (ctx: GithubKeyBuilderContext, source) => {
 			const authType = ctx.authType;
 

--- a/packages/github/index.ts
+++ b/packages/github/index.ts
@@ -7,6 +7,7 @@ import type {
 	CorsairWebhook,
 	KeyBuilderContext,
 	PickAuth,
+	PluginAuthConfig,
 	PluginPermissionsConfig,
 	RawWebhookRequest,
 	RequiredPluginEndpointMeta,
@@ -268,6 +269,7 @@ import {
 	WorkflowRunRequestedEventSchema,
 } from './webhooks/types';
 import { matchGithubTenantWebhook } from './webhooks/tenant-matcher';
+import { resolveGithubOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
 
 export {
 	createGithubEventMatch,
@@ -1714,6 +1716,15 @@ export type InternalGithubPlugin = BaseGithubPlugin<GithubPluginOptions>;
 export type ExternalGithubPlugin<PluginOptions extends GithubPluginOptions> =
 	BaseGithubPlugin<PluginOptions>;
 
+export const githubAuthConfig = {
+	api_key: {
+		account: ['installation_id'] as const,
+	},
+	oauth_2: {
+		account: ['installation_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
 export function github<const PluginOptions extends GithubPluginOptions>(
 	incomingOptions: GithubPluginOptions &
 		PluginOptions = {} as GithubPluginOptions & PluginOptions,
@@ -1724,6 +1735,7 @@ export function github<const PluginOptions extends GithubPluginOptions>(
 	};
 	return {
 		id: 'github',
+		authConfig: githubAuthConfig,
 		oauthConfig: {
 			providerName: 'GitHub',
 			authUrl: 'https://github.com/login/oauth/authorize',
@@ -1746,6 +1758,7 @@ export function github<const PluginOptions extends GithubPluginOptions>(
 			return hasGithubEvent && hasGithubSignature;
 		},
 		pluginTenantWebhookMatcher: matchGithubTenantWebhook,
+		oauthWebhookTenantLinkResolver: resolveGithubOAuthWebhookTenantLink,
 		keyBuilder: async (ctx: GithubKeyBuilderContext, source) => {
 			const authType = ctx.authType;
 

--- a/packages/github/webhooks/oauth-tenant-link.ts
+++ b/packages/github/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,13 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, toExternalId } from 'corsair/core';
+
+export function resolveGithubOAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): WebhookTenantMatch | null {
+	const installationId = toExternalId(
+		asRecord(tokens.installation)?.id ?? tokens.installation_id,
+	);
+	return installationId
+		? { linkType: 'installation_id', externalId: installationId }
+		: null;
+}

--- a/packages/github/webhooks/tenant-matcher.ts
+++ b/packages/github/webhooks/tenant-matcher.ts
@@ -1,0 +1,28 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import {
+	asRecord,
+	firstString,
+	getHeader,
+	readBodyRecord,
+} from 'corsair/core';
+
+// GitHub App webhooks include installation.id on the payload envelope.
+// See https://docs.github.com/en/webhooks/webhook-events-and-payloads
+export function matchGithubTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const githubEvent = getHeader(request.headers, 'x-github-event');
+	if (githubEvent === 'ping') return null;
+
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const installationId = firstString([
+		asRecord(body.installation)?.id,
+		getHeader(request.headers, 'x-github-hook-installation-target-id'),
+	]);
+
+	if (!installationId) return null;
+
+	return { linkType: 'installation_id', externalId: installationId };
+}

--- a/packages/gitlab/index.ts
+++ b/packages/gitlab/index.ts
@@ -61,8 +61,13 @@ import {
 	PushEventSchema,
 } from './webhooks/types';
 import { matchGitlabTenantWebhook } from './webhooks/tenant-matcher';
+import { resolveGitlabOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
 
-export const gitlabAuthConfig = {} as const satisfies PluginAuthConfig;
+export const gitlabAuthConfig = {
+	oauth_2: {
+		account: ['project_id', 'group_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
 
 export type GitlabPluginOptions = {
 	baseUrl?: string;
@@ -804,6 +809,7 @@ export function gitlab<const T extends GitlabPluginOptions>(
 			return token !== undefined || event !== undefined;
 		},
 		pluginTenantWebhookMatcher: matchGitlabTenantWebhook,
+		oauthWebhookTenantLinkResolver: resolveGitlabOAuthWebhookTenantLink,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/gitlab/index.ts
+++ b/packages/gitlab/index.ts
@@ -60,6 +60,7 @@ import {
 	PipelineEventSchema,
 	PushEventSchema,
 } from './webhooks/types';
+import { matchGitlabTenantWebhook } from './webhooks/tenant-matcher';
 
 export const gitlabAuthConfig = {} as const satisfies PluginAuthConfig;
 
@@ -802,6 +803,7 @@ export function gitlab<const T extends GitlabPluginOptions>(
 			const event = headers['x-gitlab-event'];
 			return token !== undefined || event !== undefined;
 		},
+		pluginTenantWebhookMatcher: matchGitlabTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/gitlab/jest.config.cjs
+++ b/packages/gitlab/jest.config.cjs
@@ -44,6 +44,7 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',
 	},

--- a/packages/gitlab/webhooks/oauth-tenant-link.test.ts
+++ b/packages/gitlab/webhooks/oauth-tenant-link.test.ts
@@ -1,0 +1,11 @@
+import { resolveGitlabOAuthWebhookTenantLink } from './oauth-tenant-link';
+
+describe('resolveGitlabOAuthWebhookTenantLink', () => {
+	it('returns null so project_id or group_id is set at webhook registration', () => {
+		expect(
+			resolveGitlabOAuthWebhookTenantLink({
+				access_token: 'token',
+			}),
+		).toBeNull();
+	});
+});

--- a/packages/gitlab/webhooks/oauth-tenant-link.ts
+++ b/packages/gitlab/webhooks/oauth-tenant-link.ts
@@ -1,18 +1,9 @@
 import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
-import { toExternalId } from 'corsair/core';
 
-export async function resolveGitlabOAuthWebhookTenantLink(
-	tokens: TokenResponse,
-): Promise<WebhookTenantMatch | null> {
-	const accessToken = tokens.access_token;
-	if (!accessToken) return null;
-
-	const response = await fetch('https://gitlab.com/api/v4/user', {
-		headers: { Authorization: `Bearer ${accessToken}` },
-	});
-	if (!response.ok) return null;
-
-	const payload = (await response.json()) as { id?: number | string };
-	const userId = toExternalId(payload.id);
-	return userId ? { linkType: 'user_id', externalId: userId } : null;
+// GitLab webhook payloads identify project_id / group_id, not the OAuth user id.
+// Persist the link when registering a project or group webhook via setWebhookTenantLink.
+export function resolveGitlabOAuthWebhookTenantLink(
+	_tokens: TokenResponse,
+): WebhookTenantMatch | null {
+	return null;
 }

--- a/packages/gitlab/webhooks/oauth-tenant-link.ts
+++ b/packages/gitlab/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,18 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { toExternalId } from 'corsair/core';
+
+export async function resolveGitlabOAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): Promise<WebhookTenantMatch | null> {
+	const accessToken = tokens.access_token;
+	if (!accessToken) return null;
+
+	const response = await fetch('https://gitlab.com/api/v4/user', {
+		headers: { Authorization: `Bearer ${accessToken}` },
+	});
+	if (!response.ok) return null;
+
+	const payload = (await response.json()) as { id?: number | string };
+	const userId = toExternalId(payload.id);
+	return userId ? { linkType: 'user_id', externalId: userId } : null;
+}

--- a/packages/gitlab/webhooks/tenant-matcher.ts
+++ b/packages/gitlab/webhooks/tenant-matcher.ts
@@ -1,0 +1,30 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import {
+	asRecord,
+	firstString,
+	readBodyRecord,
+} from 'corsair/core';
+
+// GitLab project and group webhooks include project_id / project.id on the payload.
+// See https://docs.gitlab.com/user/project/integrations/webhook_events/
+export function matchGitlabTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const project = asRecord(body.project);
+	const group = asRecord(body.group);
+
+	const projectId = firstString([body.project_id, project?.id]);
+	if (projectId) {
+		return { linkType: 'project_id', externalId: projectId };
+	}
+
+	const groupId = firstString([body.group_id, group?.id]);
+	if (groupId) {
+		return { linkType: 'group_id', externalId: groupId };
+	}
+
+	return null;
+}

--- a/packages/gmail/index.ts
+++ b/packages/gmail/index.ts
@@ -36,6 +36,7 @@ import type {
 } from './webhooks';
 import { MessageWebhooks } from './webhooks';
 import type { PubSubNotification } from './webhooks/types';
+import { matchGmailTenantWebhook } from './webhooks/tenant-matcher';
 import {
 	decodePubSubMessage,
 	GmailWebhookEventSchema,
@@ -518,6 +519,7 @@ export function gmail<const T extends GmailPluginOptions>(
 				return false;
 			}
 		},
+		pluginTenantWebhookMatcher: matchGmailTenantWebhook,
 	} satisfies InternalGmailPlugin;
 }
 

--- a/packages/gmail/index.ts
+++ b/packages/gmail/index.ts
@@ -37,6 +37,7 @@ import type {
 import { MessageWebhooks } from './webhooks';
 import type { PubSubNotification } from './webhooks/types';
 import { matchGmailTenantWebhook } from './webhooks/tenant-matcher';
+import { resolveGmailOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
 import {
 	decodePubSubMessage,
 	GmailWebhookEventSchema,
@@ -50,6 +51,7 @@ import {
 export const gmailAuthConfig = {
 	oauth_2: {
 		integration: ['topic_id'] as const,
+		account: ['email_address'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -520,6 +522,7 @@ export function gmail<const T extends GmailPluginOptions>(
 			}
 		},
 		pluginTenantWebhookMatcher: matchGmailTenantWebhook,
+		oauthWebhookTenantLinkResolver: resolveGmailOAuthWebhookTenantLink,
 	} satisfies InternalGmailPlugin;
 }
 

--- a/packages/gmail/webhooks/oauth-tenant-link.ts
+++ b/packages/gmail/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,23 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { toExternalId } from 'corsair/core';
+
+export async function resolveGmailOAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): Promise<WebhookTenantMatch | null> {
+	const accessToken = tokens.access_token;
+	if (!accessToken) return null;
+
+	const response = await fetch(
+		'https://gmail.googleapis.com/gmail/v1/users/me/profile',
+		{
+			headers: { Authorization: `Bearer ${accessToken}` },
+		},
+	);
+	if (!response.ok) return null;
+
+	const payload = (await response.json()) as { emailAddress?: string };
+	const emailAddress = toExternalId(payload.emailAddress);
+	return emailAddress
+		? { linkType: 'email_address', externalId: emailAddress }
+		: null;
+}

--- a/packages/gmail/webhooks/tenant-matcher.ts
+++ b/packages/gmail/webhooks/tenant-matcher.ts
@@ -1,0 +1,22 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import {
+	asRecord,
+	decodePubSubData,
+	firstString,
+	readBodyRecord,
+} from 'corsair/core';
+
+// Gmail Pub/Sub push: emailAddress is in the base64-decoded message.data JSON.
+// See https://developers.google.com/workspace/gmail/api/guides/push
+export function matchGmailTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const decoded = asRecord(decodePubSubData(body));
+	const emailAddress = firstString([decoded?.emailAddress]);
+	if (!emailAddress) return null;
+
+	return { linkType: 'email_address', externalId: emailAddress };
+}

--- a/packages/googlecalendar/index.ts
+++ b/packages/googlecalendar/index.ts
@@ -7,6 +7,7 @@ import type {
 	CorsairWebhook,
 	KeyBuilderContext,
 	PickAuth,
+	PluginAuthConfig,
 	PluginPermissionsConfig,
 	RawWebhookRequest,
 	RequiredPluginEndpointMeta,
@@ -182,6 +183,12 @@ const googleCalendarEndpointMeta = {
 	},
 } satisfies RequiredPluginEndpointMeta<typeof googleCalendarEndpointsNested>;
 
+export const googleCalendarAuthConfig = {
+	oauth_2: {
+		account: ['channel_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
 export type BaseGoogleCalendarPlugin<T extends GoogleCalendarPluginOptions> =
 	CorsairPlugin<
 		'googlecalendar',
@@ -209,6 +216,7 @@ export function googlecalendar<const T extends GoogleCalendarPluginOptions>(
 	};
 	return {
 		id: 'googlecalendar',
+		authConfig: googleCalendarAuthConfig,
 		schema: GoogleCalendarSchema,
 		options: options,
 		oauthConfig: {

--- a/packages/googlecalendar/index.ts
+++ b/packages/googlecalendar/index.ts
@@ -32,6 +32,7 @@ import type {
 } from './webhooks';
 import { EventWebhooks } from './webhooks';
 import type { PubSubNotification } from './webhooks/types';
+import { matchGoogleCalendarTenantWebhook } from './webhooks/tenant-matcher';
 import {
 	decodePubSubMessage,
 	GoogleCalendarWebhookEventSchema,
@@ -314,6 +315,7 @@ export function googlecalendar<const T extends GoogleCalendarPluginOptions>(
 				return false;
 			}
 		},
+		pluginTenantWebhookMatcher: matchGoogleCalendarTenantWebhook,
 	} satisfies InternalGoogleCalendarPlugin;
 }
 

--- a/packages/googlecalendar/webhooks/tenant-matcher.ts
+++ b/packages/googlecalendar/webhooks/tenant-matcher.ts
@@ -1,0 +1,31 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import {
+	asRecord,
+	decodePubSubData,
+	firstString,
+	getHeader,
+	readBodyRecord,
+} from 'corsair/core';
+
+// Google Calendar push notifications echo the watch channel id in X-Goog-Channel-Id.
+// See https://developers.google.com/workspace/calendar/api/guides/push
+export function matchGoogleCalendarTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const channelId = firstString([
+		getHeader(request.headers, 'x-goog-channel-id'),
+	]);
+	if (channelId) {
+		return { linkType: 'channel_id', externalId: channelId };
+	}
+
+	// Fallback for Pub/Sub-wrapped calendar notifications that include channelId in data.
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const decoded = asRecord(decodePubSubData(body));
+	const pubsubChannelId = firstString([decoded?.channelId]);
+	if (!pubsubChannelId) return null;
+
+	return { linkType: 'channel_id', externalId: pubsubChannelId };
+}

--- a/packages/googledrive/index.ts
+++ b/packages/googledrive/index.ts
@@ -7,6 +7,7 @@ import type {
 	CorsairWebhook,
 	KeyBuilderContext,
 	PickAuth,
+	PluginAuthConfig,
 	PluginPermissionsConfig,
 	RawWebhookRequest,
 	RequiredPluginEndpointMeta,
@@ -339,6 +340,12 @@ const googleDriveEndpointMeta = {
 	},
 } satisfies RequiredPluginEndpointMeta<typeof googleDriveEndpointsNested>;
 
+export const googledriveAuthConfig = {
+	oauth_2: {
+		account: ['channel_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
 export type BaseGoogleDrivePlugin<T extends GoogleDrivePluginOptions> =
 	CorsairPlugin<
 		'googledrive',
@@ -365,6 +372,7 @@ export function googledrive<const T extends GoogleDrivePluginOptions>(
 	};
 	return {
 		id: 'googledrive',
+		authConfig: googledriveAuthConfig,
 		schema: GoogleDriveSchema,
 		options: options,
 		oauthConfig: {

--- a/packages/googledrive/index.ts
+++ b/packages/googledrive/index.ts
@@ -35,6 +35,7 @@ import type {
 } from './webhooks';
 import { ChangeWebhooks } from './webhooks';
 import type { PubSubNotification } from './webhooks/types';
+import { matchGoogleDriveTenantWebhook } from './webhooks/tenant-matcher';
 import {
 	DriveChangedEventSchema,
 	decodePubSubMessage,
@@ -466,6 +467,7 @@ export function googledrive<const T extends GoogleDrivePluginOptions>(
 				return false;
 			}
 		},
+		pluginTenantWebhookMatcher: matchGoogleDriveTenantWebhook,
 	} satisfies InternalGoogleDrivePlugin;
 }
 

--- a/packages/googledrive/webhooks/tenant-matcher.ts
+++ b/packages/googledrive/webhooks/tenant-matcher.ts
@@ -1,0 +1,15 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { firstString, getHeader } from 'corsair/core';
+
+// Google Drive push notifications echo the watch channel id in X-Goog-Channel-Id.
+// See https://developers.google.com/workspace/drive/api/guides/push
+export function matchGoogleDriveTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const channelId = firstString([
+		getHeader(request.headers, 'x-goog-channel-id'),
+	]);
+	if (!channelId) return null;
+
+	return { linkType: 'channel_id', externalId: channelId };
+}

--- a/packages/googlesheets/index.ts
+++ b/packages/googlesheets/index.ts
@@ -29,6 +29,7 @@ import type {
 	RangeUpdatedEvent,
 } from './webhooks';
 import { RowWebhooks } from './webhooks';
+import { matchGoogleSheetsTenantWebhook } from './webhooks/tenant-matcher';
 import {
 	GoogleAppsScriptWebhookPayloadSchema,
 	RangeUpdatedEventSchema,
@@ -359,6 +360,7 @@ export function googlesheets<const T extends GoogleSheetsPluginOptions>(
 			const hasSheetsEventType = body?.eventType === 'rangeUpdated';
 			return hasSpreadsheetId || hasSheetsEventType;
 		},
+		pluginTenantWebhookMatcher: matchGoogleSheetsTenantWebhook,
 	} satisfies InternalGoogleSheetsPlugin;
 }
 

--- a/packages/googlesheets/index.ts
+++ b/packages/googlesheets/index.ts
@@ -7,6 +7,7 @@ import type {
 	CorsairWebhook,
 	KeyBuilderContext,
 	PickAuth,
+	PluginAuthConfig,
 	PluginPermissionsConfig,
 	RawWebhookRequest,
 	RequiredPluginEndpointMeta,
@@ -242,6 +243,12 @@ const googleSheetsEndpointMeta = {
 	},
 } satisfies RequiredPluginEndpointMeta<typeof googleSheetsEndpointsNested>;
 
+export const googlesheetsAuthConfig = {
+	oauth_2: {
+		account: ['spreadsheet_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
 export type BaseGoogleSheetsPlugin<T extends GoogleSheetsPluginOptions> =
 	CorsairPlugin<
 		'googlesheets',
@@ -268,6 +275,7 @@ export function googlesheets<const T extends GoogleSheetsPluginOptions>(
 	};
 	return {
 		id: 'googlesheets',
+		authConfig: googlesheetsAuthConfig,
 		schema: GoogleSheetsSchema,
 		options: options,
 		oauthConfig: {

--- a/packages/googlesheets/webhooks/tenant-matcher.ts
+++ b/packages/googlesheets/webhooks/tenant-matcher.ts
@@ -1,0 +1,15 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { firstString, readBodyRecord } from 'corsair/core';
+
+// Google Sheets webhooks are Apps Script payloads keyed by spreadsheetId.
+export function matchGoogleSheetsTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const spreadsheetId = firstString([body.spreadsheetId]);
+	if (!spreadsheetId) return null;
+
+	return { linkType: 'spreadsheet_id', externalId: spreadsheetId };
+}

--- a/packages/grafana/index.ts
+++ b/packages/grafana/index.ts
@@ -58,7 +58,7 @@ export type GrafanaPluginOptions = {
  */
 export const grafanaAuthConfig = {
 	api_key: {
-		account: ['grafana_url'] as const,
+		account: ['grafana_url', 'org_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 

--- a/packages/grafana/index.ts
+++ b/packages/grafana/index.ts
@@ -33,6 +33,7 @@ import {
 } from './endpoints/types';
 import { errorHandlers } from './error-handlers';
 import { GrafanaSchema } from './schema';
+import { matchGrafanaTenantWebhook } from './webhooks/tenant-matcher';
 
 export type GrafanaPluginOptions = {
 	authType?: PickAuth<'api_key'>;
@@ -262,6 +263,7 @@ export function grafana<const T extends GrafanaPluginOptions>(
 		endpointSchemas: grafanaEndpointSchemas,
 		// Grafana has no webhooks — no incoming webhook requests to match
 		pluginWebhookMatcher: (_request) => false,
+		pluginTenantWebhookMatcher: matchGrafanaTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/grafana/webhooks/tenant-matcher.ts
+++ b/packages/grafana/webhooks/tenant-matcher.ts
@@ -1,0 +1,19 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// Grafana alerting webhook notifier includes orgId on the default payload envelope.
+// See https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier/
+export function matchGrafanaTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const alerts = Array.isArray(body.alerts) ? body.alerts : [];
+	const firstAlert = asRecord(alerts[0]);
+
+	const orgId = firstString([body.orgId, firstAlert?.orgId]);
+	if (!orgId) return null;
+
+	return { linkType: 'org_id', externalId: orgId };
+}

--- a/packages/hackernews/index.ts
+++ b/packages/hackernews/index.ts
@@ -22,6 +22,7 @@ import {
 } from './endpoints/types';
 import { errorHandlers } from './error-handlers';
 import { HackerNewsSchema } from './schema';
+import { matchHackerNewsTenantWebhook } from './webhooks/tenant-matcher';
 
 export type HackerNewsPluginOptions = {
 	// HackerNews is a public API (NO_AUTH) — api_key auth type is kept for framework compatibility
@@ -331,6 +332,7 @@ export function hackernews<const T extends HackerNewsPluginOptions>(
 		endpointSchemas: hackerNewsEndpointSchemas,
 		// HackerNews has no webhooks — no incoming webhook requests to match
 		pluginWebhookMatcher: (_request) => false,
+		pluginTenantWebhookMatcher: matchHackerNewsTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/hackernews/index.ts
+++ b/packages/hackernews/index.ts
@@ -290,9 +290,7 @@ const hackerNewsEndpointMeta = {
 } satisfies RequiredPluginEndpointMeta<typeof hackerNewsEndpointsNested>;
 
 export const hackerNewsAuthConfig = {
-	api_key: {
-		account: ['one'] as const,
-	},
+	api_key: {},
 } as const satisfies PluginAuthConfig;
 
 export type BaseHackerNewsPlugin<T extends HackerNewsPluginOptions> =
@@ -322,6 +320,7 @@ export function hackernews<const T extends HackerNewsPluginOptions>(
 	};
 	return {
 		id: 'hackernews',
+		authConfig: hackerNewsAuthConfig,
 		schema: HackerNewsSchema,
 		options,
 		hooks: options.hooks,

--- a/packages/hackernews/webhooks/tenant-matcher.ts
+++ b/packages/hackernews/webhooks/tenant-matcher.ts
@@ -1,0 +1,8 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+
+// Hacker News is a public read-only API with no webhook delivery mechanism.
+export function matchHackerNewsTenantWebhook(
+	_request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	return null;
+}

--- a/packages/hubspot/index.ts
+++ b/packages/hubspot/index.ts
@@ -55,6 +55,7 @@ import {
 	DealWebhooks,
 	TicketWebhooks,
 } from './webhooks';
+import { matchHubspotTenantWebhook } from './webhooks/tenant-matcher';
 import {
 	CompanyCreatedEventSchema,
 	CompanyDeletedEventSchema,
@@ -631,6 +632,7 @@ export function hubspot<const PluginOptions extends HubSpotPluginOptions>(
 			);
 			return hasHubSpotSignature || hasHubSpotPayload;
 		},
+		pluginTenantWebhookMatcher: matchHubspotTenantWebhook,
 		errorHandlers: options.errorHandlers || errorHandlers,
 		keyBuilder: async (ctx: HubSpotKeyBuilderContext, source) => {
 			const authType = ctx.authType;

--- a/packages/hubspot/index.ts
+++ b/packages/hubspot/index.ts
@@ -8,6 +8,7 @@ import type {
 	CorsairWebhook,
 	KeyBuilderContext,
 	PickAuth,
+	PluginAuthConfig,
 	PluginPermissionsConfig,
 	RawWebhookRequest,
 	RequiredPluginEndpointMeta,
@@ -56,6 +57,7 @@ import {
 	TicketWebhooks,
 } from './webhooks';
 import { matchHubspotTenantWebhook } from './webhooks/tenant-matcher';
+import { resolveHubspotOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
 import {
 	CompanyCreatedEventSchema,
 	CompanyDeletedEventSchema,
@@ -425,6 +427,11 @@ const hubspotWebhookSchemas = {
 
 const defaultAuthType = 'api_key' as const;
 
+export const hubspotAuthConfig = {
+	api_key: { account: ['portal_id'] as const },
+	oauth_2: { account: ['portal_id'] as const },
+} as const satisfies PluginAuthConfig;
+
 /**
  * Risk-level metadata for each HubSpot endpoint.
  * Used by the MCP server permission system to decide allow / deny / require_approval.
@@ -596,6 +603,7 @@ export function hubspot<const PluginOptions extends HubSpotPluginOptions>(
 	};
 	return {
 		id: 'hubspot',
+		authConfig: hubspotAuthConfig,
 		oauthConfig: {
 			providerName: 'HubSpot',
 			authUrl: 'https://app.hubspot.com/oauth/authorize',
@@ -633,6 +641,7 @@ export function hubspot<const PluginOptions extends HubSpotPluginOptions>(
 			return hasHubSpotSignature || hasHubSpotPayload;
 		},
 		pluginTenantWebhookMatcher: matchHubspotTenantWebhook,
+		oauthWebhookTenantLinkResolver: resolveHubspotOAuthWebhookTenantLink,
 		errorHandlers: options.errorHandlers || errorHandlers,
 		keyBuilder: async (ctx: HubSpotKeyBuilderContext, source) => {
 			const authType = ctx.authType;

--- a/packages/hubspot/webhooks/oauth-tenant-link.ts
+++ b/packages/hubspot/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,27 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, toExternalId } from 'corsair/core';
+
+export async function resolveHubspotOAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): Promise<WebhookTenantMatch | null> {
+	const portalId = toExternalId(
+		tokens.hub_id ?? asRecord(tokens.hub_domain)?.hub_id,
+	);
+	if (portalId) {
+		return { linkType: 'portal_id', externalId: portalId };
+	}
+
+	const accessToken = tokens.access_token;
+	if (!accessToken) return null;
+
+	const response = await fetch(
+		`https://api.hubapi.com/oauth/v1/access-tokens/${encodeURIComponent(accessToken)}`,
+	);
+	if (!response.ok) return null;
+
+	const payload = (await response.json()) as { hub_id?: number | string };
+	const fetchedPortalId = toExternalId(payload.hub_id);
+	return fetchedPortalId
+		? { linkType: 'portal_id', externalId: fetchedPortalId }
+		: null;
+}

--- a/packages/hubspot/webhooks/tenant-matcher.ts
+++ b/packages/hubspot/webhooks/tenant-matcher.ts
@@ -1,0 +1,28 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString } from 'corsair/core';
+
+function hubspotEvents(body: unknown): Record<string, unknown>[] {
+	if (Array.isArray(body)) {
+		return body.filter(
+			(event): event is Record<string, unknown> =>
+				event !== null && typeof event === 'object' && !Array.isArray(event),
+		);
+	}
+
+	const record = asRecord(body);
+	return record ? [record] : [];
+}
+
+// HubSpot subscription notifications include portalId on each event object.
+// See https://developers.hubspot.com/docs/api/webhooks
+export function matchHubspotTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const events = hubspotEvents(request.body);
+	if (events.length === 0) return null;
+
+	const portalId = firstString(events.map((event) => event.portalId));
+	if (!portalId) return null;
+
+	return { linkType: 'portal_id', externalId: portalId };
+}

--- a/packages/intercom/index.ts
+++ b/packages/intercom/index.ts
@@ -662,7 +662,7 @@ const intercomEndpointMeta = {
 
 export const intercomAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['app_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -729,6 +729,7 @@ export function intercom<const T extends IntercomPluginOptions>(
 	};
 	return {
 		id: 'intercom',
+		authConfig: intercomAuthConfig,
 		schema: IntercomSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/intercom/index.ts
+++ b/packages/intercom/index.ts
@@ -38,6 +38,7 @@ import {
 	ConversationWebhooks,
 	PingWebhooks,
 } from './webhooks';
+import { matchIntercomTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	ContactCreatedEvent,
 	ContactDeletedEvent,
@@ -743,6 +744,7 @@ export function intercom<const T extends IntercomPluginOptions>(
 			const hasSubscriptionId = 'intercom-webhook-subscription-id' in headers;
 			return hasSignature && hasSubscriptionId;
 		},
+		pluginTenantWebhookMatcher: matchIntercomTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/intercom/webhooks/tenant-matcher.ts
+++ b/packages/intercom/webhooks/tenant-matcher.ts
@@ -1,0 +1,16 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { firstString, readBodyRecord } from 'corsair/core';
+
+// Intercom notification payloads include app_id, which identifies the workspace.
+// See https://developers.intercom.com/docs/references/webhooks/webhook-models
+export function matchIntercomTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const appId = firstString([body.app_id]);
+	if (!appId) return null;
+
+	return { linkType: 'app_id', externalId: appId };
+}

--- a/packages/jira/index.ts
+++ b/packages/jira/index.ts
@@ -47,6 +47,7 @@ import {
 	NewProjectEventSchema,
 	UpdatedIssueEventSchema,
 } from './webhooks/types';
+import { matchJiraTenantWebhook } from './webhooks/tenant-matcher';
 
 export type JiraPluginOptions = {
 	authType?: PickAuth<'api_key'>;
@@ -521,6 +522,7 @@ export function jira<const T extends JiraPluginOptions>(
 			const headers = request.headers;
 			return 'x-atlassian-webhook-identifier' in headers;
 		},
+		pluginTenantWebhookMatcher: matchJiraTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/jira/webhooks/tenant-matcher.ts
+++ b/packages/jira/webhooks/tenant-matcher.ts
@@ -1,0 +1,43 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+function cloudUrlFromSelf(self: unknown): string | undefined {
+	if (typeof self !== 'string') return undefined;
+	try {
+		const url = new URL(self);
+		return `${url.protocol}//${url.host}`;
+	} catch {
+		return undefined;
+	}
+}
+
+function extractJiraCloudUrl(body: Record<string, unknown>): string | undefined {
+	const issue = asRecord(body.issue);
+	const project = asRecord(body.project);
+	const user = asRecord(body.user);
+
+	const issueFields = asRecord(issue?.fields);
+	const issueProject = asRecord(issueFields?.project);
+
+	return firstString([
+		cloudUrlFromSelf(issue?.self),
+		cloudUrlFromSelf(issueProject?.self),
+		cloudUrlFromSelf(project?.self),
+		cloudUrlFromSelf(user?.self),
+	]);
+}
+
+// Jira Cloud webhooks embed the site hostname in issue/project self URLs.
+// cloudId is not included on webhook payloads; cloud_url matches jiraAuthConfig.
+// See https://developer.atlassian.com/cloud/jira/software/webhooks/
+export function matchJiraTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const cloudUrl = extractJiraCloudUrl(body);
+	if (!cloudUrl) return null;
+
+	return { linkType: 'cloud_url', externalId: cloudUrl };
+}

--- a/packages/linear/index.ts
+++ b/packages/linear/index.ts
@@ -8,6 +8,7 @@ import type {
 	CorsairWebhook,
 	KeyBuilderContext,
 	PickAuth,
+	PluginAuthConfig,
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
@@ -47,6 +48,7 @@ import {
 	ProjectUpdatedEventSchema,
 } from './webhooks/types';
 import { matchLinearTenantWebhook } from './webhooks/tenant-matcher';
+import { resolveLinearOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
 
 export type LinearPluginOptions = {
 	authType?: PickAuth<'api_key' | 'oauth_2'>;
@@ -295,6 +297,11 @@ const linearWebhookSchemas = {
 
 const defaultAuthType = 'api_key' as const;
 
+export const linearAuthConfig = {
+	api_key: { account: ['organization_id'] as const },
+	oauth_2: { account: ['organization_id'] as const },
+} as const satisfies PluginAuthConfig;
+
 /**
  * Risk-level metadata for each Linear endpoint.
  * Used by the MCP server permission system to decide allow / deny / require_approval.
@@ -384,6 +391,7 @@ export function linear<const T extends LinearPluginOptions>(
 	};
 	return {
 		id: 'linear',
+		authConfig: linearAuthConfig,
 		oauthConfig: {
 			providerName: 'Linear',
 			authUrl: 'https://linear.app/oauth/authorize',
@@ -406,6 +414,7 @@ export function linear<const T extends LinearPluginOptions>(
 			return hasLinearSignature;
 		},
 		pluginTenantWebhookMatcher: matchLinearTenantWebhook,
+		oauthWebhookTenantLinkResolver: resolveLinearOAuthWebhookTenantLink,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/linear/index.ts
+++ b/packages/linear/index.ts
@@ -46,6 +46,7 @@ import {
 	ProjectDeletedEventSchema,
 	ProjectUpdatedEventSchema,
 } from './webhooks/types';
+import { matchLinearTenantWebhook } from './webhooks/tenant-matcher';
 
 export type LinearPluginOptions = {
 	authType?: PickAuth<'api_key' | 'oauth_2'>;
@@ -404,6 +405,7 @@ export function linear<const T extends LinearPluginOptions>(
 			const hasLinearSignature = 'linear-signature' in headers;
 			return hasLinearSignature;
 		},
+		pluginTenantWebhookMatcher: matchLinearTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/linear/webhooks/oauth-tenant-link.ts
+++ b/packages/linear/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,31 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { toExternalId } from 'corsair/core';
+
+export async function resolveLinearOAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): Promise<WebhookTenantMatch | null> {
+	const accessToken = tokens.access_token;
+	if (!accessToken) return null;
+
+	const response = await fetch('https://api.linear.app/graphql', {
+		method: 'POST',
+		headers: {
+			Authorization: accessToken,
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({
+			query: 'query { viewer { organization { id } } }',
+		}),
+	});
+	if (!response.ok) return null;
+
+	const payload = (await response.json()) as {
+		data?: { viewer?: { organization?: { id?: string } } };
+	};
+	const organizationId = toExternalId(
+		payload.data?.viewer?.organization?.id,
+	);
+	return organizationId
+		? { linkType: 'organization_id', externalId: organizationId }
+		: null;
+}

--- a/packages/linear/webhooks/tenant-matcher.ts
+++ b/packages/linear/webhooks/tenant-matcher.ts
@@ -1,0 +1,16 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { firstString, readBodyRecord } from 'corsair/core';
+
+// Linear webhook payloads include organizationId on every event envelope.
+// See https://developers.linear.app/docs/graphql/webhooks
+export function matchLinearTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const organizationId = firstString([body.organizationId]);
+	if (!organizationId) return null;
+
+	return { linkType: 'organization_id', externalId: organizationId };
+}

--- a/packages/monday/index.ts
+++ b/packages/monday/index.ts
@@ -484,7 +484,7 @@ const mondayEndpointMeta = {
 
 export const mondayAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['accountId'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -511,6 +511,7 @@ export function monday<const T extends MondayPluginOptions>(
 	};
 	return {
 		id: 'monday',
+		authConfig: mondayAuthConfig,
 		schema: MondaySchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/monday/index.ts
+++ b/packages/monday/index.ts
@@ -40,6 +40,7 @@ import {
 	ItemWebhooks,
 	StatusWebhooks,
 } from './webhooks';
+import { matchMondayTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	ColumnValueChangedEvent,
 	ItemCreatedEvent,
@@ -540,6 +541,7 @@ export function monday<const T extends MondayPluginOptions>(
 				return false;
 			}
 		},
+		pluginTenantWebhookMatcher: matchMondayTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/monday/webhooks/tenant-matcher.ts
+++ b/packages/monday/webhooks/tenant-matcher.ts
@@ -1,0 +1,53 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import {
+	asRecord,
+	firstString,
+	getHeader,
+	readBodyRecord,
+} from 'corsair/core';
+
+function readJwtPayload(
+	request: RawWebhookRequest,
+): Record<string, unknown> | null {
+	const authorization = getHeader(request.headers, 'authorization');
+	if (!authorization) return null;
+
+	const token = authorization.startsWith('Bearer ')
+		? authorization.slice('Bearer '.length)
+		: authorization;
+	const parts = token.split('.');
+	const payloadSegment = parts[1];
+	if (!payloadSegment) return null;
+
+	try {
+		const normalized = payloadSegment.replace(/-/g, '+').replace(/_/g, '/');
+		const padded = normalized.padEnd(
+			normalized.length + ((4 - (normalized.length % 4)) % 4),
+			'=',
+		);
+		return asRecord(JSON.parse(Buffer.from(padded, 'base64').toString('utf8')));
+	} catch {
+		return null;
+	}
+}
+
+// Monday board webhooks sign requests with a JWT that includes accountId.
+// App lifecycle webhooks may also include accountId at the top level.
+// Challenge handshakes only carry challenge and should not resolve a tenant.
+// See https://developer.monday.com/apps/docs/integration-authorization
+export function matchMondayTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	if (typeof body.challenge === 'string') return null;
+
+	const accountId = firstString([
+		body.accountId,
+		readJwtPayload(request)?.accountId,
+	]);
+	if (!accountId) return null;
+
+	return { linkType: 'accountId', externalId: accountId };
+}

--- a/packages/notion/index.ts
+++ b/packages/notion/index.ts
@@ -26,6 +26,7 @@ import {
 import { errorHandlers } from './error-handlers';
 import { NotionSchema } from './schema';
 import { NotionWebhooks } from './webhooks';
+import { matchNotionTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	NotionWebhookOutputs,
 	PageCreatedEvent,
@@ -344,6 +345,7 @@ export function notion<const T extends NotionPluginOptions>(
 			const hasSignature = 'x-notion-signature' in headers;
 			return hasSignature;
 		},
+		pluginTenantWebhookMatcher: matchNotionTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/notion/index.ts
+++ b/packages/notion/index.ts
@@ -27,6 +27,7 @@ import { errorHandlers } from './error-handlers';
 import { NotionSchema } from './schema';
 import { NotionWebhooks } from './webhooks';
 import { matchNotionTenantWebhook } from './webhooks/tenant-matcher';
+import { resolveNotionOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
 import type {
 	NotionWebhookOutputs,
 	PageCreatedEvent,
@@ -285,9 +286,11 @@ const defaultAuthType: AuthTypes = 'api_key' as const;
 
 export const notionAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['workspace_id'] as const,
 	},
-	oauth_2: {},
+	oauth_2: {
+		account: ['workspace_id'] as const,
+	},
 } as const satisfies PluginAuthConfig;
 
 export type BaseNotionPlugin<T extends NotionPluginOptions> = CorsairPlugin<
@@ -346,6 +349,7 @@ export function notion<const T extends NotionPluginOptions>(
 			return hasSignature;
 		},
 		pluginTenantWebhookMatcher: matchNotionTenantWebhook,
+		oauthWebhookTenantLinkResolver: resolveNotionOAuthWebhookTenantLink,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/notion/webhooks/oauth-tenant-link.ts
+++ b/packages/notion/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,27 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, toExternalId } from 'corsair/core';
+
+export async function resolveNotionOAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): Promise<WebhookTenantMatch | null> {
+	const workspaceId = toExternalId(tokens.workspace_id);
+	if (workspaceId) {
+		return { linkType: 'workspace_id', externalId: workspaceId };
+	}
+
+	const accessToken = tokens.access_token;
+	if (!accessToken) return null;
+
+	const response = await fetch('https://api.notion.com/v1/users/me', {
+		headers: { Authorization: `Bearer ${accessToken}` },
+	});
+	if (!response.ok) return null;
+
+	const payload = (await response.json()) as Record<string, unknown>;
+	const fetchedWorkspaceId = toExternalId(
+		asRecord(payload.bot)?.workspace_id ?? payload.workspace_id,
+	);
+	return fetchedWorkspaceId
+		? { linkType: 'workspace_id', externalId: fetchedWorkspaceId }
+		: null;
+}

--- a/packages/notion/webhooks/tenant-matcher.ts
+++ b/packages/notion/webhooks/tenant-matcher.ts
@@ -1,0 +1,19 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { firstString, readBodyRecord } from 'corsair/core';
+
+// Notion webhook payloads include workspace_id on every event notification.
+// Verification handshakes only carry verification_token and should not resolve a tenant.
+// See https://developers.notion.com/reference/webhooks
+export function matchNotionTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	if (typeof body.verification_token === 'string') return null;
+
+	const workspaceId = firstString([body.workspace_id]);
+	if (!workspaceId) return null;
+
+	return { linkType: 'workspace_id', externalId: workspaceId };
+}

--- a/packages/onedrive/index.ts
+++ b/packages/onedrive/index.ts
@@ -40,6 +40,7 @@ import type {
 	OnedriveWebhookOutputs,
 	OnedriveWebhookPayload,
 } from './webhooks/types';
+import { matchOnedriveTenantWebhook } from './webhooks/tenant-matcher';
 import {
 	createOnedriveMatch,
 	createOnedriveValidationMatch,
@@ -800,6 +801,7 @@ export function onedrive<const PluginOptions extends OnedrivePluginOptions>(
 			}
 			return createOnedriveMatch()(request);
 		},
+		pluginTenantWebhookMatcher: matchOnedriveTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/onedrive/index.ts
+++ b/packages/onedrive/index.ts
@@ -743,7 +743,7 @@ const defaultAuthType = 'oauth_2' as const;
 
 export const onedriveAuthConfig = {
 	oauth_2: {
-		account: ['one'] as const,
+		account: ['subscription_id', 'client_state'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 

--- a/packages/onedrive/webhooks/tenant-matcher.ts
+++ b/packages/onedrive/webhooks/tenant-matcher.ts
@@ -1,0 +1,37 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+import { extractOnedriveValidationToken } from './types';
+
+function extractGraphNotificationTenant(
+	notifications: unknown[],
+): WebhookTenantMatch | null {
+	for (const item of notifications) {
+		const notification = asRecord(item);
+		if (!notification) continue;
+
+		const subscriptionId = firstString([notification.subscriptionId]);
+		if (subscriptionId) {
+			return { linkType: 'subscription_id', externalId: subscriptionId };
+		}
+
+		const clientState = firstString([notification.clientState]);
+		if (clientState) {
+			return { linkType: 'client_state', externalId: clientState };
+		}
+	}
+
+	return null;
+}
+
+// Microsoft Graph change notifications: subscriptionId and clientState in body.value[].
+// See https://learn.microsoft.com/en-us/graph/change-notifications-delivery-webhooks
+export function matchOnedriveTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	if (extractOnedriveValidationToken(request)) return null;
+
+	const body = readBodyRecord(request);
+	if (!body || !Array.isArray(body.value)) return null;
+
+	return extractGraphNotificationTenant(body.value);
+}

--- a/packages/openweathermap/index.ts
+++ b/packages/openweathermap/index.ts
@@ -156,9 +156,7 @@ const openWeatherMapEndpointMeta = {
 const defaultAuthType: AuthTypes = 'api_key' as const;
 
 export const openWeatherMapAuthConfig = {
-	api_key: {
-		account: ['one'] as const,
-	},
+	api_key: {},
 } as const satisfies PluginAuthConfig;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -200,6 +198,7 @@ export function openweathermap<const T extends OpenWeatherMapPluginOptions>(
 	};
 	return {
 		id: 'openweathermap',
+		authConfig: openWeatherMapAuthConfig,
 		schema: OpenWeatherMapSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/oura/index.ts
+++ b/packages/oura/index.ts
@@ -155,7 +155,7 @@ const ouraEndpointMeta = {
 
 export const ouraAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['user_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -181,6 +181,7 @@ export function oura<const T extends OuraPluginOptions>(
 	};
 	return {
 		id: 'oura',
+		authConfig: ouraAuthConfig,
 		schema: OuraSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/oura/index.ts
+++ b/packages/oura/index.ts
@@ -26,6 +26,7 @@ import {
 import { errorHandlers } from './error-handlers';
 import { OuraSchema } from './schema';
 import { SummaryWebhooks } from './webhooks';
+import { matchOuraTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	DailyActivityWebhookEvent,
 	DailyReadinessWebhookEvent,
@@ -192,6 +193,7 @@ export function oura<const T extends OuraPluginOptions>(
 			const headers = request.headers;
 			return 'x-oura-signature' in headers;
 		},
+		pluginTenantWebhookMatcher: matchOuraTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/oura/webhooks/tenant-matcher.ts
+++ b/packages/oura/webhooks/tenant-matcher.ts
@@ -1,0 +1,16 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { firstString, readBodyRecord } from 'corsair/core';
+
+// Oura webhook callbacks include user_id for the subscribed ring owner.
+// See https://cloud.ouraring.com/v2/docs
+export function matchOuraTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const userId = firstString([body.user_id]);
+	if (!userId) return null;
+
+	return { linkType: 'user_id', externalId: userId };
+}

--- a/packages/outlook/index.ts
+++ b/packages/outlook/index.ts
@@ -530,7 +530,7 @@ const outlookWebhookSchemas = {
 
 export const outlookAuthConfig = {
 	oauth_2: {
-		account: ['one'] as const,
+		account: ['subscription_id', 'client_state'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 

--- a/packages/outlook/index.ts
+++ b/packages/outlook/index.ts
@@ -45,6 +45,7 @@ import type {
 	OutlookWebhookPayload,
 	SubscriptionValidationPayload,
 } from './webhooks/types';
+import { matchOutlookTenantWebhook } from './webhooks/tenant-matcher';
 import {
 	ContactCreatedEventSchema,
 	EventChangedEventSchema,
@@ -609,6 +610,7 @@ export function outlook<const T extends OutlookPluginOptions>(
 			}
 			return false;
 		},
+		pluginTenantWebhookMatcher: matchOutlookTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/outlook/webhooks/tenant-matcher.ts
+++ b/packages/outlook/webhooks/tenant-matcher.ts
@@ -1,0 +1,59 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import {
+	asRecord,
+	firstString,
+	getHeader,
+	readBodyRecord,
+} from 'corsair/core';
+
+function isOutlookValidationHandshake(request: RawWebhookRequest): boolean {
+	const body = readBodyRecord(request);
+	if (
+		body &&
+		typeof body.validationToken === 'string' &&
+		body.validationToken.length > 0
+	) {
+		return true;
+	}
+
+	const contentType = getHeader(request.headers, 'content-type');
+	if (contentType?.includes('text/plain')) {
+		return !body || Object.keys(body).length === 0;
+	}
+
+	return false;
+}
+
+function extractGraphNotificationTenant(
+	notifications: unknown[],
+): WebhookTenantMatch | null {
+	for (const item of notifications) {
+		const notification = asRecord(item);
+		if (!notification) continue;
+
+		const subscriptionId = firstString([notification.subscriptionId]);
+		if (subscriptionId) {
+			return { linkType: 'subscription_id', externalId: subscriptionId };
+		}
+
+		const clientState = firstString([notification.clientState]);
+		if (clientState) {
+			return { linkType: 'client_state', externalId: clientState };
+		}
+	}
+
+	return null;
+}
+
+// Microsoft Graph change notifications: subscriptionId and clientState in body.value[].
+// See https://learn.microsoft.com/en-us/graph/change-notifications-delivery-webhooks
+export function matchOutlookTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	if (isOutlookValidationHandshake(request)) return null;
+
+	const body = readBodyRecord(request);
+	if (!body || !Array.isArray(body.value)) return null;
+
+	return extractGraphNotificationTenant(body.value);
+}

--- a/packages/pagerduty/index.ts
+++ b/packages/pagerduty/index.ts
@@ -225,7 +225,7 @@ const pagerdutyEndpointMeta = {
 
 export const pagerdutyAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['subdomain'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -292,6 +292,7 @@ export function pagerduty<const T extends PagerdutyPluginOptions>(
 	};
 	return {
 		id: 'pagerduty',
+		authConfig: pagerdutyAuthConfig,
 		schema: PagerdutySchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/pagerduty/index.ts
+++ b/packages/pagerduty/index.ts
@@ -25,6 +25,7 @@ import {
 import { errorHandlers } from './error-handlers';
 import { PagerdutySchema } from './schema';
 import { IncidentWebhooks } from './webhooks';
+import { matchPagerdutyTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	IncidentAcknowledgedEvent,
 	IncidentAssignedEvent,
@@ -304,6 +305,7 @@ export function pagerduty<const T extends PagerdutyPluginOptions>(
 			const headers = request.headers;
 			return 'x-pagerduty-signature' in headers;
 		},
+		pluginTenantWebhookMatcher: matchPagerdutyTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/pagerduty/webhooks/tenant-matcher.ts
+++ b/packages/pagerduty/webhooks/tenant-matcher.ts
@@ -1,0 +1,34 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+function extractPagerdutySubdomain(url: unknown): string | undefined {
+	if (typeof url !== 'string') return undefined;
+
+	const match = url.match(/^https?:\/\/([^.]+)\.pagerduty\.com/i);
+	return match?.[1];
+}
+
+// PagerDuty V3 webhooks encode the account subdomain in html_url fields.
+// See https://support.pagerduty.com/docs/webhooks
+export function matchPagerdutyTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const event = asRecord(body.event);
+	if (!event) return null;
+
+	const data = asRecord(event.data);
+	const agent = asRecord(event.agent);
+	const service = asRecord(data?.service);
+
+	const subdomain = firstString([
+		extractPagerdutySubdomain(data?.html_url),
+		extractPagerdutySubdomain(service?.html_url),
+		extractPagerdutySubdomain(agent?.html_url),
+	]);
+	if (!subdomain) return null;
+
+	return { linkType: 'subdomain', externalId: subdomain };
+}

--- a/packages/posthog/index.ts
+++ b/packages/posthog/index.ts
@@ -24,6 +24,7 @@ import {
 import { PostHogSchema } from './schema';
 import type { EventCapturedEvent, PostHogWebhookOutputs } from './webhooks';
 import { EventWebhooks } from './webhooks';
+import { matchPostHogTenantWebhook } from './webhooks/tenant-matcher';
 import { EventCapturedEventSchema } from './webhooks/types';
 
 export type PostHogPluginOptions = {
@@ -204,6 +205,7 @@ export function posthog<const T extends PostHogPluginOptions>(
 				'distinct_id' in parsedBody;
 			return hasPostHogSignature || hasPostHogPayload;
 		},
+		pluginTenantWebhookMatcher: matchPostHogTenantWebhook,
 		errorHandlers: options.errorHandlers,
 		keyBuilder: async (ctx: PostHogKeyBuilderContext, source) => {
 			const authType = ctx.authType;

--- a/packages/posthog/index.ts
+++ b/packages/posthog/index.ts
@@ -8,6 +8,7 @@ import type {
 	CorsairWebhook,
 	KeyBuilderContext,
 	PickAuth,
+	PluginAuthConfig,
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
@@ -126,6 +127,10 @@ const posthogWebhookSchemas = {
 
 const defaultAuthType = 'api_key' as const;
 
+export const posthogAuthConfig = {
+	api_key: { account: ['project_id'] as const },
+} as const satisfies PluginAuthConfig;
+
 /**
  * Risk-level metadata for each PostHog endpoint.
  * Used by the MCP server permission system to decide allow / deny / require_approval.
@@ -181,6 +186,7 @@ export function posthog<const T extends PostHogPluginOptions>(
 	};
 	return {
 		id: 'posthog',
+		authConfig: posthogAuthConfig,
 		schema: PostHogSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/posthog/webhooks/tenant-matcher.ts
+++ b/packages/posthog/webhooks/tenant-matcher.ts
@@ -1,0 +1,30 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// PostHog webhook destinations can include project metadata when configured.
+// The default flat capture schema has no guaranteed tenant field.
+// See https://posthog.com/docs/cdp/destinations/customizing-destinations
+export function matchPostHogTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const project = asRecord(body.project);
+	const projectId = firstString([project?.id]);
+	if (projectId) {
+		return { linkType: 'project_id', externalId: projectId };
+	}
+
+	const properties = asRecord(body.properties);
+	const teamId = firstString([
+		properties?.team_id,
+		properties?.$team_id,
+		properties?.$project_id,
+	]);
+	if (teamId) {
+		return { linkType: 'project_id', externalId: teamId };
+	}
+
+	return null;
+}

--- a/packages/razorpay/index.ts
+++ b/packages/razorpay/index.ts
@@ -9,6 +9,7 @@ import type {
 	CorsairWebhook,
 	KeyBuilderContext,
 	PickAuth,
+	PluginAuthConfig,
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 	RequiredPluginEndpointSchemas,
@@ -355,6 +356,10 @@ const razorpayWebhookSchemas = {
 
 const defaultAuthType: AuthTypes = 'api_key' as const;
 
+export const razorpayAuthConfig = {
+	api_key: { account: ['account_id'] as const },
+} as const satisfies PluginAuthConfig;
+
 const razorpayEndpointMeta = {
 	'orders.create': {
 		riskLevel: 'write',
@@ -482,6 +487,7 @@ export function razorpay<const T extends RazorpayPluginOptions>(
 	};
 	return {
 		id: 'razorpay',
+		authConfig: razorpayAuthConfig,
 		schema: RazorpaySchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/razorpay/index.ts
+++ b/packages/razorpay/index.ts
@@ -59,6 +59,7 @@ import {
 import { errorHandlers } from './error-handlers';
 import { RazorpaySchema } from './schema';
 import { OrderWebhooks, PaymentWebhooks, RefundWebhooks } from './webhooks';
+import { matchRazorpayTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	RazorpayOrderPaidEvent,
 	RazorpayPaymentCapturedEvent,
@@ -493,6 +494,7 @@ export function razorpay<const T extends RazorpayPluginOptions>(
 		pluginWebhookMatcher: (request) => {
 			return 'x-razorpay-signature' in request.headers;
 		},
+		pluginTenantWebhookMatcher: matchRazorpayTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/razorpay/webhooks/tenant-matcher.ts
+++ b/packages/razorpay/webhooks/tenant-matcher.ts
@@ -1,0 +1,16 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { firstString, readBodyRecord } from 'corsair/core';
+
+// Razorpay event webhooks include account_id on the outer envelope.
+// See https://razorpay.com/docs/webhooks/payments/
+export function matchRazorpayTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const accountId = firstString([body.account_id]);
+	if (!accountId) return null;
+
+	return { linkType: 'account_id', externalId: accountId };
+}

--- a/packages/reddit/index.ts
+++ b/packages/reddit/index.ts
@@ -336,7 +336,7 @@ const redditEndpointMeta = {
 
 export const redditAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['subreddit_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -363,6 +363,7 @@ export function reddit<const T extends RedditPluginOptions>(
 	};
 	return {
 		id: 'reddit',
+		authConfig: redditAuthConfig,
 		schema: RedditSchema,
 		options,
 		hooks: options.hooks,

--- a/packages/reddit/index.ts
+++ b/packages/reddit/index.ts
@@ -22,6 +22,7 @@ import {
 } from './endpoints/types';
 import { errorHandlers } from './error-handlers';
 import { RedditSchema } from './schema';
+import { matchRedditTenantWebhook } from './webhooks/tenant-matcher';
 
 export type RedditPluginOptions = {
 	authType?: PickAuth<'api_key'>;
@@ -371,6 +372,7 @@ export function reddit<const T extends RedditPluginOptions>(
 		endpointMeta: redditEndpointMeta,
 		endpointSchemas: redditEndpointSchemas,
 		pluginWebhookMatcher: (_request) => false,
+		pluginTenantWebhookMatcher: matchRedditTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/reddit/webhooks/tenant-matcher.ts
+++ b/packages/reddit/webhooks/tenant-matcher.ts
@@ -1,0 +1,23 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// Reddit public API has no webhooks; Devvit server triggers include subredditId on events.
+// See https://developers.reddit.com/docs/capabilities/server/triggers
+export function matchRedditTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const subreddit = asRecord(body.subreddit);
+
+	const subredditId = firstString([
+		body.subredditId,
+		body.subreddit_id,
+		subreddit?.id,
+	]);
+
+	if (!subredditId) return null;
+
+	return { linkType: 'subreddit_id', externalId: subredditId };
+}

--- a/packages/resend/index.ts
+++ b/packages/resend/index.ts
@@ -36,6 +36,7 @@ import type {
 	ResendWebhookOutputs,
 } from './webhooks';
 import { DomainWebhooks, EmailWebhooks } from './webhooks';
+import { matchResendTenantWebhook } from './webhooks/tenant-matcher';
 import {
 	DomainCreatedEventSchema,
 	DomainUpdatedEventSchema,
@@ -311,6 +312,7 @@ export function resend<const T extends ResendPluginOptions>(
 				'svix-signature' in headers || 'x-resend-signature' in headers;
 			return hasResendSignature;
 		},
+		pluginTenantWebhookMatcher: matchResendTenantWebhook,
 		errorHandlers: options.errorHandlers,
 		keyBuilder: async (ctx: ResendKeyBuilderContext, source) => {
 			const authType = ctx.authType;

--- a/packages/resend/webhooks/tenant-matcher.ts
+++ b/packages/resend/webhooks/tenant-matcher.ts
@@ -1,0 +1,10 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+
+// Resend webhook payloads identify events, not the owning account. Routing uses
+// the per-endpoint signing secret instead.
+// See https://resend.com/docs/webhooks/verify-webhooks-requests
+export function matchResendTenantWebhook(
+	_request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	return null;
+}

--- a/packages/sentry/index.ts
+++ b/packages/sentry/index.ts
@@ -458,7 +458,7 @@ const sentryEndpointMeta = {
 
 export const sentryAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['installation_id', 'organization_slug'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -485,6 +485,7 @@ export function sentry<const T extends SentryPluginOptions>(
 	};
 	return {
 		id: 'sentry',
+		authConfig: sentryAuthConfig,
 		schema: SentrySchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/sentry/index.ts
+++ b/packages/sentry/index.ts
@@ -58,6 +58,7 @@ import {
 	IssueResolvedEventSchema,
 	MetricAlertEventSchema,
 } from './webhooks/types';
+import { matchSentryTenantWebhook } from './webhooks/tenant-matcher';
 
 export type SentryPluginOptions = {
 	authType?: PickAuth<'api_key'>;
@@ -499,6 +500,7 @@ export function sentry<const T extends SentryPluginOptions>(
 				'sentry-hook-signature' in headers && 'sentry-hook-resource' in headers
 			);
 		},
+		pluginTenantWebhookMatcher: matchSentryTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/sentry/webhooks/tenant-matcher.ts
+++ b/packages/sentry/webhooks/tenant-matcher.ts
@@ -1,0 +1,43 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+function extractOrganizationSlugFromIssueUrl(
+	issue: Record<string, unknown> | null,
+): string | undefined {
+	if (!issue) return undefined;
+
+	const issueUrl = firstString([issue.web_url, issue.permalink]);
+	if (!issueUrl) return undefined;
+
+	const match = issueUrl.match(/^https?:\/\/([^.]+)\.sentry\.io/i);
+	return match?.[1];
+}
+
+// Sentry Integration Platform webhooks map requests via installation.uuid.
+// See https://docs.sentry.io/integrations/integration-platform/webhooks/
+export function matchSentryTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const installationUuid = firstString([
+		asRecord(body.installation)?.uuid,
+		asRecord(asRecord(body.data)?.installation)?.uuid,
+	]);
+	if (installationUuid) {
+		return { linkType: 'installation_id', externalId: installationUuid };
+	}
+
+	const organizationSlug = firstString([
+		asRecord(asRecord(asRecord(body.data)?.installation)?.organization)?.slug,
+		extractOrganizationSlugFromIssueUrl(
+			asRecord(asRecord(body.data)?.issue),
+		),
+	]);
+	if (organizationSlug) {
+		return { linkType: 'organization_slug', externalId: organizationSlug };
+	}
+
+	return null;
+}

--- a/packages/sharepoint/index.ts
+++ b/packages/sharepoint/index.ts
@@ -62,7 +62,7 @@ const defaultAuthType = 'oauth_2' as const;
 export const sharepointAuthConfig = {
 	oauth_2: {
 		// site_id is the Graph API site identifier e.g. "tenant.sharepoint.com:/sites/MySite"
-		account: ['site_id'] as const,
+		account: ['site_id', 'subscription_id', 'client_state'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 

--- a/packages/sharepoint/index.ts
+++ b/packages/sharepoint/index.ts
@@ -45,6 +45,7 @@ import type {
 	SharepointListChangedPayload,
 	SharepointWebhookOutputs,
 } from './webhooks/types';
+import { matchSharepointTenantWebhook } from './webhooks/tenant-matcher';
 import {
 	ListChangedEventSchema,
 	SharepointListChangedPayloadSchema,
@@ -1361,6 +1362,7 @@ export function sharepoint<const T extends SharepointPluginOptions>(
 				contentType.includes('application/json')
 			);
 		},
+		pluginTenantWebhookMatcher: matchSharepointTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/sharepoint/webhooks/list-changes.ts
+++ b/packages/sharepoint/webhooks/list-changes.ts
@@ -1,4 +1,5 @@
 import { logEventFromContext } from 'corsair/core';
+import { extractMicrosoftGraphValidationToken } from 'corsair/core';
 import type { SharepointWebhooks } from '../index';
 import {
 	createSharepointMatch,
@@ -9,29 +10,20 @@ export const listChanged: SharepointWebhooks['listChanged'] = {
 	match: createSharepointMatch('listChanged'),
 
 	handler: async (ctx, request) => {
-		// SharePoint subscription validation handshake:
-		// Respond with the validationtoken to confirm the endpoint
-		// RawWebhookRequest does not include url; cast through unknown to access the framework-extended url field
-		const url = (request as unknown as { url?: string }).url ?? '';
-		if (url.includes('validationtoken')) {
-			const params = new URLSearchParams(url.split('?')[1] ?? '');
-			const token = params.get('validationtoken') ?? '';
+		const validationToken = extractMicrosoftGraphValidationToken({
+			headers: request.headers,
+			payload: request.payload,
+			query: request.query,
+		});
+		if (validationToken) {
 			return {
 				success: true,
-				data: {
-					subscriptionId: '',
-					resource: '',
-					siteUrl: '',
-					webId: '',
-					tenantId: '',
-					receivedAt: new Date(),
-				},
+				returnToSender: { validationToken },
 				statusCode: 200,
-				// Return raw validation token text — the framework forwards this to SharePoint
-				headers: { 'Content-Type': 'text/plain' },
-				rawBody: token,
-				// rawBody and headers are framework extensions not in the base WebhookResponse type; cast through unknown
-			} as unknown as ReturnType<typeof listChanged.handler>;
+				responseHeaders: {
+					'Content-Type': 'text/plain; charset=utf-8',
+				},
+			};
 		}
 
 		const clientState = ctx.options?.webhookClientState;

--- a/packages/sharepoint/webhooks/tenant-matcher.test.ts
+++ b/packages/sharepoint/webhooks/tenant-matcher.test.ts
@@ -1,0 +1,50 @@
+import type { RawWebhookRequest } from 'corsair/core';
+import {
+	extractMicrosoftGraphValidationToken,
+	isMicrosoftGraphValidationHandshake,
+} from 'corsair/core';
+import { matchSharepointTenantWebhook } from './tenant-matcher';
+
+describe('matchSharepointTenantWebhook', () => {
+	it('returns null for validationToken query param handshakes', () => {
+		const request: RawWebhookRequest = {
+			headers: { 'content-type': 'text/plain' },
+			body: {},
+			query: { validationToken: 'abc123' },
+		};
+
+		expect(isMicrosoftGraphValidationHandshake(request)).toBe(true);
+		expect(matchSharepointTenantWebhook(request)).toBeNull();
+	});
+
+	it('returns null for validationToken in forwarded URI headers', () => {
+		const request: RawWebhookRequest = {
+			headers: {
+				'x-forwarded-uri': '/webhooks/sharepoint?validationToken=abc123',
+			},
+			body: {},
+		};
+
+		expect(extractMicrosoftGraphValidationToken(request)).toBe('abc123');
+		expect(matchSharepointTenantWebhook(request)).toBeNull();
+	});
+
+	it('extracts subscription_id from notification payloads', () => {
+		const request: RawWebhookRequest = {
+			headers: { 'content-type': 'application/json' },
+			body: {
+				value: [
+					{
+						subscriptionId: 'sub-123',
+						clientState: 'state-456',
+					},
+				],
+			},
+		};
+
+		expect(matchSharepointTenantWebhook(request)).toEqual({
+			linkType: 'subscription_id',
+			externalId: 'sub-123',
+		});
+	});
+});

--- a/packages/sharepoint/webhooks/tenant-matcher.ts
+++ b/packages/sharepoint/webhooks/tenant-matcher.ts
@@ -1,19 +1,10 @@
 import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
-import { asRecord, firstString, readBodyRecord } from 'corsair/core';
-
-function isSharepointValidationHandshake(
-	request: RawWebhookRequest,
-): boolean {
-	const url = (request as unknown as { url?: string }).url ?? '';
-	if (url.toLowerCase().includes('validationtoken')) return true;
-
-	const body = readBodyRecord(request);
-	return (
-		!!body &&
-		typeof body.validationToken === 'string' &&
-		body.validationToken.length > 0
-	);
-}
+import {
+	asRecord,
+	firstString,
+	isMicrosoftGraphValidationHandshake,
+	readBodyRecord,
+} from 'corsair/core';
 
 function extractGraphNotificationTenant(
 	notifications: unknown[],
@@ -41,7 +32,7 @@ function extractGraphNotificationTenant(
 export function matchSharepointTenantWebhook(
 	request: RawWebhookRequest,
 ): WebhookTenantMatch | null {
-	if (isSharepointValidationHandshake(request)) return null;
+	if (isMicrosoftGraphValidationHandshake(request)) return null;
 
 	const body = readBodyRecord(request);
 	if (!body || !Array.isArray(body.value)) return null;

--- a/packages/sharepoint/webhooks/tenant-matcher.ts
+++ b/packages/sharepoint/webhooks/tenant-matcher.ts
@@ -1,0 +1,50 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+function isSharepointValidationHandshake(
+	request: RawWebhookRequest,
+): boolean {
+	const url = (request as unknown as { url?: string }).url ?? '';
+	if (url.toLowerCase().includes('validationtoken')) return true;
+
+	const body = readBodyRecord(request);
+	return (
+		!!body &&
+		typeof body.validationToken === 'string' &&
+		body.validationToken.length > 0
+	);
+}
+
+function extractGraphNotificationTenant(
+	notifications: unknown[],
+): WebhookTenantMatch | null {
+	for (const item of notifications) {
+		const notification = asRecord(item);
+		if (!notification) continue;
+
+		const subscriptionId = firstString([notification.subscriptionId]);
+		if (subscriptionId) {
+			return { linkType: 'subscription_id', externalId: subscriptionId };
+		}
+
+		const clientState = firstString([notification.clientState]);
+		if (clientState) {
+			return { linkType: 'client_state', externalId: clientState };
+		}
+	}
+
+	return null;
+}
+
+// SharePoint list webhooks use the Microsoft Graph-style value[] notification envelope.
+// See https://learn.microsoft.com/en-us/graph/change-notifications-delivery-webhooks
+export function matchSharepointTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	if (isSharepointValidationHandshake(request)) return null;
+
+	const body = readBodyRecord(request);
+	if (!body || !Array.isArray(body.value)) return null;
+
+	return extractGraphNotificationTenant(body.value);
+}

--- a/packages/sharepoint/webhooks/types.ts
+++ b/packages/sharepoint/webhooks/types.ts
@@ -3,6 +3,9 @@ import type {
 	RawWebhookRequest,
 	WebhookRequest,
 } from 'corsair/core';
+import {
+	isMicrosoftGraphValidationHandshake,
+} from 'corsair/core';
 import { z } from 'zod';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -68,10 +71,7 @@ export function createSharepointMatch(
 	eventType: string,
 ): CorsairWebhookMatcher {
 	return (request: RawWebhookRequest) => {
-		// Subscription validation handshake — SharePoint sends a GET/POST with validationtoken
-		// RawWebhookRequest does not include url; cast through unknown to access the framework-extended url field
-		const url = (request as unknown as { url?: string }).url ?? '';
-		if (url.includes('validationtoken')) {
+		if (isMicrosoftGraphValidationHandshake(request)) {
 			return true;
 		}
 

--- a/packages/slack/index.ts
+++ b/packages/slack/index.ts
@@ -14,6 +14,7 @@ import type {
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
 import { matchSlackTenantWebhook } from './webhooks/tenant-matcher';
+import { resolveSlackOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
 import type { SlackEndpointInputs, SlackEndpointOutputs } from './endpoints';
 import {
 	Channels,
@@ -637,7 +638,10 @@ type SlackEndpoint<K extends keyof SlackEndpointOutputs> = CorsairEndpoint<
 >;
 export const slackAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['team_id'] as const,
+	},
+	oauth_2: {
+		account: ['team_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -706,6 +710,7 @@ export function slack<const PluginOptions extends SlackPluginOptions>(
 	};
 	return {
 		id: 'slack',
+		authConfig: slackAuthConfig,
 		oauthConfig: {
 			providerName: 'Slack',
 			authUrl: 'https://slack.com/oauth/v2/authorize',
@@ -737,6 +742,7 @@ export function slack<const PluginOptions extends SlackPluginOptions>(
 			return hasSlackSignature && hasSlackTimestamp;
 		},
 		pluginTenantWebhookMatcher: matchSlackTenantWebhook,
+		oauthWebhookTenantLinkResolver: resolveSlackOAuthWebhookTenantLink,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/slack/index.ts
+++ b/packages/slack/index.ts
@@ -13,6 +13,7 @@ import type {
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { matchSlackTenantWebhook } from './webhooks/tenant-matcher';
 import type { SlackEndpointInputs, SlackEndpointOutputs } from './endpoints';
 import {
 	Channels,
@@ -735,6 +736,7 @@ export function slack<const PluginOptions extends SlackPluginOptions>(
 
 			return hasSlackSignature && hasSlackTimestamp;
 		},
+		pluginTenantWebhookMatcher: matchSlackTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/slack/webhooks/oauth-tenant-link.ts
+++ b/packages/slack/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,9 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, toExternalId } from 'corsair/core';
+
+export function resolveSlackOAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): WebhookTenantMatch | null {
+	const teamId = toExternalId(asRecord(tokens.team)?.id);
+	return teamId ? { linkType: 'team_id', externalId: teamId } : null;
+}

--- a/packages/slack/webhooks/tenant-matcher.ts
+++ b/packages/slack/webhooks/tenant-matcher.ts
@@ -1,0 +1,29 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import {
+	asRecord,
+	firstString,
+	readBodyRecord,
+} from 'corsair/core';
+
+// Slack Events API: team_id is on the outer envelope for event_callback payloads.
+// See https://api.slack.com/apis/connections/events-api#the-events-api__receiving-events
+export function matchSlackTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	if (body.type === 'url_verification') return null;
+
+	const teamId = firstString([
+		body.team_id,
+		asRecord(body.event)?.team,
+		Array.isArray(body.authorizations)
+			? asRecord(body.authorizations[0])?.team_id
+			: undefined,
+	]);
+
+	if (!teamId) return null;
+
+	return { linkType: 'team_id', externalId: teamId };
+}

--- a/packages/spotify/index.ts
+++ b/packages/spotify/index.ts
@@ -34,6 +34,7 @@ import {
 import { errorHandlers } from './error-handlers';
 import { SpotifySchema } from './schema';
 import { ExampleWebhooks } from './webhooks';
+import { matchSpotifyTenantWebhook } from './webhooks/tenant-matcher';
 import type { ExampleEvent, SpotifyWebhookOutputs } from './webhooks/types';
 import { ExampleEventSchema } from './webhooks/types';
 
@@ -497,6 +498,7 @@ export function spotify<const T extends SpotifyPluginOptions>(
 			const headers = request.headers;
 			return 'x-spotify-signature' in headers || 'spotify-webhook' in headers;
 		},
+		pluginTenantWebhookMatcher: matchSpotifyTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/spotify/webhooks/tenant-matcher.ts
+++ b/packages/spotify/webhooks/tenant-matcher.ts
@@ -1,0 +1,9 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+
+// Spotify does not offer a public webhook API; payloads have no tenant identifier.
+// See https://github.com/spotify/web-api/issues/538
+export function matchSpotifyTenantWebhook(
+	_request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	return null;
+}

--- a/packages/strava/index.ts
+++ b/packages/strava/index.ts
@@ -375,7 +375,7 @@ const stravaEndpointMeta = {
 
 export const stravaAuthConfig = {
 	oauth_2: {
-		account: ['one'] as const,
+		account: ['owner_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -407,6 +407,7 @@ export function strava<const T extends StravaPluginOptions>(
 	};
 	return {
 		id: 'strava',
+		authConfig: stravaAuthConfig,
 		schema: StravaSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/strava/index.ts
+++ b/packages/strava/index.ts
@@ -35,6 +35,7 @@ import {
 } from './endpoints/types';
 import { errorHandlers } from './error-handlers';
 import { StravaSchema } from './schema';
+import { matchStravaTenantWebhook } from './webhooks/tenant-matcher';
 import type { StravaWebhookOutputs } from './webhooks/types';
 
 export type StravaPluginOptions = {
@@ -419,6 +420,7 @@ export function strava<const T extends StravaPluginOptions>(
 			// Webhooks are not implemented yet
 			return false;
 		},
+		pluginTenantWebhookMatcher: matchStravaTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/strava/webhooks/tenant-matcher.ts
+++ b/packages/strava/webhooks/tenant-matcher.ts
@@ -1,0 +1,16 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { firstString, readBodyRecord } from 'corsair/core';
+
+// Strava push events include owner_id (athlete id) on activity/athlete webhooks.
+// See https://developers.strava.com/docs/webhooks/
+export function matchStravaTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const ownerId = firstString([body.owner_id]);
+	if (!ownerId) return null;
+
+	return { linkType: 'owner_id', externalId: ownerId };
+}

--- a/packages/stripe/index.ts
+++ b/packages/stripe/index.ts
@@ -43,6 +43,7 @@ import {
 	PingWebhooks,
 } from './webhooks';
 import { matchStripeTenantWebhook } from './webhooks/tenant-matcher';
+import { resolveStripeOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
 import type {
 	StripeChargeFailedEvent,
 	StripeChargeRefundedEvent,
@@ -424,7 +425,10 @@ const stripeWebhookSchemas = {
 
 export const stripeAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['account_id'] as const,
+	},
+	oauth_2: {
+		account: ['account_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -452,6 +456,7 @@ export function stripe<const T extends StripePluginOptions>(
 	};
 	return {
 		id: 'stripe',
+		authConfig: stripeAuthConfig,
 		schema: StripeSchema,
 		options: options,
 		oauthConfig: {
@@ -473,6 +478,7 @@ export function stripe<const T extends StripePluginOptions>(
 			return 'stripe-signature' in request.headers;
 		},
 		pluginTenantWebhookMatcher: matchStripeTenantWebhook,
+		oauthWebhookTenantLinkResolver: resolveStripeOAuthWebhookTenantLink,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/stripe/index.ts
+++ b/packages/stripe/index.ts
@@ -42,6 +42,7 @@ import {
 	PaymentIntentWebhooks,
 	PingWebhooks,
 } from './webhooks';
+import { matchStripeTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	StripeChargeFailedEvent,
 	StripeChargeRefundedEvent,
@@ -471,6 +472,7 @@ export function stripe<const T extends StripePluginOptions>(
 		pluginWebhookMatcher: (request) => {
 			return 'stripe-signature' in request.headers;
 		},
+		pluginTenantWebhookMatcher: matchStripeTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/stripe/webhooks/oauth-tenant-link.ts
+++ b/packages/stripe/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,13 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, toExternalId } from 'corsair/core';
+
+export function resolveStripeOAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): WebhookTenantMatch | null {
+	const accountId = toExternalId(
+		tokens.stripe_user_id ?? asRecord(tokens.stripe_user)?.id,
+	);
+	return accountId
+		? { linkType: 'account_id', externalId: accountId }
+		: null;
+}

--- a/packages/stripe/webhooks/tenant-matcher.ts
+++ b/packages/stripe/webhooks/tenant-matcher.ts
@@ -1,0 +1,17 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// Stripe Connect events include a top-level `account` field with the connected
+// account id (acct_...). Platform-only events omit it.
+// See https://docs.stripe.com/connect/webhooks
+export function matchStripeTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const accountId = firstString([body.account]);
+	if (!accountId) return null;
+
+	return { linkType: 'account_id', externalId: accountId };
+}

--- a/packages/tally/index.ts
+++ b/packages/tally/index.ts
@@ -34,6 +34,7 @@ import {
 import { errorHandlers } from './error-handlers';
 import { TallySchema } from './schema';
 import { FormResponseWebhooks } from './webhooks';
+import { matchTallyTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	TallyFormResponseEvent,
 	TallyWebhookOutputs,
@@ -460,6 +461,7 @@ export function tally<const T extends TallyPluginOptions>(
 		pluginWebhookMatcher: (request) => {
 			return 'tally-signature' in request.headers;
 		},
+		pluginTenantWebhookMatcher: matchTallyTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/tally/index.ts
+++ b/packages/tally/index.ts
@@ -412,7 +412,7 @@ const tallyWebhookSchemas = {
 
 export const tallyAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['form_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -449,6 +449,7 @@ export function tally<const T extends TallyPluginOptions>(
 	};
 	return {
 		id: 'tally',
+		authConfig: tallyAuthConfig,
 		schema: TallySchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/tally/webhooks/tenant-matcher.ts
+++ b/packages/tally/webhooks/tenant-matcher.ts
@@ -1,0 +1,17 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// Tally FORM_RESPONSE webhooks include the form id on data.formId.
+// See https://tally.so/help/webhooks
+export function matchTallyTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const data = asRecord(body.data);
+	const formId = firstString([data?.formId]);
+	if (!formId) return null;
+
+	return { linkType: 'form_id', externalId: formId };
+}

--- a/packages/tavily/index.ts
+++ b/packages/tavily/index.ts
@@ -23,6 +23,7 @@ import {
 } from './endpoints/types';
 import { errorHandlers } from './error-handlers';
 import { TavilySchema } from './schema';
+import { matchTavilyTenantWebhook } from './webhooks/tenant-matcher';
 
 export type TavilyPluginOptions = {
 	authType?: PickAuth<'api_key'>;
@@ -141,6 +142,7 @@ export function tavily<const T extends TavilyPluginOptions>(
 		endpointMeta: tavilyEndpointMeta,
 		endpointSchemas: tavilyEndpointSchemas,
 		pluginWebhookMatcher: () => false,
+		pluginTenantWebhookMatcher: matchTavilyTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/tavily/webhooks/tenant-matcher.ts
+++ b/packages/tavily/webhooks/tenant-matcher.ts
@@ -1,0 +1,8 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+
+// Tavily does not expose incoming webhooks; tenant routing is not applicable.
+export function matchTavilyTenantWebhook(
+	_request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	return null;
+}

--- a/packages/teams/index.ts
+++ b/packages/teams/index.ts
@@ -35,6 +35,7 @@ import type {
 	TeamsMembershipChangedEvent,
 	TeamsWebhookOutputs,
 } from './webhooks/types';
+import { matchTeamsTenantWebhook } from './webhooks/tenant-matcher';
 import {
 	TeamsChannelCreatedEventSchema,
 	TeamsChannelCreatedPayloadSchema,
@@ -452,6 +453,7 @@ export function teams<const T extends TeamsPluginOptions>(
 				headers['content-type']?.includes('application/json') ?? false;
 			return hasTeamsHeader && isJsonPost;
 		},
+		pluginTenantWebhookMatcher: matchTeamsTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/teams/index.ts
+++ b/packages/teams/index.ts
@@ -392,7 +392,7 @@ const teamsWebhookSchemas = {
 
 export const teamsAuthConfig = {
 	oauth_2: {
-		account: ['one'] as const,
+		account: ['subscription_id', 'client_state'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 

--- a/packages/teams/webhooks/tenant-matcher.ts
+++ b/packages/teams/webhooks/tenant-matcher.ts
@@ -1,0 +1,59 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import {
+	asRecord,
+	firstString,
+	getHeader,
+	readBodyRecord,
+} from 'corsair/core';
+
+function isTeamsValidationHandshake(request: RawWebhookRequest): boolean {
+	const body = readBodyRecord(request);
+	if (
+		body &&
+		typeof body.validationToken === 'string' &&
+		body.validationToken.length > 0
+	) {
+		return true;
+	}
+
+	const contentType = getHeader(request.headers, 'content-type');
+	if (contentType?.includes('text/plain')) {
+		return !body || Object.keys(body).length === 0;
+	}
+
+	return false;
+}
+
+function extractGraphNotificationTenant(
+	notifications: unknown[],
+): WebhookTenantMatch | null {
+	for (const item of notifications) {
+		const notification = asRecord(item);
+		if (!notification) continue;
+
+		const subscriptionId = firstString([notification.subscriptionId]);
+		if (subscriptionId) {
+			return { linkType: 'subscription_id', externalId: subscriptionId };
+		}
+
+		const clientState = firstString([notification.clientState]);
+		if (clientState) {
+			return { linkType: 'client_state', externalId: clientState };
+		}
+	}
+
+	return null;
+}
+
+// Microsoft Graph change notifications: subscriptionId and clientState in body.value[].
+// See https://learn.microsoft.com/en-us/graph/change-notifications-delivery-webhooks
+export function matchTeamsTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	if (isTeamsValidationHandshake(request)) return null;
+
+	const body = readBodyRecord(request);
+	if (!body || !Array.isArray(body.value)) return null;
+
+	return extractGraphNotificationTenant(body.value);
+}

--- a/packages/telegram/index.ts
+++ b/packages/telegram/index.ts
@@ -51,6 +51,7 @@ import type {
 	ShippingQueryEvent,
 	TelegramWebhookOutputs,
 } from './webhooks/types';
+import { matchTelegramTenantWebhook } from './webhooks/tenant-matcher';
 
 /**
  * Plugin options type - configure authentication and behavior
@@ -335,6 +336,7 @@ export function telegram<const T extends TelegramPluginOptions>(
 
 			return hasSignature && 'update_id' in body;
 		},
+		pluginTenantWebhookMatcher: matchTelegramTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/telegram/index.ts
+++ b/packages/telegram/index.ts
@@ -282,7 +282,7 @@ const defaultAuthType: AuthTypes = 'bot_token';
 
 export const telegramAuthConfig = {
 	bot_token: {
-		account: ['one'] as const,
+		account: ['bot_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 

--- a/packages/telegram/webhooks/tenant-matcher.ts
+++ b/packages/telegram/webhooks/tenant-matcher.ts
@@ -1,0 +1,42 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+function extractBotUserIdFromChatMember(
+	member: Record<string, unknown> | null,
+): string | undefined {
+	if (!member) return undefined;
+
+	const user = asRecord(member.user);
+	if (user?.is_bot !== true) return undefined;
+
+	return firstString([user.id]);
+}
+
+// Telegram Update objects do not identify the receiving bot on most updates.
+// my_chat_member / chat_member include the bot user when membership changes.
+// See https://core.telegram.org/bots/api#update
+export function matchTelegramTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	for (const updateKey of ['my_chat_member', 'chat_member'] as const) {
+		const membershipUpdate = asRecord(body[updateKey]);
+		if (!membershipUpdate) continue;
+
+		const botId = firstString([
+			extractBotUserIdFromChatMember(
+				asRecord(membershipUpdate.new_chat_member),
+			),
+			extractBotUserIdFromChatMember(
+				asRecord(membershipUpdate.old_chat_member),
+			),
+		]);
+		if (botId) {
+			return { linkType: 'bot_id', externalId: botId };
+		}
+	}
+
+	return null;
+}

--- a/packages/todoist/index.ts
+++ b/packages/todoist/index.ts
@@ -30,6 +30,7 @@ import { todoistEndpointSchemas } from './endpoints/types';
 import { errorHandlers } from './error-handlers';
 import { TodoistSchema } from './schema';
 import { ItemWebhooks, NoteWebhooks, ProjectWebhooks } from './webhooks';
+import { matchTodoistTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	ItemAddedEvent,
 	ItemCompletedEvent,
@@ -461,6 +462,7 @@ export function todoist<const T extends TodoistPluginOptions>(
 			const hasDeliveryId = 'x-todoist-delivery-id' in headers;
 			return hasDeliveryId;
 		},
+		pluginTenantWebhookMatcher: matchTodoistTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/todoist/index.ts
+++ b/packages/todoist/index.ts
@@ -416,7 +416,7 @@ const todoistWebhookSchemas = {
 
 export const todoistAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['user_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -448,6 +448,7 @@ export function todoist<const T extends TodoistPluginOptions>(
 	};
 	return {
 		id: 'todoist',
+		authConfig: todoistAuthConfig,
 		schema: TodoistSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/todoist/webhooks/tenant-matcher.ts
+++ b/packages/todoist/webhooks/tenant-matcher.ts
@@ -1,0 +1,16 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { firstString, readBodyRecord } from 'corsair/core';
+
+// Todoist webhook payloads include user_id for the account that owns the webhook.
+// See https://developer.todoist.com/api/v1/#webhooks
+export function matchTodoistTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const userId = firstString([body.user_id]);
+	if (!userId) return null;
+
+	return { linkType: 'user_id', externalId: userId };
+}

--- a/packages/trello/index.ts
+++ b/packages/trello/index.ts
@@ -378,7 +378,7 @@ const defaultAuthType = 'api_key' as const;
 
 export const trelloAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['idModel'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -407,6 +407,7 @@ export function trello<const T extends TrelloPluginOptions>(
 	};
 	return {
 		id: 'trello',
+		authConfig: trelloAuthConfig,
 		schema: TrelloSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/trello/index.ts
+++ b/packages/trello/index.ts
@@ -30,6 +30,7 @@ import {
 	ListWebhooks,
 	MemberWebhooks,
 } from './webhooks';
+import { matchTrelloTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	TrelloCardCreatedEvent,
 	TrelloCardUpdatedEvent,
@@ -419,6 +420,7 @@ export function trello<const T extends TrelloPluginOptions>(
 			const headers = request.headers;
 			return 'x-trello-webhook' in headers;
 		},
+		pluginTenantWebhookMatcher: matchTrelloTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/trello/webhooks/tenant-matcher.ts
+++ b/packages/trello/webhooks/tenant-matcher.ts
@@ -1,0 +1,20 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// Trello webhook payloads include the subscribed model on webhook.idModel and a
+// snapshot of that resource on model.id (board, list, card, or member).
+// See https://developer.atlassian.com/cloud/trello/guides/rest-api/webhooks
+export function matchTrelloTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const idModel = firstString([
+		asRecord(body.webhook)?.idModel,
+		asRecord(body.model)?.id,
+	]);
+	if (!idModel) return null;
+
+	return { linkType: 'idModel', externalId: idModel };
+}

--- a/packages/twilio/index.ts
+++ b/packages/twilio/index.ts
@@ -26,6 +26,7 @@ import {
 import { errorHandlers } from './error-handlers';
 import { TwilioSchema } from './schema';
 import { CallWebhooks, MessageWebhooks } from './webhooks';
+import { matchTwilioTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	CallStatusEvent,
 	MessageReceivedEvent,
@@ -266,6 +267,7 @@ export function twilio<const T extends TwilioPluginOptions>(
 		pluginWebhookMatcher: (request) => {
 			return 'x-twilio-signature' in request.headers;
 		},
+		pluginTenantWebhookMatcher: matchTwilioTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/twilio/webhooks/tenant-matcher.ts
+++ b/packages/twilio/webhooks/tenant-matcher.ts
@@ -1,0 +1,33 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString } from 'corsair/core';
+
+function readTwilioBody(request: RawWebhookRequest) {
+	const { body } = request;
+	if (typeof body === 'string') {
+		try {
+			return asRecord(JSON.parse(body));
+		} catch {
+			const params = new URLSearchParams(body);
+			const record: Record<string, unknown> = {};
+			for (const [key, value] of params) {
+				record[key] = value;
+			}
+			return Object.keys(record).length > 0 ? record : null;
+		}
+	}
+	return asRecord(body);
+}
+
+// Twilio status callbacks and incoming webhooks include AccountSid in the POST body.
+// See https://www.twilio.com/docs/usage/webhooks/webhooks-overview
+export function matchTwilioTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readTwilioBody(request);
+	if (!body) return null;
+
+	const accountSid = firstString([body.AccountSid]);
+	if (!accountSid) return null;
+
+	return { linkType: 'accountSid', externalId: accountSid };
+}

--- a/packages/twitter/index.ts
+++ b/packages/twitter/index.ts
@@ -111,7 +111,7 @@ const twitterEndpointMeta = {
 
 export const twitterAuthConfig = {
 	oauth_2: {
-		account: ['one'] as const,
+		account: ['for_user_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -145,6 +145,7 @@ export function twitter<const T extends TwitterPluginOptions>(
 
 	return {
 		id: 'twitter',
+		authConfig: twitterAuthConfig,
 		schema: TwitterSchema,
 		options,
 		hooks: options.hooks,

--- a/packages/twitter/index.ts
+++ b/packages/twitter/index.ts
@@ -23,6 +23,7 @@ import type {
 } from './endpoints/types';
 import { errorHandlers } from './error-handlers';
 import { TwitterSchema } from './schema';
+import { matchTwitterTenantWebhook } from './webhooks/tenant-matcher';
 
 // ── Context & Key Builder ─────────────────────────────────────────────────────
 
@@ -160,6 +161,7 @@ export function twitter<const T extends TwitterPluginOptions>(
 			// Webhooks not implemented yet
 			return false;
 		},
+		pluginTenantWebhookMatcher: matchTwitterTenantWebhook,
 		keyBuilder: async (ctx: TwitterKeyBuilderContext, source) => {
 			const authType = ctx.authType;
 

--- a/packages/twitter/webhooks/tenant-matcher.ts
+++ b/packages/twitter/webhooks/tenant-matcher.ts
@@ -1,0 +1,19 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { firstString, readBodyRecord } from 'corsair/core';
+
+// X Account Activity API: for_user_id identifies the subscribed user on the envelope.
+// See https://developer.x.com/en/docs/x-api/account-activity/guides/account-activity-data-sources
+export function matchTwitterTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	// CRC and other non-event payloads do not include a resolvable tenant id.
+	if ('crc_token' in body || 'response_token' in body) return null;
+
+	const forUserId = firstString([body.for_user_id]);
+	if (!forUserId) return null;
+
+	return { linkType: 'for_user_id', externalId: forUserId };
+}

--- a/packages/twitterapiio/index.ts
+++ b/packages/twitterapiio/index.ts
@@ -640,7 +640,7 @@ const twitterApiIOEndpointMeta = {
 
 export const twitterApiIOAuthConfig = {
 	api_key: {
-		account: ['one'] as const,
+		account: ['user_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -677,6 +677,7 @@ export function twitterapiio<const T extends TwitterApiIOPluginOptions>(
 
 	return {
 		id: 'twitterapiio',
+		authConfig: twitterApiIOAuthConfig,
 		schema: TwitterApiIOSchema,
 		options,
 		hooks: options.hooks,

--- a/packages/twitterapiio/index.ts
+++ b/packages/twitterapiio/index.ts
@@ -33,6 +33,7 @@ import type {
 import { errorHandlers } from './error-handlers';
 import { TwitterApiIOSchema } from './schema';
 import { TweetWebhooks } from './webhooks';
+import { matchTwitterApiIOTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	TweetCreatedEvent,
 	TweetFilterMatchEvent,
@@ -711,6 +712,7 @@ export function twitterapiio<const T extends TwitterApiIOPluginOptions>(
 				body?.type === 'tweet.created' || body?.type === 'tweet.filter_match';
 			return hasSignature || hasKnownType;
 		},
+		pluginTenantWebhookMatcher: matchTwitterApiIOTenantWebhook,
 		keyBuilder: async (ctx: TwitterApiIOKeyBuilderContext, source) => {
 			const authType = ctx.authType;
 

--- a/packages/twitterapiio/webhooks/tenant-matcher.ts
+++ b/packages/twitterapiio/webhooks/tenant-matcher.ts
@@ -1,0 +1,26 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// twitterapi.io webhook payloads include userId on tweet.created / tweet.filter_match events.
+export function matchTwitterApiIOTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const data = asRecord(body.data);
+	const user = asRecord(data?.user);
+	const tweet = asRecord(data?.tweet);
+	const author = asRecord(tweet?.author);
+
+	const userId = firstString([
+		body.userId,
+		user?.id,
+		author?.id,
+		tweet?.author_id,
+	]);
+
+	if (!userId) return null;
+
+	return { linkType: 'user_id', externalId: userId };
+}

--- a/packages/typeform/index.ts
+++ b/packages/typeform/index.ts
@@ -481,7 +481,7 @@ const typeformWebhookSchemas = {
 
 export const typeformAuthConfig = {
 	oauth_2: {
-		account: ['one'] as const,
+		account: ['form_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -513,6 +513,7 @@ export function typeform<const T extends TypeformPluginOptions>(
 
 	return {
 		id: 'typeform',
+		authConfig: typeformAuthConfig,
 		schema: TypeformSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/typeform/index.ts
+++ b/packages/typeform/index.ts
@@ -35,6 +35,7 @@ import {
 import { errorHandlers } from './error-handlers';
 import { TypeformSchema } from './schema';
 import { FormWebhooks } from './webhooks';
+import { matchTypeformTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	TypeformFormResponseEvent,
 	TypeformWebhookOutputs,
@@ -525,6 +526,7 @@ export function typeform<const T extends TypeformPluginOptions>(
 			const headers = request.headers;
 			return 'typeform-signature' in headers || 'Typeform-Signature' in headers;
 		},
+		pluginTenantWebhookMatcher: matchTypeformTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/typeform/webhooks/tenant-matcher.ts
+++ b/packages/typeform/webhooks/tenant-matcher.ts
@@ -1,0 +1,20 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// Typeform delivers form_response webhooks with form_id but no account id.
+// See https://www.typeform.com/developers/webhooks/example-payload/
+export function matchTypeformTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const formResponse = asRecord(body.form_response);
+	const formId = firstString([
+		formResponse?.form_id,
+		asRecord(formResponse?.definition)?.id,
+	]);
+	if (!formId) return null;
+
+	return { linkType: 'form_id', externalId: formId };
+}

--- a/packages/vapi/index.ts
+++ b/packages/vapi/index.ts
@@ -553,7 +553,9 @@ const vapiEndpointMeta = {
 } as const satisfies RequiredPluginEndpointMeta<typeof vapiEndpointsNested>;
 
 export const vapiAuthConfig = {
-	api_key: {},
+	api_key: {
+		account: ['org_id'] as const,
+	},
 } as const satisfies PluginAuthConfig;
 
 export type BaseVapiPlugin<T extends VapiPluginOptions> = CorsairPlugin<
@@ -578,6 +580,7 @@ export function vapi<const T extends VapiPluginOptions>(
 	};
 	return {
 		id: 'vapi',
+		authConfig: vapiAuthConfig,
 		schema: VapiSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/vapi/index.ts
+++ b/packages/vapi/index.ts
@@ -50,6 +50,7 @@ import {
 	VapiTransferDestinationRequestEventSchema,
 	VapiWorkflowNodeStartedEventSchema,
 } from './webhooks';
+import { matchVapiTenantWebhook } from './webhooks/tenant-matcher';
 
 export type VapiPluginOptions = {
 	authType?: PickAuth<'api_key'>;
@@ -589,6 +590,7 @@ export function vapi<const T extends VapiPluginOptions>(
 		pluginWebhookMatcher: (request) => {
 			return 'x-vapi-secret' in request.headers;
 		},
+		pluginTenantWebhookMatcher: matchVapiTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/vapi/webhooks/tenant-matcher.ts
+++ b/packages/vapi/webhooks/tenant-matcher.ts
@@ -1,0 +1,19 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// Vapi Server URL events wrap payloads in message; call.orgId identifies the org.
+// See https://docs.vapi.ai/server-url/events
+export function matchVapiTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const message = asRecord(body.message);
+	const call = asRecord(message?.call);
+
+	const orgId = firstString([call?.orgId, call?.org_id]);
+	if (!orgId) return null;
+
+	return { linkType: 'org_id', externalId: orgId };
+}

--- a/packages/vercel/index.ts
+++ b/packages/vercel/index.ts
@@ -13,6 +13,7 @@ import type {
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { matchVercelTenantWebhook } from './webhooks/tenant-matcher';
 import {
 	aliases,
 	deployments,
@@ -295,6 +296,7 @@ export function vercel<const T extends VercelPluginOptions>(
 			const headers = request.headers;
 			return 'x-vercel-signature' in headers;
 		},
+		pluginTenantWebhookMatcher: matchVercelTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/vercel/index.ts
+++ b/packages/vercel/index.ts
@@ -9,6 +9,7 @@ import type {
 	CorsairWebhook,
 	KeyBuilderContext,
 	PickAuth,
+	PluginAuthConfig,
 	PluginPermissionsConfig,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
@@ -260,6 +261,12 @@ const vercelEndpointMeta = {
 	'teams.getTeams': { riskLevel: 'read', description: 'Get all teams' },
 } satisfies RequiredPluginEndpointMeta<typeof vercelEndpointsNested>;
 
+export const vercelAuthConfig = {
+	api_key: {
+		account: ['team_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
 export type BaseVercelPlugin<T extends VercelPluginOptions> = CorsairPlugin<
 	'vercel',
 	typeof VercelSchema,
@@ -282,6 +289,7 @@ export function vercel<const T extends VercelPluginOptions>(
 	};
 	return {
 		id: 'vercel',
+		authConfig: vercelAuthConfig,
 		schema: VercelSchema,
 		options: options,
 		oauthConfig: undefined,

--- a/packages/vercel/webhooks/tenant-matcher.ts
+++ b/packages/vercel/webhooks/tenant-matcher.ts
@@ -1,7 +1,8 @@
 import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
-import { firstString, readBodyRecord } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
 
-// Vercel webhook payloads include teamId for team-scoped events.
+// Vercel integration webhooks expose team id at payload.team.id (possibly null for personal accounts).
+// Legacy payloads may still include top-level teamId.
 // See https://vercel.com/docs/observability/webhooks-overview/webhooks-api
 export function matchVercelTenantWebhook(
 	request: RawWebhookRequest,
@@ -9,7 +10,11 @@ export function matchVercelTenantWebhook(
 	const body = readBodyRecord(request);
 	if (!body) return null;
 
-	const teamId = firstString([body.teamId]);
+	const payload = asRecord(body.payload);
+	const teamId = firstString([
+		asRecord(payload?.team)?.id,
+		body.teamId,
+	]);
 	if (!teamId) return null;
 
 	return { linkType: 'team_id', externalId: teamId };

--- a/packages/vercel/webhooks/tenant-matcher.ts
+++ b/packages/vercel/webhooks/tenant-matcher.ts
@@ -1,0 +1,16 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { firstString, readBodyRecord } from 'corsair/core';
+
+// Vercel webhook payloads include teamId for team-scoped events.
+// See https://vercel.com/docs/observability/webhooks-overview/webhooks-api
+export function matchVercelTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const teamId = firstString([body.teamId]);
+	if (!teamId) return null;
+
+	return { linkType: 'team_id', externalId: teamId };
+}

--- a/packages/xquik/index.ts
+++ b/packages/xquik/index.ts
@@ -41,6 +41,7 @@ import type {
 	XquikWebhookPayload,
 } from './webhooks/types';
 import { hasXquikSignature } from './webhooks/types';
+import { matchXquikTenantWebhook } from './webhooks/tenant-matcher';
 
 export type XquikPluginOptions = {
 	authType?: PickAuth<'api_key'>;
@@ -454,6 +455,7 @@ export function xquik<const T extends XquikPluginOptions>(
 		},
 		options,
 		pluginWebhookMatcher: hasXquikSignature,
+		pluginTenantWebhookMatcher: matchXquikTenantWebhook,
 		schema: XquikSchema,
 		webhookHooks: options.webhookHooks,
 		webhookSchemas: xquikWebhookSchemas,

--- a/packages/xquik/index.ts
+++ b/packages/xquik/index.ts
@@ -388,9 +388,7 @@ const xquikEndpointMeta = {
 } as const satisfies RequiredPluginEndpointMeta<typeof xquikEndpointsNested>;
 
 export const xquikAuthConfig = {
-	api_key: {
-		account: ['one', 'webhook_signature'] as const,
-	},
+	api_key: {},
 } as const satisfies PluginAuthConfig;
 
 export type XquikKeyBuilderContext = KeyBuilderContext<
@@ -422,6 +420,7 @@ export function xquik<const T extends XquikPluginOptions>(
 	};
 
 	return {
+		id: 'xquik',
 		authConfig: xquikAuthConfig,
 		endpointMeta: xquikEndpointMeta,
 		endpointSchemas: xquikEndpointSchemas,
@@ -431,7 +430,6 @@ export function xquik<const T extends XquikPluginOptions>(
 			...options.errorHandlers,
 		},
 		hooks: options.hooks,
-		id: 'xquik',
 		keyBuilder: async (ctx: XquikKeyBuilderContext, source) => {
 			if (source === 'webhook' && options.webhookSecret) {
 				return options.webhookSecret;

--- a/packages/xquik/webhooks/tenant-matcher.ts
+++ b/packages/xquik/webhooks/tenant-matcher.ts
@@ -1,0 +1,10 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+
+// Xquik webhooks are registered per API key and verified via X-Xquik-Signature.
+// The optional username field identifies the monitored X account, not the Xquik
+// API tenant — see https://docs.xquik.com/webhooks/overview
+export function matchXquikTenantWebhook(
+	_request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	return null;
+}

--- a/packages/youtube/index.ts
+++ b/packages/youtube/index.ts
@@ -38,6 +38,7 @@ import type {
 } from './endpoints/types';
 import { errorHandlers } from './error-handlers';
 import { YoutubeSchema } from './schema';
+import { matchYoutubeTenantWebhook } from './webhooks/tenant-matcher';
 import type { YoutubeWebhookOutputs } from './webhooks/types';
 
 // ── Context & Key Builder ─────────────────────────────────────────────────────
@@ -703,6 +704,7 @@ export function youtube<const T extends YoutubePluginOptions>(
 			// Webhooks not implemented yet
 			return false;
 		},
+		pluginTenantWebhookMatcher: matchYoutubeTenantWebhook,
 		keyBuilder: async (ctx: YoutubeKeyBuilderContext, source) => {
 			const authType = ctx.authType;
 

--- a/packages/youtube/index.ts
+++ b/packages/youtube/index.ts
@@ -653,7 +653,7 @@ const youtubeEndpointMeta = {
 
 export const youtubeAuthConfig = {
 	oauth_2: {
-		account: ['one'] as const,
+		account: ['channel_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -688,6 +688,7 @@ export function youtube<const T extends YoutubePluginOptions>(
 
 	return {
 		id: 'youtube',
+		authConfig: youtubeAuthConfig,
 		schema: YoutubeSchema,
 		options,
 		hooks: options.hooks,

--- a/packages/youtube/webhooks/tenant-matcher.ts
+++ b/packages/youtube/webhooks/tenant-matcher.ts
@@ -1,0 +1,59 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import {
+	asRecord,
+	decodePubSubData,
+	firstString,
+} from 'corsair/core';
+
+const CHANNEL_ID_PATTERN = /channel_id=([A-Za-z0-9_-]+)/;
+
+function extractChannelIdFromAtomXml(body: string): string | undefined {
+	const channelIdMatch = body.match(/<yt:channelId>([^<]+)<\/yt:channelId>/);
+	if (channelIdMatch?.[1]) return channelIdMatch[1];
+
+	const topicMatch = body.match(CHANNEL_ID_PATTERN);
+	if (topicMatch?.[1]) return topicMatch[1];
+
+	const uriMatch = body.match(
+		/<uri>https?:\/\/www\.youtube\.com\/channel\/([^<]+)<\/uri>/,
+	);
+	if (uriMatch?.[1]) return uriMatch[1];
+
+	return undefined;
+}
+
+function extractYoutubeChannelId(body: unknown): string | undefined {
+	if (typeof body === 'string') {
+		const trimmed = body.trim();
+		if (!trimmed) return undefined;
+		return extractChannelIdFromAtomXml(trimmed);
+	}
+
+	const bodyRecord = asRecord(body);
+	if (!bodyRecord) return undefined;
+
+	const decoded = decodePubSubData(bodyRecord);
+	if (typeof decoded === 'string') {
+		return extractChannelIdFromAtomXml(decoded);
+	}
+
+	return firstString([
+		bodyRecord.channel_id,
+		bodyRecord.channelId,
+		asRecord(bodyRecord.entry)?.channel_id,
+	]);
+}
+
+// YouTube PubSubHubbub: Atom XML notifications include yt:channelId on each entry.
+// See https://developers.google.com/youtube/v3/guides/push_notifications
+export function matchYoutubeTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = request.body;
+	if (body === null || body === undefined) return null;
+
+	const channelId = extractYoutubeChannelId(body);
+	if (!channelId) return null;
+
+	return { linkType: 'channel_id', externalId: channelId };
+}

--- a/packages/zendesk/index.ts
+++ b/packages/zendesk/index.ts
@@ -45,7 +45,7 @@ export type ZendeskPluginOptions = {
 
 export const zendeskAuthConfig = {
 	api_key: {
-		account: ['subdomain'] as const,
+		account: ['subdomain', 'account_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 

--- a/packages/zendesk/index.ts
+++ b/packages/zendesk/index.ts
@@ -28,6 +28,7 @@ import {
 import { errorHandlers } from './error-handlers';
 import { ZendeskSchema } from './schema';
 import { ExampleWebhooks } from './webhooks';
+import { matchZendeskTenantWebhook } from './webhooks/tenant-matcher';
 import type { ExampleEvent, ZendeskWebhookOutputs } from './webhooks/types';
 import { ExampleEventSchema } from './webhooks/types';
 
@@ -265,6 +266,7 @@ export function zendesk<const T extends ZendeskPluginOptions>(
 			const headers = request.headers;
 			return 'x-zendesk-webhook-signature' in headers;
 		},
+		pluginTenantWebhookMatcher: matchZendeskTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/zendesk/webhooks/tenant-matcher.ts
+++ b/packages/zendesk/webhooks/tenant-matcher.ts
@@ -1,0 +1,24 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import {
+	firstString,
+	getHeader,
+	readBodyRecord,
+} from 'corsair/core';
+
+// Zendesk event webhooks include account_id on the envelope and in
+// x-zendesk-account-id. Trigger/automation payloads are custom and may omit it.
+// See https://developer.zendesk.com/api-reference/webhooks/event-types/webhook-event-types/
+export function matchZendeskTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const accountId = firstString([
+		getHeader(request.headers, 'x-zendesk-account-id'),
+		body.account_id,
+	]);
+	if (!accountId) return null;
+
+	return { linkType: 'account_id', externalId: accountId };
+}

--- a/packages/zohomail/index.ts
+++ b/packages/zohomail/index.ts
@@ -47,7 +47,11 @@ import {
 } from './webhooks/types';
 
 /** Zoho Mail uses standard OAuth2; no plugin-specific integration fields. */
-export const zohoMailAuthConfig = {} as const satisfies PluginAuthConfig;
+export const zohoMailAuthConfig = {
+	oauth_2: {
+		account: ['zuid'] as const,
+	},
+} as const satisfies PluginAuthConfig;
 
 export type ZohoMailContext = CorsairPluginContext<
 	typeof ZohoMailSchema,

--- a/packages/zohomail/index.ts
+++ b/packages/zohomail/index.ts
@@ -32,6 +32,7 @@ import { errorHandlers } from './error-handlers';
 import type { ZohoMailCredentials } from './schema';
 import { ZohoMailSchema } from './schema';
 import { ChallengeWebhooks, MessageWebhooks } from './webhooks';
+import { matchZohoMailTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	ZohoMailChallengePayload,
 	ZohoMailWebhookEvent,
@@ -325,6 +326,7 @@ export function zohomail<const T extends ZohoMailPluginOptions>(
 				getZohoWebhookSecretFromRequest(headers) !== undefined
 			);
 		},
+		pluginTenantWebhookMatcher: matchZohoMailTenantWebhook,
 		keyBuilder: async (ctx: ZohoMailKeyBuilderContext, source) => {
 			const authType = ctx.authType;
 

--- a/packages/zohomail/webhooks/tenant-matcher.ts
+++ b/packages/zohomail/webhooks/tenant-matcher.ts
@@ -1,0 +1,20 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { firstString, getHeader, readBodyRecord } from 'corsair/core';
+
+// Zoho Mail outgoing webhooks include zuid (Zoho User ID) in the payload.
+// Handshake requests only carry x-hook-secret and cannot be tenant-mapped.
+// See https://www.zoho.com/mail/help/dev-platform/webhook.html
+export function matchZohoMailTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const headers = request.headers ?? {};
+	if (getHeader(headers, 'x-hook-secret') !== undefined) return null;
+
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const zuid = firstString([body.zuid]);
+	if (!zuid) return null;
+
+	return { linkType: 'zuid', externalId: zuid };
+}

--- a/packages/zoom/index.ts
+++ b/packages/zoom/index.ts
@@ -37,6 +37,7 @@ import {
 	RecordingWebhooks,
 	WebinarWebhooks,
 } from './webhooks';
+import { matchZoomTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	MeetingCancelledEvent,
 	MeetingCreatedEvent,
@@ -415,6 +416,7 @@ export function zoom<const PluginOptions extends ZoomPluginOptions>(
 			const headers = request.headers;
 			return 'x-zm-signature' in headers;
 		},
+		pluginTenantWebhookMatcher: matchZoomTenantWebhook,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/zoom/index.ts
+++ b/packages/zoom/index.ts
@@ -371,7 +371,7 @@ const zoomEndpointMeta = {
 
 export const zoomAuthConfig = {
 	oauth_2: {
-		account: ['one'] as const,
+		account: ['account_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 
@@ -403,6 +403,7 @@ export function zoom<const PluginOptions extends ZoomPluginOptions>(
 	};
 	return {
 		id: 'zoom',
+		authConfig: zoomAuthConfig,
 		schema: ZoomSchema,
 		options: options,
 		hooks: options.hooks,

--- a/packages/zoom/webhooks/tenant-matcher.ts
+++ b/packages/zoom/webhooks/tenant-matcher.ts
@@ -1,0 +1,20 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// Zoom event notifications include payload.account_id. URL validation
+// challenges cannot be mapped to a tenant.
+// See https://developers.zoom.us/docs/api/webhooks/
+export function matchZoomTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	if (body.event === 'endpoint.url_validation') return null;
+
+	const payload = asRecord(body.payload);
+	const accountId = firstString([payload?.account_id]);
+	if (!accountId) return null;
+
+	return { linkType: 'account_id', externalId: accountId };
+}

--- a/scripts/generate-plugin-from-json.ts
+++ b/scripts/generate-plugin-from-json.ts
@@ -1,6 +1,13 @@
 import { execSync } from 'child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { join, resolve } from 'path';
+import {
+	buildAuthConfigTs,
+	buildOAuthTenantLinkTs,
+	buildTenantMatcherTs,
+	formatTenantRoutingPluginFields,
+	TENANT_ROUTING_AGENT_CHECKLIST,
+} from './plugin-tenant-routing-scaffold.ts';
 
 // ── JSON shape ────────────────────────────────────────────────────────────────
 
@@ -169,7 +176,7 @@ function pickAuthType(schemes: AuthScheme[]): string {
 		case 'OAUTH2':
 		case 'DCR_OAUTH':
 		case 'S2S_OAUTH2':
-			return 'oauth2';
+			return 'oauth_2';
 		case 'BASIC':
 		case 'BASIC_WITH_JWT':
 			return 'basic';
@@ -506,12 +513,10 @@ export function verify${pascal}WebhookSignature(
 `;
 }
 
-function buildWebhooksIndex(): string {
-	return `// TODO: Add webhook event handlers here once you've identified the event types.
-// See webhooks/types.ts for the base payload and helper functions.
-// Follow the pattern in packages/resend/webhooks/emails.ts as a reference.
-
-export * from './types';
+function buildWebhooksIndex(_pascal: string): string {
+	return `export * from './types';
+export * from './tenant-matcher';
+export * from './oauth-tenant-link';
 `;
 }
 
@@ -566,7 +571,8 @@ function buildIndexTs(
 	});
 
 	const authTypeLiteral = `'${authType}'`;
-	const hasWebhooks = false; // placeholder — filled by agent
+	const authConfigBlock = buildAuthConfigTs(camel, [authType]);
+	const tenantRoutingPluginFields = formatTenantRoutingPluginFields(pascal);
 
 	return `import type {
 \tBindEndpoints,
@@ -590,6 +596,8 @@ import type { ${pascal}WebhookOutputs } from './webhooks/types';
 import { ${groupImports} } from './endpoints';
 import { ${pascal}Schema } from './schema';
 import { errorHandlers } from './error-handlers';
+import { match${pascal}TenantWebhook } from './webhooks/tenant-matcher';
+import { resolve${pascal}OAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
 
 export type ${pascal}PluginOptions = {
 \t/** ${description} */
@@ -636,11 +644,7 @@ const ${camel}EndpointMeta = {
 ${metaLines.join('\n')}
 } satisfies RequiredPluginEndpointMeta<typeof ${camel}EndpointsNested>;
 
-export const ${camel}AuthConfig = {
-\t${authType}: {
-\t\taccount: ['one'] as const,
-\t},
-} as const satisfies PluginAuthConfig;
+${authConfigBlock}
 
 export type Base${pascal}Plugin<T extends ${pascal}PluginOptions> = CorsairPlugin<
 \t'${lower}',
@@ -663,6 +667,7 @@ export function ${lower}<const T extends ${pascal}PluginOptions>(
 \t};
 \treturn {
 \t\tid: '${lower}',
+\t\tauthConfig: ${camel}AuthConfig,
 \t\tschema: ${pascal}Schema,
 \t\toptions,
 \t\thooks: options.hooks,
@@ -675,6 +680,7 @@ export function ${lower}<const T extends ${pascal}PluginOptions>(
 \t\t\t// TODO: Update to match ${pascal} webhook signature headers
 \t\t\treturn 'x-${lower}-signature' in request.headers;
 \t\t},
+${tenantRoutingPluginFields}
 \t\terrorHandlers: {
 \t\t\t...errorHandlers,
 \t\t\t...options.errorHandlers,
@@ -688,6 +694,10 @@ export function ${lower}<const T extends ${pascal}PluginOptions>(
 \t\t\tif (source === 'endpoint' && options.key) return options.key;
 \t\t\tif (source === 'endpoint' && ctx.authType === 'api_key') {
 \t\t\t\tconst res = await ctx.keys.get_api_key();
+\t\t\t\treturn res ?? '';
+\t\t\t}
+\t\t\tif (source === 'endpoint' && ctx.authType === 'oauth_2') {
+\t\t\t\tconst res = await ctx.keys.get_access_token();
 \t\t\t\treturn res ?? '';
 \t\t\t}
 \t\t\treturn '';
@@ -876,6 +886,7 @@ This integration has webhook-related operations. Check the docs for:
 - [ ] Update \`pluginWebhookMatcher\` in \`index.ts\` to check the correct header
 - [ ] Add event-specific schemas to \`webhooks/types.ts\`
 - [ ] Implement webhook handlers in \`webhooks/\`
+${TENANT_ROUTING_AGENT_CHECKLIST}
 `
 		: `
 This integration does not have documented webhook triggers in the scraped spec.
@@ -883,6 +894,7 @@ This integration does not have documented webhook triggers in the scraped spec.
 Check the docs to confirm:
 - [ ] Does ${def.name} support webhooks? If yes, add them following the Resend plugin as a reference (\`packages/resend/webhooks/\`).
 - [ ] If no webhooks, the empty \`webhooksNested\` in \`index.ts\` is correct.
+${TENANT_ROUTING_AGENT_CHECKLIST}
 `
 }
 
@@ -1183,8 +1195,20 @@ export const errorHandlers = {
 		buildWebhooksTypes(pascalName, lowerName),
 	);
 
+	writeFileSync(
+		join(pluginDir, 'webhooks', 'tenant-matcher.ts'),
+		buildTenantMatcherTs(pascalName, lowerName),
+	);
+	writeFileSync(
+		join(pluginDir, 'webhooks', 'oauth-tenant-link.ts'),
+		buildOAuthTenantLinkTs(pascalName),
+	);
+
 	// ── webhooks/index.ts ──
-	writeFileSync(join(pluginDir, 'webhooks', 'index.ts'), buildWebhooksIndex());
+	writeFileSync(
+		join(pluginDir, 'webhooks', 'index.ts'),
+		buildWebhooksIndex(pascalName),
+	);
 
 	// ── index.ts ──
 	writeFileSync(
@@ -1265,7 +1289,8 @@ export const errorHandlers = {
 	console.log(`  1. Read packages/${lowerName}/AGENT.md for full instructions`);
 	console.log(`  2. Fill in client.ts (API base URL + auth header)`);
 	console.log(`  3. Fill in each endpoint's path and method`);
-	console.log(`  4. Run: cd packages/${lowerName} && pnpm typecheck`);
+	console.log(`  4. Configure webhook tenant routing (tenant-matcher, oauth-tenant-link, authConfig)`);
+	console.log(`  5. Run: cd packages/${lowerName} && pnpm typecheck`);
 }
 
 // ── Entry ─────────────────────────────────────────────────────────────────────

--- a/scripts/generate-plugin.ts
+++ b/scripts/generate-plugin.ts
@@ -1,6 +1,12 @@
 import { execSync } from 'child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
+import {
+	buildAuthConfigTs,
+	buildOAuthTenantLinkTs,
+	buildTenantMatcherTs,
+	formatTenantRoutingPluginFields,
+} from './plugin-tenant-routing-scaffold.ts';
 
 function validatePascalCase(name: string): void {
 	if (name.includes('-')) {
@@ -56,6 +62,9 @@ function generatePlugin(pluginName: string) {
 	mkdirSync(join(pluginDir, 'endpoints'), { recursive: true });
 	mkdirSync(join(pluginDir, 'webhooks'), { recursive: true });
 	mkdirSync(join(pluginDir, 'schema'), { recursive: true });
+
+	const tenantRoutingPluginFields = formatTenantRoutingPluginFields(pascalName);
+	const authConfigBlock = buildAuthConfigTs(camelName, ['api_key', 'oauth_2']);
 
 	// ── package.json ──────────────────────────────────────────────────────────
 	const packageJson = {
@@ -144,6 +153,16 @@ export default defineConfig({
 `,
 	);
 
+	// ── webhooks/tenant-matcher.ts + oauth-tenant-link.ts ─────────────────────
+	writeFileSync(
+		join(pluginDir, 'webhooks', 'tenant-matcher.ts'),
+		buildTenantMatcherTs(pascalName, lowerName),
+	);
+	writeFileSync(
+		join(pluginDir, 'webhooks', 'oauth-tenant-link.ts'),
+		buildOAuthTenantLinkTs(pascalName),
+	);
+
 	// ── index.ts ──────────────────────────────────────────────────────────────
 	writeFileSync(
 		join(pluginDir, 'index.ts'),
@@ -175,9 +194,11 @@ import { Example } from './endpoints';
 import { ${pascalName}Schema } from './schema';
 import { ExampleWebhooks } from './webhooks';
 import { errorHandlers } from './error-handlers';
+import { match${pascalName}TenantWebhook } from './webhooks/tenant-matcher';
+import { resolve${pascalName}OAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
 
 export type ${pascalName}PluginOptions = {
-\tauthType?: PickAuth<'api_key'>;
+\tauthType?: PickAuth<'api_key' | 'oauth_2'>;
 \tkey?: string;
 \twebhookSecret?: string;
 \thooks?: Internal${pascalName}Plugin['hooks'];
@@ -254,11 +275,7 @@ const ${camelName}EndpointMeta = {
 \t},
 } as const satisfies RequiredPluginEndpointMeta<typeof ${camelName}EndpointsNested>;
 
-export const ${camelName}AuthConfig = {
-\tapi_key: {
-\t\taccount: ['one'] as const,
-\t},
-} as const satisfies PluginAuthConfig;
+${authConfigBlock}
 
 export type Base${pascalName}Plugin<T extends ${pascalName}PluginOptions> = CorsairPlugin<
 \t'${lowerName}',
@@ -283,6 +300,7 @@ export function ${lowerName}<const T extends ${pascalName}PluginOptions>(
 \t};
 \treturn {
 \t\tid: '${lowerName}',
+\t\tauthConfig: ${camelName}AuthConfig,
 \t\tschema: ${pascalName}Schema,
 \t\toptions: options,
 \t\thooks: options.hooks,
@@ -297,6 +315,7 @@ export function ${lowerName}<const T extends ${pascalName}PluginOptions>(
 \t\t\t// TODO: Update to match your webhook signature headers
 \t\t\treturn 'x-${lowerName}-signature' in headers;
 \t\t},
+${tenantRoutingPluginFields}
 \t\terrorHandlers: {
 \t\t\t...errorHandlers,
 \t\t\t...options.errorHandlers,
@@ -317,6 +336,11 @@ export function ${lowerName}<const T extends ${pascalName}PluginOptions>(
 
 \t\t\tif (source === 'endpoint' && ctx.authType === 'api_key') {
 \t\t\t\tconst res = await ctx.keys.get_api_key();
+\t\t\t\treturn res ?? '';
+\t\t\t}
+
+\t\t\tif (source === 'endpoint' && ctx.authType === 'oauth_2') {
+\t\t\t\tconst res = await ctx.keys.get_access_token();
 \t\t\t\treturn res ?? '';
 \t\t\t}
 
@@ -619,6 +643,8 @@ export const ExampleWebhooks = {
 };
 
 export * from './types';
+export * from './tenant-matcher';
+export * from './oauth-tenant-link';
 `,
 	);
 
@@ -710,8 +736,9 @@ export * from './types';
 	console.log(`\n📝 Next steps:`);
 	console.log(`   1. Run: pnpm install`);
 	console.log(`   2. Update the API base URL and auth in client.ts`);
-	console.log(`   3. Replace the example endpoints/webhooks with real ones`);
-	console.log(`   4. Run: cd packages/${lowerName} && pnpm typecheck`);
+	console.log(`   3. Configure webhook tenant routing (tenant-matcher, oauth-tenant-link, authConfig)`);
+	console.log(`   4. Replace the example endpoints/webhooks with real ones`);
+	console.log(`   5. Run: cd packages/${lowerName} && pnpm typecheck`);
 }
 
 const pluginName = process.argv[2];

--- a/scripts/plugin-tenant-routing-scaffold.ts
+++ b/scripts/plugin-tenant-routing-scaffold.ts
@@ -1,0 +1,114 @@
+/**
+ * Shared templates for webhook tenant routing conventions:
+ * - webhooks/tenant-matcher.ts  → pluginTenantWebhookMatcher
+ * - webhooks/oauth-tenant-link.ts → oauthWebhookTenantLinkResolver
+ * - authConfig.account fields must use the same linkType as the matcher
+ */
+
+export const DEFAULT_TENANT_LINK_TYPE = 'tenant_external_id';
+
+export function buildTenantMatcherTs(
+	pascalName: string,
+	lowerName: string,
+): string {
+	return `import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// TODO: Rename linkType '${DEFAULT_TENANT_LINK_TYPE}' to match the provider field
+// (e.g. team_id, installation_id, organization_id). Must match authConfig.account
+// and oauthWebhookTenantLinkResolver.
+// Return null for URL verification / handshake payloads that have no tenant id.
+export function match${pascalName}TenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	// TODO: Extract the stable external id from the webhook payload.
+	// Example:
+	// const externalId = firstString([body.${DEFAULT_TENANT_LINK_TYPE}, asRecord(body.data)?.id]);
+	const externalId = firstString([
+		body.${DEFAULT_TENANT_LINK_TYPE},
+		asRecord(body.data)?.${DEFAULT_TENANT_LINK_TYPE},
+	]);
+
+	if (!externalId) return null;
+
+	return { linkType: '${DEFAULT_TENANT_LINK_TYPE}', externalId };
+}
+`;
+}
+
+export function buildOAuthTenantLinkTs(pascalName: string): string {
+	return `import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, toExternalId } from 'corsair/core';
+
+// TODO: Rename linkType '${DEFAULT_TENANT_LINK_TYPE}' to match pluginTenantWebhookMatcher.
+// Called after OAuth to store the routing id on corsair_accounts.config.
+export async function resolve${pascalName}OAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): Promise<WebhookTenantMatch | null> {
+	// TODO: Read from token response when the provider includes a stable id.
+	// const externalId = toExternalId(asRecord(tokens.team)?.id);
+	const externalId = toExternalId(tokens.${DEFAULT_TENANT_LINK_TYPE});
+	if (externalId) {
+		return { linkType: '${DEFAULT_TENANT_LINK_TYPE}', externalId };
+	}
+
+	const accessToken = tokens.access_token;
+	if (!accessToken) return null;
+
+	// TODO: Fetch from provider API when the token response omits the id.
+	// const response = await fetch('https://api.example.com/me', {
+	// \theaders: { Authorization: \`Bearer \${accessToken}\` },
+	// });
+	// if (!response.ok) return null;
+	// const payload = (await response.json()) as { id?: string };
+	// const fetchedId = toExternalId(payload.id);
+	// return fetchedId
+	// \t? { linkType: '${DEFAULT_TENANT_LINK_TYPE}', externalId: fetchedId }
+	// \t: null;
+
+	return null;
+}
+`;
+}
+
+export function buildAuthConfigTs(
+	camelName: string,
+	authTypes: readonly string[],
+): string {
+	const blocks = authTypes.map((authType) => {
+		return `\t${authType}: {
+\t\taccount: ['${DEFAULT_TENANT_LINK_TYPE}'] as const,
+\t},`;
+	});
+
+	return `export const ${camelName}AuthConfig = {
+${blocks.join('\n')}
+} as const satisfies PluginAuthConfig;`;
+}
+
+export function formatTenantRoutingPluginFields(pascalName: string): string {
+	return `\t\tpluginTenantWebhookMatcher: match${pascalName}TenantWebhook,
+\t\toauthWebhookTenantLinkResolver: resolve${pascalName}OAuthWebhookTenantLink,`;
+}
+
+export const TENANT_ROUTING_AGENT_CHECKLIST = `
+## Webhook tenant routing
+
+Corsair routes multi-tenant webhooks using three linked pieces. **linkType must match across all three:**
+
+| Piece | File | Purpose |
+|---|---|---|
+| \`pluginTenantWebhookMatcher\` | \`webhooks/tenant-matcher.ts\` | Extract id from incoming webhook |
+| \`authConfig.{authType}.account\` | \`index.ts\` | Field name stored on \`corsair_accounts.config\` |
+| \`oauthWebhookTenantLinkResolver\` | \`webhooks/oauth-tenant-link.ts\` | Populate field after OAuth (if applicable) |
+
+- [ ] Rename \`${DEFAULT_TENANT_LINK_TYPE}\` to the provider's real field (e.g. \`team_id\`, \`installation_id\`)
+- [ ] Update \`match{Plugin}TenantWebhook\` to parse the webhook payload (return \`null\` for handshakes)
+- [ ] Update \`{plugin}AuthConfig\` account fields to use the same linkType
+- [ ] If OAuth: implement \`resolve{Plugin}OAuthWebhookTenantLink\` (token response and/or post-OAuth API call)
+- [ ] Wire \`pluginTenantWebhookMatcher\` and \`oauthWebhookTenantLinkResolver\` on the plugin return object
+- [ ] Reference: \`packages/slack/webhooks/tenant-matcher.ts\` and \`packages/slack/webhooks/oauth-tenant-link.ts\`
+`;


### PR DESCRIPTION
## Description

Every plugin currently has a matcher that inspects the header and the body of the incoming webhook to decide if that webhook matches that plugin. However, we have no way of extracting the unique tenant id that could help us identify the tenant associated with that plugin. 