### PR TITLE
fix(www): disable claim button when user has active wip claim

### DIFF
--- a/www/src/app/oss/oss-sections.tsx
+++ b/www/src/app/oss/oss-sections.tsx
@@ -147,6 +147,7 @@ export async function OssIntegrationsSection({
 							integration={integration}
 							session={Boolean(session)}
 							index={startIndex + index + 1}
+							wipIntegrationName={integrationsData.wipIntegrationName}
 						/>
 					))}
 				</div>

--- a/www/src/server/oss-public-cache.ts
+++ b/www/src/server/oss-public-cache.ts
@@ -1,7 +1,7 @@
 import { revalidateTag, unstable_cache } from 'next/cache';
 
 import { db } from '@/db';
-import { getActiveClaimsForUser } from '@/db/integration-status';
+import { getActiveClaimsForUser, getUserWipClaim } from '@/db/integration-status';
 import { appRouter } from '@/server/api/root';
 
 export const OSS_CACHE_TAGS = {
@@ -84,14 +84,20 @@ export async function getIntegrationListForPage(
 	if (!userId) return list;
 
 	try {
-		const claims = await getActiveClaimsForUser(db, userId);
+		const [claims, wipClaim] = await Promise.all([
+			getActiveClaimsForUser(db, userId),
+			getUserWipClaim(db, userId),
+		]);
 		const claimedIds = new Set(claims.map((claim) => claim.integrationId));
+		const userCanClaim = wipClaim == null;
 
 		return {
 			...list,
+			wipIntegrationName: wipClaim?.name ?? null,
 			items: list.items.map((item) => ({
 				...item,
 				claimedByCurrentUser: claimedIds.has(item.id),
+				userCanClaim,
 			})),
 		};
 	} catch (error) {

--- a/www/src/server/oss-public-cache.ts
+++ b/www/src/server/oss-public-cache.ts
@@ -1,7 +1,10 @@
 import { revalidateTag, unstable_cache } from 'next/cache';
 
 import { db } from '@/db';
-import { getActiveClaimsForUser, getUserWipClaim } from '@/db/integration-status';
+import {
+	getActiveClaimsForUser,
+	getUserWipClaim,
+} from '@/db/integration-status';
 import { appRouter } from '@/server/api/root';
 
 export const OSS_CACHE_TAGS = {
@@ -102,7 +105,15 @@ export async function getIntegrationListForPage(
 		};
 	} catch (error) {
 		console.error('[oss] claim overlay failed', error);
-		return list;
+		// Fail safe: disable claim buttons rather than showing stale public-cache state.
+		return {
+			...list,
+			wipIntegrationName: null,
+			items: list.items.map((item) => ({
+				...item,
+				userCanClaim: false,
+			})),
+		};
 	}
 }
 


### PR DESCRIPTION
## What

After claiming an integration, the Claim buttons for all other integrations on the list page stayed enabled. Clicking one caused a Server Components render error.

## Why

`getIntegrationListForPage` overlays per-user data on top of the cached public list, but only patched `claimedByCurrentUser` — never `userCanClaim` or `wipIntegrationName`. The public caller always returns `userCanClaim: true`, so the UI had no way to know the user already had an active WIP claim.

## Fix

- `oss-public-cache.ts` — also call `getUserWipClaim` in the per-user overlay and stamp each item with the real `userCanClaim` + set `wipIntegrationName` on the list response
- `oss-sections.tsx` — pass `wipIntegrationName` down to each `IntegrationCard` so the tooltip shows correctly