### PR TITLE
docs: generate safer plugin overview examples

### DIFF
--- a/docs/plugins/airtable/overview.mdx
+++ b/docs/plugins/airtable/overview.mdx
@@ -114,17 +114,23 @@ Synced entities support `corsair.airtable.db.<entity>.search()` and `.list()`. S
 
 ## Example API calls
 
-**Read-style (read):** `bases.getMany`
+**Read-style (read):** `bases.getSchema`
 
 ```ts
-await corsair.airtable.api.bases.getMany({});
+await corsair.airtable.api.bases.getSchema({
+	baseId: 'example_baseid',
+});
 ```
 
 
 **Write-style (write):** `records.create`
 
 ```ts
-await corsair.airtable.api.records.create({});
+await corsair.airtable.api.records.create({
+	baseId: 'example_baseid',
+	tableIdOrName: 'example_tableidorname',
+	fields: {},
+});
 ```
 
 

--- a/docs/plugins/amplitude/overview.mdx
+++ b/docs/plugins/amplitude/overview.mdx
@@ -114,17 +114,22 @@ Synced entities support `corsair.amplitude.db.<entity>.search()` and `.list()`. 
 
 ## Example API calls
 
-**Read-style (read):** `annotations.list`
+**Read-style (read):** `charts.get`
 
 ```ts
-await corsair.amplitude.api.annotations.list({});
+await corsair.amplitude.api.charts.get({
+	chart_id: 'example_chart_id',
+});
 ```
 
 
 **Write-style (write):** `annotations.create`
 
 ```ts
-await corsair.amplitude.api.annotations.create({});
+await corsair.amplitude.api.annotations.create({
+	date: '2026-01-01T00:00:00Z',
+	label: 'example_label',
+});
 ```
 
 

--- a/docs/plugins/asana/overview.mdx
+++ b/docs/plugins/asana/overview.mdx
@@ -130,14 +130,19 @@ Synced entities support `corsair.asana.db.<entity>.search()` and `.list()`. See 
 **Read-style (read):** `projects.get`
 
 ```ts
-await corsair.asana.api.projects.get({});
+await corsair.asana.api.projects.get({
+	project_gid: 'example_project_gid',
+});
 ```
 
 
 **Write-style (write):** `projects.addFollowers`
 
 ```ts
-await corsair.asana.api.projects.addFollowers({});
+await corsair.asana.api.projects.addFollowers({
+	project_gid: 'example_project_gid',
+	followers: ['example_followers'],
+});
 ```
 
 

--- a/docs/plugins/bitwarden/overview.mdx
+++ b/docs/plugins/bitwarden/overview.mdx
@@ -110,7 +110,10 @@ Synced entities support `corsair.bitwarden.db.<entity>.search()` and `.list()`. 
 **Read-style (read):** `collections.get`
 
 ```ts
-await corsair.bitwarden.api.collections.get({});
+await corsair.bitwarden.api.collections.get({
+	organizationId: 'example_organizationid',
+	id: 'example_id',
+});
 ```
 
 

--- a/docs/plugins/bluesky/overview.mdx
+++ b/docs/plugins/bluesky/overview.mdx
@@ -107,17 +107,21 @@ Synced entities support `corsair.bluesky.db.<entity>.search()` and `.list()`. Se
 
 ## Example API calls
 
-**Read-style (read):** `feeds.getTimeline`
+**Read-style (read):** `profiles.get`
 
 ```ts
-await corsair.bluesky.api.feeds.getTimeline({});
+await corsair.bluesky.api.profiles.get({
+	actor: 'example_actor',
+});
 ```
 
 
 **Write-style (write):** `posts.create`
 
 ```ts
-await corsair.bluesky.api.posts.create({});
+await corsair.bluesky.api.posts.create({
+	text: 'example_text',
+});
 ```
 
 

--- a/docs/plugins/box/overview.mdx
+++ b/docs/plugins/box/overview.mdx
@@ -114,17 +114,22 @@ Synced entities support `corsair.box.db.<entity>.search()` and `.list()`. See [D
 
 ## Example API calls
 
-**Read-style (read):** `files.download`
+**Read-style (read):** `files.get`
 
 ```ts
-await corsair.box.api.files.download({});
+await corsair.box.api.files.get({
+	file_id: 'example_file_id',
+});
 ```
 
 
-**Write-style (write):** `files.copy`
+**Write-style (write):** `folders.create`
 
 ```ts
-await corsair.box.api.files.copy({});
+await corsair.box.api.folders.create({
+	name: 'example_name',
+	parent_id: 'example_parent_id',
+});
 ```
 
 

--- a/docs/plugins/cal/overview.mdx
+++ b/docs/plugins/cal/overview.mdx
@@ -117,14 +117,24 @@ Synced entities support `corsair.cal.db.<entity>.search()` and `.list()`. See [D
 **Read-style (read):** `bookings.get`
 
 ```ts
-await corsair.cal.api.bookings.get({});
+await corsair.cal.api.bookings.get({
+	uid: 'example_uid',
+});
 ```
 
 
-**Write-style (destructive):** `bookings.cancel`
+**Write-style (write):** `bookings.create`
 
 ```ts
-await corsair.cal.api.bookings.cancel({});
+await corsair.cal.api.bookings.create({
+	start: 'example_start',
+	eventTypeId: 1,
+	attendee: {
+		name: 'example_name',
+		email: 'user@example.com',
+		timeZone: 'America/New_York',
+	},
+});
 ```
 
 

--- a/docs/plugins/calendly/overview.mdx
+++ b/docs/plugins/calendly/overview.mdx
@@ -117,14 +117,19 @@ Synced entities support `corsair.calendly.db.<entity>.search()` and `.list()`. S
 **Read-style (read):** `activityLog.list`
 
 ```ts
-await corsair.calendly.api.activityLog.list({});
+await corsair.calendly.api.activityLog.list({
+	organization: 'example_organization',
+});
 ```
 
 
 **Write-style (write):** `eventTypes.create`
 
 ```ts
-await corsair.calendly.api.eventTypes.create({});
+await corsair.calendly.api.eventTypes.create({
+	name: 'example_name',
+	host: 'example_host',
+});
 ```
 
 

--- a/docs/plugins/cloudflare/overview.mdx
+++ b/docs/plugins/cloudflare/overview.mdx
@@ -110,14 +110,22 @@ Synced entities support `corsair.cloudflare.db.<entity>.search()` and `.list()`.
 **Read-style (read):** `dns.get`
 
 ```ts
-await corsair.cloudflare.api.dns.get({});
+await corsair.cloudflare.api.dns.get({
+	zone_id: 'example_zone_id',
+	dns_record_id: 'example_dns_record_id',
+});
 ```
 
 
 **Write-style (write):** `dns.create`
 
 ```ts
-await corsair.cloudflare.api.dns.create({});
+await corsair.cloudflare.api.dns.create({
+	zone_id: 'example_zone_id',
+	type: 'example_type',
+	name: 'example_name',
+	content: 'example_content',
+});
 ```
 
 

--- a/docs/plugins/cursor/overview.mdx
+++ b/docs/plugins/cursor/overview.mdx
@@ -107,10 +107,12 @@ Synced entities support `corsair.cursor.db.<entity>.search()` and `.list()`. See
 
 ## Example API calls
 
-**Read-style (read):** `account.getMe`
+**Read-style (read):** `agents.getConversation`
 
 ```ts
-await corsair.cursor.api.account.getMe({});
+await corsair.cursor.api.agents.getConversation({
+	id: 'example_id',
+});
 ```
 
 

--- a/docs/plugins/discord/overview.mdx
+++ b/docs/plugins/discord/overview.mdx
@@ -117,14 +117,18 @@ Synced entities support `corsair.discord.db.<entity>.search()` and `.list()`. Se
 **Read-style (read):** `channels.list`
 
 ```ts
-await corsair.discord.api.channels.list({});
+await corsair.discord.api.channels.list({
+	guild_id: 'example_guild_id',
+});
 ```
 
 
-**Write-style (destructive):** `messages.delete`
+**Write-style (write):** `messages.send`
 
 ```ts
-await corsair.discord.api.messages.delete({});
+await corsair.discord.api.messages.send({
+	channel_id: 'C0123456789',
+});
 ```
 
 

--- a/docs/plugins/dodopayments/overview.mdx
+++ b/docs/plugins/dodopayments/overview.mdx
@@ -117,14 +117,19 @@ Synced entities support `corsair.dodopayments.db.<entity>.search()` and `.list()
 **Read-style (read):** `customers.get`
 
 ```ts
-await corsair.dodopayments.api.customers.get({});
+await corsair.dodopayments.api.customers.get({
+	id: 'example_id',
+});
 ```
 
 
 **Write-style (write):** `customers.create`
 
 ```ts
-await corsair.dodopayments.api.customers.create({});
+await corsair.dodopayments.api.customers.create({
+	name: 'example_name',
+	email: 'user@example.com',
+});
 ```
 
 

--- a/docs/plugins/dropbox/overview.mdx
+++ b/docs/plugins/dropbox/overview.mdx
@@ -114,17 +114,21 @@ Synced entities support `corsair.dropbox.db.<entity>.search()` and `.list()`. Se
 
 ## Example API calls
 
-**Read-style (read):** `files.download`
+**Read-style (read):** `folders.list`
 
 ```ts
-await corsair.dropbox.api.files.download({});
+await corsair.dropbox.api.folders.list({
+	path: 'example_path',
+});
 ```
 
 
-**Write-style (write):** `files.copy`
+**Write-style (write):** `folders.create`
 
 ```ts
-await corsair.dropbox.api.files.copy({});
+await corsair.dropbox.api.folders.create({
+	path: 'example_path',
+});
 ```
 
 

--- a/docs/plugins/exa/overview.mdx
+++ b/docs/plugins/exa/overview.mdx
@@ -117,14 +117,19 @@ Synced entities support `corsair.exa.db.<entity>.search()` and `.list()`. See [D
 **Read-style (read):** `answer.get`
 
 ```ts
-await corsair.exa.api.answer.get({});
+await corsair.exa.api.answer.get({
+	query: 'example_query',
+});
 ```
 
 
 **Write-style (write):** `imports.create`
 
 ```ts
-await corsair.exa.api.imports.create({});
+await corsair.exa.api.imports.create({
+	websetId: 'example_websetid',
+	urls: ['https://example.com'],
+});
 ```
 
 

--- a/docs/plugins/figma/overview.mdx
+++ b/docs/plugins/figma/overview.mdx
@@ -114,17 +114,23 @@ Synced entities support `corsair.figma.db.<entity>.search()` and `.list()`. See 
 
 ## Example API calls
 
-**Read-style (read):** `activityLogs.list`
+**Read-style (read):** `comments.getReactions`
 
 ```ts
-await corsair.figma.api.activityLogs.list({});
+await corsair.figma.api.comments.getReactions({
+	file_key: 'example_file_key',
+	comment_id: 'example_comment_id',
+});
 ```
 
 
 **Write-style (write):** `comments.add`
 
 ```ts
-await corsair.figma.api.comments.add({});
+await corsair.figma.api.comments.add({
+	message: 'example_message',
+	file_key: 'example_file_key',
+});
 ```
 
 

--- a/docs/plugins/firecrawl/overview.mdx
+++ b/docs/plugins/firecrawl/overview.mdx
@@ -117,14 +117,18 @@ Synced entities support `corsair.firecrawl.db.<entity>.search()` and `.list()`. 
 **Read-style (read):** `agent.get`
 
 ```ts
-await corsair.firecrawl.api.agent.get({});
+await corsair.firecrawl.api.agent.get({
+	id: 'example_id',
+});
 ```
 
 
-**Write-style (write):** `agent.cancel`
+**Write-style (write):** `agent.start`
 
 ```ts
-await corsair.firecrawl.api.agent.cancel({});
+await corsair.firecrawl.api.agent.start({
+	prompt: 'example_prompt',
+});
 ```
 
 

--- a/docs/plugins/fireflies/overview.mdx
+++ b/docs/plugins/fireflies/overview.mdx
@@ -114,17 +114,21 @@ Synced entities support `corsair.fireflies.db.<entity>.search()` and `.list()`. 
 
 ## Example API calls
 
-**Read-style (read):** `aiApp.getOutputs`
+**Read-style (read):** `askFred.getThread`
 
 ```ts
-await corsair.fireflies.api.aiApp.getOutputs({});
+await corsair.fireflies.api.askFred.getThread({
+	threadId: 'example_threadid',
+});
 ```
 
 
-**Write-style (write):** `askFred.continueThread`
+**Write-style (write):** `askFred.createThread`
 
 ```ts
-await corsair.fireflies.api.askFred.continueThread({});
+await corsair.fireflies.api.askFred.createThread({
+	query: 'example_query',
+});
 ```
 
 

--- a/docs/plugins/github/overview.mdx
+++ b/docs/plugins/github/overview.mdx
@@ -130,14 +130,23 @@ Synced entities support `corsair.github.db.<entity>.search()` and `.list()`. See
 **Read-style (read):** `comments.get`
 
 ```ts
-await corsair.github.api.comments.get({});
+await corsair.github.api.comments.get({
+	owner: 'example_owner',
+	repo: 'example_repo',
+	commentId: 1,
+});
 ```
 
 
-**Write-style (write):** `comments.delete`
+**Write-style (write):** `comments.update`
 
 ```ts
-await corsair.github.api.comments.delete({});
+await corsair.github.api.comments.update({
+	owner: 'example_owner',
+	repo: 'example_repo',
+	commentId: 1,
+	body: 'example_body',
+});
 ```
 
 

--- a/docs/plugins/gitlab/overview.mdx
+++ b/docs/plugins/gitlab/overview.mdx
@@ -130,14 +130,21 @@ Synced entities support `corsair.gitlab.db.<entity>.search()` and `.list()`. See
 **Read-style (read):** `branches.get`
 
 ```ts
-await corsair.gitlab.api.branches.get({});
+await corsair.gitlab.api.branches.get({
+	project_id: 'example_project_id',
+	branch: 'example_branch',
+});
 ```
 
 
 **Write-style (write):** `branches.create`
 
 ```ts
-await corsair.gitlab.api.branches.create({});
+await corsair.gitlab.api.branches.create({
+	project_id: 'example_project_id',
+	branch: 'example_branch',
+	ref: 'example_ref',
+});
 ```
 
 

--- a/docs/plugins/gmail/overview.mdx
+++ b/docs/plugins/gmail/overview.mdx
@@ -117,14 +117,18 @@ Synced entities support `corsair.gmail.db.<entity>.search()` and `.list()`. See 
 **Read-style (read):** `drafts.get`
 
 ```ts
-await corsair.gmail.api.drafts.get({});
+await corsair.gmail.api.drafts.get({
+	id: 'example_id',
+});
 ```
 
 
-**Write-style (write):** `drafts.create`
+**Write-style (write):** `drafts.update`
 
 ```ts
-await corsair.gmail.api.drafts.create({});
+await corsair.gmail.api.drafts.update({
+	id: 'example_id',
+});
 ```
 
 

--- a/docs/plugins/googlecalendar/overview.mdx
+++ b/docs/plugins/googlecalendar/overview.mdx
@@ -117,14 +117,27 @@ Synced entities support `corsair.googlecalendar.db.<entity>.search()` and `.list
 **Read-style (read):** `calendar.getAvailability`
 
 ```ts
-await corsair.googlecalendar.api.calendar.getAvailability({});
+await corsair.googlecalendar.api.calendar.getAvailability({
+	timeMin: '2026-01-01T00:00:00Z',
+	timeMax: '2026-01-01T00:00:00Z',
+});
 ```
 
 
 **Write-style (write):** `events.create`
 
 ```ts
-await corsair.googlecalendar.api.events.create({});
+await corsair.googlecalendar.api.events.create({
+	event: {
+		summary: 'example_summary',
+		start: {
+			dateTime: '2026-01-01T00:00:00Z',
+		},
+		end: {
+			dateTime: '2026-01-01T00:00:00Z',
+		},
+	},
+});
 ```
 
 

--- a/docs/plugins/googledrive/overview.mdx
+++ b/docs/plugins/googledrive/overview.mdx
@@ -114,17 +114,22 @@ Synced entities support `corsair.googledrive.db.<entity>.search()` and `.list()`
 
 ## Example API calls
 
-**Read-style (read):** `files.download`
+**Read-style (read):** `files.get`
 
 ```ts
-await corsair.googledrive.api.files.download({});
+await corsair.googledrive.api.files.get({
+	fileId: 'example_fileid',
+});
 ```
 
 
-**Write-style (write):** `files.copy`
+**Write-style (write):** `files.createFromText`
 
 ```ts
-await corsair.googledrive.api.files.copy({});
+await corsair.googledrive.api.files.createFromText({
+	name: 'example_name',
+	content: 'example_content',
+});
 ```
 
 

--- a/docs/plugins/googlemeet/overview.mdx
+++ b/docs/plugins/googlemeet/overview.mdx
@@ -110,14 +110,18 @@ Synced entities support `corsair.googlemeet.db.<entity>.search()` and `.list()`.
 **Read-style (read):** `conferenceRecords.get`
 
 ```ts
-await corsair.googlemeet.api.conferenceRecords.get({});
+await corsair.googlemeet.api.conferenceRecords.get({
+	name: 'example_name',
+});
 ```
 
 
-**Write-style (write):** `spaces.create`
+**Write-style (write):** `spaces.patch`
 
 ```ts
-await corsair.googlemeet.api.spaces.create({});
+await corsair.googlemeet.api.spaces.patch({
+	name: 'example_name',
+});
 ```
 
 

--- a/docs/plugins/googlesheets/overview.mdx
+++ b/docs/plugins/googlesheets/overview.mdx
@@ -117,14 +117,18 @@ Synced entities support `corsair.googlesheets.db.<entity>.search()` and `.list()
 **Read-style (read):** `sheets.getRows`
 
 ```ts
-await corsair.googlesheets.api.sheets.getRows({});
+await corsair.googlesheets.api.sheets.getRows({
+	spreadsheetId: 'example_spreadsheetid',
+});
 ```
 
 
-**Write-style (write):** `sheets.appendOrUpdateRow`
+**Write-style (write):** `sheets.createSheet`
 
 ```ts
-await corsair.googlesheets.api.sheets.appendOrUpdateRow({});
+await corsair.googlesheets.api.sheets.createSheet({
+	spreadsheetId: 'example_spreadsheetid',
+});
 ```
 
 

--- a/docs/plugins/grafana/overview.mdx
+++ b/docs/plugins/grafana/overview.mdx
@@ -107,17 +107,19 @@ Synced entities support `corsair.grafana.db.<entity>.search()` and `.list()`. Se
 
 ## Example API calls
 
-**Read-style (read):** `dashboards.queryPublic`
+**Read-style (read):** `health.get`
 
 ```ts
-await corsair.grafana.api.dashboards.queryPublic({});
+await corsair.grafana.api.health.get({});
 ```
 
 
 **Write-style (write):** `logs.createOtlp`
 
 ```ts
-await corsair.grafana.api.logs.createOtlp({});
+await corsair.grafana.api.logs.createOtlp({
+	resourceLogs: [{}],
+});
 ```
 
 

--- a/docs/plugins/hackernews/overview.mdx
+++ b/docs/plugins/hackernews/overview.mdx
@@ -110,15 +110,15 @@ Synced entities support `corsair.hackernews.db.<entity>.search()` and `.list()`.
 **Read-style (read):** `items.get`
 
 ```ts
-await corsair.hackernews.api.items.get({});
+await corsair.hackernews.api.items.get({
+	id: 1,
+});
 ```
 
 
-**Write-style (read):** `updates.get`
+**Write-style (write):** `—`
 
-```ts
-await corsair.hackernews.api.updates.get({});
-```
+_No write-style endpoint inferred; pick any operation from the reference below._
 
 
 See the full list on the [API](/plugins/hackernews/api) page. Use `pnpm corsair list --plugin=hackernews` and `pnpm corsair schema <path>` locally to inspect schemas.

--- a/docs/plugins/hubspot/overview.mdx
+++ b/docs/plugins/hubspot/overview.mdx
@@ -130,14 +130,18 @@ Synced entities support `corsair.hubspot.db.<entity>.search()` and `.list()`. Se
 **Read-style (read):** `companies.get`
 
 ```ts
-await corsair.hubspot.api.companies.get({});
+await corsair.hubspot.api.companies.get({
+	companyId: 'example_companyid',
+});
 ```
 
 
-**Write-style (write):** `companies.create`
+**Write-style (write):** `companies.update`
 
 ```ts
-await corsair.hubspot.api.companies.create({});
+await corsair.hubspot.api.companies.update({
+	companyId: 'example_companyid',
+});
 ```
 
 

--- a/docs/plugins/intercom/overview.mdx
+++ b/docs/plugins/intercom/overview.mdx
@@ -117,14 +117,19 @@ Synced entities support `corsair.intercom.db.<entity>.search()` and `.list()`. S
 **Read-style (read):** `admins.get`
 
 ```ts
-await corsair.intercom.api.admins.get({});
+await corsair.intercom.api.admins.get({
+	id: 'example_id',
+});
 ```
 
 
 **Write-style (write):** `admins.setAway`
 
 ```ts
-await corsair.intercom.api.admins.setAway({});
+await corsair.intercom.api.admins.setAway({
+	id: 'example_id',
+	away_mode_enabled: true,
+});
 ```
 
 

--- a/docs/plugins/jira/overview.mdx
+++ b/docs/plugins/jira/overview.mdx
@@ -117,14 +117,20 @@ Synced entities support `corsair.jira.db.<entity>.search()` and `.list()`. See [
 **Read-style (read):** `comments.get`
 
 ```ts
-await corsair.jira.api.comments.get({});
+await corsair.jira.api.comments.get({
+	issue_id_or_key: 'example_issue_id_or_key',
+	comment_id: 'example_comment_id',
+});
 ```
 
 
 **Write-style (write):** `comments.add`
 
 ```ts
-await corsair.jira.api.comments.add({});
+await corsair.jira.api.comments.add({
+	issue_id_or_key: 'example_issue_id_or_key',
+	comment: 'example_comment',
+});
 ```
 
 

--- a/docs/plugins/linear/overview.mdx
+++ b/docs/plugins/linear/overview.mdx
@@ -130,14 +130,19 @@ Synced entities support `corsair.linear.db.<entity>.search()` and `.list()`. See
 **Read-style (read):** `comments.list`
 
 ```ts
-await corsair.linear.api.comments.list({});
+await corsair.linear.api.comments.list({
+	issueId: 'example_issueid',
+});
 ```
 
 
 **Write-style (write):** `comments.create`
 
 ```ts
-await corsair.linear.api.comments.create({});
+await corsair.linear.api.comments.create({
+	issueId: 'example_issueid',
+	body: 'example_body',
+});
 ```
 
 

--- a/docs/plugins/monday/overview.mdx
+++ b/docs/plugins/monday/overview.mdx
@@ -117,14 +117,18 @@ Synced entities support `corsair.monday.db.<entity>.search()` and `.list()`. See
 **Read-style (read):** `boards.get`
 
 ```ts
-await corsair.monday.api.boards.get({});
+await corsair.monday.api.boards.get({
+	board_id: 'example_board_id',
+});
 ```
 
 
-**Write-style (write):** `boards.archive`
+**Write-style (write):** `boards.create`
 
 ```ts
-await corsair.monday.api.boards.archive({});
+await corsair.monday.api.boards.create({
+	board_name: 'example_board_name',
+});
 ```
 
 

--- a/docs/plugins/notion/overview.mdx
+++ b/docs/plugins/notion/overview.mdx
@@ -130,14 +130,19 @@ Synced entities support `corsair.notion.db.<entity>.search()` and `.list()`. See
 **Read-style (read):** `blocks.getManyChildBlocks`
 
 ```ts
-await corsair.notion.api.blocks.getManyChildBlocks({});
+await corsair.notion.api.blocks.getManyChildBlocks({
+	block_id: 'example_block_id',
+});
 ```
 
 
-**Write-style (write):** `blocks.appendBlock`
+**Write-style (write):** `databasePages.createDatabasePage`
 
 ```ts
-await corsair.notion.api.blocks.appendBlock({});
+await corsair.notion.api.databasePages.createDatabasePage({
+	database_id: 'example_database_id',
+	properties: {},
+});
 ```
 
 

--- a/docs/plugins/onedrive/overview.mdx
+++ b/docs/plugins/onedrive/overview.mdx
@@ -117,14 +117,18 @@ Synced entities support `corsair.onedrive.db.<entity>.search()` and `.list()`. S
 **Read-style (read):** `drive.get`
 
 ```ts
-await corsair.onedrive.api.drive.get({});
+await corsair.onedrive.api.drive.get({
+	drive_id: 'example_drive_id',
+});
 ```
 
 
 **Write-style (write):** `files.createFolder`
 
 ```ts
-await corsair.onedrive.api.files.createFolder({});
+await corsair.onedrive.api.files.createFolder({
+	name: 'example_name',
+});
 ```
 
 

--- a/docs/plugins/openweathermap/overview.mdx
+++ b/docs/plugins/openweathermap/overview.mdx
@@ -110,7 +110,11 @@ Synced entities support `corsair.openweathermap.db.<entity>.search()` and `.list
 **Read-style (read):** `history.timeMachine`
 
 ```ts
-await corsair.openweathermap.api.history.timeMachine({});
+await corsair.openweathermap.api.history.timeMachine({
+	lat: 1,
+	lon: 1,
+	dt: 1,
+});
 ```
 
 

--- a/docs/plugins/outlook/overview.mdx
+++ b/docs/plugins/outlook/overview.mdx
@@ -117,14 +117,18 @@ Synced entities support `corsair.outlook.db.<entity>.search()` and `.list()`. Se
 **Read-style (read):** `calendars.get`
 
 ```ts
-await corsair.outlook.api.calendars.get({});
+await corsair.outlook.api.calendars.get({
+	calendar_id: 'example_calendar_id',
+});
 ```
 
 
 **Write-style (write):** `calendars.create`
 
 ```ts
-await corsair.outlook.api.calendars.create({});
+await corsair.outlook.api.calendars.create({
+	name: 'example_name',
+});
 ```
 
 

--- a/docs/plugins/pagerduty/overview.mdx
+++ b/docs/plugins/pagerduty/overview.mdx
@@ -117,14 +117,19 @@ Synced entities support `corsair.pagerduty.db.<entity>.search()` and `.list()`. 
 **Read-style (read):** `incidentNotes.list`
 
 ```ts
-await corsair.pagerduty.api.incidentNotes.list({});
+await corsair.pagerduty.api.incidentNotes.list({
+	incident_id: 'example_incident_id',
+});
 ```
 
 
 **Write-style (write):** `incidentNotes.create`
 
 ```ts
-await corsair.pagerduty.api.incidentNotes.create({});
+await corsair.pagerduty.api.incidentNotes.create({
+	incident_id: 'example_incident_id',
+	content: 'example_content',
+});
 ```
 
 

--- a/docs/plugins/posthog/overview.mdx
+++ b/docs/plugins/posthog/overview.mdx
@@ -122,7 +122,10 @@ _No read-style endpoint inferred; pick any operation from the reference below._
 **Write-style (write):** `events.aliasCreate`
 
 ```ts
-await corsair.posthog.api.events.aliasCreate({});
+await corsair.posthog.api.events.aliasCreate({
+	distinct_id: 'example_distinct_id',
+	alias: 'example_alias',
+});
 ```
 
 

--- a/docs/plugins/razorpay/overview.mdx
+++ b/docs/plugins/razorpay/overview.mdx
@@ -117,14 +117,18 @@ Synced entities support `corsair.razorpay.db.<entity>.search()` and `.list()`. S
 **Read-style (read):** `customers.get`
 
 ```ts
-await corsair.razorpay.api.customers.get({});
+await corsair.razorpay.api.customers.get({
+	id: 'example_id',
+});
 ```
 
 
 **Write-style (write):** `customers.create`
 
 ```ts
-await corsair.razorpay.api.customers.create({});
+await corsair.razorpay.api.customers.create({
+	name: 'example_name',
+});
 ```
 
 

--- a/docs/plugins/reddit/overview.mdx
+++ b/docs/plugins/reddit/overview.mdx
@@ -107,18 +107,18 @@ Synced entities support `corsair.reddit.db.<entity>.search()` and `.list()`. See
 
 ## Example API calls
 
-**Read-style (read):** `feeds.getAll`
+**Read-style (read):** `posts.getById`
 
 ```ts
-await corsair.reddit.api.feeds.getAll({});
+await corsair.reddit.api.posts.getById({
+	names: 'example_names',
+});
 ```
 
 
-**Write-style (read):** `posts.getById`
+**Write-style (write):** `—`
 
-```ts
-await corsair.reddit.api.posts.getById({});
-```
+_No write-style endpoint inferred; pick any operation from the reference below._
 
 
 See the full list on the [API](/plugins/reddit/api) page. Use `pnpm corsair list --plugin=reddit` and `pnpm corsair schema <path>` locally to inspect schemas.

--- a/docs/plugins/resend/overview.mdx
+++ b/docs/plugins/resend/overview.mdx
@@ -117,14 +117,18 @@ Synced entities support `corsair.resend.db.<entity>.search()` and `.list()`. See
 **Read-style (read):** `domains.get`
 
 ```ts
-await corsair.resend.api.domains.get({});
+await corsair.resend.api.domains.get({
+	id: 'example_id',
+});
 ```
 
 
 **Write-style (write):** `domains.create`
 
 ```ts
-await corsair.resend.api.domains.create({});
+await corsair.resend.api.domains.create({
+	name: 'example_name',
+});
 ```
 
 

--- a/docs/plugins/sentry/overview.mdx
+++ b/docs/plugins/sentry/overview.mdx
@@ -117,14 +117,20 @@ Synced entities support `corsair.sentry.db.<entity>.search()` and `.list()`. See
 **Read-style (read):** `events.get`
 
 ```ts
-await corsair.sentry.api.events.get({});
+await corsair.sentry.api.events.get({
+	organizationSlug: 'example_organizationslug',
+	projectSlug: 'example_projectslug',
+	eventId: 'example_eventid',
+});
 ```
 
 
-**Write-style (destructive):** `issues.delete`
+**Write-style (write):** `issues.update`
 
 ```ts
-await corsair.sentry.api.issues.delete({});
+await corsair.sentry.api.issues.update({
+	issueId: 'example_issueid',
+});
 ```
 
 

--- a/docs/plugins/sharepoint/overview.mdx
+++ b/docs/plugins/sharepoint/overview.mdx
@@ -117,14 +117,20 @@ Synced entities support `corsair.sharepoint.db.<entity>.search()` and `.list()`.
 **Read-style (read):** `contentTypes.get`
 
 ```ts
-await corsair.sharepoint.api.contentTypes.get({});
+await corsair.sharepoint.api.contentTypes.get({
+	content_type_id: 'example_content_type_id',
+});
 ```
 
 
 **Write-style (write):** `contentTypes.addFieldLink`
 
 ```ts
-await corsair.sharepoint.api.contentTypes.addFieldLink({});
+await corsair.sharepoint.api.contentTypes.addFieldLink({
+	listid: 'example_listid',
+	contenttypeid: 'example_contenttypeid',
+	field_internal_name: 'example_field_internal_name',
+});
 ```
 
 

--- a/docs/plugins/slack/overview.mdx
+++ b/docs/plugins/slack/overview.mdx
@@ -130,14 +130,18 @@ Synced entities support `corsair.slack.db.<entity>.search()` and `.list()`. See 
 **Read-style (read):** `channels.get`
 
 ```ts
-await corsair.slack.api.channels.get({});
+await corsair.slack.api.channels.get({
+	channel: 'C0123456789',
+});
 ```
 
 
-**Write-style (destructive):** `channels.archive`
+**Write-style (write):** `channels.create`
 
 ```ts
-await corsair.slack.api.channels.archive({});
+await corsair.slack.api.channels.create({
+	name: 'example_name',
+});
 ```
 
 

--- a/docs/plugins/spotify/overview.mdx
+++ b/docs/plugins/spotify/overview.mdx
@@ -123,14 +123,18 @@ Synced entities support `corsair.spotify.db.<entity>.search()` and `.list()`. Se
 **Read-style (read):** `albums.get`
 
 ```ts
-await corsair.spotify.api.albums.get({});
+await corsair.spotify.api.albums.get({
+	id: 'example_id',
+});
 ```
 
 
 **Write-style (write):** `player.addToQueue`
 
 ```ts
-await corsair.spotify.api.player.addToQueue({});
+await corsair.spotify.api.player.addToQueue({
+	uri: 'https://example.com',
+});
 ```
 
 

--- a/docs/plugins/strava/overview.mdx
+++ b/docs/plugins/strava/overview.mdx
@@ -110,14 +110,21 @@ Synced entities support `corsair.strava.db.<entity>.search()` and `.list()`. See
 **Read-style (read):** `activities.get`
 
 ```ts
-await corsair.strava.api.activities.get({});
+await corsair.strava.api.activities.get({
+	id: 1,
+});
 ```
 
 
 **Write-style (write):** `activities.create`
 
 ```ts
-await corsair.strava.api.activities.create({});
+await corsair.strava.api.activities.create({
+	name: 'example_name',
+	sport_type: 'example_sport_type',
+	start_date_local: '2026-01-01T00:00:00Z',
+	elapsed_time: 1,
+});
 ```
 
 

--- a/docs/plugins/stripe/overview.mdx
+++ b/docs/plugins/stripe/overview.mdx
@@ -127,17 +127,22 @@ Synced entities support `corsair.stripe.db.<entity>.search()` and `.list()`. See
 
 ## Example API calls
 
-**Read-style (read):** `balance.get`
+**Read-style (read):** `charges.get`
 
 ```ts
-await corsair.stripe.api.balance.get({});
+await corsair.stripe.api.charges.get({
+	id: 'example_id',
+});
 ```
 
 
 **Write-style (write):** `charges.create`
 
 ```ts
-await corsair.stripe.api.charges.create({});
+await corsair.stripe.api.charges.create({
+	amount: 1,
+	currency: 'example_currency',
+});
 ```
 
 

--- a/docs/plugins/supabase/overview.mdx
+++ b/docs/plugins/supabase/overview.mdx
@@ -126,17 +126,19 @@ Synced entities support `corsair.supabase.db.<entity>.search()` and `.list()`. S
 
 ```ts
 await corsair.supabase.api.advisors.getPerformanceAdvisors({
-  ref: 'abcdefghijklmnopqrst',
-})
+	ref: 'example_ref',
+});
 ```
+
 
 **Write-style (write):** `auth.createProjectSigningKey`
 
 ```ts
 await corsair.supabase.api.auth.createProjectSigningKey({
-  ref: 'abcdefghijklmnopqrst',
-})
+	ref: 'example_ref',
+});
 ```
+
 
 See the full list on the [API](/plugins/supabase/api) page. Use `pnpm corsair list --plugin=supabase` and `pnpm corsair schema <path>` locally to inspect schemas.
 

--- a/docs/plugins/tally/overview.mdx
+++ b/docs/plugins/tally/overview.mdx
@@ -117,14 +117,19 @@ Synced entities support `corsair.tally.db.<entity>.search()` and `.list()`. See 
 **Read-style (read):** `forms.get`
 
 ```ts
-await corsair.tally.api.forms.get({});
+await corsair.tally.api.forms.get({
+	formId: 'example_formid',
+});
 ```
 
 
 **Write-style (write):** `forms.create`
 
 ```ts
-await corsair.tally.api.forms.create({});
+await corsair.tally.api.forms.create({
+	status: 'example_status',
+	blocks: [{}],
+});
 ```
 
 

--- a/docs/plugins/tavily/overview.mdx
+++ b/docs/plugins/tavily/overview.mdx
@@ -107,10 +107,12 @@ Synced entities support `corsair.tavily.db.<entity>.search()` and `.list()`. See
 
 ## Example API calls
 
-**Read-style (read):** `crawl.crawl`
+**Read-style (read):** `search.search`
 
 ```ts
-await corsair.tavily.api.crawl.crawl({});
+await corsair.tavily.api.search.search({
+	query: 'example_query',
+});
 ```
 
 

--- a/docs/plugins/teams/overview.mdx
+++ b/docs/plugins/teams/overview.mdx
@@ -117,14 +117,20 @@ Synced entities support `corsair.teams.db.<entity>.search()` and `.list()`. See 
 **Read-style (read):** `channels.get`
 
 ```ts
-await corsair.teams.api.channels.get({});
+await corsair.teams.api.channels.get({
+	teamId: 'T0123456789',
+	channelId: 'C0123456789',
+});
 ```
 
 
 **Write-style (write):** `channels.create`
 
 ```ts
-await corsair.teams.api.channels.create({});
+await corsair.teams.api.channels.create({
+	teamId: 'T0123456789',
+	displayName: 'example_displayname',
+});
 ```
 
 

--- a/docs/plugins/todoist/overview.mdx
+++ b/docs/plugins/todoist/overview.mdx
@@ -117,14 +117,18 @@ Synced entities support `corsair.todoist.db.<entity>.search()` and `.list()`. Se
 **Read-style (read):** `comments.get`
 
 ```ts
-await corsair.todoist.api.comments.get({});
+await corsair.todoist.api.comments.get({
+	id: 'example_id',
+});
 ```
 
 
 **Write-style (write):** `comments.create`
 
 ```ts
-await corsair.todoist.api.comments.create({});
+await corsair.todoist.api.comments.create({
+	content: 'example_content',
+});
 ```
 
 

--- a/docs/plugins/trello/overview.mdx
+++ b/docs/plugins/trello/overview.mdx
@@ -117,14 +117,18 @@ Synced entities support `corsair.trello.db.<entity>.search()` and `.list()`. See
 **Read-style (read):** `boards.get`
 
 ```ts
-await corsair.trello.api.boards.get({});
+await corsair.trello.api.boards.get({
+	boardId: 'example_boardid',
+});
 ```
 
 
 **Write-style (write):** `boards.create`
 
 ```ts
-await corsair.trello.api.boards.create({});
+await corsair.trello.api.boards.create({
+	name: 'example_name',
+});
 ```
 
 

--- a/docs/plugins/twilio/overview.mdx
+++ b/docs/plugins/twilio/overview.mdx
@@ -117,14 +117,19 @@ Synced entities support `corsair.twilio.db.<entity>.search()` and `.list()`. See
 **Read-style (read):** `calls.get`
 
 ```ts
-await corsair.twilio.api.calls.get({});
+await corsair.twilio.api.calls.get({
+	callSid: 'example_callsid',
+});
 ```
 
 
 **Write-style (write):** `calls.create`
 
 ```ts
-await corsair.twilio.api.calls.create({});
+await corsair.twilio.api.calls.create({
+	To: 'example_to',
+	From: 'example_from',
+});
 ```
 
 

--- a/docs/plugins/twitter/overview.mdx
+++ b/docs/plugins/twitter/overview.mdx
@@ -115,7 +115,9 @@ _No read-style endpoint inferred; pick any operation from the reference below._
 **Write-style (write):** `tweets.create`
 
 ```ts
-await corsair.twitter.api.tweets.create({});
+await corsair.twitter.api.tweets.create({
+	text: 'example_text',
+});
 ```
 
 

--- a/docs/plugins/twitterapiio/overview.mdx
+++ b/docs/plugins/twitterapiio/overview.mdx
@@ -114,17 +114,23 @@ Synced entities support `corsair.twitterapiio.db.<entity>.search()` and `.list()
 
 ## Example API calls
 
-**Read-style (read):** `api.webhooks.getRules`
+**Read-style (read):** `communities.getById`
 
 ```ts
-await corsair.twitterapiio.api.api.webhooks.getRules({});
+await corsair.twitterapiio.api.communities.getById({
+	communityId: 'example_communityid',
+});
 ```
 
 
 **Write-style (write):** `api.webhooks.addRule`
 
 ```ts
-await corsair.twitterapiio.api.api.webhooks.addRule({});
+await corsair.twitterapiio.api.api.webhooks.addRule({
+	tag: 'example_tag',
+	value: 'example_value',
+	intervalSeconds: 1,
+});
 ```
 
 

--- a/docs/plugins/typeform/overview.mdx
+++ b/docs/plugins/typeform/overview.mdx
@@ -117,14 +117,18 @@ Synced entities support `corsair.typeform.db.<entity>.search()` and `.list()`. S
 **Read-style (read):** `forms.get`
 
 ```ts
-await corsair.typeform.api.forms.get({});
+await corsair.typeform.api.forms.get({
+	form_id: 'example_form_id',
+});
 ```
 
 
 **Write-style (write):** `forms.create`
 
 ```ts
-await corsair.typeform.api.forms.create({});
+await corsair.typeform.api.forms.create({
+	title: 'example_title',
+});
 ```
 
 

--- a/docs/plugins/vapi/overview.mdx
+++ b/docs/plugins/vapi/overview.mdx
@@ -117,14 +117,18 @@ Synced entities support `corsair.vapi.db.<entity>.search()` and `.list()`. See [
 **Read-style (read):** `assistants.get`
 
 ```ts
-await corsair.vapi.api.assistants.get({});
+await corsair.vapi.api.assistants.get({
+	id: 'example_id',
+});
 ```
 
 
-**Write-style (write):** `assistants.create`
+**Write-style (write):** `assistants.update`
 
 ```ts
-await corsair.vapi.api.assistants.create({});
+await corsair.vapi.api.assistants.update({
+	id: 'example_id',
+});
 ```
 
 

--- a/docs/plugins/vercel/overview.mdx
+++ b/docs/plugins/vercel/overview.mdx
@@ -106,23 +106,23 @@ Synced entities support `corsair.vercel.db.<entity>.search()` and `.list()`. See
 
 ## Example API calls
 
-**Read-style (read):** `projects.getProjects`
+**Read-style (read):** `deployments.getDeployment`
 
 ```ts
-await corsair.vercel.api.projects.getProjects({});
-```
-
-**Write-style (destructive):** `envs.createEnvVariable`
-
-```ts
-await corsair.vercel.api.envs.createEnvVariable({
-    idOrName: 'my-project',
-    key: 'MY_VAR',
-    value: 'secret_value',
-    type: 'secret',
-    target: ['production']
+await corsair.vercel.api.deployments.getDeployment({
+	idOrUrl: 'https://example.com',
 });
 ```
+
+
+**Write-style (write):** `deployments.createDeployment`
+
+```ts
+await corsair.vercel.api.deployments.createDeployment({
+	name: 'example_name',
+});
+```
+
 
 See the full list on the [API](/plugins/vercel/api) page. Use `pnpm corsair list --plugin=vercel` and `pnpm corsair schema <path>` locally to inspect schemas.
 

--- a/docs/plugins/xquik/overview.mdx
+++ b/docs/plugins/xquik/overview.mdx
@@ -114,17 +114,21 @@ Synced entities support `corsair.xquik.db.<entity>.search()` and `.list()`. See 
 
 ## Example API calls
 
-**Read-style (read):** `media.download`
+**Read-style (read):** `tweets.get`
 
 ```ts
-await corsair.xquik.api.media.download({});
+await corsair.xquik.api.tweets.get({
+	id: 'example_id',
+});
 ```
 
 
-**Write-style (write):** `media.uploadFromUrl`
+**Write-style (write):** `tweets.create`
 
 ```ts
-await corsair.xquik.api.media.uploadFromUrl({});
+await corsair.xquik.api.tweets.create({
+	account: 'example_account',
+});
 ```
 
 

--- a/docs/plugins/youtube/overview.mdx
+++ b/docs/plugins/youtube/overview.mdx
@@ -110,14 +110,19 @@ Synced entities support `corsair.youtube.db.<entity>.search()` and `.list()`. Se
 **Read-style (read):** `captions.list`
 
 ```ts
-await corsair.youtube.api.captions.list({});
+await corsair.youtube.api.captions.list({
+	video_id: 'example_video_id',
+});
 ```
 
 
 **Write-style (write):** `captions.update`
 
 ```ts
-await corsair.youtube.api.captions.update({});
+await corsair.youtube.api.captions.update({
+	id: 'example_id',
+	snippet: {},
+});
 ```
 
 

--- a/docs/plugins/zendesk/overview.mdx
+++ b/docs/plugins/zendesk/overview.mdx
@@ -110,14 +110,18 @@ Synced entities support `corsair.zendesk.db.<entity>.search()` and `.list()`. Se
 **Read-style (read):** `comments.list`
 
 ```ts
-await corsair.zendesk.api.comments.list({});
+await corsair.zendesk.api.comments.list({
+	ticket_id: 1,
+});
 ```
 
 
-**Write-style (write):** `tickets.create`
+**Write-style (write):** `tickets.update`
 
 ```ts
-await corsair.zendesk.api.tickets.create({});
+await corsair.zendesk.api.tickets.update({
+	id: 1,
+});
 ```
 
 

--- a/docs/plugins/zohomail/overview.mdx
+++ b/docs/plugins/zohomail/overview.mdx
@@ -129,14 +129,18 @@ Synced entities support `corsair.zohomail.db.<entity>.search()` and `.list()`. S
 **Read-style (read):** `folders.get`
 
 ```ts
-await corsair.zohomail.api.folders.get({});
+await corsair.zohomail.api.folders.get({
+	folderId: 'example_folderid',
+});
 ```
 
 
 **Write-style (write):** `folders.create`
 
 ```ts
-await corsair.zohomail.api.folders.create({});
+await corsair.zohomail.api.folders.create({
+	folderName: 'example_foldername',
+});
 ```
 
 

--- a/docs/plugins/zoom/overview.mdx
+++ b/docs/plugins/zoom/overview.mdx
@@ -114,17 +114,23 @@ Synced entities support `corsair.zoom.db.<entity>.search()` and `.list()`. See [
 
 ## Example API calls
 
-**Read-style (read):** `archiveFiles.list`
+**Read-style (read):** `meetings.get`
 
 ```ts
-await corsair.zoom.api.archiveFiles.list({});
+await corsair.zoom.api.meetings.get({
+	meetingId: 'example_meetingid',
+});
 ```
 
 
 **Write-style (write):** `meetings.addRegistrant`
 
 ```ts
-await corsair.zoom.api.meetings.addRegistrant({});
+await corsair.zoom.api.meetings.addRegistrant({
+	meetingId: 'example_meetingid',
+	email: 'user@example.com',
+	first_name: 'example_first_name',
+});
 ```
 
 

--- a/scripts/generate-plugin-docs.ts
+++ b/scripts/generate-plugin-docs.ts
@@ -23,9 +23,13 @@ import type {
 	DocSchemaShape,
 	DocsApiEndpoint,
 	DocsWebhook,
+	FormFieldSchema,
 	PluginDocsIntrospection,
 } from '../packages/corsair/core/inspect/index.ts';
-import { introspectPluginForDocs } from '../packages/corsair/core/inspect/index.ts';
+import {
+	getStructuredSchema,
+	introspectPluginForDocs,
+} from '../packages/corsair/core/inspect/index.ts';
 import type { CorsairPlugin } from '../packages/corsair/core/plugins/index.ts';
 
 /** Optional per-plugin overrides for the doc generator (next to package.json). */
@@ -328,17 +332,308 @@ function pluginDocData(
 	return { ...data, webhooks: [] };
 }
 
+function endpointMethodSegment(shortPath: string): string {
+	const i = shortPath.lastIndexOf('.');
+	return i === -1 ? shortPath : shortPath.slice(i + 1);
+}
+
+function endpointMethodMatches(
+	endpoint: DocsApiEndpoint,
+	pattern: RegExp,
+): boolean {
+	return pattern.test(endpointMethodSegment(endpoint.shortPath));
+}
+
+function endpointHasKnownInput(endpoint: DocsApiEndpoint): boolean {
+	return !(
+		endpoint.input.kind === 'inline' && endpoint.input.type === 'unknown'
+	);
+}
+
+function endpointHasRequiredInput(endpoint: DocsApiEndpoint): boolean {
+	if (endpoint.input.kind === 'inline') {
+		return endpoint.input.type !== '{}' && endpoint.input.type !== 'unknown';
+	}
+	return endpoint.input.fields.some((field) => !field.optional);
+}
+
 function pickExampleEndpoints(api: DocsApiEndpoint[]): {
 	read?: DocsApiEndpoint;
 	write?: DocsApiEndpoint;
 } {
+	const readMethods = api.filter((e) =>
+		endpointMethodMatches(e, /^(list|get|search)/i),
+	);
+	const safeWriteMethods = api.filter(
+		(e) =>
+			e.riskLevel === 'write' &&
+			endpointMethodMatches(e, /^(create|post|update|send|add|set|start)/i),
+	);
+	const writeMethods = api.filter(
+		(e) =>
+			(e.riskLevel === 'write' || e.riskLevel === 'destructive') &&
+			endpointMethodMatches(
+				e,
+				/^(create|post|update|send|add|set|start|delete)/i,
+			),
+	);
 	const read =
-		api.find((e) => e.riskLevel === 'read') ??
-		api.find((e) => /^(list|get|search)/i.test(e.shortPath));
+		readMethods.find(
+			(e) => e.riskLevel === 'read' && endpointHasRequiredInput(e),
+		) ??
+		readMethods.find((e) => endpointHasRequiredInput(e)) ??
+		readMethods.find(
+			(e) => e.riskLevel === 'read' && endpointHasKnownInput(e),
+		) ??
+		readMethods.find((e) => endpointHasKnownInput(e)) ??
+		api.find((e) => e.riskLevel === 'read' && endpointHasKnownInput(e));
 	const write =
-		api.find((e) => e.riskLevel === 'write' || e.riskLevel === 'destructive') ??
-		api.find((e) => /^(create|post|update|delete|send)/i.test(e.shortPath));
+		safeWriteMethods.find((e) => endpointHasRequiredInput(e)) ??
+		api.find((e) => e.riskLevel === 'write' && endpointHasRequiredInput(e)) ??
+		safeWriteMethods.find((e) => endpointHasKnownInput(e)) ??
+		api.find((e) => e.riskLevel === 'write' && endpointHasKnownInput(e)) ??
+		api.find(
+			(e) => e.riskLevel === 'destructive' && endpointHasRequiredInput(e),
+		) ??
+		api.find(
+			(e) => e.riskLevel === 'destructive' && endpointHasKnownInput(e),
+		) ??
+		writeMethods.find((e) => endpointHasRequiredInput(e)) ??
+		writeMethods.find((e) => endpointHasKnownInput(e));
 	return { read, write };
+}
+
+function codeObjectKey(key: string): string {
+	return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key) ? key : JSON.stringify(key);
+}
+
+function placeholderStringForKey(key: string): string {
+	const lower = key.toLowerCase();
+	if (lower.includes('channel')) return 'C0123456789';
+	if (lower.includes('user')) return 'U0123456789';
+	if (lower.includes('team')) return 'T0123456789';
+	if (lower.includes('email')) return 'user@example.com';
+	if (
+		lower.includes('url') ||
+		lower.includes('uri') ||
+		lower.includes('link')
+	) {
+		return 'https://example.com';
+	}
+	if (lower.includes('timezone') || lower.includes('time_zone')) {
+		return 'America/New_York';
+	}
+	if (lower.includes('date') || lower.includes('time') || lower === 'ts') {
+		return '2026-01-01T00:00:00Z';
+	}
+	if (lower === 'id' || lower.endsWith('_id') || lower.endsWith('id')) {
+		return `example_${lower.replace(/[^a-z0-9]+/g, '_')}`;
+	}
+	return `example_${lower.replace(/[^a-z0-9]+/g, '_')}`;
+}
+
+function quotedStringLiteral(value: string): string {
+	return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+function unknownPlaceholderForKey(key: string): string {
+	const lower = key.toLowerCase();
+	if (
+		lower.includes('field') ||
+		lower.includes('propert') ||
+		lower.includes('event') ||
+		lower.includes('snippet') ||
+		lower.includes('payload') ||
+		lower.includes('metadata') ||
+		lower.includes('data')
+	) {
+		return '{}';
+	}
+	return quotedStringLiteral(placeholderStringForKey(key));
+}
+
+function fieldEntriesForExampleObject(
+	fields: Record<string, FormFieldSchema>,
+	parentKey: string,
+	description: string | undefined,
+): [string, FormFieldSchema][] {
+	const requiredFields = Object.entries(fields).filter(
+		([, field]) => !field.optional,
+	);
+	if (requiredFields.length > 0) {
+		return requiredFields;
+	}
+
+	const lowerParentKey = parentKey.toLowerCase();
+	if (
+		lowerParentKey === 'start' ||
+		lowerParentKey === 'end' ||
+		lowerParentKey === 'originalstarttime'
+	) {
+		const key = fields.dateTime ? 'dateTime' : fields.date ? 'date' : undefined;
+		return key ? [[key, fields[key]!]] : [];
+	}
+	if (lowerParentKey.includes('attendee') && fields.email) {
+		return [['email', fields.email]];
+	}
+
+	const hintKeys: string[] = [];
+	for (const match of description?.matchAll(/["`]([^"`]+)["`]/g) ?? []) {
+		const key = match[1];
+		if (key && fields[key] && !hintKeys.includes(key)) {
+			hintKeys.push(key);
+		}
+	}
+
+	return hintKeys.map((key) => [key, fields[key]!]);
+}
+
+function placeholderValueForFormField(
+	field: FormFieldSchema,
+	key: string,
+	depth = 0,
+	parentDescription?: string,
+): string {
+	switch (field.kind) {
+		case 'string':
+			return quotedStringLiteral(
+				field.enum?.[0] ?? placeholderStringForKey(key),
+			);
+		case 'number':
+			return '1';
+		case 'boolean':
+			return 'true';
+		case 'literal':
+			return typeof field.value === 'string'
+				? quotedStringLiteral(field.value)
+				: JSON.stringify(field.value);
+		case 'object':
+			return exampleInputObjectFromFormFields(
+				field.fields,
+				depth,
+				key,
+				field.description ?? parentDescription,
+			);
+		case 'array':
+			return `[${placeholderValueForFormField(
+				field.items,
+				key,
+				depth,
+				field.description,
+			)}]`;
+		case 'unknown':
+			return unknownPlaceholderForKey(key);
+	}
+}
+
+function exampleInputObjectFromFormFields(
+	fields: Record<string, FormFieldSchema>,
+	depth = 0,
+	parentKey = 'input',
+	description?: string,
+): string {
+	const exampleFields = fieldEntriesForExampleObject(
+		fields,
+		parentKey,
+		description,
+	);
+	if (exampleFields.length === 0) return '{}';
+	const pad = '\t'.repeat(depth + 1);
+	const closePad = '\t'.repeat(depth);
+	const rows = exampleFields.map(
+		([key, field]) =>
+			`${pad}${codeObjectKey(key)}: ${placeholderValueForFormField(
+				field,
+				key,
+				depth + 1,
+			)},`,
+	);
+	return `{\n${rows.join('\n')}\n${closePad}}`;
+}
+
+function exampleInputObjectFromFormField(
+	field: FormFieldSchema | null,
+): string {
+	if (field === null) return '{}';
+	if (field.kind === 'object') {
+		return exampleInputObjectFromFormFields(field.fields);
+	}
+	return placeholderValueForFormField(field, 'input');
+}
+
+function placeholderValueForType(type: string, key: string): string {
+	const t = type.trim();
+	if (t.endsWith('[]')) {
+		const itemType = t.slice(0, -2).trim();
+		return `[${placeholderValueForType(itemType, key)}]`;
+	}
+	if (t.startsWith('{')) return '{}';
+	if (t === 'Date') return 'new Date()';
+	if (/\bboolean\b/.test(t)) return 'true';
+	if (/\bnumber\b/.test(t)) return '1';
+	if (/\bstring\b/.test(t))
+		return quotedStringLiteral(placeholderStringForKey(key));
+	if (t.includes('|')) {
+		const first = t
+			.split('|')
+			.map((part) => part.trim())
+			.find((part) => part !== 'null' && part !== 'undefined');
+		if (first) {
+			if (first === 'true' || first === 'false') return first;
+			if (/^-?\d+(\.\d+)?$/.test(first)) return first;
+			return quotedStringLiteral(first.replace(/^['"]|['"]$/g, ''));
+		}
+	}
+	if (t === 'null') return 'null';
+	return quotedStringLiteral(placeholderStringForKey(key));
+}
+
+function exampleInputObjectFromDocShape(shape: DocSchemaShape): string {
+	if (shape.kind === 'inline') {
+		return shape.type === '{}'
+			? '{}'
+			: placeholderValueForType(shape.type, 'input');
+	}
+	const requiredFields = shape.fields.filter((f) => !f.optional);
+	if (requiredFields.length === 0) return '{}';
+	const rows = requiredFields.map(
+		(f) =>
+			`\t${codeObjectKey(f.key)}: ${placeholderValueForType(f.type, f.key)},`,
+	);
+	return `{\n${rows.join('\n')}\n}`;
+}
+
+function exampleInputObject(
+	endpoint: DocsApiEndpoint,
+	exampleInputsByPath: ReadonlyMap<string, FormFieldSchema>,
+): string {
+	const structuredInput = exampleInputsByPath.get(endpoint.path);
+	if (structuredInput) {
+		return exampleInputObjectFromFormField(structuredInput);
+	}
+	return exampleInputObjectFromDocShape(endpoint.input);
+}
+
+function exampleApiCall(
+	pluginId: string,
+	endpoint: DocsApiEndpoint,
+	exampleInputsByPath: ReadonlyMap<string, FormFieldSchema>,
+): string {
+	return `\`\`\`ts
+await corsair.${pluginId}.api.${endpoint.shortPath}(${exampleInputObject(endpoint, exampleInputsByPath)});
+\`\`\`
+`;
+}
+
+function destructiveExampleWarning(endpoint: DocsApiEndpoint): string {
+	if (endpoint.riskLevel !== 'destructive' && endpoint.irreversible !== true) {
+		return '';
+	}
+	return `<Warning>
+This example can modify or delete provider data. Confirm credentials, permissions, and approval hooks before running it. See [Permissions](/concepts/permissions) and [Hooks](/concepts/hooks).
+</Warning>
+
+`;
 }
 
 function buildMainMdx(opts: {
@@ -348,6 +643,7 @@ function buildMainMdx(opts: {
 	npmPackageName: string;
 	frontmatterDescription: string;
 	data: PluginDocsIntrospection;
+	exampleInputsByPath: ReadonlyMap<string, FormFieldSchema>;
 	authTypes: string[];
 	defaultAuthType: string | undefined;
 	overviewNote?: string;
@@ -359,6 +655,7 @@ function buildMainMdx(opts: {
 		npmPackageName,
 		frontmatterDescription,
 		data,
+		exampleInputsByPath,
 		authTypes,
 		defaultAuthType,
 		overviewNote,
@@ -446,17 +743,11 @@ Synced entities support \`corsair.${pluginId}.db.<entity>.search()\` and \`.list
 `;
 
 	const exampleRead = exRead
-		? `\`\`\`ts
-await corsair.${pluginId}.api.${exRead.shortPath}({});
-\`\`\`
-`
+		? exampleApiCall(pluginId, exRead, exampleInputsByPath)
 		: '_No read-style endpoint inferred; pick any operation from the reference below._\n';
 
 	const exampleWrite = exWrite
-		? `\`\`\`ts
-await corsair.${pluginId}.api.${exWrite.shortPath}({});
-\`\`\`
-`
+		? `${destructiveExampleWarning(exWrite)}${exampleApiCall(pluginId, exWrite, exampleInputsByPath)}`
 		: '_No write-style endpoint inferred; pick any operation from the reference below._\n';
 
 	return `---
@@ -1219,6 +1510,13 @@ async function generatePluginDocsForEntry(
 	}
 	const { data } = result;
 	const docData = pluginDocData(data, pluginId);
+	const exampleInputsByPath = new Map<string, FormFieldSchema>();
+	for (const endpoint of docData.api) {
+		const structuredInput = getStructuredSchema([plugin], endpoint.path)?.input;
+		if (structuredInput) {
+			exampleInputsByPath.set(endpoint.path, structuredInput);
+		}
+	}
 
 	const outDir = join(docsRoot(root), pluginId);
 	mkdirSync(outDir, { recursive: true });
@@ -1242,6 +1540,7 @@ async function generatePluginDocsForEntry(
 				npmPackageName: pkgMeta.npmName,
 				frontmatterDescription,
 				data: docData,
+				exampleInputsByPath,
 				authTypes,
 				defaultAuthType,
 				overviewNote: docsConfig.overviewNote?.trim(),


### PR DESCRIPTION
## Description

Fixes #299.

This updates the plugin docs generator so overview examples are safer and more useful:

- Generate example API call arguments from structured input schemas, including nested required or hinted body fields.
- Prefer read examples with real inputs and write examples that are not destructive when safer write operations exist.
- Avoid showing read-only endpoints as `Write-style` examples.
- Add a warning wrapper when a destructive or irreversible endpoint must be shown.
- Regenerate existing plugin overview `Example API calls` blocks while preserving the rest of each overview page.

## Validation

- `pnpm generate:docs -- --all`
- custom schema-aware overview check: no examples use `{}` for operations with required input, and no read-only endpoint is shown as `Write-style`
- `git diff --check`
- `pnpm exec biome check scripts/generate-plugin-docs.ts`
- `pnpm typecheck`
- `pnpm --filter corsair build`

## Notes

Known pre-existing repository-level failures observed during validation:

- `pnpm lint` fails in unrelated `www/` files and on the existing large `explorer/data/plugins.json`.
- `pnpm run validate:plugins` fails because the existing `agentql` package is missing Jest/test configuration and test files.
