### PR TITLE
fix(www): format landing and oss pages

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -15,7 +15,13 @@
       "tailwindDirectives": true
     }
   },
-  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
   "linter": {
     "enabled": true,
     "rules": {
@@ -89,7 +95,8 @@
       "!**/.tmp",
       "!**/packages/create/template/**",
       "!**/.pnpm-store/**",
-      "!**/demo/sdk/**"
+      "!**/demo/sdk/**",
+      "!**/.claude/**"
     ]
   }
 }

--- a/www/src/app/oss/[slug]/integration-claim-callout.tsx
+++ b/www/src/app/oss/[slug]/integration-claim-callout.tsx
@@ -44,8 +44,8 @@ export function IntegrationClaimCallout({
 							variant="inline"
 							className="font-[family-name:var(--font-landing-mono)] text-[#1c1c1c]"
 						/>
-						{' when we merge it to main.'} You have 1 hour to link an issue, then
-						3 hours to open a PR with the plugin scaffold.
+						{' when we merge it to main.'} You have 1 hour to link an issue,
+						then 3 hours to open a PR with the plugin scaffold.
 					</p>
 					<div className="mt-6">
 						{session ? (

--- a/www/src/app/oss/[slug]/integration-detail-sidebar.tsx
+++ b/www/src/app/oss/[slug]/integration-detail-sidebar.tsx
@@ -1,9 +1,8 @@
 import type { ReactNode } from 'react';
 import type { IntegrationPhase } from '@/db/schema';
-
-import { IntegrationStatusBadge } from '../integration-status-badge';
 import { ContributorLink } from '../contributor-link';
 import { IntegrationRewardDisplay } from '../integration-reward-display';
+import { IntegrationStatusBadge } from '../integration-status-badge';
 import { UnclaimIntegrationButton } from '../unclaim-integration-button';
 import { ClaimTimeline } from './claim-timeline';
 import { IntegrationUrlsSection } from './integration-urls-section';

--- a/www/src/app/oss/admin/admin-review-queue.tsx
+++ b/www/src/app/oss/admin/admin-review-queue.tsx
@@ -6,13 +6,12 @@ import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import type { IntegrationPhase, IntegrationUrls } from '@/db/schema';
-
+import { adminMarkIntegrationMerged } from '@/server/actions/admin-mark-merged';
 import { ContributorLink } from '../contributor-link';
 import { FramedPanel } from '../framed-panel';
-import { IntegrationStatusBadge } from '../integration-status-badge';
 import { formatPoints } from '../integration-reward';
+import { IntegrationStatusBadge } from '../integration-status-badge';
 import { buildOssIntegrationHref } from '../oss-url';
-import { adminMarkIntegrationMerged } from '@/server/actions/admin-mark-merged';
 
 type ReviewQueueItem = {
 	id: string;

--- a/www/src/app/oss/admin/layout.tsx
+++ b/www/src/app/oss/admin/layout.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react';
 import { redirect } from 'next/navigation';
+import type { ReactNode } from 'react';
 
 import { getSession } from '@/lib/auth-server';
 import { isOssAdminEmail } from '@/lib/oss-admin';

--- a/www/src/app/oss/contributor-profile.tsx
+++ b/www/src/app/oss/contributor-profile.tsx
@@ -4,8 +4,8 @@ import type { IntegrationPhase } from '@/db/schema';
 import { legacyStatusFromPhase } from '@/lib/integration-phases';
 
 import { FramedPanel } from './framed-panel';
-import { IntegrationRewardDisplay } from './integration-reward-display';
 import { formatPoints } from './integration-reward';
+import { IntegrationRewardDisplay } from './integration-reward-display';
 import { IntegrationStatusBadge } from './integration-status-badge';
 import { buildOssIntegrationHref } from './oss-url';
 
@@ -61,7 +61,11 @@ function formatMemberSince(isoDate: string) {
 	}).format(new Date(isoDate));
 }
 
-export function ContributorProfile({ profile }: { profile: ContributorProfileData }) {
+export function ContributorProfile({
+	profile,
+}: {
+	profile: ContributorProfileData;
+}) {
 	const finishedIntegrations = profile.integrations.filter(
 		(integration) => integration.phase === 'finished',
 	);
@@ -130,9 +134,7 @@ export function ContributorProfile({ profile }: { profile: ContributorProfileDat
 						<StatBlock
 							label="Rank"
 							value={profile.rank ? `#${profile.rank}` : '—'}
-							subtitle={
-								profile.rank ? 'on the leaderboard' : 'not ranked yet'
-							}
+							subtitle={profile.rank ? 'on the leaderboard' : 'not ranked yet'}
 						/>
 					</div>
 				</FramedPanel>

--- a/www/src/app/oss/how-it-works.tsx
+++ b/www/src/app/oss/how-it-works.tsx
@@ -36,7 +36,9 @@ export function HowItWorks({ signedIn }: { signedIn: boolean }) {
 				))}
 			</ol>
 			<p className="mt-4 rounded-lg border border-[#4a38f5]/20 bg-[#4a38f508] px-3 py-2.5 text-[13px] leading-snug text-[#1c1c1c99]">
-				<span className="font-medium text-[#1c1c1c]">Your code, in production.</span>{' '}
+				<span className="font-medium text-[#1c1c1c]">
+					Your code, in production.
+				</span>{' '}
 				Merged plugins go into Corsair&apos;s open catalog and get used by
 				thousands of developers building agents.
 			</p>

--- a/www/src/app/oss/integration-card.tsx
+++ b/www/src/app/oss/integration-card.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link';
-
-import type { ClaimBlockReason } from '@/lib/integration-claim-limits';
 import type { IntegrationPhase } from '@/db/schema';
+import type { ClaimBlockReason } from '@/lib/integration-claim-limits';
 import { cn } from '@/lib/utils';
 import { ClaimIntegrationButton } from './claim-integration-button';
 import { ContributorLink } from './contributor-link';

--- a/www/src/app/oss/integration-reward-display.tsx
+++ b/www/src/app/oss/integration-reward-display.tsx
@@ -52,7 +52,9 @@ export function IntegrationRewardDisplay({
 	}
 
 	return (
-		<span className={cn('inline-flex flex-col items-end leading-none', className)}>
+		<span
+			className={cn('inline-flex flex-col items-end leading-none', className)}
+		>
 			<span
 				className={cn(
 					'font-[family-name:var(--font-landing-mono)] text-[13px] font-medium tabular-nums',

--- a/www/src/app/oss/oss-hero.tsx
+++ b/www/src/app/oss/oss-hero.tsx
@@ -108,11 +108,7 @@ export function OssHero({ signedIn, stats }: OssHeroProps) {
 
 				<FramedPanel>
 					<div className="grid grid-cols-1 gap-px bg-[#1c1c1c1a] sm:grid-cols-2">
-						<HeroStatBlock
-							accent
-							value="$30,000+"
-							label="AI credits to earn"
-						/>
+						<HeroStatBlock accent value="$30,000+" label="AI credits to earn" />
 						<HeroStatBlock
 							value={numberFormatter.format(stats.unclaimed)}
 							label="Integrations available"

--- a/www/src/app/oss/oss-sections.tsx
+++ b/www/src/app/oss/oss-sections.tsx
@@ -226,7 +226,10 @@ export async function OssSidebarSection({ view }: OssSidebarSectionProps) {
 		]);
 
 	if (recentActivityResult.status === 'rejected') {
-		console.error('[oss sidebar] recent activity failed', recentActivityResult.reason);
+		console.error(
+			'[oss sidebar] recent activity failed',
+			recentActivityResult.reason,
+		);
 	}
 	if (leaderboardResult.status === 'rejected') {
 		console.error('[oss sidebar] leaderboard failed', leaderboardResult.reason);

--- a/www/src/app/oss/page.tsx
+++ b/www/src/app/oss/page.tsx
@@ -24,7 +24,7 @@ import type { OssIntegrationsView } from './view-tabs';
 export const metadata: Metadata = {
 	title: 'OSS Integrations',
 	description:
-		'Build integrations in the open and earn AI credits — 1 point = $1. Your code ships to thousands of developers via Corsair\'s open catalog.',
+		"Build integrations in the open and earn AI credits — 1 point = $1. Your code ships to thousands of developers via Corsair's open catalog.",
 };
 
 type PageProps = {

--- a/www/src/app/oss/u/[username]/page.tsx
+++ b/www/src/app/oss/u/[username]/page.tsx
@@ -1,10 +1,9 @@
+import { TRPCError } from '@trpc/server';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { TRPCError } from '@trpc/server';
-
-import { ContributorProfile } from '../../contributor-profile';
 import { getCachedContributorProfile } from '@/server/oss-public-cache';
+import { ContributorProfile } from '../../contributor-profile';
 
 type PageProps = {
 	params: Promise<{ username: string }>;

--- a/www/src/components/landing/choose-your-path/choose-your-path-section.tsx
+++ b/www/src/components/landing/choose-your-path/choose-your-path-section.tsx
@@ -1,8 +1,8 @@
+import { APP_URL, DOCS_URL } from '@/lib/site-links';
 import {
 	CopyableCodeSnippet,
 	LANDING_CTA_BOX_CLASS,
 } from '../copyable-code-snippet';
-import { APP_URL, DOCS_URL } from '@/lib/site-links';
 
 const SDK_INSTALL_COMMAND = 'npm install corsair';
 

--- a/www/src/components/landing/hero/hero-app-cta.tsx
+++ b/www/src/components/landing/hero/hero-app-cta.tsx
@@ -96,7 +96,11 @@ export function HeroAppCta() {
 					<span className="landing-send-cta-ring absolute inline-flex size-full rounded-full bg-white/70" />
 					<span className="relative inline-flex size-1.5 rounded-full bg-white/90" />
 				</span>
-				<Sparkle className="sparkle-icon-glow size-[15px]" weight="fill" aria-hidden />
+				<Sparkle
+					className="sparkle-icon-glow size-[15px]"
+					weight="fill"
+					aria-hidden
+				/>
 			</button>
 
 			{open ? (

--- a/www/src/components/landing/hero/landing-hero.tsx
+++ b/www/src/components/landing/hero/landing-hero.tsx
@@ -52,15 +52,15 @@ export function LandingHero({ starCount }: { starCount?: number | null }) {
 						className="star-button-shine group inline-flex items-center justify-center rounded-lg border border-amber-200/60 bg-gradient-to-b from-amber-50/80 to-white/60 text-sm font-[family-name:var(--landing-font-sans)] font-medium text-[#1c1c1c] no-underline shadow-[0_2px_8px_rgba(251,191,36,0.12)] backdrop-blur-sm transition-all duration-300 ease-out hover:border-amber-300/80 hover:shadow-[0_4px_20px_rgba(251,191,36,0.22)] hover:-translate-y-0.5 active:translate-y-0"
 					>
 						<span className="inline-flex items-center gap-2 px-4 py-3">
-							<Star
-								weight="fill"
-								className="star-icon-glow size-4"
-							/>
+							<Star weight="fill" className="star-icon-glow size-4" />
 							Star on GitHub
 						</span>
 						{starCount != null ? (
 							<>
-								<span className="self-stretch w-px bg-amber-200/60" aria-hidden />
+								<span
+									className="self-stretch w-px bg-amber-200/60"
+									aria-hidden
+								/>
 								<span className="px-3.5 py-3 font-[family-name:var(--landing-font-mono)] text-[13px] font-semibold text-amber-600 tabular-nums">
 									{formatStarCount(starCount)}
 								</span>

--- a/www/src/components/landing/menu/site-menu.tsx
+++ b/www/src/components/landing/menu/site-menu.tsx
@@ -204,7 +204,11 @@ export function SiteMenu() {
 							onClick={() => setIsMobileMenuOpen(false)}
 						>
 							GitHub
-							<GithubLogo size={16} weight="fill" className="text-[#1c1c1c]/50" />
+							<GithubLogo
+								size={16}
+								weight="fill"
+								className="text-[#1c1c1c]/50"
+							/>
 						</a>
 						<a
 							href={DISCORD_URL}
@@ -214,7 +218,11 @@ export function SiteMenu() {
 							onClick={() => setIsMobileMenuOpen(false)}
 						>
 							Discord
-							<DiscordLogo size={16} weight="fill" className="text-[#1c1c1c]/50" />
+							<DiscordLogo
+								size={16}
+								weight="fill"
+								className="text-[#1c1c1c]/50"
+							/>
 						</a>
 					</div>
 				</div>

--- a/www/src/components/landing/theme.css
+++ b/www/src/components/landing/theme.css
@@ -27,12 +27,14 @@
 }
 
 @keyframes sparkle-glow {
-	0%, 100% {
+	0%,
+	100% {
 		filter: drop-shadow(0 0 2px rgba(255, 255, 255, 0.4));
 		opacity: 0.7;
 	}
 	50% {
-		filter: drop-shadow(0 0 6px rgba(255, 255, 255, 1)) drop-shadow(0 0 12px rgba(255, 255, 255, 0.5));
+		filter: drop-shadow(0 0 6px rgba(255, 255, 255, 1))
+			drop-shadow(0 0 12px rgba(255, 255, 255, 0.5));
 		opacity: 1;
 	}
 }
@@ -44,12 +46,14 @@
 }
 
 @keyframes star-glow {
-	0%, 100% {
+	0%,
+	100% {
 		filter: drop-shadow(0 0 3px rgba(251, 191, 36, 0.55));
 		color: #f59e0b;
 	}
 	50% {
-		filter: drop-shadow(0 0 8px rgba(251, 191, 36, 1)) drop-shadow(0 0 18px rgba(251, 191, 36, 0.5));
+		filter: drop-shadow(0 0 8px rgba(251, 191, 36, 1))
+			drop-shadow(0 0 18px rgba(251, 191, 36, 0.5));
 		color: #fcd34d;
 	}
 }
@@ -61,8 +65,12 @@
 }
 
 @keyframes button-shine {
-	0% { transform: translateX(-120%) skewX(-20deg); }
-	100% { transform: translateX(420%) skewX(-20deg); }
+	0% {
+		transform: translateX(-120%) skewX(-20deg);
+	}
+	100% {
+		transform: translateX(420%) skewX(-20deg);
+	}
 }
 
 @media (prefers-reduced-motion: no-preference) {
@@ -71,7 +79,7 @@
 		overflow: hidden;
 	}
 	.star-button-shine::after {
-		content: '';
+		content: "";
 		position: absolute;
 		inset: 0;
 		background: linear-gradient(
@@ -383,14 +391,21 @@
 }
 
 /* Nav links (Docs, Contribute, Github, Discord) */
-.site-menu-container nav a:not(.group):not([aria-label="Corsair home"]):not([aria-label="GitHub"]):not([aria-label="Discord"]) {
+.site-menu-container nav
+	a:not(.group):not([aria-label="Corsair home"]):not([aria-label="GitHub"]):not(
+		[aria-label="Discord"]
+	) {
 	transition:
 		padding 1.2s cubic-bezier(0.22, 1, 0.36, 1),
 		font-size 1.2s cubic-bezier(0.22, 1, 0.36, 1),
 		color 0.3s ease;
 }
 
-.site-menu-scrolled nav a:not(.group):not([aria-label="Corsair home"]):not([aria-label="GitHub"]):not([aria-label="Discord"]) {
+.site-menu-scrolled
+	nav
+	a:not(.group):not([aria-label="Corsair home"]):not([aria-label="GitHub"]):not(
+		[aria-label="Discord"]
+	) {
 	padding: 0.375rem 0.5rem;
 	font-size: 0.8125rem;
 }

--- a/www/src/db/integration-status.ts
+++ b/www/src/db/integration-status.ts
@@ -4,14 +4,16 @@ import type { DB } from '@/db';
 import { user } from '@/db/auth-schema';
 import type { IntegrationPhase, IntegrationReleaseReason } from '@/db/schema';
 import { integrationStatus, integrations } from '@/db/schema';
+import type { ClaimBlockReason } from '@/lib/integration-claim-limits';
+import { MAX_USER_BUILT_INTEGRATIONS } from '@/lib/integration-claim-limits';
 import {
 	isIntegrationActivelyClaimed,
 	isWipPhase,
 } from '@/lib/integration-phases';
 
-import type { ClaimBlockReason } from '@/lib/integration-claim-limits';
-import { MAX_USER_BUILT_INTEGRATIONS } from '@/lib/integration-claim-limits';
+export type { ClaimBlockReason } from '@/lib/integration-claim-limits';
 
+export { MAX_USER_BUILT_INTEGRATIONS } from '@/lib/integration-claim-limits';
 export {
 	isIntegrationActivelyClaimed,
 	isIntegrationAvailable,
@@ -20,9 +22,6 @@ export {
 	phaseLabel,
 	WIP_PHASES,
 } from '@/lib/integration-phases';
-
-export { MAX_USER_BUILT_INTEGRATIONS } from '@/lib/integration-claim-limits';
-export type { ClaimBlockReason } from '@/lib/integration-claim-limits';
 
 export const ISSUE_DEADLINE_MS = 60 * 60 * 1000;
 export const PR_DEADLINE_MS = 3 * 60 * 60 * 1000;

--- a/www/src/server/api/routers/admin.ts
+++ b/www/src/server/api/routers/admin.ts
@@ -4,8 +4,8 @@ import { z } from 'zod';
 
 import { user } from '@/db/auth-schema';
 import {
-	getLatestStatusForIntegration,
 	getLatestStatusesForIntegrations,
+	getLatestStatusForIntegration,
 	insertIntegrationStatus,
 	isIntegrationActivelyClaimed,
 } from '@/db/integration-status';
@@ -54,7 +54,9 @@ export const adminRouter = createTRPCRouter({
 				status.phase !== 'finished',
 		);
 
-		const claimerIds = [...new Set(activeStatuses.map((status) => status.userId))];
+		const claimerIds = [
+			...new Set(activeStatuses.map((status) => status.userId)),
+		];
 		const claimers =
 			claimerIds.length > 0
 				? await ctx.db
@@ -67,7 +69,9 @@ export const adminRouter = createTRPCRouter({
 						.where(inArray(user.id, claimerIds))
 				: [];
 
-		const claimersById = new Map(claimers.map((claimer) => [claimer.id, claimer]));
+		const claimersById = new Map(
+			claimers.map((claimer) => [claimer.id, claimer]),
+		);
 		const urlsByIntegration = await fetchIntegrationUrlsByIntegrationIds(
 			ctx.db,
 			activeStatuses.map((status) => status.integrationId),
@@ -99,8 +103,7 @@ export const adminRouter = createTRPCRouter({
 					claimerAvatarUrl: githubUsername
 						? (avatars.get(githubUsername) ?? null)
 						: null,
-					urls:
-						urlsByIntegration.get(integration.id) ?? emptyIntegrationUrls(),
+					urls: urlsByIntegration.get(integration.id) ?? emptyIntegrationUrls(),
 				};
 			})
 			.filter((item): item is NonNullable<typeof item> => item !== null)

--- a/www/src/server/api/routers/contributors.ts
+++ b/www/src/server/api/routers/contributors.ts
@@ -3,11 +3,11 @@ import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { user } from '@/db/auth-schema';
-import { getGithubUserAvatar } from '@/server/github-users';
 import {
 	buildContributorRankings,
 	getContributorRank,
 } from '@/server/contributor-rankings';
+import { getGithubUserAvatar } from '@/server/github-users';
 
 import { githubUsernameSchema } from '../schemas/usernames';
 import { createTRPCRouter, publicProcedure } from '../trpc';

--- a/www/src/server/contributor-rankings.ts
+++ b/www/src/server/contributor-rankings.ts
@@ -94,9 +94,9 @@ export async function buildContributorRankings(
 
 	return users
 		.map((row) => {
-			const contributorIntegrations = (
-				userClaims.get(row.id) ?? []
-			).sort((left, right) => left.name.localeCompare(right.name));
+			const contributorIntegrations = (userClaims.get(row.id) ?? []).sort(
+				(left, right) => left.name.localeCompare(right.name),
+			);
 			const totals = summarizeIntegrations(contributorIntegrations);
 
 			return {


### PR DESCRIPTION
## Description
Formats the www files that landed via direct pushes to main and currently fail `pnpm lint` on every PR (import sorting + formatting only, no logic changes). Also excludes `.claude/` local worktrees from biome so local lint matches CI.

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)
Formatting only — no visual changes.