### PR TITLE
docs: add orphaned pages to navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -25,7 +25,6 @@
             "group": "Get Started",
             "pages": [
               "getting-started/introduction",
-              "getting-started/comparison",
               "getting-started/quick-start",
               "getting-started/setup"
             ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -25,6 +25,7 @@
             "group": "Get Started",
             "pages": [
               "getting-started/introduction",
+              "getting-started/comparison",
               "getting-started/quick-start",
               "getting-started/setup"
             ]
@@ -153,6 +154,7 @@
                 "pages": [
                   "plugins/ahrefs/overview",
                   "plugins/ahrefs/get-credentials",
+                  "plugins/ahrefs/api",
                   "plugins/ahrefs/database"
                 ]
               },
@@ -703,6 +705,16 @@
                 ]
               },
               {
+                "group": "Vercel",
+                "pages": [
+                  "plugins/vercel/overview",
+                  "plugins/vercel/get-credentials",
+                  "plugins/vercel/api",
+                  "plugins/vercel/database",
+                  "plugins/vercel/webhooks"
+                ]
+              },
+              {
                 "group": "Xquik",
                 "pages": [
                   "plugins/xquik/overview",
@@ -758,7 +770,12 @@
         "groups": [
           {
             "group": "Guides",
-            "pages": ["guides/webhooks", "guides/workflows", "guides/dashboard"]
+            "pages": [
+              "guides/webhooks",
+              "guides/workflows",
+              "guides/dashboard",
+              "guides/plugin-credentials"
+            ]
           }
         ]
       }


### PR DESCRIPTION
## Summary

- add the orphaned `getting-started/comparison` and `guides/plugin-credentials` pages to the docs navigation
- add the missing `plugins/ahrefs/api` entry under the Ahrefs plugin docs
- add the Vercel plugin docs group so all Vercel pages are reachable from the Plugins tab

Fixes #298.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('docs/docs.json','utf8'))"`
- structured docs navigation check: 0 non-snippet `.mdx` pages missing from `docs/docs.json`, 0 stale nav entries
- `git diff --check`
- `git merge-tree` conflict checks against open docs PRs #303 and #307
