### PR TITLE
fix(ci): post round marker only when the agent actually runs

### DIFF
--- a/.github/workflows/plugin-pr-review-loop.yml
+++ b/.github/workflows/plugin-pr-review-loop.yml
@@ -109,6 +109,28 @@ jobs:
           wire_api = "${{ vars.LLM_WIRE_API }}"
           EOF
 
+      # The round=2 marker is the once-per-PR LLM ratchet. Posting it here —
+      # after all setup succeeded, right before the agent — means infra
+      # failures earlier in this job leave the round retryable.
+      - name: Mark fix round
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BOT_DRY_RUN: ${{ vars.PR_BOT_DRY_RUN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          BODY='<!-- corsair-review-bot round=2 -->
+          Remaining findings are being fixed by a bot commit — it will be re-reviewed automatically.'
+          if [ "$PR_BOT_DRY_RUN" = "true" ]; then
+            BODY="<!-- corsair-review-bot dry-run -->
+          <details><summary>DRY RUN — round 2 marker:</summary>
+
+          $BODY
+          </details>"
+          else
+            gh api -X POST "repos/${{ github.repository }}/issues/${PR_NUMBER}/labels" -f 'labels[]=bot:round-2'
+          fi
+          gh api -X POST "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -f "body=$BODY"
+
       - name: Run agent fix
         env:
           CORSAIR_LLM_KEY: ${{ secrets.CORSAIR_LLM_KEY }}

--- a/.github/workflows/plugin-pr-review-loop.yml
+++ b/.github/workflows/plugin-pr-review-loop.yml
@@ -109,6 +109,9 @@ jobs:
           wire_api = "${{ vars.LLM_WIRE_API }}"
           EOF
 
+      - name: Install agent
+        run: npm install -g @openai/codex@0.143.0
+
       # The round=2 marker is the once-per-PR LLM ratchet. Posting it here —
       # after all setup succeeded, right before the agent — means infra
       # failures earlier in this job leave the round retryable.
@@ -118,15 +121,14 @@ jobs:
           PR_BOT_DRY_RUN: ${{ vars.PR_BOT_DRY_RUN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          BODY='<!-- corsair-review-bot round=2 -->
-          Remaining findings are being fixed by a bot commit — it will be re-reviewed automatically.'
           if [ "$PR_BOT_DRY_RUN" = "true" ]; then
-            BODY="<!-- corsair-review-bot dry-run -->
-          <details><summary>DRY RUN — round 2 marker:</summary>
-
-          $BODY
-          </details>"
+            # Defused text (no parseable marker) so dry runs never consume
+            # real round state.
+            BODY='<!-- corsair-review-bot dry-run -->
+          DRY RUN — would mark round 2 and run the fix agent now.'
           else
+            BODY='<!-- corsair-review-bot round=2 -->
+          Remaining findings are being fixed by a bot commit — it will be re-reviewed automatically.'
             gh api -X POST "repos/${{ github.repository }}/issues/${PR_NUMBER}/labels" -f 'labels[]=bot:round-2'
           fi
           gh api -X POST "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -f "body=$BODY"
@@ -134,9 +136,7 @@ jobs:
       - name: Run agent fix
         env:
           CORSAIR_LLM_KEY: ${{ secrets.CORSAIR_LLM_KEY }}
-        run: |
-          npm install -g @openai/codex@0.143.0
-          codex exec --sandbox workspace-write "$(cat /tmp/fix-prompt.md)"
+        run: codex exec --sandbox workspace-write "$(cat /tmp/fix-prompt.md)"
 
       # This job executed untrusted fork code (the agent's pnpm runs), so it
       # never sees PR_BOT_PAT. It only exports the diff; the push job below

--- a/scripts/pr-review/loop-main.ts
+++ b/scripts/pr-review/loop-main.ts
@@ -203,20 +203,13 @@ switch (decision) {
 		label('bot:round-1');
 		break;
 	case 'fix':
-		// The workflow's fix job consumes this artifact.
+		// The workflow's fix job consumes this artifact. The round=2 marker
+		// (the once-per-PR LLM ratchet) is posted by the fix job right
+		// before the agent runs, so infra failures don't burn the round.
 		fs.writeFileSync(
 			'/tmp/findings.json',
 			JSON.stringify(findings.filter((f) => f.severity !== 'P2')),
 		);
-		// The round=2 marker is the ratchet that guarantees the LLM fix runs
-		// at most once per PR: the next Greptile review can only escalate.
-		post(
-			[
-				'<!-- corsair-review-bot round=2 -->',
-				'Remaining findings are being fixed by a bot commit — it will be re-reviewed automatically.',
-			].join('\n'),
-		);
-		label('bot:round-2');
 		break;
 	case 'escalate':
 		upsert(R3_MARKER, buildEscalationComment(findings));


### PR DESCRIPTION
## Description
Dogfooding on #399 exposed a round-burning flaw: triage posted the `round=2` marker at decision time, so when the fix job died on an infra error (the CDN 404, before Codex ever ran), the contributor's one bot-fix round was consumed and the next review escalated prematurely. The marker (the once-per-PR LLM ratchet) now gets posted by the fix job itself, after all setup succeeds and immediately before the agent runs — infra failures leave the round retryable, actual agent attempts still burn it exactly once.

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)
Sequence proven on #399: decision=fix 03:58 → fix job infra-failed → 04:29 review escalated at round=2 with zero LLM attempts made.