### PR TITLE
ci: cache turbo outputs between runs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -32,6 +32,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-
+
       - name: Lint
         run: pnpm lint
 


### PR DESCRIPTION
## Description
Caches `.turbo` (2.6 MB) via actions/cache so unchanged packages replay cached results instead of re-executing. Measured locally: cold build 1m14s → warm build 777ms (74/74 cached), tests 748ms (98/98 cached). A push touching one plugin no longer rebuilds all 74 packages. No secrets, no external services; drop-in upgrade to a remote cache later if needed.

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)
CI-only. This PR's first run is a cache miss (baseline); pushes after merge restore from main's cache.