### PR TITLE
docs: clarify OAuth credential storage

### DIFF
--- a/docs/production/tenant-provisioning.mdx
+++ b/docs/production/tenant-provisioning.mdx
@@ -57,6 +57,11 @@ await processOAuthCallback(corsair, { code, state, redirectUri });
 // creates account row for that plugin if missing
 ```
 
+On success, `processOAuthCallback` stores the OAuth credentials in the
+tenant's `corsair_accounts` row. The encrypted account `config` includes
+`access_token`, plus `refresh_token` when the provider returns one and
+`expires_at` when `expires_in` is returned.
+
 Full routes: [OAuth process](/production/oauth-process).
 
 **Runtime:**


### PR DESCRIPTION
## Description

Fixes #301.

Clarifies the Tenant Provisioning OAuth section so readers know what `processOAuthCallback` stores after a successful callback:

- ensures the tenant's `corsair_accounts` row exists
- stores OAuth credential fields in encrypted account `config`
- documents `access_token`, optional `refresh_token`, and optional `expires_at`

## Validation

- [x] `git diff --check`
- [x] `pnpm lint`
- [x] `pnpm run validate:plugins`
- [ ] `pnpm typecheck` (fails on current `main` TypeScript errors outside this docs change: missing `PermissionLookupInput`, and `ManualConnectConfig` lacking `oauthConfig`/`kek` in `packages/corsair/core/endpoints/bind.ts`)
- [ ] `pnpm build` (fails on the same existing `ManualConnectConfig` errors outside this docs change)
- [ ] `pnpm test` (not run after the unrelated typecheck/build failure)
