### PR TITLE
fix(ci): read rules from base checkout instead of raw cdn

### DIFF
--- a/.github/workflows/plugin-pr-review-loop.yml
+++ b/.github/workflows/plugin-pr-review-loop.yml
@@ -81,10 +81,19 @@ jobs:
           name: findings-${{ github.event.pull_request.number }}
           path: /tmp
 
-      - name: Fetch rules and fix prompt from base repo
+      # Passive checkout of the base repo (not the fork) — avoids the raw
+      # CDN, which caches 404s for freshly merged files.
+      - name: Checkout base repo rules
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: base-repo
+
+      - name: Stage rules and fix prompt
         run: |
-          curl -sf https://raw.githubusercontent.com/${{ github.repository }}/main/.github/PLUGIN_PR_RULES.md -o /tmp/PLUGIN_PR_RULES.md
-          curl -sf https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/pr-review/fix-prompt.md -o /tmp/fix-prompt.md
+          cp base-repo/.github/PLUGIN_PR_RULES.md /tmp/PLUGIN_PR_RULES.md
+          cp base-repo/scripts/pr-review/fix-prompt.md /tmp/fix-prompt.md
+          rm -rf base-repo
 
       - name: Configure Codex for the LLM gateway
         run: |


### PR DESCRIPTION
## Description
The fix job fetched `PLUGIN_PR_RULES.md` and `fix-prompt.md` from raw.githubusercontent.com, which cached 404s from before #403 merged and failed the first real fix round on #399 (curl exit 22). Replaces the curl with a passive checkout of the base repo's main — deterministic, no CDN.

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)
CI-only; verified against the failing run 28992959814.