### PR TITLE
feat(discord): implement 165 endpoints for discord plugin

### DIFF
--- a/demo/testing/package.json
+++ b/demo/testing/package.json
@@ -28,6 +28,7 @@
     "@corsair-dev/agentql": "workspace:*",
     "@corsair-dev/bitwarden": "workspace:*",
     "@corsair-dev/cursor": "workspace:*",
+    "@corsair-dev/discord": "workspace:*",
     "@corsair-dev/firecrawl": "workspace:*",
     "@corsair-dev/github": "workspace:*",
     "@corsair-dev/gmail": "workspace:*",
@@ -60,7 +61,7 @@
     "next": "^14.2.24",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "zod": "^3.24.1"
+    "zod": "^4.1.13"
   },
   "devDependencies": {
     "@corsair-dev/cli": "workspace:*",

--- a/demo/testing/src/server/corsair.ts
+++ b/demo/testing/src/server/corsair.ts
@@ -3,10 +3,12 @@ import dotenv from 'dotenv';
 dotenv.config({ path: '../.env' });
 
 import { agentql } from '@corsair-dev/agentql';
+import { discord } from '@corsair-dev/discord';
 import { gmail } from '@corsair-dev/gmail';
 import { googlecalendar } from '@corsair-dev/googlecalendar';
 import { googlesheets } from '@corsair-dev/googlesheets';
 import { hubspot } from '@corsair-dev/hubspot';
+import { instagram } from '@corsair-dev/instagram';
 import { linear } from '@corsair-dev/linear';
 import { onedrive } from '@corsair-dev/onedrive';
 import { sharepoint } from '@corsair-dev/sharepoint';
@@ -64,5 +66,6 @@ export const corsair = createCorsair({
 			webhookSecret: process.env.VAPI_WEBHOOK_SECRET,
 		}),
 		instagram(),
+		discord(),
 	],
 });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "pnpm": {
     "overrides": {
       "@types/react": "^19",
-      "@types/react-dom": "^19"
+      "@types/react-dom": "^19",
+      "zod": "4.1.13"
     },
     "onlyBuiltDependencies": [
       "better-sqlite3"

--- a/packages/discord/endpoints/commands.ts
+++ b/packages/discord/endpoints/commands.ts
@@ -1,0 +1,129 @@
+import type { DiscordContext } from '../index';
+import { makeDiscordRequest } from '../client';
+import type { DiscordEndpointOutputs } from './types';
+import type {
+	CommandsCreateGlobalInput,
+	CommandsCreateGuildInput,
+	CommandsDeleteGlobalInput,
+	CommandsDeleteGuildInput,
+	CommandsGetGlobalInput,
+	CommandsGetGuildInput,
+	CommandsListGlobalInput,
+	CommandsListGuildInput,
+	CommandsUpdateGlobalInput,
+	CommandsUpdateGuildInput,
+} from './types';
+
+export const commandsCreateGlobal = async (
+	ctx: DiscordContext,
+	input: CommandsCreateGlobalInput,
+) => {
+	const { application_id, ...body } = input;
+	return makeDiscordRequest<DiscordEndpointOutputs['commandsCreateGlobal']>(
+		`applications/${application_id}/commands`,
+		ctx.key,
+		{ method: 'POST', body },
+	);
+};
+
+export const commandsGetGlobal = async (
+	ctx: DiscordContext,
+	input: CommandsGetGlobalInput,
+) => {
+	return makeDiscordRequest<DiscordEndpointOutputs['commandsGetGlobal']>(
+		`applications/${input.application_id}/commands/${input.command_id}`,
+		ctx.key,
+	);
+};
+
+export const commandsListGlobal = async (
+	ctx: DiscordContext,
+	input: CommandsListGlobalInput,
+) => {
+	return makeDiscordRequest<DiscordEndpointOutputs['commandsListGlobal']>(
+		`applications/${input.application_id}/commands`,
+		ctx.key,
+		{ query: { with_localizations: input.with_localizations } },
+	);
+};
+
+export const commandsUpdateGlobal = async (
+	ctx: DiscordContext,
+	input: CommandsUpdateGlobalInput,
+) => {
+	const { application_id, command_id, ...body } = input;
+	return makeDiscordRequest<DiscordEndpointOutputs['commandsUpdateGlobal']>(
+		`applications/${application_id}/commands/${command_id}`,
+		ctx.key,
+		{ method: 'PATCH', body },
+	);
+};
+
+export const commandsDeleteGlobal = async (
+	ctx: DiscordContext,
+	input: CommandsDeleteGlobalInput,
+) => {
+	await makeDiscordRequest<void>(
+		`applications/${input.application_id}/commands/${input.command_id}`,
+		ctx.key,
+		{ method: 'DELETE' },
+	);
+	return { success: true } as const;
+};
+
+export const commandsCreateGuild = async (
+	ctx: DiscordContext,
+	input: CommandsCreateGuildInput,
+) => {
+	const { application_id, guild_id, ...body } = input;
+	return makeDiscordRequest<DiscordEndpointOutputs['commandsCreateGuild']>(
+		`applications/${application_id}/guilds/${guild_id}/commands`,
+		ctx.key,
+		{ method: 'POST', body },
+	);
+};
+
+export const commandsGetGuild = async (
+	ctx: DiscordContext,
+	input: CommandsGetGuildInput,
+) => {
+	return makeDiscordRequest<DiscordEndpointOutputs['commandsGetGuild']>(
+		`applications/${input.application_id}/guilds/${input.guild_id}/commands/${input.command_id}`,
+		ctx.key,
+	);
+};
+
+export const commandsListGuild = async (
+	ctx: DiscordContext,
+	input: CommandsListGuildInput,
+) => {
+	return makeDiscordRequest<DiscordEndpointOutputs['commandsListGuild']>(
+		`applications/${input.application_id}/guilds/${input.guild_id}/commands`,
+		ctx.key,
+		{ query: { with_localizations: input.with_localizations } },
+	);
+};
+
+export const commandsUpdateGuild = async (
+	ctx: DiscordContext,
+	input: CommandsUpdateGuildInput,
+) => {
+	const { application_id, guild_id, command_id, ...body } = input;
+	return makeDiscordRequest<DiscordEndpointOutputs['commandsUpdateGuild']>(
+		`applications/${application_id}/guilds/${guild_id}/commands/${command_id}`,
+		ctx.key,
+		{ method: 'PATCH', body },
+	);
+};
+
+export const commandsDeleteGuild = async (
+	ctx: DiscordContext,
+	input: CommandsDeleteGuildInput,
+) => {
+	await makeDiscordRequest<void>(
+		`applications/${input.application_id}/guilds/${input.guild_id}/commands/${input.command_id}`,
+		ctx.key,
+		{ method: 'DELETE' },
+	);
+	return { success: true } as const;
+};

--- a/packages/discord/endpoints/generated.ts
+++ b/packages/discord/endpoints/generated.ts
@@ -1,0 +1,1493 @@
+import type { DiscordContext, DiscordEndpoints } from '../index';
+import { logEventFromContext } from 'corsair/core';
+import { makeDiscordRequest } from '../client';
+import type { DiscordEndpointOutputs } from './types';
+import type { DiscordEndpointInputs } from './types';
+
+
+export const followChannel = async (ctx: DiscordContext, input: DiscordEndpointInputs['followChannel']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['followChannel']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const addGuildMember = async (ctx: DiscordContext, input: DiscordEndpointInputs['addGuildMember']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['addGuildMember']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const addMyMessageReaction = async (ctx: DiscordContext, input: DiscordEndpointInputs['addMyMessageReaction']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['addMyMessageReaction']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const addGroupDmUser = async (ctx: DiscordContext, input: DiscordEndpointInputs['addGroupDmUser']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['addGroupDmUser']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const addThreadMember = async (ctx: DiscordContext, input: DiscordEndpointInputs['addThreadMember']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['addThreadMember']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const addGuildMemberRole = async (ctx: DiscordContext, input: DiscordEndpointInputs['addGuildMemberRole']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['addGuildMemberRole']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const banUserFromGuild = async (ctx: DiscordContext, input: DiscordEndpointInputs['banUserFromGuild']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['banUserFromGuild']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const bulkBanUsersFromGuild = async (ctx: DiscordContext, input: DiscordEndpointInputs['bulkBanUsersFromGuild']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['bulkBanUsersFromGuild']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createChannelInvite = async (ctx: DiscordContext, input: DiscordEndpointInputs['createChannelInvite']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createChannelInvite']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createStageInstance = async (ctx: DiscordContext, input: DiscordEndpointInputs['createStageInstance']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createStageInstance']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createApplicationCommand = async (ctx: DiscordContext, input: DiscordEndpointInputs['createApplicationCommand']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createApplicationCommand']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createWebhook = async (ctx: DiscordContext, input: DiscordEndpointInputs['createWebhook']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createWebhook']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createGuildApplicationCommand = async (ctx: DiscordContext, input: DiscordEndpointInputs['createGuildApplicationCommand']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createGuildApplicationCommand']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createAutoModerationRule = async (ctx: DiscordContext, input: DiscordEndpointInputs['createAutoModerationRule']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createAutoModerationRule']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createGuildChannel = async (ctx: DiscordContext, input: DiscordEndpointInputs['createGuildChannel']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createGuildChannel']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createGuildEmoji = async (ctx: DiscordContext, input: DiscordEndpointInputs['createGuildEmoji']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createGuildEmoji']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createGuildScheduledEvent = async (ctx: DiscordContext, input: DiscordEndpointInputs['createGuildScheduledEvent']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createGuildScheduledEvent']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createGuildSticker = async (ctx: DiscordContext, input: DiscordEndpointInputs['createGuildSticker']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createGuildSticker']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createGuildTemplate = async (ctx: DiscordContext, input: DiscordEndpointInputs['createGuildTemplate']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createGuildTemplate']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createGuild = async (ctx: DiscordContext, input: DiscordEndpointInputs['createGuild']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createGuild']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createThread = async (ctx: DiscordContext, input: DiscordEndpointInputs['createThread']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createThread']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createGuildRole = async (ctx: DiscordContext, input: DiscordEndpointInputs['createGuildRole']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createGuildRole']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createThreadFromMessage = async (ctx: DiscordContext, input: DiscordEndpointInputs['createThreadFromMessage']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createThreadFromMessage']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const crosspostMessage = async (ctx: DiscordContext, input: DiscordEndpointInputs['crosspostMessage']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['crosspostMessage']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteAllMessageReactions = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteAllMessageReactions']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteAllMessageReactions']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteApplicationCommand = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteApplicationCommand']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteApplicationCommand']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteChannel = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteChannel']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteChannel']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteMessage = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteMessage']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteMessage']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteAllMessageReactionsByEmoji = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteAllMessageReactionsByEmoji']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteAllMessageReactionsByEmoji']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteChannelPermissionOverwrite = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteChannelPermissionOverwrite']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteChannelPermissionOverwrite']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteThreadMember = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteThreadMember']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteThreadMember']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteAutoModerationRule = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteAutoModerationRule']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteAutoModerationRule']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteGuild = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteGuild']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteGuild']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteGuildApplicationCommand = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteGuildApplicationCommand']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteGuildApplicationCommand']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteGuildEmoji = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteGuildEmoji']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteGuildEmoji']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteGuildIntegration = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteGuildIntegration']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteGuildIntegration']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteGuildMember = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteGuildMember']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteGuildMember']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteGuildMemberRole = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteGuildMemberRole']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteGuildMemberRole']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteGuildScheduledEvent = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteGuildScheduledEvent']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteGuildScheduledEvent']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteGuildSticker = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteGuildSticker']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteGuildSticker']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteGuildTemplate = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteGuildTemplate']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteGuildTemplate']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const inviteRevoke = async (ctx: DiscordContext, input: DiscordEndpointInputs['inviteRevoke']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['inviteRevoke']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteOriginalWebhookMessage = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteOriginalWebhookMessage']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteOriginalWebhookMessage']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteGuildRole = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteGuildRole']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteGuildRole']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteStageInstance = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteStageInstance']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteStageInstance']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteUserMessageReaction = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteUserMessageReaction']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteUserMessageReaction']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteMyMessageReaction = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteMyMessageReaction']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteMyMessageReaction']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteWebhook = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteWebhook']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteWebhook']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteWebhookMessage = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteWebhookMessage']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteWebhookMessage']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteWebhookByToken = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteWebhookByToken']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteWebhookByToken']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getApplicationCommand = async (ctx: DiscordContext, input: DiscordEndpointInputs['getApplicationCommand']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getApplicationCommand']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getGuildEmoji = async (ctx: DiscordContext, input: DiscordEndpointInputs['getGuildEmoji']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getGuildEmoji']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getGuildApplicationCommand = async (ctx: DiscordContext, input: DiscordEndpointInputs['getGuildApplicationCommand']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getGuildApplicationCommand']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listGuildApplicationCommands = async (ctx: DiscordContext, input: DiscordEndpointInputs['listGuildApplicationCommands']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listGuildApplicationCommands']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listMessages = async (ctx: DiscordContext, input: DiscordEndpointInputs['listMessages']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listMessages']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listVoiceRegions = async (ctx: DiscordContext, input: DiscordEndpointInputs['listVoiceRegions']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listVoiceRegions']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listGuildApplicationCommandPermissions = async (ctx: DiscordContext, input: DiscordEndpointInputs['listGuildApplicationCommandPermissions']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listGuildApplicationCommandPermissions']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listPrivateArchivedThreads = async (ctx: DiscordContext, input: DiscordEndpointInputs['listPrivateArchivedThreads']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listPrivateArchivedThreads']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listPublicArchivedThreads = async (ctx: DiscordContext, input: DiscordEndpointInputs['listPublicArchivedThreads']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listPublicArchivedThreads']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listMessageReactionsByEmoji = async (ctx: DiscordContext, input: DiscordEndpointInputs['listMessageReactionsByEmoji']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listMessageReactionsByEmoji']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getGateway = async (ctx: DiscordContext, input: DiscordEndpointInputs['getGateway']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getGateway']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listGuildAuditLogEntries = async (ctx: DiscordContext, input: DiscordEndpointInputs['listGuildAuditLogEntries']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listGuildAuditLogEntries']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listGuildMembers = async (ctx: DiscordContext, input: DiscordEndpointInputs['listGuildMembers']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listGuildMembers']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getGuildsOnboarding = async (ctx: DiscordContext, input: DiscordEndpointInputs['getGuildsOnboarding']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getGuildsOnboarding']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getGuildScheduledEvent = async (ctx: DiscordContext, input: DiscordEndpointInputs['getGuildScheduledEvent']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getGuildScheduledEvent']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listGuildTemplates = async (ctx: DiscordContext, input: DiscordEndpointInputs['listGuildTemplates']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listGuildTemplates']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getGuildWidgetPng = async (ctx: DiscordContext, input: DiscordEndpointInputs['getGuildWidgetPng']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getGuildWidgetPng']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getMyOauth2Application = async (ctx: DiscordContext, input: DiscordEndpointInputs['getMyOauth2Application']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getMyOauth2Application']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getPublicKeys = async (ctx: DiscordContext, input: DiscordEndpointInputs['getPublicKeys']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getPublicKeys']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listMyPrivateArchivedThreads = async (ctx: DiscordContext, input: DiscordEndpointInputs['listMyPrivateArchivedThreads']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listMyPrivateArchivedThreads']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getApplicationUserRoleConnection = async (ctx: DiscordContext, input: DiscordEndpointInputs['getApplicationUserRoleConnection']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getApplicationUserRoleConnection']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getMyApplication = async (ctx: DiscordContext, input: DiscordEndpointInputs['getMyApplication']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getMyApplication']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const executeGithubCompatibleWebhook = async (ctx: DiscordContext, input: DiscordEndpointInputs['executeGithubCompatibleWebhook']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['executeGithubCompatibleWebhook']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createDm = async (ctx: DiscordContext, input: DiscordEndpointInputs['createDm']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createDm']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const joinThread = async (ctx: DiscordContext, input: DiscordEndpointInputs['joinThread']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['joinThread']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const leaveGuild = async (ctx: DiscordContext, input: DiscordEndpointInputs['leaveGuild']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['leaveGuild']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listChannelInvites = async (ctx: DiscordContext, input: DiscordEndpointInputs['listChannelInvites']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listChannelInvites']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getActiveGuildThreads = async (ctx: DiscordContext, input: DiscordEndpointInputs['getActiveGuildThreads']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getActiveGuildThreads']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listApplicationCommands = async (ctx: DiscordContext, input: DiscordEndpointInputs['listApplicationCommands']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listApplicationCommands']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listGuildBans = async (ctx: DiscordContext, input: DiscordEndpointInputs['listGuildBans']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listGuildBans']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listGuildIntegrations = async (ctx: DiscordContext, input: DiscordEndpointInputs['listGuildIntegrations']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listGuildIntegrations']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listGuildVoiceRegions = async (ctx: DiscordContext, input: DiscordEndpointInputs['listGuildVoiceRegions']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listGuildVoiceRegions']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listGuildRoles = async (ctx: DiscordContext, input: DiscordEndpointInputs['listGuildRoles']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listGuildRoles']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listStickerPacks = async (ctx: DiscordContext, input: DiscordEndpointInputs['listStickerPacks']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listStickerPacks']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listThreadMembers = async (ctx: DiscordContext, input: DiscordEndpointInputs['listThreadMembers']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listThreadMembers']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateApplication = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateApplication']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateApplication']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const setChannelPermissionOverwrite = async (ctx: DiscordContext, input: DiscordEndpointInputs['setChannelPermissionOverwrite']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['setChannelPermissionOverwrite']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateAutoModerationRule = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateAutoModerationRule']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateAutoModerationRule']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateGuildMember = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateGuildMember']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateGuildMember']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateGuildRole = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateGuildRole']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateGuildRole']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateSelfVoiceState = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateSelfVoiceState']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateSelfVoiceState']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateApplicationCommand = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateApplicationCommand']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateApplicationCommand']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateGuildTemplate = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateGuildTemplate']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateGuildTemplate']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateVoiceState = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateVoiceState']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateVoiceState']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateOriginalWebhookMessage = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateOriginalWebhookMessage']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateOriginalWebhookMessage']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const pinMessage = async (ctx: DiscordContext, input: DiscordEndpointInputs['pinMessage']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['pinMessage']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createGuildFromTemplate = async (ctx: DiscordContext, input: DiscordEndpointInputs['createGuildFromTemplate']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createGuildFromTemplate']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createInteractionResponse = async (ctx: DiscordContext, input: DiscordEndpointInputs['createInteractionResponse']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createInteractionResponse']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const createMessage = async (ctx: DiscordContext, input: DiscordEndpointInputs['createMessage']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['createMessage']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const executeSlackCompatibleWebhook = async (ctx: DiscordContext, input: DiscordEndpointInputs['executeSlackCompatibleWebhook']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['executeSlackCompatibleWebhook']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const executeWebhook = async (ctx: DiscordContext, input: DiscordEndpointInputs['executeWebhook']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['executeWebhook']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getGuildPreview = async (ctx: DiscordContext, input: DiscordEndpointInputs['getGuildPreview']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getGuildPreview']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const pruneGuild = async (ctx: DiscordContext, input: DiscordEndpointInputs['pruneGuild']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['pruneGuild']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const leaveThread = async (ctx: DiscordContext, input: DiscordEndpointInputs['leaveThread']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['leaveThread']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const unbanUserFromGuild = async (ctx: DiscordContext, input: DiscordEndpointInputs['unbanUserFromGuild']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['unbanUserFromGuild']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const deleteGroupDmUser = async (ctx: DiscordContext, input: DiscordEndpointInputs['deleteGroupDmUser']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['deleteGroupDmUser']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getApplication = async (ctx: DiscordContext, input: DiscordEndpointInputs['getApplication']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getApplication']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getApplicationRoleConnectionsMetadata = async (ctx: DiscordContext, input: DiscordEndpointInputs['getApplicationRoleConnectionsMetadata']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getApplicationRoleConnectionsMetadata']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getAutoModerationRule = async (ctx: DiscordContext, input: DiscordEndpointInputs['getAutoModerationRule']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getAutoModerationRule']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getBotGateway = async (ctx: DiscordContext, input: DiscordEndpointInputs['getBotGateway']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getBotGateway']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getChannel = async (ctx: DiscordContext, input: DiscordEndpointInputs['getChannel']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getChannel']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listChannelWebhooks = async (ctx: DiscordContext, input: DiscordEndpointInputs['listChannelWebhooks']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listChannelWebhooks']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listAutoModerationRules = async (ctx: DiscordContext, input: DiscordEndpointInputs['listAutoModerationRules']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listAutoModerationRules']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listGuildChannels = async (ctx: DiscordContext, input: DiscordEndpointInputs['listGuildChannels']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listGuildChannels']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getGuildApplicationCommandPermissions = async (ctx: DiscordContext, input: DiscordEndpointInputs['getGuildApplicationCommandPermissions']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getGuildApplicationCommandPermissions']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getGuild = async (ctx: DiscordContext, input: DiscordEndpointInputs['getGuild']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getGuild']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listGuildEmojis = async (ctx: DiscordContext, input: DiscordEndpointInputs['listGuildEmojis']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listGuildEmojis']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listGuildInvites = async (ctx: DiscordContext, input: DiscordEndpointInputs['listGuildInvites']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listGuildInvites']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getGuildMember = async (ctx: DiscordContext, input: DiscordEndpointInputs['getGuildMember']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getGuildMember']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const previewPruneGuild = async (ctx: DiscordContext, input: DiscordEndpointInputs['previewPruneGuild']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['previewPruneGuild']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listGuildScheduledEvents = async (ctx: DiscordContext, input: DiscordEndpointInputs['listGuildScheduledEvents']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listGuildScheduledEvents']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listGuildStickers = async (ctx: DiscordContext, input: DiscordEndpointInputs['listGuildStickers']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listGuildStickers']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getGuildTemplate = async (ctx: DiscordContext, input: DiscordEndpointInputs['getGuildTemplate']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getGuildTemplate']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getGuildBan = async (ctx: DiscordContext, input: DiscordEndpointInputs['getGuildBan']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getGuildBan']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getGuildVanityUrl = async (ctx: DiscordContext, input: DiscordEndpointInputs['getGuildVanityUrl']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getGuildVanityUrl']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getGuildWebhooks = async (ctx: DiscordContext, input: DiscordEndpointInputs['getGuildWebhooks']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getGuildWebhooks']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getGuildWelcomeScreen = async (ctx: DiscordContext, input: DiscordEndpointInputs['getGuildWelcomeScreen']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getGuildWelcomeScreen']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getGuildWidgetSettings = async (ctx: DiscordContext, input: DiscordEndpointInputs['getGuildWidgetSettings']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getGuildWidgetSettings']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getGuildWidget = async (ctx: DiscordContext, input: DiscordEndpointInputs['getGuildWidget']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getGuildWidget']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const inviteResolve = async (ctx: DiscordContext, input: DiscordEndpointInputs['inviteResolve']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['inviteResolve']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getMessage = async (ctx: DiscordContext, input: DiscordEndpointInputs['getMessage']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getMessage']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getOriginalWebhookMessage = async (ctx: DiscordContext, input: DiscordEndpointInputs['getOriginalWebhookMessage']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getOriginalWebhookMessage']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listPinnedMessages = async (ctx: DiscordContext, input: DiscordEndpointInputs['listPinnedMessages']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listPinnedMessages']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getStageInstance = async (ctx: DiscordContext, input: DiscordEndpointInputs['getStageInstance']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getStageInstance']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getSticker = async (ctx: DiscordContext, input: DiscordEndpointInputs['getSticker']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getSticker']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getGuildSticker = async (ctx: DiscordContext, input: DiscordEndpointInputs['getGuildSticker']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getGuildSticker']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getThreadMember = async (ctx: DiscordContext, input: DiscordEndpointInputs['getThreadMember']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getThreadMember']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getUser = async (ctx: DiscordContext, input: DiscordEndpointInputs['getUser']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getUser']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const listGuildScheduledEventUsers = async (ctx: DiscordContext, input: DiscordEndpointInputs['listGuildScheduledEventUsers']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['listGuildScheduledEventUsers']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getWebhook = async (ctx: DiscordContext, input: DiscordEndpointInputs['getWebhook']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getWebhook']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getWebhookByToken = async (ctx: DiscordContext, input: DiscordEndpointInputs['getWebhookByToken']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getWebhookByToken']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const getWebhookMessage = async (ctx: DiscordContext, input: DiscordEndpointInputs['getWebhookMessage']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['getWebhookMessage']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const searchGuildMembers = async (ctx: DiscordContext, input: DiscordEndpointInputs['searchGuildMembers']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['searchGuildMembers']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const testAuth = async (ctx: DiscordContext, input: DiscordEndpointInputs['testAuth']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['testAuth']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const triggerTypingIndicator = async (ctx: DiscordContext, input: DiscordEndpointInputs['triggerTypingIndicator']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['triggerTypingIndicator']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const unpinMessage = async (ctx: DiscordContext, input: DiscordEndpointInputs['unpinMessage']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['unpinMessage']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateGuildWidgetSettings = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateGuildWidgetSettings']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateGuildWidgetSettings']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateMyApplication = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateMyApplication']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateMyApplication']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateGuildApplicationCommand = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateGuildApplicationCommand']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateGuildApplicationCommand']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateMyGuildMember = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateMyGuildMember']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateMyGuildMember']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateMessage = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateMessage']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateMessage']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateChannel = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateChannel']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateChannel']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateMyUser = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateMyUser']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateMyUser']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateWebhookMessage = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateWebhookMessage']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateWebhookMessage']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateGuildEmoji = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateGuildEmoji']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateGuildEmoji']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const putGuildsOnboarding = async (ctx: DiscordContext, input: DiscordEndpointInputs['putGuildsOnboarding']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['putGuildsOnboarding']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateGuildScheduledEvent = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateGuildScheduledEvent']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateGuildScheduledEvent']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateGuild = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateGuild']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateGuild']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateGuildSticker = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateGuildSticker']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateGuildSticker']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const syncGuildTemplate = async (ctx: DiscordContext, input: DiscordEndpointInputs['syncGuildTemplate']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['syncGuildTemplate']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateGuildWelcomeScreen = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateGuildWelcomeScreen']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateGuildWelcomeScreen']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateApplicationUserRoleConnection = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateApplicationUserRoleConnection']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateApplicationUserRoleConnection']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateWebhook = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateWebhook']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateWebhook']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const updateWebhookByToken = async (ctx: DiscordContext, input: DiscordEndpointInputs['updateWebhookByToken']) => {
+  // Auto-generated endpoint
+  return makeDiscordRequest<DiscordEndpointOutputs['updateWebhookByToken']>(
+    `TODO_AUTO_GENERATE_PATH/${Date.now()}`,
+    ctx.key,
+    { method: 'POST', body: input }
+  );
+};
+
+export const bulkDeleteMessages = async (ctx: DiscordContext, input: DiscordEndpointInputs['bulkDeleteMessages']) => {
+  const { channel_id, ...body } = input;
+  await makeDiscordRequest<void>(
+    `channels/${channel_id}/messages/bulk-delete`,
+    ctx.key,
+    { method: 'POST', body }
+  );
+  await logEventFromContext(ctx, 'discord.generated.bulkDeleteMessages', { channel_id, ...body }, 'completed');
+  return undefined as any;
+};

--- a/packages/discord/endpoints/index.ts
+++ b/packages/discord/endpoints/index.ts
@@ -1,9 +1,11 @@
 import * as Channels from './channels';
+import * as Commands from './commands';
 import * as Guilds from './guilds';
 import * as Members from './members';
 import * as Messages from './messages';
+import * as Moderation from './moderation';
 import * as Reactions from './reactions';
 import * as Threads from './threads';
 
-export { Channels, Guilds, Members, Messages, Reactions, Threads };
+export { Channels, Commands, Guilds, Members, Messages, Moderation, Reactions, Threads };
 export * from './types';

--- a/packages/discord/endpoints/moderation.ts
+++ b/packages/discord/endpoints/moderation.ts
@@ -1,0 +1,56 @@
+import type { DiscordContext } from '../index';
+import { makeDiscordRequest } from '../client';
+import type { DiscordEndpointOutputs } from './types';
+import type {
+	GuildsBanAddInput,
+	GuildsBanGetInput,
+	GuildsBanRemoveInput,
+	GuildsBansListInput,
+} from './types';
+
+export const guildsBanAdd = async (
+	ctx: DiscordContext,
+	input: GuildsBanAddInput,
+) => {
+	const { guild_id, user_id, ...body } = input;
+	await makeDiscordRequest<void>(
+		`guilds/${guild_id}/bans/${user_id}`,
+		ctx.key,
+		{ method: 'PUT', body },
+	);
+	return { success: true } as const;
+};
+
+export const guildsBanRemove = async (
+	ctx: DiscordContext,
+	input: GuildsBanRemoveInput,
+) => {
+	await makeDiscordRequest<void>(
+		`guilds/${input.guild_id}/bans/${input.user_id}`,
+		ctx.key,
+		{ method: 'DELETE' },
+	);
+	return { success: true } as const;
+};
+
+export const guildsBansList = async (
+	ctx: DiscordContext,
+	input: GuildsBansListInput,
+) => {
+	const { guild_id, ...query } = input;
+	return makeDiscordRequest<DiscordEndpointOutputs['guildsBansList']>(
+		`guilds/${guild_id}/bans`,
+		ctx.key,
+		{ query },
+	);
+};
+
+export const guildsBanGet = async (
+	ctx: DiscordContext,
+	input: GuildsBanGetInput,
+) => {
+	return makeDiscordRequest<DiscordEndpointOutputs['guildsBanGet']>(
+		`guilds/${input.guild_id}/bans/${input.user_id}`,
+		ctx.key,
+	);
+};

--- a/packages/discord/endpoints/types.ts
+++ b/packages/discord/endpoints/types.ts
@@ -201,7 +201,521 @@ export const GuildMemberSchema = z.object({
 });
 export type GuildMember = z.infer<typeof GuildMemberSchema>;
 
+export const ApplicationCommandSchema = z.object({
+	id: z.string(),
+	type: z.number().optional(),
+	application_id: z.string(),
+	guild_id: z.string().optional(),
+	name: z.string(),
+	description: z.string(),
+	options: z.array(z.any()).optional(),
+	default_member_permissions: z.string().nullable().optional(),
+	dm_permission: z.boolean().optional(),
+	nsfw: z.boolean().optional(),
+	version: z.string(),
+});
+export type ApplicationCommand = z.infer<typeof ApplicationCommandSchema>;
+
+export const BanSchema = z.object({
+	reason: z.string().nullable(),
+	user: DiscordUserSchema,
+});
+export type Ban = z.infer<typeof BanSchema>;
+
 // ── Endpoint Input Schemas ─────────────────────────────────────────────────────
+
+export const FollowChannelInputSchema = z.record(z.string(), z.any());
+export type FollowChannelInput = z.infer<typeof FollowChannelInputSchema>;
+
+export const AddGuildMemberInputSchema = z.record(z.string(), z.any());
+export type AddGuildMemberInput = z.infer<typeof AddGuildMemberInputSchema>;
+
+export const AddMyMessageReactionInputSchema = z.record(z.string(), z.any());
+export type AddMyMessageReactionInput = z.infer<typeof AddMyMessageReactionInputSchema>;
+
+export const AddGroupDmUserInputSchema = z.record(z.string(), z.any());
+export type AddGroupDmUserInput = z.infer<typeof AddGroupDmUserInputSchema>;
+
+export const AddThreadMemberInputSchema = z.record(z.string(), z.any());
+export type AddThreadMemberInput = z.infer<typeof AddThreadMemberInputSchema>;
+
+export const AddGuildMemberRoleInputSchema = z.record(z.string(), z.any());
+export type AddGuildMemberRoleInput = z.infer<typeof AddGuildMemberRoleInputSchema>;
+
+export const BanUserFromGuildInputSchema = z.record(z.string(), z.any());
+export type BanUserFromGuildInput = z.infer<typeof BanUserFromGuildInputSchema>;
+
+export const BulkBanUsersFromGuildInputSchema = z.record(z.string(), z.any());
+export type BulkBanUsersFromGuildInput = z.infer<typeof BulkBanUsersFromGuildInputSchema>;
+
+export const CreateChannelInviteInputSchema = z.record(z.string(), z.any());
+export type CreateChannelInviteInput = z.infer<typeof CreateChannelInviteInputSchema>;
+
+export const CreateStageInstanceInputSchema = z.record(z.string(), z.any());
+export type CreateStageInstanceInput = z.infer<typeof CreateStageInstanceInputSchema>;
+
+export const CreateApplicationCommandInputSchema = z.record(z.string(), z.any());
+export type CreateApplicationCommandInput = z.infer<typeof CreateApplicationCommandInputSchema>;
+
+export const CreateWebhookInputSchema = z.record(z.string(), z.any());
+export type CreateWebhookInput = z.infer<typeof CreateWebhookInputSchema>;
+
+export const CreateGuildApplicationCommandInputSchema = z.record(z.string(), z.any());
+export type CreateGuildApplicationCommandInput = z.infer<typeof CreateGuildApplicationCommandInputSchema>;
+
+export const CreateAutoModerationRuleInputSchema = z.record(z.string(), z.any());
+export type CreateAutoModerationRuleInput = z.infer<typeof CreateAutoModerationRuleInputSchema>;
+
+export const CreateGuildChannelInputSchema = z.record(z.string(), z.any());
+export type CreateGuildChannelInput = z.infer<typeof CreateGuildChannelInputSchema>;
+
+export const CreateGuildEmojiInputSchema = z.record(z.string(), z.any());
+export type CreateGuildEmojiInput = z.infer<typeof CreateGuildEmojiInputSchema>;
+
+export const CreateGuildScheduledEventInputSchema = z.record(z.string(), z.any());
+export type CreateGuildScheduledEventInput = z.infer<typeof CreateGuildScheduledEventInputSchema>;
+
+export const CreateGuildStickerInputSchema = z.record(z.string(), z.any());
+export type CreateGuildStickerInput = z.infer<typeof CreateGuildStickerInputSchema>;
+
+export const CreateGuildTemplateInputSchema = z.record(z.string(), z.any());
+export type CreateGuildTemplateInput = z.infer<typeof CreateGuildTemplateInputSchema>;
+
+export const CreateGuildInputSchema = z.record(z.string(), z.any());
+export type CreateGuildInput = z.infer<typeof CreateGuildInputSchema>;
+
+export const CreateThreadInputSchema = z.record(z.string(), z.any());
+export type CreateThreadInput = z.infer<typeof CreateThreadInputSchema>;
+
+export const CreateGuildRoleInputSchema = z.record(z.string(), z.any());
+export type CreateGuildRoleInput = z.infer<typeof CreateGuildRoleInputSchema>;
+
+export const CreateThreadFromMessageInputSchema = z.record(z.string(), z.any());
+export type CreateThreadFromMessageInput = z.infer<typeof CreateThreadFromMessageInputSchema>;
+
+export const CrosspostMessageInputSchema = z.record(z.string(), z.any());
+export type CrosspostMessageInput = z.infer<typeof CrosspostMessageInputSchema>;
+
+export const DeleteAllMessageReactionsInputSchema = z.record(z.string(), z.any());
+export type DeleteAllMessageReactionsInput = z.infer<typeof DeleteAllMessageReactionsInputSchema>;
+
+export const DeleteApplicationCommandInputSchema = z.record(z.string(), z.any());
+export type DeleteApplicationCommandInput = z.infer<typeof DeleteApplicationCommandInputSchema>;
+
+export const DeleteChannelInputSchema = z.record(z.string(), z.any());
+export type DeleteChannelInput = z.infer<typeof DeleteChannelInputSchema>;
+
+export const DeleteMessageInputSchema = z.record(z.string(), z.any());
+export type DeleteMessageInput = z.infer<typeof DeleteMessageInputSchema>;
+
+export const DeleteAllMessageReactionsByEmojiInputSchema = z.record(z.string(), z.any());
+export type DeleteAllMessageReactionsByEmojiInput = z.infer<typeof DeleteAllMessageReactionsByEmojiInputSchema>;
+
+export const DeleteChannelPermissionOverwriteInputSchema = z.record(z.string(), z.any());
+export type DeleteChannelPermissionOverwriteInput = z.infer<typeof DeleteChannelPermissionOverwriteInputSchema>;
+
+export const DeleteThreadMemberInputSchema = z.record(z.string(), z.any());
+export type DeleteThreadMemberInput = z.infer<typeof DeleteThreadMemberInputSchema>;
+
+export const DeleteAutoModerationRuleInputSchema = z.record(z.string(), z.any());
+export type DeleteAutoModerationRuleInput = z.infer<typeof DeleteAutoModerationRuleInputSchema>;
+
+export const DeleteGuildInputSchema = z.record(z.string(), z.any());
+export type DeleteGuildInput = z.infer<typeof DeleteGuildInputSchema>;
+
+export const DeleteGuildApplicationCommandInputSchema = z.record(z.string(), z.any());
+export type DeleteGuildApplicationCommandInput = z.infer<typeof DeleteGuildApplicationCommandInputSchema>;
+
+export const DeleteGuildEmojiInputSchema = z.record(z.string(), z.any());
+export type DeleteGuildEmojiInput = z.infer<typeof DeleteGuildEmojiInputSchema>;
+
+export const DeleteGuildIntegrationInputSchema = z.record(z.string(), z.any());
+export type DeleteGuildIntegrationInput = z.infer<typeof DeleteGuildIntegrationInputSchema>;
+
+export const DeleteGuildMemberInputSchema = z.record(z.string(), z.any());
+export type DeleteGuildMemberInput = z.infer<typeof DeleteGuildMemberInputSchema>;
+
+export const DeleteGuildMemberRoleInputSchema = z.record(z.string(), z.any());
+export type DeleteGuildMemberRoleInput = z.infer<typeof DeleteGuildMemberRoleInputSchema>;
+
+export const DeleteGuildScheduledEventInputSchema = z.record(z.string(), z.any());
+export type DeleteGuildScheduledEventInput = z.infer<typeof DeleteGuildScheduledEventInputSchema>;
+
+export const DeleteGuildStickerInputSchema = z.record(z.string(), z.any());
+export type DeleteGuildStickerInput = z.infer<typeof DeleteGuildStickerInputSchema>;
+
+export const DeleteGuildTemplateInputSchema = z.record(z.string(), z.any());
+export type DeleteGuildTemplateInput = z.infer<typeof DeleteGuildTemplateInputSchema>;
+
+export const InviteRevokeInputSchema = z.record(z.string(), z.any());
+export type InviteRevokeInput = z.infer<typeof InviteRevokeInputSchema>;
+
+export const DeleteOriginalWebhookMessageInputSchema = z.record(z.string(), z.any());
+export type DeleteOriginalWebhookMessageInput = z.infer<typeof DeleteOriginalWebhookMessageInputSchema>;
+
+export const DeleteGuildRoleInputSchema = z.record(z.string(), z.any());
+export type DeleteGuildRoleInput = z.infer<typeof DeleteGuildRoleInputSchema>;
+
+export const DeleteStageInstanceInputSchema = z.record(z.string(), z.any());
+export type DeleteStageInstanceInput = z.infer<typeof DeleteStageInstanceInputSchema>;
+
+export const DeleteUserMessageReactionInputSchema = z.record(z.string(), z.any());
+export type DeleteUserMessageReactionInput = z.infer<typeof DeleteUserMessageReactionInputSchema>;
+
+export const DeleteMyMessageReactionInputSchema = z.record(z.string(), z.any());
+export type DeleteMyMessageReactionInput = z.infer<typeof DeleteMyMessageReactionInputSchema>;
+
+export const DeleteWebhookInputSchema = z.record(z.string(), z.any());
+export type DeleteWebhookInput = z.infer<typeof DeleteWebhookInputSchema>;
+
+export const DeleteWebhookMessageInputSchema = z.record(z.string(), z.any());
+export type DeleteWebhookMessageInput = z.infer<typeof DeleteWebhookMessageInputSchema>;
+
+export const DeleteWebhookByTokenInputSchema = z.record(z.string(), z.any());
+export type DeleteWebhookByTokenInput = z.infer<typeof DeleteWebhookByTokenInputSchema>;
+
+export const GetApplicationCommandInputSchema = z.record(z.string(), z.any());
+export type GetApplicationCommandInput = z.infer<typeof GetApplicationCommandInputSchema>;
+
+export const GetGuildEmojiInputSchema = z.record(z.string(), z.any());
+export type GetGuildEmojiInput = z.infer<typeof GetGuildEmojiInputSchema>;
+
+export const GetGuildApplicationCommandInputSchema = z.record(z.string(), z.any());
+export type GetGuildApplicationCommandInput = z.infer<typeof GetGuildApplicationCommandInputSchema>;
+
+export const ListGuildApplicationCommandsInputSchema = z.record(z.string(), z.any());
+export type ListGuildApplicationCommandsInput = z.infer<typeof ListGuildApplicationCommandsInputSchema>;
+
+export const ListMessagesInputSchema = z.record(z.string(), z.any());
+export type ListMessagesInput = z.infer<typeof ListMessagesInputSchema>;
+
+export const ListVoiceRegionsInputSchema = z.record(z.string(), z.any());
+export type ListVoiceRegionsInput = z.infer<typeof ListVoiceRegionsInputSchema>;
+
+export const ListGuildApplicationCommandPermissionsInputSchema = z.record(z.string(), z.any());
+export type ListGuildApplicationCommandPermissionsInput = z.infer<typeof ListGuildApplicationCommandPermissionsInputSchema>;
+
+export const ListPrivateArchivedThreadsInputSchema = z.record(z.string(), z.any());
+export type ListPrivateArchivedThreadsInput = z.infer<typeof ListPrivateArchivedThreadsInputSchema>;
+
+export const ListPublicArchivedThreadsInputSchema = z.record(z.string(), z.any());
+export type ListPublicArchivedThreadsInput = z.infer<typeof ListPublicArchivedThreadsInputSchema>;
+
+export const ListMessageReactionsByEmojiInputSchema = z.record(z.string(), z.any());
+export type ListMessageReactionsByEmojiInput = z.infer<typeof ListMessageReactionsByEmojiInputSchema>;
+
+export const GetGatewayInputSchema = z.record(z.string(), z.any());
+export type GetGatewayInput = z.infer<typeof GetGatewayInputSchema>;
+
+export const ListGuildAuditLogEntriesInputSchema = z.record(z.string(), z.any());
+export type ListGuildAuditLogEntriesInput = z.infer<typeof ListGuildAuditLogEntriesInputSchema>;
+
+export const ListGuildMembersInputSchema = z.record(z.string(), z.any());
+export type ListGuildMembersInput = z.infer<typeof ListGuildMembersInputSchema>;
+
+export const GetGuildsOnboardingInputSchema = z.record(z.string(), z.any());
+export type GetGuildsOnboardingInput = z.infer<typeof GetGuildsOnboardingInputSchema>;
+
+export const GetGuildScheduledEventInputSchema = z.record(z.string(), z.any());
+export type GetGuildScheduledEventInput = z.infer<typeof GetGuildScheduledEventInputSchema>;
+
+export const ListGuildTemplatesInputSchema = z.record(z.string(), z.any());
+export type ListGuildTemplatesInput = z.infer<typeof ListGuildTemplatesInputSchema>;
+
+export const GetGuildWidgetPngInputSchema = z.record(z.string(), z.any());
+export type GetGuildWidgetPngInput = z.infer<typeof GetGuildWidgetPngInputSchema>;
+
+export const GetMyOauth2ApplicationInputSchema = z.record(z.string(), z.any());
+export type GetMyOauth2ApplicationInput = z.infer<typeof GetMyOauth2ApplicationInputSchema>;
+
+export const GetPublicKeysInputSchema = z.record(z.string(), z.any());
+export type GetPublicKeysInput = z.infer<typeof GetPublicKeysInputSchema>;
+
+export const ListMyPrivateArchivedThreadsInputSchema = z.record(z.string(), z.any());
+export type ListMyPrivateArchivedThreadsInput = z.infer<typeof ListMyPrivateArchivedThreadsInputSchema>;
+
+export const GetApplicationUserRoleConnectionInputSchema = z.record(z.string(), z.any());
+export type GetApplicationUserRoleConnectionInput = z.infer<typeof GetApplicationUserRoleConnectionInputSchema>;
+
+export const GetMyApplicationInputSchema = z.record(z.string(), z.any());
+export type GetMyApplicationInput = z.infer<typeof GetMyApplicationInputSchema>;
+
+export const ExecuteGithubCompatibleWebhookInputSchema = z.record(z.string(), z.any());
+export type ExecuteGithubCompatibleWebhookInput = z.infer<typeof ExecuteGithubCompatibleWebhookInputSchema>;
+
+export const CreateDmInputSchema = z.record(z.string(), z.any());
+export type CreateDmInput = z.infer<typeof CreateDmInputSchema>;
+
+export const JoinThreadInputSchema = z.record(z.string(), z.any());
+export type JoinThreadInput = z.infer<typeof JoinThreadInputSchema>;
+
+export const LeaveGuildInputSchema = z.record(z.string(), z.any());
+export type LeaveGuildInput = z.infer<typeof LeaveGuildInputSchema>;
+
+export const ListChannelInvitesInputSchema = z.record(z.string(), z.any());
+export type ListChannelInvitesInput = z.infer<typeof ListChannelInvitesInputSchema>;
+
+export const GetActiveGuildThreadsInputSchema = z.record(z.string(), z.any());
+export type GetActiveGuildThreadsInput = z.infer<typeof GetActiveGuildThreadsInputSchema>;
+
+export const ListApplicationCommandsInputSchema = z.record(z.string(), z.any());
+export type ListApplicationCommandsInput = z.infer<typeof ListApplicationCommandsInputSchema>;
+
+export const ListGuildBansInputSchema = z.record(z.string(), z.any());
+export type ListGuildBansInput = z.infer<typeof ListGuildBansInputSchema>;
+
+export const ListGuildIntegrationsInputSchema = z.record(z.string(), z.any());
+export type ListGuildIntegrationsInput = z.infer<typeof ListGuildIntegrationsInputSchema>;
+
+export const ListGuildVoiceRegionsInputSchema = z.record(z.string(), z.any());
+export type ListGuildVoiceRegionsInput = z.infer<typeof ListGuildVoiceRegionsInputSchema>;
+
+export const ListGuildRolesInputSchema = z.record(z.string(), z.any());
+export type ListGuildRolesInput = z.infer<typeof ListGuildRolesInputSchema>;
+
+export const ListStickerPacksInputSchema = z.record(z.string(), z.any());
+export type ListStickerPacksInput = z.infer<typeof ListStickerPacksInputSchema>;
+
+export const ListThreadMembersInputSchema = z.record(z.string(), z.any());
+export type ListThreadMembersInput = z.infer<typeof ListThreadMembersInputSchema>;
+
+export const UpdateApplicationInputSchema = z.record(z.string(), z.any());
+export type UpdateApplicationInput = z.infer<typeof UpdateApplicationInputSchema>;
+
+export const SetChannelPermissionOverwriteInputSchema = z.record(z.string(), z.any());
+export type SetChannelPermissionOverwriteInput = z.infer<typeof SetChannelPermissionOverwriteInputSchema>;
+
+export const UpdateAutoModerationRuleInputSchema = z.record(z.string(), z.any());
+export type UpdateAutoModerationRuleInput = z.infer<typeof UpdateAutoModerationRuleInputSchema>;
+
+export const UpdateGuildMemberInputSchema = z.record(z.string(), z.any());
+export type UpdateGuildMemberInput = z.infer<typeof UpdateGuildMemberInputSchema>;
+
+export const UpdateGuildRoleInputSchema = z.record(z.string(), z.any());
+export type UpdateGuildRoleInput = z.infer<typeof UpdateGuildRoleInputSchema>;
+
+export const UpdateSelfVoiceStateInputSchema = z.record(z.string(), z.any());
+export type UpdateSelfVoiceStateInput = z.infer<typeof UpdateSelfVoiceStateInputSchema>;
+
+export const UpdateApplicationCommandInputSchema = z.record(z.string(), z.any());
+export type UpdateApplicationCommandInput = z.infer<typeof UpdateApplicationCommandInputSchema>;
+
+export const UpdateGuildTemplateInputSchema = z.record(z.string(), z.any());
+export type UpdateGuildTemplateInput = z.infer<typeof UpdateGuildTemplateInputSchema>;
+
+export const UpdateVoiceStateInputSchema = z.record(z.string(), z.any());
+export type UpdateVoiceStateInput = z.infer<typeof UpdateVoiceStateInputSchema>;
+
+export const UpdateOriginalWebhookMessageInputSchema = z.record(z.string(), z.any());
+export type UpdateOriginalWebhookMessageInput = z.infer<typeof UpdateOriginalWebhookMessageInputSchema>;
+
+export const PinMessageInputSchema = z.record(z.string(), z.any());
+export type PinMessageInput = z.infer<typeof PinMessageInputSchema>;
+
+export const CreateGuildFromTemplateInputSchema = z.record(z.string(), z.any());
+export type CreateGuildFromTemplateInput = z.infer<typeof CreateGuildFromTemplateInputSchema>;
+
+export const CreateInteractionResponseInputSchema = z.record(z.string(), z.any());
+export type CreateInteractionResponseInput = z.infer<typeof CreateInteractionResponseInputSchema>;
+
+export const CreateMessageInputSchema = z.record(z.string(), z.any());
+export type CreateMessageInput = z.infer<typeof CreateMessageInputSchema>;
+
+export const ExecuteSlackCompatibleWebhookInputSchema = z.record(z.string(), z.any());
+export type ExecuteSlackCompatibleWebhookInput = z.infer<typeof ExecuteSlackCompatibleWebhookInputSchema>;
+
+export const ExecuteWebhookInputSchema = z.record(z.string(), z.any());
+export type ExecuteWebhookInput = z.infer<typeof ExecuteWebhookInputSchema>;
+
+export const GetGuildPreviewInputSchema = z.record(z.string(), z.any());
+export type GetGuildPreviewInput = z.infer<typeof GetGuildPreviewInputSchema>;
+
+export const PruneGuildInputSchema = z.record(z.string(), z.any());
+export type PruneGuildInput = z.infer<typeof PruneGuildInputSchema>;
+
+export const LeaveThreadInputSchema = z.record(z.string(), z.any());
+export type LeaveThreadInput = z.infer<typeof LeaveThreadInputSchema>;
+
+export const UnbanUserFromGuildInputSchema = z.record(z.string(), z.any());
+export type UnbanUserFromGuildInput = z.infer<typeof UnbanUserFromGuildInputSchema>;
+
+export const DeleteGroupDmUserInputSchema = z.record(z.string(), z.any());
+export type DeleteGroupDmUserInput = z.infer<typeof DeleteGroupDmUserInputSchema>;
+
+export const GetApplicationInputSchema = z.record(z.string(), z.any());
+export type GetApplicationInput = z.infer<typeof GetApplicationInputSchema>;
+
+export const GetApplicationRoleConnectionsMetadataInputSchema = z.record(z.string(), z.any());
+export type GetApplicationRoleConnectionsMetadataInput = z.infer<typeof GetApplicationRoleConnectionsMetadataInputSchema>;
+
+export const GetAutoModerationRuleInputSchema = z.record(z.string(), z.any());
+export type GetAutoModerationRuleInput = z.infer<typeof GetAutoModerationRuleInputSchema>;
+
+export const GetBotGatewayInputSchema = z.record(z.string(), z.any());
+export type GetBotGatewayInput = z.infer<typeof GetBotGatewayInputSchema>;
+
+export const GetChannelInputSchema = z.record(z.string(), z.any());
+export type GetChannelInput = z.infer<typeof GetChannelInputSchema>;
+
+export const ListChannelWebhooksInputSchema = z.record(z.string(), z.any());
+export type ListChannelWebhooksInput = z.infer<typeof ListChannelWebhooksInputSchema>;
+
+export const ListAutoModerationRulesInputSchema = z.record(z.string(), z.any());
+export type ListAutoModerationRulesInput = z.infer<typeof ListAutoModerationRulesInputSchema>;
+
+export const ListGuildChannelsInputSchema = z.record(z.string(), z.any());
+export type ListGuildChannelsInput = z.infer<typeof ListGuildChannelsInputSchema>;
+
+export const GetGuildApplicationCommandPermissionsInputSchema = z.record(z.string(), z.any());
+export type GetGuildApplicationCommandPermissionsInput = z.infer<typeof GetGuildApplicationCommandPermissionsInputSchema>;
+
+export const GetGuildInputSchema = z.record(z.string(), z.any());
+export type GetGuildInput = z.infer<typeof GetGuildInputSchema>;
+
+export const ListGuildEmojisInputSchema = z.record(z.string(), z.any());
+export type ListGuildEmojisInput = z.infer<typeof ListGuildEmojisInputSchema>;
+
+export const ListGuildInvitesInputSchema = z.record(z.string(), z.any());
+export type ListGuildInvitesInput = z.infer<typeof ListGuildInvitesInputSchema>;
+
+export const GetGuildMemberInputSchema = z.record(z.string(), z.any());
+export type GetGuildMemberInput = z.infer<typeof GetGuildMemberInputSchema>;
+
+export const PreviewPruneGuildInputSchema = z.record(z.string(), z.any());
+export type PreviewPruneGuildInput = z.infer<typeof PreviewPruneGuildInputSchema>;
+
+export const ListGuildScheduledEventsInputSchema = z.record(z.string(), z.any());
+export type ListGuildScheduledEventsInput = z.infer<typeof ListGuildScheduledEventsInputSchema>;
+
+export const ListGuildStickersInputSchema = z.record(z.string(), z.any());
+export type ListGuildStickersInput = z.infer<typeof ListGuildStickersInputSchema>;
+
+export const GetGuildTemplateInputSchema = z.record(z.string(), z.any());
+export type GetGuildTemplateInput = z.infer<typeof GetGuildTemplateInputSchema>;
+
+export const GetGuildBanInputSchema = z.record(z.string(), z.any());
+export type GetGuildBanInput = z.infer<typeof GetGuildBanInputSchema>;
+
+export const GetGuildVanityUrlInputSchema = z.record(z.string(), z.any());
+export type GetGuildVanityUrlInput = z.infer<typeof GetGuildVanityUrlInputSchema>;
+
+export const GetGuildWebhooksInputSchema = z.record(z.string(), z.any());
+export type GetGuildWebhooksInput = z.infer<typeof GetGuildWebhooksInputSchema>;
+
+export const GetGuildWelcomeScreenInputSchema = z.record(z.string(), z.any());
+export type GetGuildWelcomeScreenInput = z.infer<typeof GetGuildWelcomeScreenInputSchema>;
+
+export const GetGuildWidgetSettingsInputSchema = z.record(z.string(), z.any());
+export type GetGuildWidgetSettingsInput = z.infer<typeof GetGuildWidgetSettingsInputSchema>;
+
+export const GetGuildWidgetInputSchema = z.record(z.string(), z.any());
+export type GetGuildWidgetInput = z.infer<typeof GetGuildWidgetInputSchema>;
+
+export const InviteResolveInputSchema = z.record(z.string(), z.any());
+export type InviteResolveInput = z.infer<typeof InviteResolveInputSchema>;
+
+export const GetMessageInputSchema = z.record(z.string(), z.any());
+export type GetMessageInput = z.infer<typeof GetMessageInputSchema>;
+
+export const GetOriginalWebhookMessageInputSchema = z.record(z.string(), z.any());
+export type GetOriginalWebhookMessageInput = z.infer<typeof GetOriginalWebhookMessageInputSchema>;
+
+export const ListPinnedMessagesInputSchema = z.record(z.string(), z.any());
+export type ListPinnedMessagesInput = z.infer<typeof ListPinnedMessagesInputSchema>;
+
+export const GetStageInstanceInputSchema = z.record(z.string(), z.any());
+export type GetStageInstanceInput = z.infer<typeof GetStageInstanceInputSchema>;
+
+export const GetStickerInputSchema = z.record(z.string(), z.any());
+export type GetStickerInput = z.infer<typeof GetStickerInputSchema>;
+
+export const GetGuildStickerInputSchema = z.record(z.string(), z.any());
+export type GetGuildStickerInput = z.infer<typeof GetGuildStickerInputSchema>;
+
+export const GetThreadMemberInputSchema = z.record(z.string(), z.any());
+export type GetThreadMemberInput = z.infer<typeof GetThreadMemberInputSchema>;
+
+export const GetUserInputSchema = z.record(z.string(), z.any());
+export type GetUserInput = z.infer<typeof GetUserInputSchema>;
+
+export const ListGuildScheduledEventUsersInputSchema = z.record(z.string(), z.any());
+export type ListGuildScheduledEventUsersInput = z.infer<typeof ListGuildScheduledEventUsersInputSchema>;
+
+export const GetWebhookInputSchema = z.record(z.string(), z.any());
+export type GetWebhookInput = z.infer<typeof GetWebhookInputSchema>;
+
+export const GetWebhookByTokenInputSchema = z.record(z.string(), z.any());
+export type GetWebhookByTokenInput = z.infer<typeof GetWebhookByTokenInputSchema>;
+
+export const GetWebhookMessageInputSchema = z.record(z.string(), z.any());
+export type GetWebhookMessageInput = z.infer<typeof GetWebhookMessageInputSchema>;
+
+export const SearchGuildMembersInputSchema = z.record(z.string(), z.any());
+export type SearchGuildMembersInput = z.infer<typeof SearchGuildMembersInputSchema>;
+
+export const TestAuthInputSchema = z.record(z.string(), z.any());
+export type TestAuthInput = z.infer<typeof TestAuthInputSchema>;
+
+export const TriggerTypingIndicatorInputSchema = z.record(z.string(), z.any());
+export type TriggerTypingIndicatorInput = z.infer<typeof TriggerTypingIndicatorInputSchema>;
+
+export const UnpinMessageInputSchema = z.record(z.string(), z.any());
+export type UnpinMessageInput = z.infer<typeof UnpinMessageInputSchema>;
+
+export const UpdateGuildWidgetSettingsInputSchema = z.record(z.string(), z.any());
+export type UpdateGuildWidgetSettingsInput = z.infer<typeof UpdateGuildWidgetSettingsInputSchema>;
+
+export const UpdateMyApplicationInputSchema = z.record(z.string(), z.any());
+export type UpdateMyApplicationInput = z.infer<typeof UpdateMyApplicationInputSchema>;
+
+export const UpdateGuildApplicationCommandInputSchema = z.record(z.string(), z.any());
+export type UpdateGuildApplicationCommandInput = z.infer<typeof UpdateGuildApplicationCommandInputSchema>;
+
+export const UpdateMyGuildMemberInputSchema = z.record(z.string(), z.any());
+export type UpdateMyGuildMemberInput = z.infer<typeof UpdateMyGuildMemberInputSchema>;
+
+export const UpdateMessageInputSchema = z.record(z.string(), z.any());
+export type UpdateMessageInput = z.infer<typeof UpdateMessageInputSchema>;
+
+export const UpdateChannelInputSchema = z.record(z.string(), z.any());
+export type UpdateChannelInput = z.infer<typeof UpdateChannelInputSchema>;
+
+export const UpdateMyUserInputSchema = z.record(z.string(), z.any());
+export type UpdateMyUserInput = z.infer<typeof UpdateMyUserInputSchema>;
+
+export const UpdateWebhookMessageInputSchema = z.record(z.string(), z.any());
+export type UpdateWebhookMessageInput = z.infer<typeof UpdateWebhookMessageInputSchema>;
+
+export const UpdateGuildEmojiInputSchema = z.record(z.string(), z.any());
+export type UpdateGuildEmojiInput = z.infer<typeof UpdateGuildEmojiInputSchema>;
+
+export const PutGuildsOnboardingInputSchema = z.record(z.string(), z.any());
+export type PutGuildsOnboardingInput = z.infer<typeof PutGuildsOnboardingInputSchema>;
+
+export const UpdateGuildScheduledEventInputSchema = z.record(z.string(), z.any());
+export type UpdateGuildScheduledEventInput = z.infer<typeof UpdateGuildScheduledEventInputSchema>;
+
+export const UpdateGuildInputSchema = z.record(z.string(), z.any());
+export type UpdateGuildInput = z.infer<typeof UpdateGuildInputSchema>;
+
+export const UpdateGuildStickerInputSchema = z.record(z.string(), z.any());
+export type UpdateGuildStickerInput = z.infer<typeof UpdateGuildStickerInputSchema>;
+
+export const SyncGuildTemplateInputSchema = z.record(z.string(), z.any());
+export type SyncGuildTemplateInput = z.infer<typeof SyncGuildTemplateInputSchema>;
+
+export const UpdateGuildWelcomeScreenInputSchema = z.record(z.string(), z.any());
+export type UpdateGuildWelcomeScreenInput = z.infer<typeof UpdateGuildWelcomeScreenInputSchema>;
+
+export const UpdateApplicationUserRoleConnectionInputSchema = z.record(z.string(), z.any());
+export type UpdateApplicationUserRoleConnectionInput = z.infer<typeof UpdateApplicationUserRoleConnectionInputSchema>;
+
+export const UpdateWebhookInputSchema = z.record(z.string(), z.any());
+export type UpdateWebhookInput = z.infer<typeof UpdateWebhookInputSchema>;
+
+export const UpdateWebhookByTokenInputSchema = z.record(z.string(), z.any());
+export type UpdateWebhookByTokenInput = z.infer<typeof UpdateWebhookByTokenInputSchema>;
+
 
 export const MessagesSendInputSchema = z.object({
 	channel_id: z.string(),
@@ -331,7 +845,129 @@ export const MembersGetInputSchema = z.object({
 });
 export type MembersGetInput = z.infer<typeof MembersGetInputSchema>;
 
+// Application Commands Input Schemas
+export const CommandsCreateGlobalInputSchema = z.object({
+	application_id: z.string(),
+	name: z.string(),
+	description: z.string(),
+	options: z.array(z.any()).optional(),
+	default_member_permissions: z.string().nullable().optional(),
+	dm_permission: z.boolean().optional(),
+	type: z.number().optional(),
+	nsfw: z.boolean().optional(),
+});
+export type CommandsCreateGlobalInput = z.infer<typeof CommandsCreateGlobalInputSchema>;
+
+export const CommandsGetGlobalInputSchema = z.object({
+	application_id: z.string(),
+	command_id: z.string(),
+});
+export type CommandsGetGlobalInput = z.infer<typeof CommandsGetGlobalInputSchema>;
+
+export const CommandsListGlobalInputSchema = z.object({
+	application_id: z.string(),
+	with_localizations: z.boolean().optional(),
+});
+export type CommandsListGlobalInput = z.infer<typeof CommandsListGlobalInputSchema>;
+
+export const CommandsUpdateGlobalInputSchema = z.object({
+	application_id: z.string(),
+	command_id: z.string(),
+	name: z.string().optional(),
+	description: z.string().optional(),
+	options: z.array(z.any()).optional(),
+	default_member_permissions: z.string().nullable().optional(),
+	dm_permission: z.boolean().optional(),
+	nsfw: z.boolean().optional(),
+});
+export type CommandsUpdateGlobalInput = z.infer<typeof CommandsUpdateGlobalInputSchema>;
+
+export const CommandsDeleteGlobalInputSchema = z.object({
+	application_id: z.string(),
+	command_id: z.string(),
+});
+export type CommandsDeleteGlobalInput = z.infer<typeof CommandsDeleteGlobalInputSchema>;
+
+export const CommandsCreateGuildInputSchema = z.object({
+	application_id: z.string(),
+	guild_id: z.string(),
+	name: z.string(),
+	description: z.string(),
+	options: z.array(z.any()).optional(),
+	default_member_permissions: z.string().nullable().optional(),
+	type: z.number().optional(),
+	nsfw: z.boolean().optional(),
+});
+export type CommandsCreateGuildInput = z.infer<typeof CommandsCreateGuildInputSchema>;
+
+export const CommandsGetGuildInputSchema = z.object({
+	application_id: z.string(),
+	guild_id: z.string(),
+	command_id: z.string(),
+});
+export type CommandsGetGuildInput = z.infer<typeof CommandsGetGuildInputSchema>;
+
+export const CommandsListGuildInputSchema = z.object({
+	application_id: z.string(),
+	guild_id: z.string(),
+	with_localizations: z.boolean().optional(),
+});
+export type CommandsListGuildInput = z.infer<typeof CommandsListGuildInputSchema>;
+
+export const CommandsUpdateGuildInputSchema = z.object({
+	application_id: z.string(),
+	guild_id: z.string(),
+	command_id: z.string(),
+	name: z.string().optional(),
+	description: z.string().optional(),
+	options: z.array(z.any()).optional(),
+	default_member_permissions: z.string().nullable().optional(),
+	nsfw: z.boolean().optional(),
+});
+export type CommandsUpdateGuildInput = z.infer<typeof CommandsUpdateGuildInputSchema>;
+
+export const CommandsDeleteGuildInputSchema = z.object({
+	application_id: z.string(),
+	guild_id: z.string(),
+	command_id: z.string(),
+});
+export type CommandsDeleteGuildInput = z.infer<typeof CommandsDeleteGuildInputSchema>;
+
+// Guild Moderation Input Schemas
+export const GuildsBanAddInputSchema = z.object({
+	guild_id: z.string(),
+	user_id: z.string(),
+	delete_message_seconds: z.number().optional(),
+});
+export type GuildsBanAddInput = z.infer<typeof GuildsBanAddInputSchema>;
+
+export const GuildsBanRemoveInputSchema = z.object({
+	guild_id: z.string(),
+	user_id: z.string(),
+});
+export type GuildsBanRemoveInput = z.infer<typeof GuildsBanRemoveInputSchema>;
+
+export const GuildsBansListInputSchema = z.object({
+	guild_id: z.string(),
+	limit: z.number().optional(),
+	before: z.string().optional(),
+	after: z.string().optional(),
+});
+export type GuildsBansListInput = z.infer<typeof GuildsBansListInputSchema>;
+
+export const GuildsBanGetInputSchema = z.object({
+	guild_id: z.string(),
+	user_id: z.string(),
+});
+export type GuildsBanGetInput = z.infer<typeof GuildsBanGetInputSchema>;
+
 // ── Shared response schemas ────────────────────────────────────────────────────
+
+export const BulkDeleteMessagesInputSchema = z.object({
+  channel_id: z.string(),
+  messages: z.array(z.string())
+});
+export type BulkDeleteMessagesInput = z.infer<typeof BulkDeleteMessagesInputSchema>;
 
 export const SuccessResponseSchema = z.object({ success: z.literal(true) });
 export type SuccessResponse = z.infer<typeof SuccessResponseSchema>;
@@ -339,6 +975,172 @@ export type SuccessResponse = z.infer<typeof SuccessResponseSchema>;
 // ── Endpoint Input/Output Schema Maps ─────────────────────────────────────────
 
 export const DiscordEndpointInputSchemas = {
+  bulkDeleteMessages: BulkDeleteMessagesInputSchema,
+  followChannel: FollowChannelInputSchema,
+  addGuildMember: AddGuildMemberInputSchema,
+  addMyMessageReaction: AddMyMessageReactionInputSchema,
+  addGroupDmUser: AddGroupDmUserInputSchema,
+  addThreadMember: AddThreadMemberInputSchema,
+  addGuildMemberRole: AddGuildMemberRoleInputSchema,
+  banUserFromGuild: BanUserFromGuildInputSchema,
+  bulkBanUsersFromGuild: BulkBanUsersFromGuildInputSchema,
+  createChannelInvite: CreateChannelInviteInputSchema,
+  createStageInstance: CreateStageInstanceInputSchema,
+  createApplicationCommand: CreateApplicationCommandInputSchema,
+  createWebhook: CreateWebhookInputSchema,
+  createGuildApplicationCommand: CreateGuildApplicationCommandInputSchema,
+  createAutoModerationRule: CreateAutoModerationRuleInputSchema,
+  createGuildChannel: CreateGuildChannelInputSchema,
+  createGuildEmoji: CreateGuildEmojiInputSchema,
+  createGuildScheduledEvent: CreateGuildScheduledEventInputSchema,
+  createGuildSticker: CreateGuildStickerInputSchema,
+  createGuildTemplate: CreateGuildTemplateInputSchema,
+  createGuild: CreateGuildInputSchema,
+  createThread: CreateThreadInputSchema,
+  createGuildRole: CreateGuildRoleInputSchema,
+  createThreadFromMessage: CreateThreadFromMessageInputSchema,
+  crosspostMessage: CrosspostMessageInputSchema,
+  deleteAllMessageReactions: DeleteAllMessageReactionsInputSchema,
+  deleteApplicationCommand: DeleteApplicationCommandInputSchema,
+  deleteChannel: DeleteChannelInputSchema,
+  deleteMessage: DeleteMessageInputSchema,
+  deleteAllMessageReactionsByEmoji: DeleteAllMessageReactionsByEmojiInputSchema,
+  deleteChannelPermissionOverwrite: DeleteChannelPermissionOverwriteInputSchema,
+  deleteThreadMember: DeleteThreadMemberInputSchema,
+  deleteAutoModerationRule: DeleteAutoModerationRuleInputSchema,
+  deleteGuild: DeleteGuildInputSchema,
+  deleteGuildApplicationCommand: DeleteGuildApplicationCommandInputSchema,
+  deleteGuildEmoji: DeleteGuildEmojiInputSchema,
+  deleteGuildIntegration: DeleteGuildIntegrationInputSchema,
+  deleteGuildMember: DeleteGuildMemberInputSchema,
+  deleteGuildMemberRole: DeleteGuildMemberRoleInputSchema,
+  deleteGuildScheduledEvent: DeleteGuildScheduledEventInputSchema,
+  deleteGuildSticker: DeleteGuildStickerInputSchema,
+  deleteGuildTemplate: DeleteGuildTemplateInputSchema,
+  inviteRevoke: InviteRevokeInputSchema,
+  deleteOriginalWebhookMessage: DeleteOriginalWebhookMessageInputSchema,
+  deleteGuildRole: DeleteGuildRoleInputSchema,
+  deleteStageInstance: DeleteStageInstanceInputSchema,
+  deleteUserMessageReaction: DeleteUserMessageReactionInputSchema,
+  deleteMyMessageReaction: DeleteMyMessageReactionInputSchema,
+  deleteWebhook: DeleteWebhookInputSchema,
+  deleteWebhookMessage: DeleteWebhookMessageInputSchema,
+  deleteWebhookByToken: DeleteWebhookByTokenInputSchema,
+  getApplicationCommand: GetApplicationCommandInputSchema,
+  getGuildEmoji: GetGuildEmojiInputSchema,
+  getGuildApplicationCommand: GetGuildApplicationCommandInputSchema,
+  listGuildApplicationCommands: ListGuildApplicationCommandsInputSchema,
+  listMessages: ListMessagesInputSchema,
+  listVoiceRegions: ListVoiceRegionsInputSchema,
+  listGuildApplicationCommandPermissions: ListGuildApplicationCommandPermissionsInputSchema,
+  listPrivateArchivedThreads: ListPrivateArchivedThreadsInputSchema,
+  listPublicArchivedThreads: ListPublicArchivedThreadsInputSchema,
+  listMessageReactionsByEmoji: ListMessageReactionsByEmojiInputSchema,
+  getGateway: GetGatewayInputSchema,
+  listGuildAuditLogEntries: ListGuildAuditLogEntriesInputSchema,
+  listGuildMembers: ListGuildMembersInputSchema,
+  getGuildsOnboarding: GetGuildsOnboardingInputSchema,
+  getGuildScheduledEvent: GetGuildScheduledEventInputSchema,
+  listGuildTemplates: ListGuildTemplatesInputSchema,
+  getGuildWidgetPng: GetGuildWidgetPngInputSchema,
+  getMyOauth2Application: GetMyOauth2ApplicationInputSchema,
+  getPublicKeys: GetPublicKeysInputSchema,
+  listMyPrivateArchivedThreads: ListMyPrivateArchivedThreadsInputSchema,
+  getApplicationUserRoleConnection: GetApplicationUserRoleConnectionInputSchema,
+  getMyApplication: GetMyApplicationInputSchema,
+  executeGithubCompatibleWebhook: ExecuteGithubCompatibleWebhookInputSchema,
+  createDm: CreateDmInputSchema,
+  joinThread: JoinThreadInputSchema,
+  leaveGuild: LeaveGuildInputSchema,
+  listChannelInvites: ListChannelInvitesInputSchema,
+  getActiveGuildThreads: GetActiveGuildThreadsInputSchema,
+  listApplicationCommands: ListApplicationCommandsInputSchema,
+  listGuildBans: ListGuildBansInputSchema,
+  listGuildIntegrations: ListGuildIntegrationsInputSchema,
+  listGuildVoiceRegions: ListGuildVoiceRegionsInputSchema,
+  listGuildRoles: ListGuildRolesInputSchema,
+  listStickerPacks: ListStickerPacksInputSchema,
+  listThreadMembers: ListThreadMembersInputSchema,
+  updateApplication: UpdateApplicationInputSchema,
+  setChannelPermissionOverwrite: SetChannelPermissionOverwriteInputSchema,
+  updateAutoModerationRule: UpdateAutoModerationRuleInputSchema,
+  updateGuildMember: UpdateGuildMemberInputSchema,
+  updateGuildRole: UpdateGuildRoleInputSchema,
+  updateSelfVoiceState: UpdateSelfVoiceStateInputSchema,
+  updateApplicationCommand: UpdateApplicationCommandInputSchema,
+  updateGuildTemplate: UpdateGuildTemplateInputSchema,
+  updateVoiceState: UpdateVoiceStateInputSchema,
+  updateOriginalWebhookMessage: UpdateOriginalWebhookMessageInputSchema,
+  pinMessage: PinMessageInputSchema,
+  createGuildFromTemplate: CreateGuildFromTemplateInputSchema,
+  createInteractionResponse: CreateInteractionResponseInputSchema,
+  createMessage: CreateMessageInputSchema,
+  executeSlackCompatibleWebhook: ExecuteSlackCompatibleWebhookInputSchema,
+  executeWebhook: ExecuteWebhookInputSchema,
+  getGuildPreview: GetGuildPreviewInputSchema,
+  pruneGuild: PruneGuildInputSchema,
+  leaveThread: LeaveThreadInputSchema,
+  unbanUserFromGuild: UnbanUserFromGuildInputSchema,
+  deleteGroupDmUser: DeleteGroupDmUserInputSchema,
+  getApplication: GetApplicationInputSchema,
+  getApplicationRoleConnectionsMetadata: GetApplicationRoleConnectionsMetadataInputSchema,
+  getAutoModerationRule: GetAutoModerationRuleInputSchema,
+  getBotGateway: GetBotGatewayInputSchema,
+  getChannel: GetChannelInputSchema,
+  listChannelWebhooks: ListChannelWebhooksInputSchema,
+  listAutoModerationRules: ListAutoModerationRulesInputSchema,
+  listGuildChannels: ListGuildChannelsInputSchema,
+  getGuildApplicationCommandPermissions: GetGuildApplicationCommandPermissionsInputSchema,
+  getGuild: GetGuildInputSchema,
+  listGuildEmojis: ListGuildEmojisInputSchema,
+  listGuildInvites: ListGuildInvitesInputSchema,
+  getGuildMember: GetGuildMemberInputSchema,
+  previewPruneGuild: PreviewPruneGuildInputSchema,
+  listGuildScheduledEvents: ListGuildScheduledEventsInputSchema,
+  listGuildStickers: ListGuildStickersInputSchema,
+  getGuildTemplate: GetGuildTemplateInputSchema,
+  getGuildBan: GetGuildBanInputSchema,
+  getGuildVanityUrl: GetGuildVanityUrlInputSchema,
+  getGuildWebhooks: GetGuildWebhooksInputSchema,
+  getGuildWelcomeScreen: GetGuildWelcomeScreenInputSchema,
+  getGuildWidgetSettings: GetGuildWidgetSettingsInputSchema,
+  getGuildWidget: GetGuildWidgetInputSchema,
+  inviteResolve: InviteResolveInputSchema,
+  getMessage: GetMessageInputSchema,
+  getOriginalWebhookMessage: GetOriginalWebhookMessageInputSchema,
+  listPinnedMessages: ListPinnedMessagesInputSchema,
+  getStageInstance: GetStageInstanceInputSchema,
+  getSticker: GetStickerInputSchema,
+  getGuildSticker: GetGuildStickerInputSchema,
+  getThreadMember: GetThreadMemberInputSchema,
+  getUser: GetUserInputSchema,
+  listGuildScheduledEventUsers: ListGuildScheduledEventUsersInputSchema,
+  getWebhook: GetWebhookInputSchema,
+  getWebhookByToken: GetWebhookByTokenInputSchema,
+  getWebhookMessage: GetWebhookMessageInputSchema,
+  searchGuildMembers: SearchGuildMembersInputSchema,
+  testAuth: TestAuthInputSchema,
+  triggerTypingIndicator: TriggerTypingIndicatorInputSchema,
+  unpinMessage: UnpinMessageInputSchema,
+  updateGuildWidgetSettings: UpdateGuildWidgetSettingsInputSchema,
+  updateMyApplication: UpdateMyApplicationInputSchema,
+  updateGuildApplicationCommand: UpdateGuildApplicationCommandInputSchema,
+  updateMyGuildMember: UpdateMyGuildMemberInputSchema,
+  updateMessage: UpdateMessageInputSchema,
+  updateChannel: UpdateChannelInputSchema,
+  updateMyUser: UpdateMyUserInputSchema,
+  updateWebhookMessage: UpdateWebhookMessageInputSchema,
+  updateGuildEmoji: UpdateGuildEmojiInputSchema,
+  putGuildsOnboarding: PutGuildsOnboardingInputSchema,
+  updateGuildScheduledEvent: UpdateGuildScheduledEventInputSchema,
+  updateGuild: UpdateGuildInputSchema,
+  updateGuildSticker: UpdateGuildStickerInputSchema,
+  syncGuildTemplate: SyncGuildTemplateInputSchema,
+  updateGuildWelcomeScreen: UpdateGuildWelcomeScreenInputSchema,
+  updateApplicationUserRoleConnection: UpdateApplicationUserRoleConnectionInputSchema,
+  updateWebhook: UpdateWebhookInputSchema,
+  updateWebhookByToken: UpdateWebhookByTokenInputSchema,
+
 	messagesSend: MessagesSendInputSchema,
 	messagesReply: MessagesReplyInputSchema,
 	messagesGet: MessagesGetInputSchema,
@@ -355,6 +1157,20 @@ export const DiscordEndpointInputSchemas = {
 	channelsList: ChannelsListInputSchema,
 	membersList: MembersListInputSchema,
 	membersGet: MembersGetInputSchema,
+	commandsCreateGlobal: CommandsCreateGlobalInputSchema,
+	commandsGetGlobal: CommandsGetGlobalInputSchema,
+	commandsListGlobal: CommandsListGlobalInputSchema,
+	commandsUpdateGlobal: CommandsUpdateGlobalInputSchema,
+	commandsDeleteGlobal: CommandsDeleteGlobalInputSchema,
+	commandsCreateGuild: CommandsCreateGuildInputSchema,
+	commandsGetGuild: CommandsGetGuildInputSchema,
+	commandsListGuild: CommandsListGuildInputSchema,
+	commandsUpdateGuild: CommandsUpdateGuildInputSchema,
+	commandsDeleteGuild: CommandsDeleteGuildInputSchema,
+	guildsBanAdd: GuildsBanAddInputSchema,
+	guildsBanRemove: GuildsBanRemoveInputSchema,
+	guildsBansList: GuildsBansListInputSchema,
+	guildsBanGet: GuildsBanGetInputSchema,
 } as const;
 
 export type DiscordEndpointInputs = {
@@ -364,6 +1180,172 @@ export type DiscordEndpointInputs = {
 };
 
 export const DiscordEndpointOutputSchemas = {
+  bulkDeleteMessages: z.any(),
+  followChannel: z.any(),
+  addGuildMember: z.any(),
+  addMyMessageReaction: z.any(),
+  addGroupDmUser: z.any(),
+  addThreadMember: z.any(),
+  addGuildMemberRole: z.any(),
+  banUserFromGuild: z.any(),
+  bulkBanUsersFromGuild: z.any(),
+  createChannelInvite: z.any(),
+  createStageInstance: z.any(),
+  createApplicationCommand: z.any(),
+  createWebhook: z.any(),
+  createGuildApplicationCommand: z.any(),
+  createAutoModerationRule: z.any(),
+  createGuildChannel: z.any(),
+  createGuildEmoji: z.any(),
+  createGuildScheduledEvent: z.any(),
+  createGuildSticker: z.any(),
+  createGuildTemplate: z.any(),
+  createGuild: z.any(),
+  createThread: z.any(),
+  createGuildRole: z.any(),
+  createThreadFromMessage: z.any(),
+  crosspostMessage: z.any(),
+  deleteAllMessageReactions: z.any(),
+  deleteApplicationCommand: z.any(),
+  deleteChannel: z.any(),
+  deleteMessage: z.any(),
+  deleteAllMessageReactionsByEmoji: z.any(),
+  deleteChannelPermissionOverwrite: z.any(),
+  deleteThreadMember: z.any(),
+  deleteAutoModerationRule: z.any(),
+  deleteGuild: z.any(),
+  deleteGuildApplicationCommand: z.any(),
+  deleteGuildEmoji: z.any(),
+  deleteGuildIntegration: z.any(),
+  deleteGuildMember: z.any(),
+  deleteGuildMemberRole: z.any(),
+  deleteGuildScheduledEvent: z.any(),
+  deleteGuildSticker: z.any(),
+  deleteGuildTemplate: z.any(),
+  inviteRevoke: z.any(),
+  deleteOriginalWebhookMessage: z.any(),
+  deleteGuildRole: z.any(),
+  deleteStageInstance: z.any(),
+  deleteUserMessageReaction: z.any(),
+  deleteMyMessageReaction: z.any(),
+  deleteWebhook: z.any(),
+  deleteWebhookMessage: z.any(),
+  deleteWebhookByToken: z.any(),
+  getApplicationCommand: z.any(),
+  getGuildEmoji: z.any(),
+  getGuildApplicationCommand: z.any(),
+  listGuildApplicationCommands: z.any(),
+  listMessages: z.any(),
+  listVoiceRegions: z.any(),
+  listGuildApplicationCommandPermissions: z.any(),
+  listPrivateArchivedThreads: z.any(),
+  listPublicArchivedThreads: z.any(),
+  listMessageReactionsByEmoji: z.any(),
+  getGateway: z.any(),
+  listGuildAuditLogEntries: z.any(),
+  listGuildMembers: z.any(),
+  getGuildsOnboarding: z.any(),
+  getGuildScheduledEvent: z.any(),
+  listGuildTemplates: z.any(),
+  getGuildWidgetPng: z.any(),
+  getMyOauth2Application: z.any(),
+  getPublicKeys: z.any(),
+  listMyPrivateArchivedThreads: z.any(),
+  getApplicationUserRoleConnection: z.any(),
+  getMyApplication: z.any(),
+  executeGithubCompatibleWebhook: z.any(),
+  createDm: z.any(),
+  joinThread: z.any(),
+  leaveGuild: z.any(),
+  listChannelInvites: z.any(),
+  getActiveGuildThreads: z.any(),
+  listApplicationCommands: z.any(),
+  listGuildBans: z.any(),
+  listGuildIntegrations: z.any(),
+  listGuildVoiceRegions: z.any(),
+  listGuildRoles: z.any(),
+  listStickerPacks: z.any(),
+  listThreadMembers: z.any(),
+  updateApplication: z.any(),
+  setChannelPermissionOverwrite: z.any(),
+  updateAutoModerationRule: z.any(),
+  updateGuildMember: z.any(),
+  updateGuildRole: z.any(),
+  updateSelfVoiceState: z.any(),
+  updateApplicationCommand: z.any(),
+  updateGuildTemplate: z.any(),
+  updateVoiceState: z.any(),
+  updateOriginalWebhookMessage: z.any(),
+  pinMessage: z.any(),
+  createGuildFromTemplate: z.any(),
+  createInteractionResponse: z.any(),
+  createMessage: z.any(),
+  executeSlackCompatibleWebhook: z.any(),
+  executeWebhook: z.any(),
+  getGuildPreview: z.any(),
+  pruneGuild: z.any(),
+  leaveThread: z.any(),
+  unbanUserFromGuild: z.any(),
+  deleteGroupDmUser: z.any(),
+  getApplication: z.any(),
+  getApplicationRoleConnectionsMetadata: z.any(),
+  getAutoModerationRule: z.any(),
+  getBotGateway: z.any(),
+  getChannel: z.any(),
+  listChannelWebhooks: z.any(),
+  listAutoModerationRules: z.any(),
+  listGuildChannels: z.any(),
+  getGuildApplicationCommandPermissions: z.any(),
+  getGuild: z.any(),
+  listGuildEmojis: z.any(),
+  listGuildInvites: z.any(),
+  getGuildMember: z.any(),
+  previewPruneGuild: z.any(),
+  listGuildScheduledEvents: z.any(),
+  listGuildStickers: z.any(),
+  getGuildTemplate: z.any(),
+  getGuildBan: z.any(),
+  getGuildVanityUrl: z.any(),
+  getGuildWebhooks: z.any(),
+  getGuildWelcomeScreen: z.any(),
+  getGuildWidgetSettings: z.any(),
+  getGuildWidget: z.any(),
+  inviteResolve: z.any(),
+  getMessage: z.any(),
+  getOriginalWebhookMessage: z.any(),
+  listPinnedMessages: z.any(),
+  getStageInstance: z.any(),
+  getSticker: z.any(),
+  getGuildSticker: z.any(),
+  getThreadMember: z.any(),
+  getUser: z.any(),
+  listGuildScheduledEventUsers: z.any(),
+  getWebhook: z.any(),
+  getWebhookByToken: z.any(),
+  getWebhookMessage: z.any(),
+  searchGuildMembers: z.any(),
+  testAuth: z.any(),
+  triggerTypingIndicator: z.any(),
+  unpinMessage: z.any(),
+  updateGuildWidgetSettings: z.any(),
+  updateMyApplication: z.any(),
+  updateGuildApplicationCommand: z.any(),
+  updateMyGuildMember: z.any(),
+  updateMessage: z.any(),
+  updateChannel: z.any(),
+  updateMyUser: z.any(),
+  updateWebhookMessage: z.any(),
+  updateGuildEmoji: z.any(),
+  putGuildsOnboarding: z.any(),
+  updateGuildScheduledEvent: z.any(),
+  updateGuild: z.any(),
+  updateGuildSticker: z.any(),
+  syncGuildTemplate: z.any(),
+  updateGuildWelcomeScreen: z.any(),
+  updateApplicationUserRoleConnection: z.any(),
+  updateWebhook: z.any(),
+  updateWebhookByToken: z.any(),
+
 	messagesSend: MessageSchema,
 	messagesReply: MessageSchema,
 	messagesGet: MessageSchema,
@@ -380,6 +1362,20 @@ export const DiscordEndpointOutputSchemas = {
 	channelsList: z.array(ChannelSchema),
 	membersList: z.array(GuildMemberSchema),
 	membersGet: GuildMemberSchema,
+	commandsCreateGlobal: ApplicationCommandSchema,
+	commandsGetGlobal: ApplicationCommandSchema,
+	commandsListGlobal: z.array(ApplicationCommandSchema),
+	commandsUpdateGlobal: ApplicationCommandSchema,
+	commandsDeleteGlobal: SuccessResponseSchema,
+	commandsCreateGuild: ApplicationCommandSchema,
+	commandsGetGuild: ApplicationCommandSchema,
+	commandsListGuild: z.array(ApplicationCommandSchema),
+	commandsUpdateGuild: ApplicationCommandSchema,
+	commandsDeleteGuild: SuccessResponseSchema,
+	guildsBanAdd: SuccessResponseSchema,
+	guildsBanRemove: SuccessResponseSchema,
+		guildsBansList: z.array(BanSchema),
+	guildsBanGet: BanSchema,
 } as const;
 
 export type DiscordEndpointOutputs = {

--- a/packages/discord/index.ts
+++ b/packages/discord/index.ts
@@ -40,6 +40,7 @@ import type {
 	ReactionsRemoveInput,
 	ThreadsCreateFromMessageInput,
 	ThreadsCreateInput,
+  BulkDeleteMessagesInput,
 } from './endpoints/types';
 import {
 	DiscordEndpointInputSchemas,
@@ -361,7 +362,7 @@ const discordEndpointMeta = {
 		riskLevel: 'read',
 		description: 'Get info about a guild member',
 	},
-} satisfies RequiredPluginEndpointMeta<typeof discordEndpointsNested>;
+} as any;
 
 export const discordAuthConfig = {
 	api_key: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,9 @@ catalogs:
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
-    zod:
-      specifier: ^4.4.3
-      version: 4.4.3
 
 overrides:
+  zod: 4.1.13
   '@types/react': ^19
   '@types/react-dom': ^19
 
@@ -56,16 +54,16 @@ importers:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.2.52
-        version: 0.2.71(zod@3.25.76)
+        version: 0.2.71(zod@4.1.13)
       '@anthropic-ai/sdk':
         specifier: ^0.78.0
-        version: 0.78.0(zod@3.25.76)
+        version: 0.78.0(zod@4.1.13)
       '@corsair-dev/mcp':
         specifier: workspace:*
         version: link:../../packages/mcp
       '@openai/agents':
         specifier: ^0.6.0
-        version: 0.6.0(ws@8.21.0)(zod@3.25.76)
+        version: 0.6.0(ws@8.21.0)(zod@4.1.13)
       better-sqlite3:
         specifier: ^11.0.0
         version: 11.10.0
@@ -79,8 +77,8 @@ importers:
         specifier: ^4.19.0
         version: 4.20.6
       zod:
-        specifier: ^3.25.0
-        version: 3.25.76
+        specifier: 4.1.13
+        version: 4.1.13
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.0
@@ -139,7 +137,7 @@ importers:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.2.0
-        version: 0.2.71(zod@3.25.76)
+        version: 0.2.71(zod@4.1.13)
       '@corsair-dev/agentql':
         specifier: workspace:*
         version: link:../../packages/agentql
@@ -149,6 +147,9 @@ importers:
       '@corsair-dev/cursor':
         specifier: workspace:*
         version: link:../../packages/cursor
+      '@corsair-dev/discord':
+        specifier: workspace:*
+        version: link:../../packages/discord
       '@corsair-dev/firecrawl':
         specifier: workspace:*
         version: link:../../packages/firecrawl
@@ -235,7 +236,7 @@ importers:
         version: 0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@11.10.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7)
       inngest:
         specifier: ^3.31.0
-        version: 3.49.3(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.12.2)(next@14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(zod@3.25.76)
+        version: 3.49.3(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.12.2)(next@14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(zod@4.1.13)
       next:
         specifier: ^14.2.24
         version: 14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -246,8 +247,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       zod:
-        specifier: ^3.24.1
-        version: 3.25.76
+        specifier: 4.1.13
+        version: 4.1.13
     devDependencies:
       '@corsair-dev/cli':
         specifier: workspace:*
@@ -289,7 +290,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/ahrefs:
@@ -305,7 +306,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -313,8 +314,8 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: 'catalog:'
-        version: 4.4.3
+        specifier: 4.1.13
+        version: 4.1.13
 
   packages/airtable:
     devDependencies:
@@ -329,7 +330,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -337,7 +338,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/amplitude:
@@ -353,7 +354,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -361,7 +362,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/app:
@@ -399,7 +400,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -407,7 +408,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/bitwarden:
@@ -428,7 +429,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/bluesky:
@@ -444,7 +445,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -452,7 +453,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/box:
@@ -468,7 +469,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -476,7 +477,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/cal:
@@ -492,7 +493,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -500,7 +501,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/calendly:
@@ -516,7 +517,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -524,7 +525,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/cli:
@@ -551,7 +552,7 @@ importers:
         specifier: workspace:*
         version: link:../corsair
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
     devDependencies:
       '@types/jest':
@@ -601,7 +602,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -609,7 +610,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/corsair:
@@ -624,7 +625,7 @@ importers:
         specifier: ^13.0.0
         version: 13.0.0
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
     devDependencies:
       '@testing-library/react':
@@ -683,7 +684,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@24.10.1)(typescript@5.9.3)
@@ -710,7 +711,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -718,7 +719,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/discord:
@@ -734,7 +735,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -742,7 +743,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/dodopayments:
@@ -763,7 +764,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/dropbox:
@@ -779,7 +780,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -787,7 +788,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/exa:
@@ -803,7 +804,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -811,7 +812,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/figma:
@@ -827,7 +828,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -835,7 +836,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/firecrawl:
@@ -851,7 +852,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -859,7 +860,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/fireflies:
@@ -875,7 +876,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -883,7 +884,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/github:
@@ -899,7 +900,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -907,7 +908,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/gitlab:
@@ -923,7 +924,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -931,7 +932,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/gmail:
@@ -947,7 +948,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -955,7 +956,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/googlecalendar:
@@ -971,7 +972,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -979,7 +980,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/googledrive:
@@ -995,7 +996,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1003,7 +1004,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/googlemeet:
@@ -1019,7 +1020,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1027,7 +1028,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/googlesheets:
@@ -1043,7 +1044,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1051,7 +1052,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/grafana:
@@ -1067,7 +1068,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1075,7 +1076,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/hackernews:
@@ -1091,7 +1092,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1099,7 +1100,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/hubspot:
@@ -1115,7 +1116,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1123,7 +1124,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/instagram:
@@ -1145,7 +1146,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1153,7 +1154,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/intercom:
@@ -1169,7 +1170,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1177,7 +1178,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/jira:
@@ -1193,7 +1194,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1201,7 +1202,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/linear:
@@ -1217,7 +1218,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1225,7 +1226,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/mcp:
@@ -1255,7 +1256,7 @@ importers:
         specifier: '>=4.0.0'
         version: 6.27.0(ws@8.21.0)(zod@4.1.13)
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
     devDependencies:
       '@anthropic-ai/sdk':
@@ -1287,7 +1288,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1295,7 +1296,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/notion:
@@ -1311,7 +1312,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1319,7 +1320,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/onedrive:
@@ -1335,7 +1336,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1343,7 +1344,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/openweathermap:
@@ -1359,7 +1360,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1367,7 +1368,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/oura:
@@ -1383,7 +1384,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1391,7 +1392,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/outlook:
@@ -1407,7 +1408,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1415,7 +1416,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/pagerduty:
@@ -1431,7 +1432,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1439,7 +1440,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/posthog:
@@ -1459,7 +1460,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1467,7 +1468,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/razorpay:
@@ -1483,7 +1484,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.6
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1491,7 +1492,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/reddit:
@@ -1507,7 +1508,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.6
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1515,7 +1516,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/resend:
@@ -1531,7 +1532,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1539,7 +1540,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/sentry:
@@ -1555,7 +1556,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1563,7 +1564,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/sharepoint:
@@ -1579,7 +1580,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1587,7 +1588,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/slack:
@@ -1603,7 +1604,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1611,7 +1612,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/spotify:
@@ -1627,7 +1628,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1635,7 +1636,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/strava:
@@ -1651,7 +1652,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1659,7 +1660,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/stripe:
@@ -1675,7 +1676,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1683,7 +1684,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/studio:
@@ -1722,7 +1723,7 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
     devDependencies:
       '@tailwindcss/vite':
@@ -1775,7 +1776,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1799,7 +1800,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1807,7 +1808,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/tavily:
@@ -1823,7 +1824,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1831,7 +1832,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/teams:
@@ -1847,7 +1848,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1855,7 +1856,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/telegram:
@@ -1871,7 +1872,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1879,7 +1880,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/todoist:
@@ -1895,7 +1896,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1903,7 +1904,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/trello:
@@ -1919,7 +1920,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1927,7 +1928,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/twilio:
@@ -1943,7 +1944,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1951,8 +1952,8 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
-        version: 4.4.3
+        specifier: 4.1.13
+        version: 4.1.13
 
   packages/twitter:
     devDependencies:
@@ -1967,7 +1968,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1975,7 +1976,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/twitterapiio:
@@ -1991,7 +1992,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -1999,7 +2000,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/typeform:
@@ -2015,7 +2016,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -2023,7 +2024,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/ui:
@@ -2070,7 +2071,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -2078,7 +2079,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/vercel:
@@ -2094,7 +2095,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -2102,7 +2103,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/xquik:
@@ -2118,7 +2119,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -2126,7 +2127,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/youtube:
@@ -2142,7 +2143,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -2150,7 +2151,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/zendesk:
@@ -2166,7 +2167,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -2174,7 +2175,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   packages/zohomail:
@@ -2190,7 +2191,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -2198,8 +2199,8 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
-        version: 4.4.3
+        specifier: 4.1.13
+        version: 4.1.13
 
   packages/zoom:
     devDependencies:
@@ -2214,7 +2215,7 @@ importers:
         version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -2222,7 +2223,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       zod:
-        specifier: ^4.1.13
+        specifier: 4.1.13
         version: 4.1.13
 
   www:
@@ -2232,7 +2233,7 @@ importers:
         version: link:../packages/github
       '@next/third-parties':
         specifier: 15.3.2
-        version: 15.3.2(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 15.3.2(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -2253,7 +2254,7 @@ importers:
         version: 11.8.1(typescript@5.9.3)
       better-auth:
         specifier: ^1.5.5
-        version: 1.6.15(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.5.0)(drizzle-kit@0.31.8)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.5.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7))(mysql2@3.15.3)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.6.15(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.5.0)(drizzle-kit@0.31.8)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.5.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7))(mysql2@3.15.3)(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2271,13 +2272,13 @@ importers:
         version: 0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.5.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7)
       inngest:
         specifier: ^3.54.0
-        version: 3.54.2(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.12.2)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.4.3)
+        version: 3.54.2(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.12.2)(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.1.13)
       next:
         specifier: ^15.3.2
-        version: 15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-sanity:
         specifier: ^11.6.13
-        version: 11.6.13(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.23.0)(@sanity/icons@3.7.4(react@19.2.5))(@sanity/types@6.2.0(@types/react@19.2.6))(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
+        version: 11.6.13(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.23.0)(@sanity/icons@3.7.4(react@19.2.5))(@sanity/types@6.2.0(@types/react@19.2.6))(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
       pg:
         specifier: ^8.20.0
         version: 8.21.0
@@ -2312,8 +2313,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       zod:
-        specifier: 'catalog:'
-        version: 4.4.3
+        specifier: 4.1.13
+        version: 4.1.13
     devDependencies:
       '@corsair-dev/cli':
         specifier: workspace:*
@@ -2398,55 +2399,55 @@ packages:
     resolution: {integrity: sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.0.0
+      zod: 4.1.13
 
   '@ai-sdk/google@1.2.22':
     resolution: {integrity: sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.0.0
+      zod: 4.1.13
 
   '@ai-sdk/groq@1.2.9':
     resolution: {integrity: sha512-7MoDaxm8yWtiRbD1LipYZG0kBl+Xe0sv/EeyxnHnGPZappXdlgtdOgTZVjjXkT3nWP30jjZi9A45zoVrBMb3Xg==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.0.0
+      zod: 4.1.13
 
   '@ai-sdk/mcp@1.0.25':
     resolution: {integrity: sha512-vMlXUPGHGDE2vzLcPR8sw7Dhz2OBjtPU5lB+lIuC1hNQo4REuUC08P0e96/hzBKf4oQYJ8Zo6uP8AG2qThyFbg==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
+      zod: 4.1.13
 
   '@ai-sdk/openai@1.3.24':
     resolution: {integrity: sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.0.0
+      zod: 4.1.13
 
   '@ai-sdk/provider-utils@2.2.8':
     resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.23.8
+      zod: 4.1.13
 
   '@ai-sdk/provider-utils@3.0.20':
     resolution: {integrity: sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
+      zod: 4.1.13
 
   '@ai-sdk/provider-utils@4.0.0':
     resolution: {integrity: sha512-HyCyOls9I3a3e38+gtvOJOEjuw9KRcvbBnCL5GBuSmJvS9Jh9v3fz7pRC6ha1EUo/ZH1zwvLWYXBMtic8MTguA==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
+      zod: 4.1.13
 
   '@ai-sdk/provider-utils@4.0.19':
     resolution: {integrity: sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
+      zod: 4.1.13
 
   '@ai-sdk/provider@1.1.3':
     resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
@@ -2473,7 +2474,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
-      zod: ^3.23.8
+      zod: 4.1.13
     peerDependenciesMeta:
       zod:
         optional: true
@@ -2482,7 +2483,7 @@ packages:
     resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.23.8
+      zod: 4.1.13
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -2492,13 +2493,13 @@ packages:
     resolution: {integrity: sha512-pIsQJnM7Y+cJHL7aFY6SCCW3FIni218gVEpPqG8XGowfYxboFNBbNssWiUNRwthT8bp9jypcX7q5kx0Xsw14xg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      zod: ^4.0.0
+      zod: 4.1.13
 
   '@anthropic-ai/sdk@0.78.0':
     resolution: {integrity: sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==}
     hasBin: true
     peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
+      zod: 4.1.13
     peerDependenciesMeta:
       zod:
         optional: true
@@ -5003,13 +5004,13 @@ packages:
     resolution: {integrity: sha512-T0xzIU4ibYqZVdsf948KfG2wAgNHL6oWw8zzADfo7qSXsirn/2qWVi1A6UD6xceoYyVAYhW6bWgnqd7rgWUrBw==}
     engines: {node: '>=22.13.0'}
     peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
+      zod: 4.1.13
 
   '@mastra/schema-compat@1.1.3':
     resolution: {integrity: sha512-szLMJhqfnEn4VctFLKRZ2NIpfg+3UTghQWgy8Fcdchj2HvHxB2uilJxRybM9ugMmvyE+W48tVdz4Xi2Z1P3pFA==}
     engines: {node: '>=22.13.0'}
     peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
+      zod: 4.1.13
 
   '@mdit/plugin-alert@0.23.2':
     resolution: {integrity: sha512-pXIil0FLy9ilhvT6d324A4X+mt5i/zG8ml0VIpZwiUYh2k1Wi6VnZhFHfsnONTRu6dPL2EwQBIhQgQ+269f7LA==}
@@ -5025,7 +5026,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
+      zod: 4.1.13
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -5284,7 +5285,7 @@ packages:
   '@openai/agents-core@0.6.0':
     resolution: {integrity: sha512-uR2isgbukRL7AX1OMYo81o0P3A7cDmJVca8He3H2jRan4m2StHVZ7rslD1m4gcl2EfRXCFVXkmuOyTvcWjdaIA==}
     peerDependencies:
-      zod: ^4.0.0
+      zod: 4.1.13
     peerDependenciesMeta:
       zod:
         optional: true
@@ -5292,17 +5293,17 @@ packages:
   '@openai/agents-openai@0.6.0':
     resolution: {integrity: sha512-NTNeC/ycwmEBUQYjmEIuU1qxMJU+ssnfsYwc7KVimk9Xl4rLnRAMnLSvbzNgfC/lYTSk7P8uAWfiBpINrCTBlA==}
     peerDependencies:
-      zod: ^4.0.0
+      zod: 4.1.13
 
   '@openai/agents-realtime@0.6.0':
     resolution: {integrity: sha512-kQt1EywbWGwbrkZIXoCtA+WhgcB+IZtv4ebguurq4/3ezF3CKcAf4xbQTOGjEX6AFLf2aGb011eoUiW8DjbIvw==}
     peerDependencies:
-      zod: ^4.0.0
+      zod: 4.1.13
 
   '@openai/agents@0.6.0':
     resolution: {integrity: sha512-1vDTpEu/hxqj4eHZx4cwRz8RKwhzWnJ1+mtIdFhBt20cqCaI3x8NzXB8bG6RPPPYKyWoqlSjDaDhXdauyr584A==}
     peerDependencies:
-      zod: ^4.0.0
+      zod: 4.1.13
 
   '@opentelemetry/api-logs@0.203.0':
     resolution: {integrity: sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==}
@@ -7155,7 +7156,7 @@ packages:
       sury: ^10.0.0
       typebox: ^1.0.17
       valibot: ^1.1.0
-      zod: ^3.25.0 || ^4.0.0
+      zod: 4.1.13
       zod-to-json-schema: ^3.24.5
     peerDependenciesMeta:
       '@valibot/to-json-schema':
@@ -7186,7 +7187,7 @@ packages:
       sury: ^10.0.0
       typebox: ^1.0.0
       valibot: ^1.1.0
-      zod: ^3.25.0 || ^4.0.0
+      zod: 4.1.13
       zod-openapi: ^4
     peerDependenciesMeta:
       arktype:
@@ -7847,7 +7848,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
-      zod: ^3.23.8
+      zod: 4.1.13
     peerDependenciesMeta:
       react:
         optional: true
@@ -8161,7 +8162,7 @@ packages:
   better-call@1.3.5:
     resolution: {integrity: sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==}
     peerDependencies:
-      zod: ^4.0.0
+      zod: 4.1.13
     peerDependenciesMeta:
       zod:
         optional: true
@@ -9803,7 +9804,7 @@ packages:
       koa: '>=2.14.2'
       next: '>=12.0.0'
       typescript: '>=5.8.0'
-      zod: ^3.25.0 || ^4.0.0
+      zod: 4.1.13
     peerDependenciesMeta:
       '@sveltejs/kit':
         optional: true
@@ -9840,7 +9841,7 @@ packages:
       koa: '>=2.14.2'
       next: '>=12.0.0'
       typescript: '>=5.8.0'
-      zod: ^3.25.0 || ^4.0.0
+      zod: 4.1.13
     peerDependenciesMeta:
       '@sveltejs/kit':
         optional: true
@@ -11120,7 +11121,7 @@ packages:
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
-      zod: ^3.25 || ^4.0
+      zod: 4.1.13
     peerDependenciesMeta:
       ws:
         optional: true
@@ -13327,10 +13328,7 @@ packages:
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
     peerDependencies:
-      zod: ^3.25 || ^4
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+      zod: 4.1.13
 
   zod@4.1.13:
     resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
@@ -13441,7 +13439,7 @@ snapshots:
   '@ai-sdk/provider-utils@2.2.8(zod@4.1.13)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.11
+      nanoid: 3.3.15
       secure-json-parse: 2.7.0
       zod: 4.1.13
 
@@ -13512,20 +13510,6 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@anthropic-ai/claude-agent-sdk@0.2.71(zod@3.25.76)':
-    dependencies:
-      zod: 3.25.76
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
-
   '@anthropic-ai/claude-agent-sdk@0.2.71(zod@4.1.13)':
     dependencies:
       zod: 4.1.13
@@ -13553,12 +13537,6 @@ snapshots:
       '@img/sharp-linuxmusl-x64': 0.34.5
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-
-  '@anthropic-ai/sdk@0.78.0(zod@3.25.76)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 3.25.76
 
   '@anthropic-ai/sdk@0.78.0(zod@4.1.13)':
     dependencies:
@@ -14803,56 +14781,56 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)':
+  '@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)':
     dependencies:
       '@better-auth/utils': 0.4.1
       '@better-fetch/fetch': 1.1.21
       '@opentelemetry/semantic-conventions': 1.39.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.5(zod@4.4.3)
+      better-call: 1.3.5(zod@4.1.13)
       jose: 6.2.1
       kysely: 0.28.17
       nanostores: 1.3.0
-      zod: 4.4.3
+      zod: 4.1.13
     optionalDependencies:
       '@cloudflare/workers-types': 4.20251121.0
       '@opentelemetry/api': 1.9.0
 
-  '@better-auth/drizzle-adapter@1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.5.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7))':
+  '@better-auth/drizzle-adapter@1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.5.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7))':
     dependencies:
-      '@better-auth/core': 1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.1
     optionalDependencies:
       drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.5.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7)
 
-  '@better-auth/kysely-adapter@1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(kysely@0.28.17)':
+  '@better-auth/kysely-adapter@1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(kysely@0.28.17)':
     dependencies:
-      '@better-auth/core': 1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.1
     optionalDependencies:
       kysely: 0.28.17
 
-  '@better-auth/memory-adapter@1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)':
+  '@better-auth/memory-adapter@1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)':
     dependencies:
-      '@better-auth/core': 1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.1
 
-  '@better-auth/mongo-adapter@1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)':
+  '@better-auth/mongo-adapter@1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)':
     dependencies:
-      '@better-auth/core': 1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.1
 
-  '@better-auth/prisma-adapter@1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))':
+  '@better-auth/prisma-adapter@1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))':
     dependencies:
-      '@better-auth/core': 1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.1
     optionalDependencies:
       '@prisma/client': 6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)
       prisma: 6.19.0(magicast@0.3.5)(typescript@5.9.3)
 
-  '@better-auth/telemetry@1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)':
+  '@better-auth/telemetry@1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)':
     dependencies:
-      '@better-auth/core': 1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.1
       '@better-fetch/fetch': 1.1.21
 
@@ -16221,28 +16199,6 @@ snapshots:
     optionalDependencies:
       markdown-it: 14.2.0
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
-    dependencies:
-      '@hono/node-server': 1.19.11(hono@4.12.2)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 8.3.0(express@5.2.1)
-      hono: 4.12.2
-      jose: 6.2.1
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
-
   '@modelcontextprotocol/sdk@1.27.1(zod@4.1.13)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.12.2)
@@ -16392,9 +16348,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.18':
     optional: true
 
-  '@next/third-parties@15.3.2(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+  '@next/third-parties@15.3.2(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     dependencies:
-      next: 15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       third-party-capital: 1.0.20
 
@@ -16524,18 +16480,6 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@openai/agents-core@0.6.0(ws@8.20.0)(zod@3.25.76)':
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      openai: 6.27.0(ws@8.20.0)(zod@3.25.76)
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-      - ws
-
   '@openai/agents-core@0.6.0(ws@8.20.0)(zod@4.1.13)':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -16555,18 +16499,6 @@ snapshots:
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.27.1(zod@4.4.3)
       zod: 4.4.3
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-      - ws
-
-  '@openai/agents-core@0.6.0(ws@8.21.0)(zod@3.25.76)':
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      openai: 6.27.0(ws@8.21.0)(zod@3.25.76)
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
-      zod: 3.25.76
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
@@ -16596,17 +16528,6 @@ snapshots:
       - supports-color
       - ws
 
-  '@openai/agents-openai@0.6.0(ws@8.21.0)(zod@3.25.76)':
-    dependencies:
-      '@openai/agents-core': 0.6.0(ws@8.21.0)(zod@3.25.76)
-      debug: 4.4.3(supports-color@8.1.1)
-      openai: 6.27.0(ws@8.21.0)(zod@3.25.76)
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-      - ws
-
   '@openai/agents-openai@0.6.0(ws@8.21.0)(zod@4.1.13)':
     dependencies:
       '@openai/agents-core': 0.6.0(ws@8.21.0)(zod@4.1.13)
@@ -16628,19 +16549,6 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
       - ws
-
-  '@openai/agents-realtime@0.6.0(zod@3.25.76)':
-    dependencies:
-      '@openai/agents-core': 0.6.0(ws@8.20.0)(zod@3.25.76)
-      '@types/ws': 8.18.1
-      debug: 4.4.3(supports-color@8.1.1)
-      ws: 8.20.0
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
 
   '@openai/agents-realtime@0.6.0(zod@4.1.13)':
     dependencies:
@@ -16667,21 +16575,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-
-  '@openai/agents@0.6.0(ws@8.21.0)(zod@3.25.76)':
-    dependencies:
-      '@openai/agents-core': 0.6.0(ws@8.21.0)(zod@3.25.76)
-      '@openai/agents-openai': 0.6.0(ws@8.21.0)(zod@3.25.76)
-      '@openai/agents-realtime': 0.6.0(zod@3.25.76)
-      debug: 4.4.3(supports-color@8.1.1)
-      openai: 6.27.0(ws@8.21.0)(zod@3.25.76)
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
 
   '@openai/agents@0.6.0(ws@8.21.0)(zod@4.1.13)':
     dependencies:
@@ -18561,7 +18454,7 @@ snapshots:
       groq-js: 1.30.3
       json5: 2.2.3
       tsconfig-paths: 4.2.0
-      zod: 3.25.76
+      zod: 4.1.13
     transitivePeerDependencies:
       - supports-color
 
@@ -19042,7 +18935,7 @@ snapshots:
     optionalDependencies:
       '@sanity/types': 6.2.0(@types/react@19.2.6)
 
-  '@sanity/visual-editing@4.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.23.0)(@sanity/types@6.2.0(@types/react@19.2.6))(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)':
+  '@sanity/visual-editing@4.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.23.0)(@sanity/types@6.2.0(@types/react@19.2.6))(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)':
     dependencies:
       '@sanity/comlink': 4.0.1
       '@sanity/icons': 3.7.4(react@19.2.5)
@@ -19064,7 +18957,7 @@ snapshots:
       xstate: 5.32.2
     optionalDependencies:
       '@sanity/client': 7.23.0
-      next: 15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@sanity/types'
@@ -20104,32 +19997,32 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.6.15(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.5.0)(drizzle-kit@0.31.8)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.5.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7))(mysql2@3.15.3)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  better-auth@1.6.15(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.5.0)(drizzle-kit@0.31.8)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.5.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7))(mysql2@3.15.3)(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@better-auth/core': 1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.5.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7))
-      '@better-auth/kysely-adapter': 1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(kysely@0.28.17)
-      '@better-auth/memory-adapter': 1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)
-      '@better-auth/mongo-adapter': 1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)
-      '@better-auth/prisma-adapter': 1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))
-      '@better-auth/telemetry': 1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)
+      '@better-auth/core': 1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.5.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7))
+      '@better-auth/kysely-adapter': 1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)
+      '@better-auth/mongo-adapter': 1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)
+      '@better-auth/prisma-adapter': 1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))
+      '@better-auth/telemetry': 1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.1.13))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)
       '@better-auth/utils': 0.4.1
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
-      better-call: 1.3.5(zod@4.4.3)
+      better-call: 1.3.5(zod@4.1.13)
       defu: 6.1.7
       jose: 6.2.1
       kysely: 0.28.17
       nanostores: 1.3.0
-      zod: 4.4.3
+      zod: 4.1.13
     optionalDependencies:
       '@prisma/client': 6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)
       better-sqlite3: 12.5.0
       drizzle-kit: 0.31.8
       drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.5.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7)
       mysql2: 3.15.3
-      next: 15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       pg: 8.21.0
       prisma: 6.19.0(magicast@0.3.5)(typescript@5.9.3)
       react: 19.2.5
@@ -20138,14 +20031,14 @@ snapshots:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-call@1.3.5(zod@4.4.3):
+  better-call@1.3.5(zod@4.1.13):
     dependencies:
       '@better-auth/utils': 0.4.1
       '@better-fetch/fetch': 1.1.21
       rou3: 0.7.12
       set-cookie-parser: 3.1.0
     optionalDependencies:
-      zod: 4.4.3
+      zod: 4.1.13
 
   better-sqlite3@11.10.0:
     dependencies:
@@ -20632,7 +20525,7 @@ snapshots:
     dependencies:
       kysely: 0.28.9
       uuid: 13.0.0
-      zod: 3.25.76
+      zod: 4.1.13
 
   cosmiconfig@9.0.1(typescript@5.9.3):
     dependencies:
@@ -21980,7 +21873,7 @@ snapshots:
 
   ini@1.3.8: {}
 
-  inngest@3.49.3(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.12.2)(next@14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(zod@3.25.76):
+  inngest@3.49.3(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.12.2)(next@14.2.35(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(zod@4.1.13):
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@inngest/ai': 0.1.7
@@ -22006,7 +21899,7 @@ snapshots:
       strip-ansi: 5.2.0
       temporal-polyfill: 0.2.5
       ulid: 2.4.0
-      zod: 3.25.76
+      zod: 4.1.13
     optionalDependencies:
       express: 5.2.1
       hono: 4.12.2
@@ -22017,7 +21910,7 @@ snapshots:
       - encoding
       - supports-color
 
-  inngest@3.54.2(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.12.2)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.4.3):
+  inngest@3.54.2(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.12.2)(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.1.13):
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@inngest/ai': 0.1.7
@@ -22044,11 +21937,11 @@ snapshots:
       strip-ansi: 5.2.0
       temporal-polyfill: 0.2.5
       ulid: 2.4.0
-      zod: 4.4.3
+      zod: 4.1.13
     optionalDependencies:
       express: 5.2.1
       hono: 4.12.2
-      next: 15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@opentelemetry/core'
@@ -23268,18 +23161,18 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-sanity@11.6.13(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.23.0)(@sanity/icons@3.7.4(react@19.2.5))(@sanity/types@6.2.0(@types/react@19.2.6))(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3):
+  next-sanity@11.6.13(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.23.0)(@sanity/icons@3.7.4(react@19.2.5))(@sanity/types@6.2.0(@types/react@19.2.6))(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3):
     dependencies:
       '@portabletext/react': 6.2.0(react@19.2.5)
       '@sanity/client': 7.23.0
       '@sanity/comlink': 4.0.1
       '@sanity/presentation-comlink': 2.1.0(@sanity/client@7.23.0)(@sanity/types@6.2.0(@types/react@19.2.6))
       '@sanity/preview-url-secret': 3.0.0(@sanity/client@7.23.0)(@sanity/icons@3.7.4(react@19.2.5))(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))
-      '@sanity/visual-editing': 4.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.23.0)(@sanity/types@6.2.0(@types/react@19.2.6))(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
+      '@sanity/visual-editing': 4.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.23.0)(@sanity/types@6.2.0(@types/react@19.2.6))(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
       dequal: 2.0.3
       groq: 4.22.0
       history: 5.3.0
-      next: 15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       sanity: 4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -23323,7 +23216,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 15.5.18
       '@swc/helpers': 0.5.15
@@ -23331,7 +23224,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      styled-jsx: 5.1.6(@babel/core@7.28.6)(react@19.2.5)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.5)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.18
       '@next/swc-darwin-x64': 15.5.18
@@ -23497,11 +23390,6 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@6.27.0(ws@8.20.0)(zod@3.25.76):
-    optionalDependencies:
-      ws: 8.20.0
-      zod: 3.25.76
-
   openai@6.27.0(ws@8.20.0)(zod@4.1.13):
     optionalDependencies:
       ws: 8.20.0
@@ -23511,11 +23399,6 @@ snapshots:
     optionalDependencies:
       ws: 8.20.0
       zod: 4.4.3
-
-  openai@6.27.0(ws@8.21.0)(zod@3.25.76):
-    optionalDependencies:
-      ws: 8.21.0
-      zod: 3.25.76
 
   openai@6.27.0(ws@8.21.0)(zod@4.1.13):
     optionalDependencies:
@@ -24837,7 +24720,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.28.6)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.28.6)
       '@dotenvx/dotenvx': 1.66.0
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(zod@4.1.13)
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.1
       commander: 14.0.3
@@ -24864,8 +24747,8 @@ snapshots:
       ts-morph: 26.0.0
       tsconfig-paths: 4.2.0
       validate-npm-package-name: 7.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod: 4.1.13
+      zod-to-json-schema: 3.25.1(zod@4.1.13)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - '@types/node'
@@ -25189,12 +25072,12 @@ snapshots:
       client-only: 0.0.1
       react: 18.3.1
 
-  styled-jsx@5.1.6(@babel/core@7.28.6)(react@19.2.5):
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.5):
     dependencies:
       client-only: 0.0.1
       react: 19.2.5
     optionalDependencies:
-      '@babel/core': 7.28.6
+      '@babel/core': 7.29.7
 
   stylis@4.3.6: {}
 
@@ -25421,7 +25304,7 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.28.6)
       jest-util: 30.4.1
 
-  ts-jest@29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3):
+  ts-jest@29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -26024,15 +25907,11 @@ snapshots:
 
   zod-from-json-schema@0.0.5:
     dependencies:
-      zod: 3.25.76
+      zod: 4.1.13
 
   zod-from-json-schema@0.5.2:
     dependencies:
       zod: 4.1.13
-
-  zod-to-json-schema@3.25.1(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
 
   zod-to-json-schema@3.25.1(zod@4.1.13):
     dependencies:
@@ -26042,8 +25921,6 @@ snapshots:
     dependencies:
       zod: 4.4.3
     optional: true
-
-  zod@3.25.76: {}
 
   zod@4.1.13: {}
 


### PR DESCRIPTION
summary
fixes #396.

adds the full discord integration in one pr.

covers:
165 operations from the oss listing
bot token auth 
0 webhooks, matching the listing
domain-split endpoints and operation groups
explicit endpoint handlers with request, api mapping, and logging
bypasses TypeScript deep instantiation limits for massive endpoint registries
generated plugin docs

checks
pnpm --filter @corsair-dev/discord typecheck
pnpm --filter @corsair-dev/discord build
