### PR TITLE
feat(ci): automated plugin PR review loop

### DIFF
--- a/.github/PLUGIN_PR_RULES.md
+++ b/.github/PLUGIN_PR_RULES.md
@@ -20,13 +20,17 @@ produces exactly this footprint.
 ## R2 — Tests required
 
 At least one `*.test.ts` inside `packages/<plugin>/` (see `packages/slack/`
-for `api.test.ts` + `integration.test.ts` examples). CI tests must pass.
+for `api.test.ts` + `integration.test.ts` examples), with real assertions —
+zero `expect()`/`assert()` calls fails the gate; fewer than 5 is flagged.
+Every implemented endpoint should have a corresponding test. CI tests must
+pass.
 
 ## R3 — PR description
 
 Every checklist box in the PR template ticked. Description section filled in
-with real content (not the template placeholder comments). Link the issue if
-one exists.
+with real content (not the template placeholder comments) that states exactly
+what was built — reviewers check the implementation against this. Link the
+issue or claim (`Fixes #…`) if one exists.
 
 ## R4 — Working proof (required before human merge)
 
@@ -42,4 +46,21 @@ No placeholder base URLs, no commented-out auth headers, no leftover
 ## R6 — Hard prohibitions
 
 No `eval`, no `new Function()`, no execution of dynamically-generated code.
-Bots never edit outside the PR's plugin scope. Nothing is ever auto-merged.
+No hardcoded secrets, tokens, or API keys anywhere. Bots never edit outside
+the PR's plugin scope. Nothing is ever auto-merged.
+
+## R7 — Documentation
+
+`packages/<plugin>/README.md` is required: auth/credential setup, an overview
+of the endpoints provided, and any provider quirks. It must match what the
+code actually implements.
+
+## R8 — Production quality
+
+- Inputs and outputs validated with zod schemas on every endpoint.
+- Errors routed through the plugin's `error-handlers.ts`, including
+  rate-limit (429) handling.
+- List endpoints support pagination when the provider API offers it.
+- No `any` on exported/public surfaces.
+- Follow the structure `pnpm generate:plugin` produces; `validate:plugins`
+  must pass.

--- a/.github/PLUGIN_PR_RULES.md
+++ b/.github/PLUGIN_PR_RULES.md
@@ -1,0 +1,45 @@
+# Plugin PR Rules
+
+These rules apply to every PR that adds or changes an integration plugin
+(any `packages/<plugin>/` except `corsair`, `cli`, `mcp`, `studio`, `ui`, `app`).
+They are enforced by Greptile (`greptile.json`), the deterministic gate job in
+`pr-checks.yml`, and the review bot. Human review is the last step; nothing
+merges automatically.
+
+## R1 — Scope confinement
+
+A plugin PR may only touch:
+
+- `packages/<plugin>/**` (exactly one plugin per PR)
+- the registration edit in `packages/corsair/core/constants.ts`
+- `pnpm-lock.yaml`
+
+Anything else fails the gate. Use `pnpm generate:plugin` to scaffold — it
+produces exactly this footprint.
+
+## R2 — Tests required
+
+At least one `*.test.ts` inside `packages/<plugin>/` (see `packages/slack/`
+for `api.test.ts` + `integration.test.ts` examples). CI tests must pass.
+
+## R3 — PR description
+
+Every checklist box in the PR template ticked. Description section filled in
+with real content (not the template placeholder comments). Link the issue if
+one exists.
+
+## R4 — Working proof (required before human merge)
+
+A demo video or recording showing the integration working, in the
+"Screenshots / Demos" section. Neither CI nor review bots can call the real
+third-party API — the video is that verification.
+
+## R5 — No boilerplate residue
+
+No placeholder base URLs, no commented-out auth headers, no leftover
+`endpoints/example.ts`, no TODO stubs left from the generator.
+
+## R6 — Hard prohibitions
+
+No `eval`, no `new Function()`, no execution of dynamically-generated code.
+Bots never edit outside the PR's plugin scope. Nothing is ever auto-merged.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,6 @@
+<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
+<!-- Automated review (Greptile + gate) starts when you mark it ready. -->
+
 ## Description
 
 <!-- Briefly describe the changes you've made and why they're necessary. -->

--- a/.github/workflows/plugin-pr-review-loop.yml
+++ b/.github/workflows/plugin-pr-review-loop.yml
@@ -104,7 +104,7 @@ jobs:
         env:
           CORSAIR_LLM_KEY: ${{ secrets.CORSAIR_LLM_KEY }}
         run: |
-          npm install -g @openai/codex
+          npm install -g @openai/codex@0.143.0
           codex exec --sandbox workspace-write "$(cat /tmp/fix-prompt.md)"
 
       # This job executed untrusted fork code (the agent's pnpm runs), so it

--- a/.github/workflows/plugin-pr-review-loop.yml
+++ b/.github/workflows/plugin-pr-review-loop.yml
@@ -146,6 +146,9 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      # job-level permissions replace the workflow block, and the patch
+      # fallback posts a PR comment
+      issues: write
     steps:
       # Fresh runner: checkout is passive, no install, no script execution —
       # the PAT never coexists with running untrusted code.

--- a/.github/workflows/plugin-pr-review-loop.yml
+++ b/.github/workflows/plugin-pr-review-loop.yml
@@ -75,27 +75,31 @@ jobs:
           name: findings-${{ github.event.pull_request.number }}
           path: /tmp
 
-      - name: Fetch rules file from base repo
-        run: curl -sf https://raw.githubusercontent.com/${{ github.repository }}/main/.github/PLUGIN_PR_RULES.md -o /tmp/PLUGIN_PR_RULES.md
-
-      - name: Run Claude Code fix
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      - name: Fetch rules and fix prompt from base repo
         run: |
-          npx -y @anthropic-ai/claude-code@latest -p "$(cat <<'EOF'
-          You are fixing specific code-review findings on an open-source PR.
-          The findings are in /tmp/findings.json (file, line, severity, title, detail).
-          The repo rules are in /tmp/PLUGIN_PR_RULES.md.
-          Fix ONLY the listed findings. Do not refactor, do not touch files
-          outside the plugin package the findings point at (plus
-          packages/corsair/core/constants.ts if a finding names it).
-          Never use eval or new Function. After fixing, run:
-            pnpm lint && pnpm typecheck
-          and fix any errors your changes introduced. Do not commit.
+          curl -sf https://raw.githubusercontent.com/${{ github.repository }}/main/.github/PLUGIN_PR_RULES.md -o /tmp/PLUGIN_PR_RULES.md
+          curl -sf https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/pr-review/fix-prompt.md -o /tmp/fix-prompt.md
+
+      - name: Configure Codex for the LLM gateway
+        run: |
+          mkdir -p ~/.codex
+          cat > ~/.codex/config.toml <<EOF
+          model = "${{ vars.LLM_MODEL }}"
+          model_provider = "corsair"
+
+          [model_providers.corsair]
+          name = "corsair"
+          base_url = "${{ vars.LLM_GATEWAY_URL }}"
+          env_key = "CORSAIR_LLM_KEY"
+          wire_api = "${{ vars.LLM_WIRE_API }}"
           EOF
-          )" \
-          --allowedTools "Read,Edit,Write,Glob,Grep,Bash(pnpm lint),Bash(pnpm lint:fix),Bash(pnpm typecheck),Bash(pnpm test)" \
-          --max-turns 40
+
+      - name: Run agent fix
+        env:
+          CORSAIR_LLM_KEY: ${{ secrets.CORSAIR_LLM_KEY }}
+        run: |
+          npm install -g @openai/codex
+          codex exec --sandbox workspace-write "$(cat /tmp/fix-prompt.md)"
 
       - name: Commit and push (or dry-run comment)
         env:

--- a/.github/workflows/plugin-pr-review-loop.yml
+++ b/.github/workflows/plugin-pr-review-loop.yml
@@ -70,7 +70,10 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        # --ignore-scripts: the lockfile comes from the untrusted fork, so
+        # lifecycle scripts are attacker-controlled code. lint/typecheck
+        # (all the agent runs) need no native builds.
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Download findings
         uses: actions/download-artifact@v4
@@ -104,33 +107,77 @@ jobs:
           npm install -g @openai/codex
           codex exec --sandbox workspace-write "$(cat /tmp/fix-prompt.md)"
 
-      - name: Commit and push (or dry-run comment)
+      # This job executed untrusted fork code (the agent's pnpm runs), so it
+      # never sees PR_BOT_PAT. It only exports the diff; the push job below
+      # runs on a fresh runner where no untrusted code executes.
+      - name: Export fix patch (or dry-run comment)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_BOT_PAT: ${{ secrets.PR_BOT_PAT }}
           PR_BOT_DRY_RUN: ${{ vars.PR_BOT_DRY_RUN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          git config user.name "corsair-review-bot"
-          git config user.email "bot@corsair.dev"
           if git diff --quiet; then
             echo "No changes produced"; exit 0
           fi
+          git diff > /tmp/fix.patch
           if [ "$PR_BOT_DRY_RUN" = "true" ]; then
             {
               echo '<!-- corsair-review-bot dry-run -->'
               echo '<details><summary>DRY RUN — would push this fix commit:</summary>'
               echo
               echo '```diff'
-              git diff | head -400
+              head -c 60000 /tmp/fix.patch
               echo '```'
               echo '</details>'
             } > /tmp/dry.md
             gh api -X POST "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -F body=@/tmp/dry.md
-          else
-            git add -A
-            git commit -m "fix: address review findings (corsair review bot)"
-            git push "https://x-access-token:${PR_BOT_PAT}@github.com/${HEAD_REPO}.git" "HEAD:${HEAD_REF}"
           fi
+
+      - name: Upload fix patch
+        uses: actions/upload-artifact@v4
+        with:
+          name: fix-patch-${{ github.event.pull_request.number }}
+          path: /tmp/fix.patch
+          if-no-files-found: ignore
+
+  push:
+    needs: fix
+    if: vars.PR_BOT_DRY_RUN != 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      # Fresh runner: checkout is passive, no install, no script execution —
+      # the PAT never coexists with running untrusted code.
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false
+
+      - name: Download fix patch
+        id: patch
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: fix-patch-${{ github.event.pull_request.number }}
+          path: /tmp
+
+      - name: Apply, scan, and push
+        if: steps.patch.outcome == 'success'
+        env:
+          PR_BOT_PAT: ${{ secrets.PR_BOT_PAT }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          [ -s /tmp/fix.patch ] || { echo "Empty patch"; exit 0; }
+          if grep -qE '(sk-[A-Za-z0-9_-]{16,}|ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|AKIA[A-Z0-9]{16})' /tmp/fix.patch; then
+            echo "::error::Patch contains a credential-shaped string — refusing to push"; exit 1
+          fi
+          git config user.name "corsair-review-bot"
+          git config user.email "bot@corsair.dev"
+          git apply /tmp/fix.patch
+          git add -A
+          git commit -m "fix: address review findings (corsair review bot)"
+          git push "https://x-access-token:${PR_BOT_PAT}@github.com/${HEAD_REPO}.git" "HEAD:${HEAD_REF}"

--- a/.github/workflows/plugin-pr-review-loop.yml
+++ b/.github/workflows/plugin-pr-review-loop.yml
@@ -1,0 +1,126 @@
+name: Plugin PR Review Loop
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+concurrency:
+  group: review-loop-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  triage:
+    if: github.event.review.user.login == 'greptile-apps[bot]' && github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    outputs:
+      decision: ${{ steps.loop.outputs.decision }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+
+      - name: Run review loop triage
+        id: loop
+        run: node --experimental-strip-types scripts/pr-review/loop-main.ts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BOT_DRY_RUN: ${{ vars.PR_BOT_DRY_RUN }}
+
+      - name: Upload findings for fix job
+        if: steps.loop.outputs.decision == 'fix'
+        uses: actions/upload-artifact@v4
+        with:
+          name: findings-${{ github.event.pull_request.number }}
+          path: /tmp/findings.json
+
+  fix:
+    needs: triage
+    if: needs.triage.outputs.decision == 'fix'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.PR_BOT_PAT }}
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.20.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download findings
+        uses: actions/download-artifact@v4
+        with:
+          name: findings-${{ github.event.pull_request.number }}
+          path: /tmp
+
+      - name: Fetch rules file from base repo
+        run: curl -sf https://raw.githubusercontent.com/${{ github.repository }}/main/.github/PLUGIN_PR_RULES.md -o /tmp/PLUGIN_PR_RULES.md
+
+      - name: Run Claude Code fix
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          npx -y @anthropic-ai/claude-code@latest -p "$(cat <<'EOF'
+          You are fixing specific code-review findings on an open-source PR.
+          The findings are in /tmp/findings.json (file, line, severity, title, detail).
+          The repo rules are in /tmp/PLUGIN_PR_RULES.md.
+          Fix ONLY the listed findings. Do not refactor, do not touch files
+          outside the plugin package the findings point at (plus
+          packages/corsair/core/constants.ts if a finding names it).
+          Never use eval or new Function. After fixing, run:
+            pnpm lint && pnpm typecheck
+          and fix any errors your changes introduced. Do not commit.
+          EOF
+          )" \
+          --allowedTools "Read,Edit,Write,Glob,Grep,Bash(pnpm lint),Bash(pnpm lint:fix),Bash(pnpm typecheck),Bash(pnpm test)" \
+          --max-turns 40
+
+      - name: Commit and push (or dry-run comment)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BOT_DRY_RUN: ${{ vars.PR_BOT_DRY_RUN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          git config user.name "corsair-review-bot"
+          git config user.email "bot@corsair.dev"
+          if git diff --quiet; then
+            echo "No changes produced"; exit 0
+          fi
+          if [ "$PR_BOT_DRY_RUN" = "true" ]; then
+            {
+              echo '<!-- corsair-review-bot dry-run -->'
+              echo '<details><summary>DRY RUN — would push this fix commit:</summary>'
+              echo
+              echo '```diff'
+              git diff | head -400
+              echo '```'
+              echo '</details>'
+            } > /tmp/dry.md
+            gh api -X POST "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -F body=@/tmp/dry.md
+          else
+            git add -A
+            git commit -m "fix: address review findings (corsair review bot)"
+            git push
+          fi

--- a/.github/workflows/plugin-pr-review-loop.yml
+++ b/.github/workflows/plugin-pr-review-loop.yml
@@ -54,7 +54,10 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.PR_BOT_PAT }}
+          # PR head repos are public; no token needed to read, and
+          # persist-credentials: false keeps credentials out of .git/config
+          # while the agent runs over untrusted PR code.
+          persist-credentials: false
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
@@ -104,8 +107,11 @@ jobs:
       - name: Commit and push (or dry-run comment)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BOT_PAT: ${{ secrets.PR_BOT_PAT }}
           PR_BOT_DRY_RUN: ${{ vars.PR_BOT_DRY_RUN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           git config user.name "corsair-review-bot"
           git config user.email "bot@corsair.dev"
@@ -126,5 +132,5 @@ jobs:
           else
             git add -A
             git commit -m "fix: address review findings (corsair review bot)"
-            git push
+            git push "https://x-access-token:${PR_BOT_PAT}@github.com/${HEAD_REPO}.git" "HEAD:${HEAD_REF}"
           fi

--- a/.github/workflows/plugin-pr-review-loop.yml
+++ b/.github/workflows/plugin-pr-review-loop.yml
@@ -167,7 +167,9 @@ jobs:
       - name: Apply, scan, and push
         if: steps.patch.outcome == 'success'
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_BOT_PAT: ${{ secrets.PR_BOT_PAT }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
@@ -180,4 +182,16 @@ jobs:
           git apply /tmp/fix.patch
           git add -A
           git commit -m "fix: address review findings (corsair review bot)"
-          git push "https://x-access-token:${PR_BOT_PAT}@github.com/${HEAD_REPO}.git" "HEAD:${HEAD_REF}"
+          if ! git push "https://x-access-token:${PR_BOT_PAT}@github.com/${HEAD_REPO}.git" "HEAD:${HEAD_REF}"; then
+            # Fork without "allow edits by maintainers" — deliver the fix as
+            # a patch comment instead of failing silently into escalation.
+            {
+              echo '<!-- corsair-review-bot patch-fallback -->'
+              echo 'The bot prepared a fix but cannot push to your branch (enable "Allow edits by maintainers" on this PR, or apply the patch below with `git apply`):'
+              echo
+              echo '```diff'
+              head -c 60000 /tmp/fix.patch
+              echo '```'
+            } > /tmp/fallback.md
+            gh api -X POST "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -F body=@/tmp/fallback.md
+          fi

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,6 +10,8 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: write
+  issues: write
 
 jobs:
   ci:
@@ -47,3 +49,20 @@ jobs:
         env:
           CI: true
           SKIP_PG_TESTS: 1
+
+  plugin-gate:
+    name: Plugin PR Gate
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+
+      - name: Run plugin PR gate
+        run: node --experimental-strip-types scripts/pr-review/gate-main.ts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,12 @@ Corsair is an open-source integration layer for agents (~70 plugin packages).
 (scope, tests, description, demo video). Greptile + the gate job enforce it.
 Never auto-merge; never use `eval`/`new Function()` on generated content.
 
+## LLM gateway
+
+Model calls go through `llm.corsair.dev` (LiteLLM, OpenAI-compatible) with
+budget-limited keys — never provider SDKs or personal provider keys.
+Docs: docs.corsair.dev/llm-gateway.
+
 ## Product note
 
 The hosted product moved from `corsairdev/hosted` to `corsairdev/hub`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Corsair — agent guide
+
+Corsair is an open-source integration layer for agents (~70 plugin packages).
+
+## Layout
+
+- `packages/<plugin>/` — one integration each (slack, gmail, …). Everything
+  except `corsair`, `cli`, `mcp`, `studio`, `ui`, `app` is a plugin.
+- `packages/corsair/` — core; plugins register in `core/constants.ts`.
+- `www/` — corsair.dev site incl. the OSS contributor dashboard (`src/app/oss/`).
+- `scripts/pr-review/` — automated PR review loop (see `docs/pr-review-bot.md`).
+
+## Commands
+
+- `pnpm lint` / `pnpm lint:fix` (biome), `pnpm typecheck`, `pnpm build`, `pnpm test`
+- `pnpm generate:plugin` — scaffold a new plugin (correct footprint: its own
+  package + one registration edit in `packages/corsair/core/constants.ts`)
+- `pnpm run validate:plugins` — structural plugin checks
+
+## PR rules
+
+`.github/PLUGIN_PR_RULES.md` is the source of truth for plugin PRs
+(scope, tests, description, demo video). Greptile + the gate job enforce it.
+Never auto-merge; never use `eval`/`new Function()` on generated content.
+
+## Product note
+
+The hosted product moved from `corsairdev/hosted` to `corsairdev/hub`.
+`hosted` receives documentation updates only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,12 @@ Corsair is an open-source integration layer for agents (~70 plugin packages).
 (scope, tests, description, demo video). Greptile + the gate job enforce it.
 Never auto-merge; never use `eval`/`new Function()` on generated content.
 
+## LLM gateway
+
+Model calls go through `llm.corsair.dev` (LiteLLM, OpenAI-compatible) with
+budget-limited keys — never provider SDKs or personal provider keys.
+Docs: docs.corsair.dev/llm-gateway.
+
 ## Product note
 
 The hosted product moved from `corsairdev/hosted` to `corsairdev/hub`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# Corsair — agent guide
+
+Corsair is an open-source integration layer for agents (~70 plugin packages).
+
+## Layout
+
+- `packages/<plugin>/` — one integration each (slack, gmail, …). Everything
+  except `corsair`, `cli`, `mcp`, `studio`, `ui`, `app` is a plugin.
+- `packages/corsair/` — core; plugins register in `core/constants.ts`.
+- `www/` — corsair.dev site incl. the OSS contributor dashboard (`src/app/oss/`).
+- `scripts/pr-review/` — automated PR review loop (see `docs/pr-review-bot.md`).
+
+## Commands
+
+- `pnpm lint` / `pnpm lint:fix` (biome), `pnpm typecheck`, `pnpm build`, `pnpm test`
+- `pnpm generate:plugin` — scaffold a new plugin (correct footprint: its own
+  package + one registration edit in `packages/corsair/core/constants.ts`)
+- `pnpm run validate:plugins` — structural plugin checks
+
+## PR rules
+
+`.github/PLUGIN_PR_RULES.md` is the source of truth for plugin PRs
+(scope, tests, description, demo video). Greptile + the gate job enforce it.
+Never auto-merge; never use `eval`/`new Function()` on generated content.
+
+## Product note
+
+The hosted product moved from `corsairdev/hosted` to `corsairdev/hub`.
+`hosted` receives documentation updates only.

--- a/docs/pr-review-bot.md
+++ b/docs/pr-review-bot.md
@@ -17,8 +17,10 @@ nothing merges automatically. Rules live in `.github/PLUGIN_PR_RULES.md`.
    - **Round 1** — posts one consolidated comment with every P0/P1 finding,
      gate failures, and P2s as optional. Templated, no LLM. Label `bot:round-1`.
    - **Round 2** — if P0/P1s remain after the contributor's next push AND the
-     gate passes, headless Claude Code fixes only the listed findings, runs
-     lint/typecheck, and pushes one commit. Label `bot:round-2`.
+     gate passes, Codex CLI (`codex exec`, sandboxed, network off) fixes only
+     the listed findings via the LLM gateway (`llm.corsair.dev`), runs
+     lint/typecheck, and pushes one commit. Label `bot:round-2`. The prompt
+     lives in `scripts/pr-review/fix-prompt.md`.
    - **Round 3** — hard stop: summary comment + `needs-maintainer` label.
      This label is the maintainer queue (syncs to the internal dashboard).
 
@@ -30,15 +32,29 @@ nothing merges automatically. Rules live in `.github/PLUGIN_PR_RULES.md`.
 - The fix round is deferred while the gate fails (incomplete PRs never spend
   LLM tokens).
 - Drafts are skipped everywhere. Greptile is free for this repo (OSS plan).
+- The bot's gateway key is budget-limited in LiteLLM — even a loop bug cannot
+  overspend it.
+
+## LLM gateway
+
+All model calls go through `llm.corsair.dev` (LiteLLM, OpenAI-compatible;
+docs: docs.corsair.dev/llm-gateway). No provider SDKs, no provider keys.
+
+- Repo variables: `LLM_GATEWAY_URL` (e.g. `https://llm.corsair.dev/v1`),
+  `LLM_MODEL` (default `gpt-5.3-codex`), `LLM_WIRE_API` (`responses`; use
+  `chat` + a chat model like `gpt-5.5` if the gateway's Responses passthrough
+  misbehaves).
+- Swapping model or provider is a variable change — no code changes.
 
 ## Operations
 
 - **Dry run:** repo variable `PR_BOT_DRY_RUN=true` makes the loop post what it
   *would* do as `<!-- corsair-review-bot dry-run -->` comments and never push.
   Flip with `gh variable set PR_BOT_DRY_RUN -R corsairdev/corsair --body "false"`.
-- **Secrets:** `ANTHROPIC_API_KEY` (fix step), `PR_BOT_PAT` (fine-grained PAT
-  with `contents: read/write` — the default `GITHUB_TOKEN` cannot push to fork
-  branches). Rotate via `gh secret set <NAME> -R corsairdev/corsair`.
+- **Secrets:** `CORSAIR_LLM_KEY` (budget-limited LiteLLM key for the fix
+  step), `PR_BOT_PAT` (fine-grained PAT with `contents: read/write` — the
+  default `GITHUB_TOKEN` cannot push to fork branches). Rotate via
+  `gh secret set <NAME> -R corsairdev/corsair`.
 - **Labels used:** `gate:failed`, `bot:round-1`, `bot:round-2`,
   `needs-maintainer`. Create once with `gh label create`.
 - **Required checks:** mark Greptile's status check and `Plugin PR Gate` as

--- a/docs/pr-review-bot.md
+++ b/docs/pr-review-bot.md
@@ -1,0 +1,62 @@
+# PR review bot — runbook
+
+Automated review loop for plugin PRs. Human review is always the last step;
+nothing merges automatically. Rules live in `.github/PLUGIN_PR_RULES.md`.
+
+## How it works
+
+1. **Greptile** reviews every non-draft PR (config: `greptile.json`) and
+   re-reviews on every push. Its blocking status check prevents merging with
+   unresolved findings.
+2. **Gate job** (`plugin-gate` in `pr-checks.yml`) deterministically checks
+   R1 scope, R2 tests, R3 description, R4 demo video. It maintains one sticky
+   comment (`<!-- corsair-pr-gate -->`) and the `gate:failed` label.
+3. **Review loop** (`plugin-pr-review-loop.yml`) fires on each Greptile
+   review and reads its round from comment markers
+   (`<!-- corsair-review-bot round=N -->`):
+   - **Round 1** — posts one consolidated comment with every P0/P1 finding,
+     gate failures, and P2s as optional. Templated, no LLM. Label `bot:round-1`.
+   - **Round 2** — if P0/P1s remain after the contributor's next push AND the
+     gate passes, headless Claude Code fixes only the listed findings, runs
+     lint/typecheck, and pushes one commit. Label `bot:round-2`.
+   - **Round 3** — hard stop: summary comment + `needs-maintainer` label.
+     This label is the maintainer queue (syncs to the internal dashboard).
+
+## Cost guards (by construction)
+
+- Round-1 comments are templated — zero LLM cost, no matter how many pushes.
+- The LLM fix runs **at most once per PR**: the `round=2` marker is a ratchet;
+  after it exists the loop can only escalate or stop.
+- The fix round is deferred while the gate fails (incomplete PRs never spend
+  LLM tokens).
+- Drafts are skipped everywhere. Greptile is free for this repo (OSS plan).
+
+## Operations
+
+- **Dry run:** repo variable `PR_BOT_DRY_RUN=true` makes the loop post what it
+  *would* do as `<!-- corsair-review-bot dry-run -->` comments and never push.
+  Flip with `gh variable set PR_BOT_DRY_RUN -R corsairdev/corsair --body "false"`.
+- **Secrets:** `ANTHROPIC_API_KEY` (fix step), `PR_BOT_PAT` (fine-grained PAT
+  with `contents: read/write` — the default `GITHUB_TOKEN` cannot push to fork
+  branches). Rotate via `gh secret set <NAME> -R corsairdev/corsair`.
+- **Labels used:** `gate:failed`, `bot:round-1`, `bot:round-2`,
+  `needs-maintainer`. Create once with `gh label create`.
+- **Required checks:** mark Greptile's status check and `Plugin PR Gate` as
+  required branch checks on `main` once live.
+- **Tests:** `pnpm exec tsx --test scripts/pr-review/*.test.ts`
+  (fixtures in `scripts/pr-review/fixtures/` are real Greptile payloads).
+
+## Dogfood checklist (before going live)
+
+1. With a non-collaborator test account, claim an integration on the OSS
+   dashboard and open a plugin PR from a fork with planted violations:
+   placeholder base URL, commented-out auth, no tests, unchecked checklist
+   box, no video.
+2. Verify: Greptile flags the plants → gate fails R2/R3/R4 with label →
+   dry-run round-1 comment lists every plant. Anything missed = fix first.
+3. Push a partial fix (leave one P1, add one new small bug). Verify re-review,
+   round advances, dry-run fix diff is correct and in-scope.
+4. Flip `PR_BOT_DRY_RUN=false`, repeat on a second test PR, verify the real
+   comment, the real bot commit, its re-review, and the escalation label.
+5. Mark the required branch checks. Watch the next 3–5 real PRs closely and
+   record actual cost (Anthropic console) per PR.

--- a/docs/pr-review-bot.md
+++ b/docs/pr-review-bot.md
@@ -52,9 +52,11 @@ docs: docs.corsair.dev/llm-gateway). No provider SDKs, no provider keys.
   *would* do as `<!-- corsair-review-bot dry-run -->` comments and never push.
   Flip with `gh variable set PR_BOT_DRY_RUN -R corsairdev/corsair --body "false"`.
 - **Secrets:** `CORSAIR_LLM_KEY` (budget-limited LiteLLM key for the fix
-  step), `PR_BOT_PAT` (fine-grained PAT with `contents: read/write` — the
-  default `GITHUB_TOKEN` cannot push to fork branches). Rotate via
-  `gh secret set <NAME> -R corsairdev/corsair`.
+  step), `PR_BOT_PAT` (**classic** PAT with `public_repo` scope — neither the
+  default `GITHUB_TOKEN` nor fine-grained PATs can push to contributor fork
+  branches; pushing also requires the PR's "allow edits by maintainers",
+  otherwise the push job fails and the PR simply stays with the round-1
+  comment). Rotate via `gh secret set <NAME> -R corsairdev/corsair`.
 - **Labels used:** `gate:failed`, `bot:round-1`, `bot:round-2`,
   `needs-maintainer`. Create once with `gh label create`.
 - **Required checks:** mark Greptile's status check and `Plugin PR Gate` as

--- a/greptile.json
+++ b/greptile.json
@@ -1,40 +1,40 @@
 {
-	"strictness": 2,
-	"commentTypes": ["logic", "syntax"],
-	"statusCheck": true,
-	"triggerOnUpdates": true,
-	"triggerOnDrafts": false,
-	"ignorePatterns": "pnpm-lock.yaml\n**/dist/**",
-	"customContext": {
-		"rules": [
-			{
-				"scope": ["packages/**"],
-				"rule": "A plugin PR must only modify files inside a single packages/<plugin>/ directory, plus packages/corsair/core/constants.ts and pnpm-lock.yaml. Flag any other modified file as a critical (P0) issue."
-			},
-			{
-				"scope": ["packages/**"],
-				"rule": "Plugin packages must include at least one *.test.ts file with real assertions against the plugin's endpoints. Flag missing, empty, or assertion-free tests as P1."
-			},
-			{
-				"scope": ["packages/**"],
-				"rule": "Flag boilerplate residue from the plugin generator as P1: placeholder base URLs, commented-out Authorization headers, leftover endpoints/example.ts files, and TODO stubs."
-			},
-			{
-				"scope": ["**"],
-				"rule": "Flag any use of eval, new Function(), or execution of dynamically generated code as a critical (P0) issue."
-			}
-		],
-		"files": [
-			{
-				"scope": ["packages/**"],
-				"path": ".github/PLUGIN_PR_RULES.md",
-				"description": "The canonical rules every plugin PR must satisfy"
-			},
-			{
-				"scope": ["packages/**"],
-				"path": "CONTRIBUTING.md",
-				"description": "Contributor guide"
-			}
-		]
-	}
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax"],
+  "statusCheck": true,
+  "triggerOnUpdates": true,
+  "triggerOnDrafts": false,
+  "ignorePatterns": "pnpm-lock.yaml\n**/dist/**",
+  "customContext": {
+    "rules": [
+      {
+        "scope": ["packages/**"],
+        "rule": "A plugin PR must only modify files inside a single packages/<plugin>/ directory, plus packages/corsair/core/constants.ts and pnpm-lock.yaml. Flag any other modified file as a critical (P0) issue."
+      },
+      {
+        "scope": ["packages/**"],
+        "rule": "Plugin packages must include at least one *.test.ts file with real assertions against the plugin's endpoints. Flag missing, empty, or assertion-free tests as P1."
+      },
+      {
+        "scope": ["packages/**"],
+        "rule": "Flag boilerplate residue from the plugin generator as P1: placeholder base URLs, commented-out Authorization headers, leftover endpoints/example.ts files, and TODO stubs."
+      },
+      {
+        "scope": ["**"],
+        "rule": "Flag any use of eval, new Function(), or execution of dynamically generated code as a critical (P0) issue."
+      }
+    ],
+    "files": [
+      {
+        "scope": ["packages/**"],
+        "path": ".github/PLUGIN_PR_RULES.md",
+        "description": "The canonical rules every plugin PR must satisfy"
+      },
+      {
+        "scope": ["packages/**"],
+        "path": "CONTRIBUTING.md",
+        "description": "Contributor guide"
+      }
+    ]
+  }
 }

--- a/greptile.json
+++ b/greptile.json
@@ -21,7 +21,19 @@
       },
       {
         "scope": ["**"],
-        "rule": "Flag any use of eval, new Function(), or execution of dynamically generated code as a critical (P0) issue."
+        "rule": "Flag any use of eval, new Function(), or execution of dynamically generated code as a critical (P0) issue. Flag hardcoded secrets, tokens, or API keys as P0."
+      },
+      {
+        "scope": ["packages/**"],
+        "rule": "Every endpoint must validate inputs and outputs with zod schemas, route errors through the plugin's error-handlers.ts including rate-limit (429) handling, and support pagination on list endpoints when the provider API offers it. Flag violations as P1."
+      },
+      {
+        "scope": ["packages/**"],
+        "rule": "Verify the implementation matches the PR description: every endpoint the description claims must exist and work as described, and the plugin README.md must accurately document the implemented endpoints and auth setup. Flag mismatches as P1."
+      },
+      {
+        "scope": ["packages/**"],
+        "rule": "Flag `any` types on exported or public surfaces as P2, and every implemented endpoint lacking a corresponding test as P1."
       }
     ],
     "files": [

--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,40 @@
+{
+	"strictness": 2,
+	"commentTypes": ["logic", "syntax"],
+	"statusCheck": true,
+	"triggerOnUpdates": true,
+	"triggerOnDrafts": false,
+	"ignorePatterns": "pnpm-lock.yaml\n**/dist/**",
+	"customContext": {
+		"rules": [
+			{
+				"scope": ["packages/**"],
+				"rule": "A plugin PR must only modify files inside a single packages/<plugin>/ directory, plus packages/corsair/core/constants.ts and pnpm-lock.yaml. Flag any other modified file as a critical (P0) issue."
+			},
+			{
+				"scope": ["packages/**"],
+				"rule": "Plugin packages must include at least one *.test.ts file with real assertions against the plugin's endpoints. Flag missing, empty, or assertion-free tests as P1."
+			},
+			{
+				"scope": ["packages/**"],
+				"rule": "Flag boilerplate residue from the plugin generator as P1: placeholder base URLs, commented-out Authorization headers, leftover endpoints/example.ts files, and TODO stubs."
+			},
+			{
+				"scope": ["**"],
+				"rule": "Flag any use of eval, new Function(), or execution of dynamically generated code as a critical (P0) issue."
+			}
+		],
+		"files": [
+			{
+				"scope": ["packages/**"],
+				"path": ".github/PLUGIN_PR_RULES.md",
+				"description": "The canonical rules every plugin PR must satisfy"
+			},
+			{
+				"scope": ["packages/**"],
+				"path": "CONTRIBUTING.md",
+				"description": "Contributor guide"
+			}
+		]
+	}
+}

--- a/scripts/pr-review/fix-prompt.md
+++ b/scripts/pr-review/fix-prompt.md
@@ -1,0 +1,15 @@
+You are fixing specific code-review findings on an open-source PR.
+
+The findings are in /tmp/findings.json (file, line, severity, title, detail).
+The repo rules are in /tmp/PLUGIN_PR_RULES.md.
+
+Fix ONLY the listed findings. Do not refactor, do not touch files outside the
+plugin package the findings point at (plus packages/corsair/core/constants.ts
+if a finding names it). Never use eval or new Function. Never hardcode
+secrets or tokens.
+
+After fixing, run:
+
+    pnpm lint && pnpm typecheck
+
+and fix any errors your changes introduced. Do not commit.

--- a/scripts/pr-review/gate-main.ts
+++ b/scripts/pr-review/gate-main.ts
@@ -1,9 +1,11 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
+import path from 'node:path';
 import type { GateResult } from './gate.ts';
-import { runGate } from './gate.ts';
+import { detectPlugin, runGate } from './gate.ts';
 
 const MARKER = '<!-- corsair-pr-gate -->';
+const STATUS_ICON = { pass: '✅', warn: '⚠️', fail: '❌' } as const;
 
 function gh(args: string[]): string {
 	return execFileSync('gh', args, {
@@ -12,19 +14,42 @@ function gh(args: string[]): string {
 	});
 }
 
-function renderComment(result: GateResult): string {
-	const lines = [MARKER, '### Plugin PR gate', ''];
-	if (result.failures.length === 0) {
-		lines.push(`✅ All gate checks passed for \`packages/${result.plugin}\`.`);
-	} else {
-		lines.push(
-			`Checks for \`packages/${result.plugin}\` — see [PLUGIN_PR_RULES.md](https://github.com/${process.env.GITHUB_REPOSITORY}/blob/main/.github/PLUGIN_PR_RULES.md):`,
-			'',
+/** Counts expect()/assert() calls across a plugin's *.test.ts files on disk. */
+export function countAssertions(pluginDir: string): number {
+	if (!fs.existsSync(pluginDir)) return 0;
+	let count = 0;
+	for (const entry of fs.readdirSync(pluginDir, {
+		recursive: true,
+		withFileTypes: true,
+	})) {
+		if (!entry.isFile() || !entry.name.endsWith('.test.ts')) continue;
+		if (entry.parentPath.includes('node_modules')) continue;
+		const content = fs.readFileSync(
+			path.join(entry.parentPath, entry.name),
+			'utf8',
 		);
-		for (const f of result.failures) {
-			lines.push(`- ❌ **${f.rule}** — ${f.message}`);
-		}
+		count += content.match(/\b(expect|assert)\s*\(/g)?.length ?? 0;
 	}
+	return count;
+}
+
+function renderComment(result: GateResult): string {
+	const lines = [
+		MARKER,
+		`### Plugin PR scorecard — \`packages/${result.plugin}\``,
+		'',
+		'| Check | Status | Notes |',
+		'| --- | --- | --- |',
+	];
+	for (const c of result.checks) {
+		lines.push(
+			`| ${c.rule} — ${c.label} | ${STATUS_ICON[c.status]} | ${c.detail ?? ''} |`,
+		);
+	}
+	lines.push(
+		'',
+		`Rules: [PLUGIN_PR_RULES.md](https://github.com/${process.env.GITHUB_REPOSITORY}/blob/main/.github/PLUGIN_PR_RULES.md) · re-runs on every push`,
+	);
 	return lines.join('\n');
 }
 
@@ -94,10 +119,15 @@ const changedFiles = execFileSync(
 	.split('\n')
 	.filter(Boolean);
 
+const plugin = detectPlugin(changedFiles);
 const result = runGate({
 	changedFiles,
 	prBody: (event.pull_request.body as string) ?? '',
 	isDraft: event.pull_request.draft as boolean,
+	readmeExists: plugin
+		? fs.existsSync(path.join('packages', plugin, 'README.md'))
+		: false,
+	assertionCount: plugin ? countAssertions(path.join('packages', plugin)) : 0,
 });
 
 if (!result.isPluginPr) {

--- a/scripts/pr-review/gate-main.ts
+++ b/scripts/pr-review/gate-main.ts
@@ -14,23 +14,30 @@ function gh(args: string[]): string {
 	});
 }
 
-/** Counts expect()/assert() calls across a plugin's *.test.ts files on disk. */
-export function countAssertions(pluginDir: string): number {
-	if (!fs.existsSync(pluginDir)) return 0;
-	let count = 0;
+/** Counts *.test.ts files and their expect()/assert() calls on disk. */
+export function countTests(pluginDir: string): {
+	testFileCount: number;
+	assertionCount: number;
+} {
+	if (!fs.existsSync(pluginDir)) {
+		return { testFileCount: 0, assertionCount: 0 };
+	}
+	let testFileCount = 0;
+	let assertionCount = 0;
 	for (const entry of fs.readdirSync(pluginDir, {
 		recursive: true,
 		withFileTypes: true,
 	})) {
 		if (!entry.isFile() || !entry.name.endsWith('.test.ts')) continue;
 		if (entry.parentPath.includes('node_modules')) continue;
+		testFileCount += 1;
 		const content = fs.readFileSync(
 			path.join(entry.parentPath, entry.name),
 			'utf8',
 		);
-		count += content.match(/\b(expect|assert)\s*\(/g)?.length ?? 0;
+		assertionCount += content.match(/\b(expect|assert)\s*\(/g)?.length ?? 0;
 	}
-	return count;
+	return { testFileCount, assertionCount };
 }
 
 function renderComment(result: GateResult): string {
@@ -120,6 +127,9 @@ const changedFiles = execFileSync(
 	.filter(Boolean);
 
 const plugin = detectPlugin(changedFiles);
+const tests = plugin
+	? countTests(path.join('packages', plugin))
+	: { testFileCount: 0, assertionCount: 0 };
 const result = runGate({
 	changedFiles,
 	prBody: (event.pull_request.body as string) ?? '',
@@ -127,7 +137,8 @@ const result = runGate({
 	readmeExists: plugin
 		? fs.existsSync(path.join('packages', plugin, 'README.md'))
 		: false,
-	assertionCount: plugin ? countAssertions(path.join('packages', plugin)) : 0,
+	testFileCount: tests.testFileCount,
+	assertionCount: tests.assertionCount,
 });
 
 if (!result.isPluginPr) {

--- a/scripts/pr-review/gate-main.ts
+++ b/scripts/pr-review/gate-main.ts
@@ -1,0 +1,117 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import type { GateResult } from './gate.ts';
+import { runGate } from './gate.ts';
+
+const MARKER = '<!-- corsair-pr-gate -->';
+
+function gh(args: string[]): string {
+	return execFileSync('gh', args, {
+		encoding: 'utf8',
+		maxBuffer: 64 * 1024 * 1024,
+	});
+}
+
+function renderComment(result: GateResult): string {
+	const lines = [MARKER, '### Plugin PR gate', ''];
+	if (result.failures.length === 0) {
+		lines.push(`✅ All gate checks passed for \`packages/${result.plugin}\`.`);
+	} else {
+		lines.push(
+			`Checks for \`packages/${result.plugin}\` — see [PLUGIN_PR_RULES.md](https://github.com/${process.env.GITHUB_REPOSITORY}/blob/main/.github/PLUGIN_PR_RULES.md):`,
+			'',
+		);
+		for (const f of result.failures) {
+			lines.push(`- ❌ **${f.rule}** — ${f.message}`);
+		}
+	}
+	return lines.join('\n');
+}
+
+function upsertComment(repo: string, pr: string, body: string): void {
+	const comments = JSON.parse(
+		gh(['api', `repos/${repo}/issues/${pr}/comments`, '--paginate']),
+	) as { id: number; body: string }[];
+	const existing = comments.find((c) => c.body.startsWith(MARKER));
+	if (existing) {
+		gh([
+			'api',
+			'-X',
+			'PATCH',
+			`repos/${repo}/issues/comments/${existing.id}`,
+			'-f',
+			`body=${body}`,
+		]);
+	} else {
+		gh([
+			'api',
+			'-X',
+			'POST',
+			`repos/${repo}/issues/${pr}/comments`,
+			'-f',
+			`body=${body}`,
+		]);
+	}
+}
+
+function setLabel(repo: string, pr: string, failed: boolean): void {
+	if (failed) {
+		gh([
+			'api',
+			'-X',
+			'POST',
+			`repos/${repo}/issues/${pr}/labels`,
+			'-f',
+			'labels[]=gate:failed',
+		]);
+	} else {
+		try {
+			gh([
+				'api',
+				'-X',
+				'DELETE',
+				`repos/${repo}/issues/${pr}/labels/gate:failed`,
+			]);
+		} catch {
+			// label was not present
+		}
+	}
+}
+
+const event = JSON.parse(
+	fs.readFileSync(process.env.GITHUB_EVENT_PATH ?? '', 'utf8'),
+);
+const repo = process.env.GITHUB_REPOSITORY ?? '';
+const pr = String(event.pull_request.number);
+const baseSha = event.pull_request.base.sha as string;
+
+const changedFiles = execFileSync(
+	'git',
+	['diff', '--name-only', `${baseSha}...HEAD`],
+	{ encoding: 'utf8' },
+)
+	.trim()
+	.split('\n')
+	.filter(Boolean);
+
+const result = runGate({
+	changedFiles,
+	prBody: (event.pull_request.body as string) ?? '',
+	isDraft: event.pull_request.draft as boolean,
+});
+
+if (!result.isPluginPr) {
+	console.log('Not a plugin PR (or draft) — gate skipped.');
+	process.exit(0);
+}
+
+upsertComment(repo, pr, renderComment(result));
+setLabel(repo, pr, result.failures.length > 0);
+
+if (result.failures.length > 0) {
+	for (const f of result.failures) {
+		console.error(`[GATE][${f.rule}] ${f.message}`);
+	}
+	process.exit(1);
+}
+console.log('Gate passed.');

--- a/scripts/pr-review/gate.test.ts
+++ b/scripts/pr-review/gate.test.ts
@@ -32,6 +32,7 @@ const goodInput = {
 	prBody: goodBody,
 	isDraft: false,
 	readmeExists: true,
+	testFileCount: 2,
 	assertionCount: 12,
 };
 
@@ -73,12 +74,17 @@ test('R1: two plugins in one PR fails', () => {
 	assert.ok(r.failures.some((f) => f.rule === 'R1'));
 });
 
-test('R2: no test file fails', () => {
+test('R2: plugin with no test files fails', () => {
+	const r = runGate({ ...goodInput, testFileCount: 0 });
+	assert.ok(r.failures.some((f) => f.rule === 'R2'));
+});
+
+test('R2: update PR not touching tests passes when tests exist on disk', () => {
 	const r = runGate({
 		...goodInput,
 		changedFiles: goodFiles.filter((f) => !f.endsWith('.test.ts')),
 	});
-	assert.ok(r.failures.some((f) => f.rule === 'R2'));
+	assert.ok(!r.failures.some((f) => f.rule === 'R2'));
 });
 
 test('R2: tests without assertions fail', () => {
@@ -129,4 +135,14 @@ test('R4: missing demo link fails', () => {
 test('R7: missing README fails', () => {
 	const r = runGate({ ...goodInput, readmeExists: false });
 	assert.ok(r.failures.some((f) => f.rule === 'R7'));
+});
+
+test('nested comment markers cannot survive stripping (CodeQL js/incomplete-multi-character-sanitization)', () => {
+	const body = goodBody.replace(
+		'Adds the 1Password Connect plugin with vaults and items endpoints.',
+		'<!<!-- inner -->-- sneaky payload -->',
+	);
+	const r = runGate({ ...goodInput, prBody: body });
+	// After full stripping the description is empty → R3 must fail.
+	assert.ok(r.failures.some((f) => f.rule === 'R3'));
 });

--- a/scripts/pr-review/gate.test.ts
+++ b/scripts/pr-review/gate.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { runGate } from './gate.ts';
+
+const goodBody = `## Description
+Adds the 1Password Connect plugin with vaults and items endpoints.
+
+## Checklist
+- [x] I have run \`pnpm lint\` and all checks pass
+- [x] I have run \`pnpm typecheck\` and there are no TypeScript errors
+- [x] I have run \`pnpm build\` and all packages build successfully
+- [x] I have run \`pnpm test\` and all tests pass
+- [x] I have added or updated tests where applicable
+- [x] I have added or updated necessary documentation
+
+## Screenshots / Demos (if applicable)
+https://github.com/user-attachments/assets/demo.mp4
+`;
+
+const goodFiles = [
+	'packages/onepassword/index.ts',
+	'packages/onepassword/api.test.ts',
+	'packages/corsair/core/constants.ts',
+	'pnpm-lock.yaml',
+];
+
+test('clean plugin PR passes', () => {
+	const r = runGate({
+		changedFiles: goodFiles,
+		prBody: goodBody,
+		isDraft: false,
+	});
+	assert.equal(r.isPluginPr, true);
+	assert.equal(r.plugin, 'onepassword');
+	assert.deepEqual(r.failures, []);
+});
+
+test('non-plugin PR is skipped', () => {
+	const r = runGate({
+		changedFiles: ['packages/cli/src/index.ts'],
+		prBody: goodBody,
+		isDraft: false,
+	});
+	assert.equal(r.isPluginPr, false);
+});
+
+test('draft plugin PR is skipped', () => {
+	const r = runGate({
+		changedFiles: goodFiles,
+		prBody: goodBody,
+		isDraft: true,
+	});
+	assert.equal(r.isPluginPr, false);
+});
+
+test('R1: out-of-scope file fails', () => {
+	const r = runGate({
+		changedFiles: [...goodFiles, 'packages/corsair/core/client.ts'],
+		prBody: goodBody,
+		isDraft: false,
+	});
+	assert.ok(r.failures.some((f) => f.rule === 'R1'));
+});
+
+test('R1: two plugins in one PR fails', () => {
+	const r = runGate({
+		changedFiles: [...goodFiles, 'packages/slack/index.ts'],
+		prBody: goodBody,
+		isDraft: false,
+	});
+	assert.ok(r.failures.some((f) => f.rule === 'R1'));
+});
+
+test('R2: no test file fails', () => {
+	const files = goodFiles.filter((f) => !f.endsWith('.test.ts'));
+	const r = runGate({ changedFiles: files, prBody: goodBody, isDraft: false });
+	assert.ok(r.failures.some((f) => f.rule === 'R2'));
+});
+
+test('R3: unchecked checklist box fails', () => {
+	const body = goodBody.replace(
+		'- [x] I have run `pnpm lint`',
+		'- [ ] I have run `pnpm lint`',
+	);
+	const r = runGate({ changedFiles: goodFiles, prBody: body, isDraft: false });
+	assert.ok(r.failures.some((f) => f.rule === 'R3'));
+});
+
+test('R3: empty description fails', () => {
+	const body = goodBody.replace(
+		'Adds the 1Password Connect plugin with vaults and items endpoints.',
+		'<!-- Briefly describe the changes -->',
+	);
+	const r = runGate({ changedFiles: goodFiles, prBody: body, isDraft: false });
+	assert.ok(r.failures.some((f) => f.rule === 'R3'));
+});
+
+test('R4: missing demo link fails', () => {
+	const body = goodBody.replace(
+		'https://github.com/user-attachments/assets/demo.mp4',
+		'',
+	);
+	const r = runGate({ changedFiles: goodFiles, prBody: body, isDraft: false });
+	assert.ok(r.failures.some((f) => f.rule === 'R4'));
+});

--- a/scripts/pr-review/gate.test.ts
+++ b/scripts/pr-review/gate.test.ts
@@ -5,6 +5,8 @@ import { runGate } from './gate.ts';
 const goodBody = `## Description
 Adds the 1Password Connect plugin with vaults and items endpoints.
 
+Fixes #123
+
 ## Checklist
 - [x] I have run \`pnpm lint\` and all checks pass
 - [x] I have run \`pnpm typecheck\` and there are no TypeScript errors
@@ -20,61 +22,74 @@ https://github.com/user-attachments/assets/demo.mp4
 const goodFiles = [
 	'packages/onepassword/index.ts',
 	'packages/onepassword/api.test.ts',
+	'packages/onepassword/README.md',
 	'packages/corsair/core/constants.ts',
 	'pnpm-lock.yaml',
 ];
 
-test('clean plugin PR passes', () => {
-	const r = runGate({
-		changedFiles: goodFiles,
-		prBody: goodBody,
-		isDraft: false,
-	});
+const goodInput = {
+	changedFiles: goodFiles,
+	prBody: goodBody,
+	isDraft: false,
+	readmeExists: true,
+	assertionCount: 12,
+};
+
+test('clean plugin PR passes every check', () => {
+	const r = runGate(goodInput);
 	assert.equal(r.isPluginPr, true);
 	assert.equal(r.plugin, 'onepassword');
 	assert.deepEqual(r.failures, []);
+	assert.ok(r.checks.length >= 6);
+	assert.ok(r.checks.every((c) => c.status === 'pass'));
 });
 
 test('non-plugin PR is skipped', () => {
 	const r = runGate({
+		...goodInput,
 		changedFiles: ['packages/cli/src/index.ts'],
-		prBody: goodBody,
-		isDraft: false,
 	});
 	assert.equal(r.isPluginPr, false);
 });
 
 test('draft plugin PR is skipped', () => {
-	const r = runGate({
-		changedFiles: goodFiles,
-		prBody: goodBody,
-		isDraft: true,
-	});
+	const r = runGate({ ...goodInput, isDraft: true });
 	assert.equal(r.isPluginPr, false);
 });
 
 test('R1: out-of-scope file fails', () => {
 	const r = runGate({
+		...goodInput,
 		changedFiles: [...goodFiles, 'packages/corsair/core/client.ts'],
-		prBody: goodBody,
-		isDraft: false,
 	});
 	assert.ok(r.failures.some((f) => f.rule === 'R1'));
 });
 
 test('R1: two plugins in one PR fails', () => {
 	const r = runGate({
+		...goodInput,
 		changedFiles: [...goodFiles, 'packages/slack/index.ts'],
-		prBody: goodBody,
-		isDraft: false,
 	});
 	assert.ok(r.failures.some((f) => f.rule === 'R1'));
 });
 
 test('R2: no test file fails', () => {
-	const files = goodFiles.filter((f) => !f.endsWith('.test.ts'));
-	const r = runGate({ changedFiles: files, prBody: goodBody, isDraft: false });
+	const r = runGate({
+		...goodInput,
+		changedFiles: goodFiles.filter((f) => !f.endsWith('.test.ts')),
+	});
 	assert.ok(r.failures.some((f) => f.rule === 'R2'));
+});
+
+test('R2: tests without assertions fail', () => {
+	const r = runGate({ ...goodInput, assertionCount: 0 });
+	assert.ok(r.failures.some((f) => f.rule === 'R2'));
+});
+
+test('R2: thin assertions warn but do not fail', () => {
+	const r = runGate({ ...goodInput, assertionCount: 2 });
+	assert.ok(!r.failures.some((f) => f.rule === 'R2'));
+	assert.ok(r.checks.some((c) => c.rule === 'R2' && c.status === 'warn'));
 });
 
 test('R3: unchecked checklist box fails', () => {
@@ -82,7 +97,7 @@ test('R3: unchecked checklist box fails', () => {
 		'- [x] I have run `pnpm lint`',
 		'- [ ] I have run `pnpm lint`',
 	);
-	const r = runGate({ changedFiles: goodFiles, prBody: body, isDraft: false });
+	const r = runGate({ ...goodInput, prBody: body });
 	assert.ok(r.failures.some((f) => f.rule === 'R3'));
 });
 
@@ -91,8 +106,15 @@ test('R3: empty description fails', () => {
 		'Adds the 1Password Connect plugin with vaults and items endpoints.',
 		'<!-- Briefly describe the changes -->',
 	);
-	const r = runGate({ changedFiles: goodFiles, prBody: body, isDraft: false });
+	const r = runGate({ ...goodInput, prBody: body });
 	assert.ok(r.failures.some((f) => f.rule === 'R3'));
+});
+
+test('R3: missing issue link warns but does not fail', () => {
+	const body = goodBody.replace('Fixes #123', '');
+	const r = runGate({ ...goodInput, prBody: body });
+	assert.ok(!r.failures.some((f) => f.rule === 'R3'));
+	assert.ok(r.checks.some((c) => c.rule === 'R3' && c.status === 'warn'));
 });
 
 test('R4: missing demo link fails', () => {
@@ -100,6 +122,11 @@ test('R4: missing demo link fails', () => {
 		'https://github.com/user-attachments/assets/demo.mp4',
 		'',
 	);
-	const r = runGate({ changedFiles: goodFiles, prBody: body, isDraft: false });
+	const r = runGate({ ...goodInput, prBody: body });
 	assert.ok(r.failures.some((f) => f.rule === 'R4'));
+});
+
+test('R7: missing README fails', () => {
+	const r = runGate({ ...goodInput, readmeExists: false });
+	assert.ok(r.failures.some((f) => f.rule === 'R7'));
 });

--- a/scripts/pr-review/gate.ts
+++ b/scripts/pr-review/gate.ts
@@ -1,6 +1,6 @@
 const IGNORED_PACKAGES = ['corsair', 'cli', 'mcp', 'studio', 'ui', 'app'];
 const ALLOWED_EXTRA = ['packages/corsair/core/constants.ts', 'pnpm-lock.yaml'];
-const ASSERTION_WARN_FLOOR = 5;
+export const ASSERTION_WARN_FLOOR = 5;
 
 export interface GateInput {
 	changedFiles: string[];
@@ -8,6 +8,8 @@ export interface GateInput {
 	isDraft: boolean;
 	/** Whether packages/<plugin>/README.md exists in the checkout. */
 	readmeExists: boolean;
+	/** Number of *.test.ts files that exist in the plugin package. */
+	testFileCount: number;
 	/** Total expect(/assert( calls across the plugin's *.test.ts files. */
 	assertionCount: number;
 }
@@ -49,7 +51,16 @@ function section(body: string, heading: string): string {
 }
 
 function stripComments(s: string): string {
-	return s.replace(/<!--[\s\S]*?-->/g, '');
+	// Strip repeatedly until stable so nested/overlapping markers
+	// cannot reassemble into a live comment (CodeQL: incomplete
+	// multi-character sanitization).
+	let out = s;
+	let prev: string;
+	do {
+		prev = out;
+		out = out.replace(/<!--[\s\S]*?-->/g, '');
+	} while (out !== prev);
+	return out;
 }
 
 export function runGate(input: GateInput): GateResult {
@@ -89,11 +100,9 @@ export function runGate(input: GateInput): GateResult {
 		});
 	}
 
-	// R2 — tests with real assertions
-	const hasTest = input.changedFiles.some(
-		(f) => pluginOf(f) !== null && f.endsWith('.test.ts'),
-	);
-	if (!hasTest) {
+	// R2 — tests with real assertions (existence checked on the plugin
+	// package itself, not the diff — update PRs need not touch tests)
+	if (input.testFileCount === 0) {
 		checks.push({
 			rule: 'R2',
 			label: 'Tests present',

--- a/scripts/pr-review/gate.ts
+++ b/scripts/pr-review/gate.ts
@@ -1,10 +1,22 @@
 const IGNORED_PACKAGES = ['corsair', 'cli', 'mcp', 'studio', 'ui', 'app'];
 const ALLOWED_EXTRA = ['packages/corsair/core/constants.ts', 'pnpm-lock.yaml'];
+const ASSERTION_WARN_FLOOR = 5;
 
 export interface GateInput {
 	changedFiles: string[];
 	prBody: string;
 	isDraft: boolean;
+	/** Whether packages/<plugin>/README.md exists in the checkout. */
+	readmeExists: boolean;
+	/** Total expect(/assert( calls across the plugin's *.test.ts files. */
+	assertionCount: number;
+}
+
+export interface GateCheck {
+	rule: string;
+	label: string;
+	status: 'pass' | 'warn' | 'fail';
+	detail?: string;
 }
 
 export interface GateFailure {
@@ -15,6 +27,7 @@ export interface GateFailure {
 export interface GateResult {
 	isPluginPr: boolean;
 	plugin: string | null;
+	checks: GateCheck[];
 	failures: GateFailure[];
 }
 
@@ -22,6 +35,11 @@ function pluginOf(file: string): string | null {
 	const m = file.match(/^packages\/([^/]+)\//);
 	if (!m) return null;
 	return IGNORED_PACKAGES.includes(m[1]) ? null : m[1];
+}
+
+/** The plugin a PR targets, or null if it touches no plugin packages. */
+export function detectPlugin(changedFiles: string[]): string | null {
+	return changedFiles.map(pluginOf).find((p) => p !== null) ?? null;
 }
 
 function section(body: string, heading: string): string {
@@ -39,60 +57,123 @@ export function runGate(input: GateInput): GateResult {
 		input.changedFiles.map(pluginOf).filter((p): p is string => p !== null),
 	);
 	if (plugins.size === 0 || input.isDraft) {
-		return { isPluginPr: false, plugin: null, failures: [] };
+		return { isPluginPr: false, plugin: null, checks: [], failures: [] };
 	}
 
-	const failures: GateFailure[] = [];
+	const checks: GateCheck[] = [];
 	const plugin = [...plugins][0];
 
-	if (plugins.size > 1) {
-		failures.push({
-			rule: 'R1',
-			message: `One plugin per PR — this PR touches: ${[...plugins].join(', ')}`,
-		});
-	}
+	// R1 — scope confinement
 	const outOfScope = input.changedFiles.filter(
 		(f) => pluginOf(f) === null && !ALLOWED_EXTRA.includes(f),
 	);
-	if (outOfScope.length > 0) {
-		failures.push({
+	if (plugins.size > 1) {
+		checks.push({
 			rule: 'R1',
-			message: `Files outside the plugin scope: ${outOfScope.join(', ')}`,
+			label: 'Scope: one plugin per PR',
+			status: 'fail',
+			detail: `This PR touches: ${[...plugins].join(', ')}`,
+		});
+	} else if (outOfScope.length > 0) {
+		checks.push({
+			rule: 'R1',
+			label: 'Scope: plugin files only',
+			status: 'fail',
+			detail: `Out of scope: ${outOfScope.join(', ')}`,
+		});
+	} else {
+		checks.push({
+			rule: 'R1',
+			label: 'Scope: plugin files only',
+			status: 'pass',
 		});
 	}
 
+	// R2 — tests with real assertions
 	const hasTest = input.changedFiles.some(
 		(f) => pluginOf(f) !== null && f.endsWith('.test.ts'),
 	);
 	if (!hasTest) {
-		failures.push({
+		checks.push({
 			rule: 'R2',
-			message: `No *.test.ts under packages/${plugin}/ — see packages/slack for examples`,
+			label: 'Tests present',
+			status: 'fail',
+			detail: `No *.test.ts under packages/${plugin}/ — see packages/slack for examples`,
 		});
+	} else if (input.assertionCount === 0) {
+		checks.push({
+			rule: 'R2',
+			label: 'Tests have assertions',
+			status: 'fail',
+			detail: 'Test files contain no expect()/assert() calls',
+		});
+	} else if (input.assertionCount < ASSERTION_WARN_FLOOR) {
+		checks.push({
+			rule: 'R2',
+			label: 'Test depth',
+			status: 'warn',
+			detail: `Only ${input.assertionCount} assertions — cover each endpoint`,
+		});
+	} else {
+		checks.push({ rule: 'R2', label: 'Tests with assertions', status: 'pass' });
 	}
 
-	if (/-\s\[\s\]/.test(input.prBody)) {
-		failures.push({
+	// R3 — description quality
+	const uncheckedBoxes = /-\s\[\s\]/.test(input.prBody);
+	const description = stripComments(section(input.prBody, 'Description'));
+	if (uncheckedBoxes) {
+		checks.push({
 			rule: 'R3',
-			message: 'PR template checklist has unchecked boxes',
+			label: 'PR template checklist',
+			status: 'fail',
+			detail: 'Checklist has unchecked boxes',
 		});
-	}
-	const description = section(input.prBody, 'Description');
-	if (stripComments(description).trim().length < 20) {
-		failures.push({
+	} else if (description.trim().length < 20) {
+		checks.push({
 			rule: 'R3',
-			message: 'Description section is empty or placeholder',
+			label: 'Description',
+			status: 'fail',
+			detail: 'Description section is empty or placeholder',
 		});
+	} else {
+		checks.push({ rule: 'R3', label: 'Description complete', status: 'pass' });
 	}
+	const hasIssueLink =
+		/(fixes|closes|resolves)\s+#\d+/i.test(input.prBody) ||
+		/corsair\.dev\/oss\//.test(input.prBody);
+	checks.push({
+		rule: 'R3',
+		label: 'Linked issue / claim',
+		status: hasIssueLink ? 'pass' : 'warn',
+		detail: hasIssueLink
+			? undefined
+			: 'No "Fixes #…" or claim link — add one if this PR has a claim or issue',
+	});
 
-	const demos = section(input.prBody, 'Screenshots / Demos');
-	if (!/https?:\/\/\S+/.test(stripComments(demos))) {
-		failures.push({
-			rule: 'R4',
-			message:
-				'No demo video/recording link in "Screenshots / Demos" — required for plugin PRs',
-		});
-	}
+	// R4 — demo video
+	const demos = stripComments(section(input.prBody, 'Screenshots / Demos'));
+	checks.push({
+		rule: 'R4',
+		label: 'Demo video / recording',
+		status: /https?:\/\/\S+/.test(demos) ? 'pass' : 'fail',
+		detail: /https?:\/\/\S+/.test(demos)
+			? undefined
+			: 'Required in "Screenshots / Demos" before a maintainer reviews',
+	});
 
-	return { isPluginPr: true, plugin, failures };
+	// R7 — plugin README
+	checks.push({
+		rule: 'R7',
+		label: 'Plugin README',
+		status: input.readmeExists ? 'pass' : 'fail',
+		detail: input.readmeExists
+			? undefined
+			: `packages/${plugin}/README.md is missing (auth setup + endpoints overview)`,
+	});
+
+	const failures = checks
+		.filter((c) => c.status === 'fail')
+		.map((c) => ({ rule: c.rule, message: c.detail ?? c.label }));
+
+	return { isPluginPr: true, plugin, checks, failures };
 }

--- a/scripts/pr-review/gate.ts
+++ b/scripts/pr-review/gate.ts
@@ -1,0 +1,98 @@
+const IGNORED_PACKAGES = ['corsair', 'cli', 'mcp', 'studio', 'ui', 'app'];
+const ALLOWED_EXTRA = ['packages/corsair/core/constants.ts', 'pnpm-lock.yaml'];
+
+export interface GateInput {
+	changedFiles: string[];
+	prBody: string;
+	isDraft: boolean;
+}
+
+export interface GateFailure {
+	rule: string;
+	message: string;
+}
+
+export interface GateResult {
+	isPluginPr: boolean;
+	plugin: string | null;
+	failures: GateFailure[];
+}
+
+function pluginOf(file: string): string | null {
+	const m = file.match(/^packages\/([^/]+)\//);
+	if (!m) return null;
+	return IGNORED_PACKAGES.includes(m[1]) ? null : m[1];
+}
+
+function section(body: string, heading: string): string {
+	const escaped = heading.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&');
+	const re = new RegExp(`##\\s*${escaped}[^\\n]*\\n([\\s\\S]*?)(?=\\n##\\s|$)`);
+	return body.match(re)?.[1] ?? '';
+}
+
+function stripComments(s: string): string {
+	return s.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+export function runGate(input: GateInput): GateResult {
+	const plugins = new Set(
+		input.changedFiles.map(pluginOf).filter((p): p is string => p !== null),
+	);
+	if (plugins.size === 0 || input.isDraft) {
+		return { isPluginPr: false, plugin: null, failures: [] };
+	}
+
+	const failures: GateFailure[] = [];
+	const plugin = [...plugins][0];
+
+	if (plugins.size > 1) {
+		failures.push({
+			rule: 'R1',
+			message: `One plugin per PR — this PR touches: ${[...plugins].join(', ')}`,
+		});
+	}
+	const outOfScope = input.changedFiles.filter(
+		(f) => pluginOf(f) === null && !ALLOWED_EXTRA.includes(f),
+	);
+	if (outOfScope.length > 0) {
+		failures.push({
+			rule: 'R1',
+			message: `Files outside the plugin scope: ${outOfScope.join(', ')}`,
+		});
+	}
+
+	const hasTest = input.changedFiles.some(
+		(f) => pluginOf(f) !== null && f.endsWith('.test.ts'),
+	);
+	if (!hasTest) {
+		failures.push({
+			rule: 'R2',
+			message: `No *.test.ts under packages/${plugin}/ — see packages/slack for examples`,
+		});
+	}
+
+	if (/-\s\[\s\]/.test(input.prBody)) {
+		failures.push({
+			rule: 'R3',
+			message: 'PR template checklist has unchecked boxes',
+		});
+	}
+	const description = section(input.prBody, 'Description');
+	if (stripComments(description).trim().length < 20) {
+		failures.push({
+			rule: 'R3',
+			message: 'Description section is empty or placeholder',
+		});
+	}
+
+	const demos = section(input.prBody, 'Screenshots / Demos');
+	if (!/https?:\/\/\S+/.test(stripComments(demos))) {
+		failures.push({
+			rule: 'R4',
+			message:
+				'No demo video/recording link in "Screenshots / Demos" — required for plugin PRs',
+		});
+	}
+
+	return { isPluginPr: true, plugin, failures };
+}

--- a/scripts/pr-review/loop-main.ts
+++ b/scripts/pr-review/loop-main.ts
@@ -71,12 +71,14 @@ const readmeExists =
 let testFileCount = 0;
 if (plugin) {
 	try {
+		// Recursive tree so nested tests (e.g. tests/) count, matching the
+		// gate job's recursive disk scan.
 		testFileCount = Number(
 			gh([
 				'api',
-				`repos/${headRepo}/contents/packages/${plugin}?ref=${headSha}`,
+				`repos/${headRepo}/git/trees/${headSha}?recursive=1`,
 				'--jq',
-				'[.[] | select(.name | endswith(".test.ts"))] | length',
+				`[.tree[] | select(.path | startswith("packages/${plugin}/") and endswith(".test.ts"))] | length`,
 			]).trim(),
 		);
 	} catch {

--- a/scripts/pr-review/loop-main.ts
+++ b/scripts/pr-review/loop-main.ts
@@ -1,0 +1,135 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { runGate } from './gate.ts';
+import {
+	buildEscalationComment,
+	buildRoundOneComment,
+	currentRound,
+	decide,
+} from './loop.ts';
+import type { ReviewComment } from './parse-greptile.ts';
+import { parseFindings } from './parse-greptile.ts';
+
+function gh(args: string[]): string {
+	return execFileSync('gh', args, {
+		encoding: 'utf8',
+		maxBuffer: 64 * 1024 * 1024,
+	});
+}
+
+function setOutput(key: string, value: string): void {
+	if (process.env.GITHUB_OUTPUT) {
+		fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+	}
+}
+
+const event = JSON.parse(
+	fs.readFileSync(process.env.GITHUB_EVENT_PATH ?? '', 'utf8'),
+);
+const repo = process.env.GITHUB_REPOSITORY ?? '';
+const dryRun = process.env.PR_BOT_DRY_RUN === 'true';
+const pr = event.pull_request.number as number;
+const reviewId = event.review.id as number;
+const author = event.pull_request.user.login as string;
+
+const changedFiles = gh([
+	'api',
+	`repos/${repo}/pulls/${pr}/files`,
+	'--paginate',
+	'--jq',
+	'.[].filename',
+])
+	.trim()
+	.split('\n')
+	.filter(Boolean);
+const gate = runGate({
+	changedFiles,
+	prBody: (event.pull_request.body as string) ?? '',
+	isDraft: event.pull_request.draft as boolean,
+});
+if (!gate.isPluginPr) {
+	console.log('Not a plugin PR (or draft) — loop skipped.');
+	setOutput('decision', 'skip');
+	process.exit(0);
+}
+
+const reviewComments = JSON.parse(
+	gh(['api', `repos/${repo}/pulls/${pr}/comments`, '--paginate']),
+) as ReviewComment[];
+const findings = parseFindings(reviewComments, reviewId);
+
+const issueComments = JSON.parse(
+	gh(['api', `repos/${repo}/issues/${pr}/comments`, '--paginate']),
+) as { body: string }[];
+const round = currentRound(issueComments);
+let decision = decide(round, findings);
+
+// Cost guard: never spend an LLM run while the PR itself is incomplete
+// (missing tests/description/video). Stay at round 1 until the gate passes;
+// the loop re-fires on the contributor's next push.
+if (decision === 'fix' && gate.failures.length > 0) {
+	console.log(
+		`Fix round deferred — gate still failing (${gate.failures.map((f) => f.rule).join(', ')}).`,
+	);
+	decision = 'done';
+}
+
+function post(body: string): void {
+	const final = dryRun
+		? `<!-- corsair-review-bot dry-run -->\n<details><summary>DRY RUN — would post:</summary>\n\n${body}\n</details>`
+		: body;
+	gh([
+		'api',
+		'-X',
+		'POST',
+		`repos/${repo}/issues/${pr}/comments`,
+		'-f',
+		`body=${final}`,
+	]);
+}
+
+function label(name: string): void {
+	if (dryRun) return;
+	gh([
+		'api',
+		'-X',
+		'POST',
+		`repos/${repo}/issues/${pr}/labels`,
+		'-f',
+		`labels[]=${name}`,
+	]);
+}
+
+switch (decision) {
+	case 'comment':
+		post(buildRoundOneComment(findings, gate.failures, author));
+		label('bot:round-1');
+		break;
+	case 'fix':
+		// The workflow's fix job consumes this artifact.
+		fs.writeFileSync(
+			'/tmp/findings.json',
+			JSON.stringify(findings.filter((f) => f.severity !== 'P2')),
+		);
+		// The round=2 marker is the ratchet that guarantees the LLM fix runs
+		// at most once per PR: the next Greptile review can only escalate.
+		post(
+			[
+				'<!-- corsair-review-bot round=2 -->',
+				'Remaining findings are being fixed by a bot commit — it will be re-reviewed automatically.',
+			].join('\n'),
+		);
+		label('bot:round-2');
+		break;
+	case 'escalate':
+		post(buildEscalationComment(findings));
+		label('needs-maintainer');
+		break;
+	case 'done':
+		console.log('Nothing to do this round.');
+		break;
+}
+setOutput('decision', decision);
+console.log(
+	`round=${round} decision=${decision} findings=${findings.length} dryRun=${dryRun}`,
+);

--- a/scripts/pr-review/loop-main.ts
+++ b/scripts/pr-review/loop-main.ts
@@ -98,11 +98,13 @@ const issueComments = JSON.parse(
 ) as { body: string }[];
 const round = currentRound(issueComments);
 let decision = decide(round, findings);
+const seriousCount = findings.filter((f) => f.severity !== 'P2').length;
 
 // Cost guard: never spend an LLM run while the PR itself is incomplete
 // (missing tests/description/video). Stay at round 1 until the gate passes;
 // the loop re-fires on the contributor's next push.
-if (decision === 'fix' && gate.failures.length > 0) {
+const fixDeferred = decision === 'fix' && gate.failures.length > 0;
+if (fixDeferred) {
 	console.log(
 		`Fix round deferred — gate still failing (${gate.failures.map((f) => f.rule).join(', ')}).`,
 	);
@@ -123,6 +125,32 @@ function post(body: string): void {
 	]);
 }
 
+// Edits the existing comment carrying the marker instead of posting a new
+// one, so each round keeps a single live comment. Falls back to post.
+function upsert(marker: string, body: string): void {
+	if (dryRun) {
+		post(body);
+		return;
+	}
+	const existing = (
+		JSON.parse(
+			gh(['api', `repos/${repo}/issues/${pr}/comments`, '--paginate']),
+		) as { id: number; body: string }[]
+	).find((c) => c.body.startsWith(marker));
+	if (existing) {
+		gh([
+			'api',
+			'-X',
+			'PATCH',
+			`repos/${repo}/issues/comments/${existing.id}`,
+			'-f',
+			`body=${body}`,
+		]);
+	} else {
+		post(body);
+	}
+}
+
 function label(name: string): void {
 	if (dryRun) return;
 	gh([
@@ -135,9 +163,21 @@ function label(name: string): void {
 	]);
 }
 
+function unlabel(name: string): void {
+	if (dryRun) return;
+	try {
+		gh(['api', '-X', 'DELETE', `repos/${repo}/issues/${pr}/labels/${name}`]);
+	} catch {
+		// label was not present
+	}
+}
+
+const R1_MARKER = '<!-- corsair-review-bot round=1 -->';
+const R3_MARKER = '<!-- corsair-review-bot round=3 -->';
+
 switch (decision) {
 	case 'comment':
-		post(buildRoundOneComment(findings, gate.failures, author));
+		upsert(R1_MARKER, buildRoundOneComment(findings, gate.failures, author));
 		label('bot:round-1');
 		break;
 	case 'fix':
@@ -157,11 +197,25 @@ switch (decision) {
 		label('bot:round-2');
 		break;
 	case 'escalate':
-		post(buildEscalationComment(findings));
+		upsert(R3_MARKER, buildEscalationComment(findings));
 		label('needs-maintainer');
 		break;
 	case 'done':
-		console.log('Nothing to do this round.');
+		if (fixDeferred) {
+			// PR incomplete — keep the round-1 findings list current so the
+			// contributor always sees the latest state in one place.
+			upsert(R1_MARKER, buildRoundOneComment(findings, gate.failures, author));
+		} else if (round >= 3 && seriousCount > 0) {
+			// Escalated but still moving — refresh the escalation summary
+			// in place; never post new comments after escalation.
+			upsert(R3_MARKER, buildEscalationComment(findings));
+		} else if (round >= 3 && seriousCount === 0 && gate.failures.length === 0) {
+			// Escalated PR became clean — clear the maintainer flag so the
+			// queue reflects reality.
+			unlabel('needs-maintainer');
+		} else {
+			console.log('Nothing to do this round.');
+		}
 		break;
 }
 setOutput('decision', decision);

--- a/scripts/pr-review/loop-main.ts
+++ b/scripts/pr-review/loop-main.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
-import { detectPlugin, runGate } from './gate.ts';
+import { ASSERTION_WARN_FLOOR, detectPlugin, runGate } from './gate.ts';
 import {
 	buildEscalationComment,
 	buildRoundOneComment,
@@ -64,7 +64,26 @@ function headFile(filePath: string): string | null {
 const plugin = detectPlugin(changedFiles);
 const readmeExists =
 	plugin !== null && headFile(`packages/${plugin}/README.md`) !== null;
-let assertionCount = 0;
+
+// Test existence comes from the head tree (update PRs need not touch
+// tests); assertion depth only inspects changed test files — the gate job
+// (full checkout) is authoritative for depth.
+let testFileCount = 0;
+if (plugin) {
+	try {
+		testFileCount = Number(
+			gh([
+				'api',
+				`repos/${headRepo}/contents/packages/${plugin}?ref=${headSha}`,
+				'--jq',
+				'[.[] | select(.name | endswith(".test.ts"))] | length',
+			]).trim(),
+		);
+	} catch {
+		testFileCount = 0;
+	}
+}
+let assertionCount = testFileCount > 0 ? ASSERTION_WARN_FLOOR : 0;
 for (const f of changedFiles) {
 	if (plugin && f.startsWith(`packages/${plugin}/`) && f.endsWith('.test.ts')) {
 		const b64 = headFile(f);
@@ -80,6 +99,7 @@ const gate = runGate({
 	prBody: (event.pull_request.body as string) ?? '',
 	isDraft: event.pull_request.draft as boolean,
 	readmeExists,
+	testFileCount,
 	assertionCount,
 });
 if (!gate.isPluginPr) {

--- a/scripts/pr-review/loop-main.ts
+++ b/scripts/pr-review/loop-main.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
-import { runGate } from './gate.ts';
+import { detectPlugin, runGate } from './gate.ts';
 import {
 	buildEscalationComment,
 	buildRoundOneComment,
@@ -42,10 +42,45 @@ const changedFiles = gh([
 	.trim()
 	.split('\n')
 	.filter(Boolean);
+// The triage job checks out the base branch, so plugin content signals come
+// from the PR head via the contents API. Assertion counting only inspects
+// changed test files — the gate job (full PR checkout) is authoritative.
+const headRepo = event.pull_request.head.repo.full_name as string;
+const headSha = event.pull_request.head.sha as string;
+
+function headFile(filePath: string): string | null {
+	try {
+		return gh([
+			'api',
+			`repos/${headRepo}/contents/${filePath}?ref=${headSha}`,
+			'--jq',
+			'.content',
+		]);
+	} catch {
+		return null;
+	}
+}
+
+const plugin = detectPlugin(changedFiles);
+const readmeExists =
+	plugin !== null && headFile(`packages/${plugin}/README.md`) !== null;
+let assertionCount = 0;
+for (const f of changedFiles) {
+	if (plugin && f.startsWith(`packages/${plugin}/`) && f.endsWith('.test.ts')) {
+		const b64 = headFile(f);
+		if (b64) {
+			const content = Buffer.from(b64, 'base64').toString('utf8');
+			assertionCount += content.match(/\b(expect|assert)\s*\(/g)?.length ?? 0;
+		}
+	}
+}
+
 const gate = runGate({
 	changedFiles,
 	prBody: (event.pull_request.body as string) ?? '',
 	isDraft: event.pull_request.draft as boolean,
+	readmeExists,
+	assertionCount,
 });
 if (!gate.isPluginPr) {
 	console.log('Not a plugin PR (or draft) — loop skipped.');

--- a/scripts/pr-review/loop.test.ts
+++ b/scripts/pr-review/loop.test.ts
@@ -39,6 +39,7 @@ test('decision table', () => {
 	assert.equal(decide(2, [f('P0')]), 'escalate');
 	assert.equal(decide(0, []), 'done');
 	assert.equal(decide(1, [f('P2')]), 'done'); // P2s alone never trigger a fix round
+	assert.equal(decide(3, [f('P0')]), 'done'); // pushes after escalation stay silent
 });
 
 test('round-1 comment contains every P0/P1 with location', () => {

--- a/scripts/pr-review/loop.test.ts
+++ b/scripts/pr-review/loop.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+	buildEscalationComment,
+	buildRoundOneComment,
+	currentRound,
+	decide,
+} from './loop.ts';
+import type { Finding } from './parse-greptile.ts';
+
+const f = (sev: Finding['severity']): Finding => ({
+	severity: sev,
+	title: 'Auth header commented out',
+	detail: 'Requests are unauthenticated.',
+	path: 'packages/facebook/client.ts',
+	line: 39,
+	commentId: 1,
+});
+
+test('round detection from markers', () => {
+	assert.equal(currentRound([]), 0);
+	assert.equal(
+		currentRound([{ body: '<!-- corsair-review-bot round=1 -->\nhi' }]),
+		1,
+	);
+	assert.equal(
+		currentRound([
+			{ body: '<!-- corsair-review-bot round=1 -->' },
+			{ body: '<!-- corsair-review-bot round=2 -->' },
+		]),
+		2,
+	);
+	assert.equal(currentRound([{ body: '<!-- corsair-pr-gate -->' }]), 0);
+});
+
+test('decision table', () => {
+	assert.equal(decide(0, [f('P0')]), 'comment');
+	assert.equal(decide(1, [f('P1')]), 'fix');
+	assert.equal(decide(2, [f('P0')]), 'escalate');
+	assert.equal(decide(0, []), 'done');
+	assert.equal(decide(1, [f('P2')]), 'done'); // P2s alone never trigger a fix round
+});
+
+test('round-1 comment contains every P0/P1 with location', () => {
+	const body = buildRoundOneComment(
+		[f('P0'), f('P1')],
+		[{ rule: 'R4', message: 'No demo video' }],
+		'someuser',
+	);
+	assert.ok(body.startsWith('<!-- corsair-review-bot round=1 -->'));
+	assert.ok(body.includes('@someuser'));
+	assert.ok(body.includes('packages/facebook/client.ts:39'));
+	assert.ok(body.includes('R4'));
+	assert.ok(body.includes('P0'));
+});
+
+test('P2-only findings go to the optional section', () => {
+	const body = buildRoundOneComment([f('P2')], [], 'someuser');
+	assert.ok(body.includes('Optional improvements'));
+});
+
+test('escalation comment has round=3 marker', () => {
+	assert.ok(
+		buildEscalationComment([f('P0')]).startsWith(
+			'<!-- corsair-review-bot round=3 -->',
+		),
+	);
+});

--- a/scripts/pr-review/loop.ts
+++ b/scripts/pr-review/loop.ts
@@ -1,0 +1,77 @@
+import type { GateFailure } from './gate.ts';
+import type { Finding } from './parse-greptile.ts';
+
+const MARKER = /<!-- corsair-review-bot round=(\d) -->/;
+
+export function currentRound(issueComments: { body: string }[]): number {
+	let round = 0;
+	for (const c of issueComments) {
+		const m = c.body.match(MARKER);
+		if (m) round = Math.max(round, Number(m[1]));
+	}
+	return round;
+}
+
+export function decide(
+	round: number,
+	findings: Finding[],
+): 'comment' | 'fix' | 'escalate' | 'done' {
+	const serious = findings.filter((f) => f.severity !== 'P2');
+	if (serious.length === 0) return 'done';
+	if (round === 0) return 'comment';
+	if (round === 1) return 'fix';
+	return 'escalate';
+}
+
+function findingLines(findings: Finding[]): string[] {
+	return findings.map(
+		(f) =>
+			`- **${f.severity}** \`${f.path}${f.line ? `:${f.line}` : ''}\` — **${f.title}**\n  ${f.detail}`,
+	);
+}
+
+export function buildRoundOneComment(
+	findings: Finding[],
+	gateFailures: GateFailure[],
+	author: string,
+): string {
+	const serious = findings.filter((f) => f.severity !== 'P2');
+	const optional = findings.filter((f) => f.severity === 'P2');
+	const parts = [
+		'<!-- corsair-review-bot round=1 -->',
+		`Hey @${author}, thanks for the contribution! 🏴‍☠️ Before a maintainer reviews, please fix the items below — the review re-runs automatically on your next push.`,
+	];
+	if (serious.length > 0) {
+		parts.push('', '### Must fix', ...findingLines(serious));
+	}
+	if (gateFailures.length > 0) {
+		parts.push(
+			'',
+			'### PR requirements ([rules](../blob/main/.github/PLUGIN_PR_RULES.md))',
+			...gateFailures.map((g) => `- **${g.rule}** — ${g.message}`),
+		);
+	}
+	if (optional.length > 0) {
+		parts.push(
+			'',
+			'<details><summary>Optional improvements (P2)</summary>',
+			'',
+			...findingLines(optional),
+			'</details>',
+		);
+	}
+	parts.push(
+		'',
+		'_If anything remains after your next push, a bot commit will clean it up; a maintainer always does the final review and merge._',
+	);
+	return parts.join('\n');
+}
+
+export function buildEscalationComment(findings: Finding[]): string {
+	return [
+		'<!-- corsair-review-bot round=3 -->',
+		'### Maintainer review needed',
+		'Automated rounds are exhausted. Remaining findings:',
+		...findingLines(findings.filter((f) => f.severity !== 'P2')),
+	].join('\n');
+}

--- a/scripts/pr-review/loop.ts
+++ b/scripts/pr-review/loop.ts
@@ -49,7 +49,7 @@ export function buildRoundOneComment(
 	if (gateFailures.length > 0) {
 		parts.push(
 			'',
-			'### PR requirements ([rules](../blob/main/.github/PLUGIN_PR_RULES.md))',
+			'### PR requirements ([rules](https://github.com/corsairdev/corsair/blob/main/.github/PLUGIN_PR_RULES.md))',
 			...gateFailures.map((g) => `- **${g.rule}** — ${g.message}`),
 		);
 	}

--- a/scripts/pr-review/loop.ts
+++ b/scripts/pr-review/loop.ts
@@ -20,7 +20,9 @@ export function decide(
 	if (serious.length === 0) return 'done';
 	if (round === 0) return 'comment';
 	if (round === 1) return 'fix';
-	return 'escalate';
+	if (round === 2) return 'escalate';
+	// Already escalated — stay silent no matter how many pushes follow.
+	return 'done';
 }
 
 function findingLines(findings: Finding[]): string[] {

--- a/scripts/pr-review/parse-greptile.test.ts
+++ b/scripts/pr-review/parse-greptile.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { test } from 'node:test';
+import { parseFindings } from './parse-greptile.ts';
+
+const fixture = JSON.parse(
+	fs.readFileSync(
+		new URL('./fixtures/greptile-comments.json', import.meta.url),
+		'utf8',
+	),
+);
+
+test('parses real Greptile comments from PR #392', () => {
+	const findings = parseFindings(fixture);
+	assert.ok(findings.length >= 2);
+	for (const f of findings) {
+		assert.match(f.severity, /^P[0-2]$/);
+		assert.ok(f.title.length > 0);
+		assert.ok(f.path.length > 0);
+	}
+	const auth = findings.find((f) => f.title.includes('Authorization header'));
+	assert.ok(auth);
+	assert.equal(auth.severity, 'P1');
+	assert.equal(auth.path, 'packages/facebook/client.ts');
+});
+
+test('ignores non-greptile comments', () => {
+	const findings = parseFindings([
+		{
+			id: 1,
+			pull_request_review_id: 9,
+			user: { login: 'someone' },
+			path: 'a.ts',
+			line: 1,
+			body: '<img alt="P0"> **x** y',
+		},
+	]);
+	assert.equal(findings.length, 0);
+});
+
+test('filters by reviewId when given', () => {
+	const all = parseFindings(fixture);
+	const byReview = parseFindings(fixture, fixture[0].pull_request_review_id);
+	assert.ok(byReview.length <= all.length);
+	assert.ok(byReview.length >= 1);
+});
+
+test('comment without severity badge is skipped', () => {
+	const findings = parseFindings([
+		{
+			id: 2,
+			pull_request_review_id: 9,
+			user: { login: 'greptile-apps[bot]' },
+			path: 'a.ts',
+			line: 1,
+			body: 'just a note',
+		},
+	]);
+	assert.equal(findings.length, 0);
+});

--- a/scripts/pr-review/parse-greptile.test.ts
+++ b/scripts/pr-review/parse-greptile.test.ts
@@ -58,3 +58,18 @@ test('comment without severity badge is skipped', () => {
 	]);
 	assert.equal(findings.length, 0);
 });
+
+const ruleFixture = JSON.parse(
+	fs.readFileSync(
+		new URL('./fixtures/greptile-rule-comment.json', import.meta.url),
+		'utf8',
+	),
+);
+
+test('rule-based finding gets a real title, not "Rule Used:"', () => {
+	const findings = parseFindings(ruleFixture);
+	assert.equal(findings.length, 1);
+	assert.equal(findings[0].severity, 'P0');
+	assert.ok(!findings[0].title.includes('Rule Used'));
+	assert.ok(findings[0].title.includes('new Function()'));
+});

--- a/scripts/pr-review/parse-greptile.ts
+++ b/scripts/pr-review/parse-greptile.ts
@@ -32,11 +32,19 @@ export function parseFindings(
 			| Finding['severity']
 			| undefined;
 		if (!sev) continue;
-		const title = c.body.match(/\*\*(.+?)\*\*/)?.[1] ?? '(untitled finding)';
-		const detail = c.body
-			.replace(/<a href[\s\S]*?<\/a>/, '')
-			.replace(/\*\*(.+?)\*\*/, '')
-			.trim();
+		// Strip badge anchors first. Title = leading bold when present;
+		// rule-based findings have no leading bold (their first bold is the
+		// "Rule Used:" label), so fall back to the first text line.
+		const stripped = c.body.replace(/<a href[\s\S]*?<\/a>\s*/g, '').trim();
+		const boldStart = stripped.match(/^\*\*(.+?)\*\*/);
+		const firstLine = (stripped.split('\n')[0] ?? '').trim();
+		const title =
+			boldStart?.[1] ?? (firstLine.slice(0, 120) || '(untitled finding)');
+		const detail = (
+			boldStart
+				? stripped.replace(/^\*\*(.+?)\*\*/, '')
+				: stripped.slice(firstLine.length)
+		).trim();
 		findings.push({
 			severity: sev,
 			title,

--- a/scripts/pr-review/parse-greptile.ts
+++ b/scripts/pr-review/parse-greptile.ts
@@ -1,0 +1,50 @@
+export interface ReviewComment {
+	id: number;
+	pull_request_review_id: number;
+	user: { login: string };
+	path: string;
+	line: number | null;
+	body: string;
+}
+
+export interface Finding {
+	severity: 'P0' | 'P1' | 'P2';
+	title: string;
+	detail: string;
+	path: string;
+	line: number | null;
+	commentId: number;
+}
+
+const GREPTILE_LOGIN = 'greptile-apps[bot]';
+
+export function parseFindings(
+	comments: ReviewComment[],
+	reviewId?: number,
+): Finding[] {
+	const findings: Finding[] = [];
+	for (const c of comments) {
+		if (c.user.login !== GREPTILE_LOGIN) continue;
+		if (reviewId !== undefined && c.pull_request_review_id !== reviewId) {
+			continue;
+		}
+		const sev = c.body.match(/alt="(P[0-2])"/)?.[1] as
+			| Finding['severity']
+			| undefined;
+		if (!sev) continue;
+		const title = c.body.match(/\*\*(.+?)\*\*/)?.[1] ?? '(untitled finding)';
+		const detail = c.body
+			.replace(/<a href[\s\S]*?<\/a>/, '')
+			.replace(/\*\*(.+?)\*\*/, '')
+			.trim();
+		findings.push({
+			severity: sev,
+			title,
+			detail,
+			path: c.path,
+			line: c.line,
+			commentId: c.id,
+		});
+	}
+	return findings;
+}


### PR DESCRIPTION
## Description
Adds the automated review flow for plugin PRs — human review stays the final step, nothing auto-merges:

- `.github/PLUGIN_PR_RULES.md` — canonical plugin PR requirements (R1–R8)
- `greptile.json` — Greptile enforces the rules with a blocking status check (validated on #399)
- Plugin PR gate job — deterministic scorecard comment + `gate:failed` label (validated on #399)
- Review loop workflow — parses Greptile findings each review: round 1 posts one consolidated findings comment (templated, no LLM), round 2 runs a sandboxed Codex fix via the LLM gateway at most once per PR, round 3 escalates with `needs-maintainer`. Comments are edited in place; drafts skipped; ships in dry-run (`PR_BOT_DRY_RUN=true`).
- Root `CLAUDE.md`/`AGENTS.md` and `docs/pr-review-bot.md` runbook
- PR template asks contributors to stay in draft until the checklist is complete

Tests: `pnpm exec tsx --test scripts/pr-review/*.test.ts` (22 tests, fixtures from real Greptile payloads).

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)
Dry-run validation on test PR #399: scorecard comment, gate label, and Greptile custom rules all confirmed working.