### PR TITLE
fix(ci): post gate scorecard from base context for fork prs

### DIFF
--- a/.github/workflows/plugin-pr-review-loop.yml
+++ b/.github/workflows/plugin-pr-review-loop.yml
@@ -3,9 +3,14 @@ name: Plugin PR Review Loop
 on:
   pull_request_review:
     types: [submitted]
+  # Fork PRs: pull_request_review runs get a read-only token and no
+  # secrets/vars. Greptile edits its summary comment every review, and
+  # issue_comment runs in base context with full permissions for any PR.
+  issue_comment:
+    types: [created, edited]
 
 concurrency:
-  group: review-loop-${{ github.event.pull_request.number }}
+  group: review-loop-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 permissions:
@@ -15,10 +20,20 @@ permissions:
 
 jobs:
   triage:
-    if: github.event.review.user.login == 'greptile-apps[bot]' && github.event.pull_request.draft == false
+    if: >-
+      (github.event_name == 'pull_request_review' &&
+       github.event.review.user.login == 'greptile-apps[bot]' &&
+       github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.comment.user.login == 'greptile-apps[bot]' &&
+       github.event.issue.pull_request != null)
     runs-on: ubuntu-24.04
     outputs:
       decision: ${{ steps.loop.outputs.decision }}
+      pr_number: ${{ steps.loop.outputs.pr_number }}
+      head_repo: ${{ steps.loop.outputs.head_repo }}
+      head_ref: ${{ steps.loop.outputs.head_ref }}
     steps:
       - uses: actions/checkout@v4
 
@@ -37,7 +52,7 @@ jobs:
         if: steps.loop.outputs.decision == 'fix'
         uses: actions/upload-artifact@v4
         with:
-          name: findings-${{ github.event.pull_request.number }}
+          name: findings-${{ steps.loop.outputs.pr_number }}
           path: /tmp/findings.json
 
   fix:
@@ -52,8 +67,8 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ needs.triage.outputs.head_repo }}
+          ref: ${{ needs.triage.outputs.head_ref }}
           # PR head repos are public; no token needed to read, and
           # persist-credentials: false keeps credentials out of .git/config
           # while the agent runs over untrusted PR code.
@@ -78,7 +93,7 @@ jobs:
       - name: Download findings
         uses: actions/download-artifact@v4
         with:
-          name: findings-${{ github.event.pull_request.number }}
+          name: findings-${{ needs.triage.outputs.pr_number }}
           path: /tmp
 
       # Passive checkout of the base repo (not the fork) — avoids the raw
@@ -119,9 +134,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_BOT_DRY_RUN: ${{ vars.PR_BOT_DRY_RUN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ needs.triage.outputs.pr_number }}
         run: |
-          if [ "$PR_BOT_DRY_RUN" = "true" ]; then
+          if [ "$PR_BOT_DRY_RUN" != "false" ]; then
             # Defused text (no parseable marker) so dry runs never consume
             # real round state.
             BODY='<!-- corsair-review-bot dry-run -->
@@ -145,13 +160,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_BOT_DRY_RUN: ${{ vars.PR_BOT_DRY_RUN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ needs.triage.outputs.pr_number }}
         run: |
           if git diff --quiet; then
             echo "No changes produced"; exit 0
           fi
           git diff > /tmp/fix.patch
-          if [ "$PR_BOT_DRY_RUN" = "true" ]; then
+          if [ "$PR_BOT_DRY_RUN" != "false" ]; then
             {
               echo '<!-- corsair-review-bot dry-run -->'
               echo '<details><summary>DRY RUN — would push this fix commit:</summary>'
@@ -167,13 +182,13 @@ jobs:
       - name: Upload fix patch
         uses: actions/upload-artifact@v4
         with:
-          name: fix-patch-${{ github.event.pull_request.number }}
+          name: fix-patch-${{ needs.triage.outputs.pr_number }}
           path: /tmp/fix.patch
           if-no-files-found: ignore
 
   push:
-    needs: fix
-    if: vars.PR_BOT_DRY_RUN != 'true'
+    needs: [triage, fix]
+    if: vars.PR_BOT_DRY_RUN == 'false'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -186,8 +201,8 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ needs.fix.outputs.head_repo || needs.triage.outputs.head_repo }}
+          ref: ${{ needs.fix.outputs.head_ref || needs.triage.outputs.head_ref }}
           persist-credentials: false
 
       - name: Download fix patch
@@ -195,7 +210,7 @@ jobs:
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
-          name: fix-patch-${{ github.event.pull_request.number }}
+          name: fix-patch-${{ needs.triage.outputs.pr_number }}
           path: /tmp
 
       - name: Apply, scan, and push
@@ -203,9 +218,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_BOT_PAT: ${{ secrets.PR_BOT_PAT }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ needs.triage.outputs.pr_number }}
+          HEAD_REPO: ${{ needs.triage.outputs.head_repo }}
+          HEAD_REF: ${{ needs.triage.outputs.head_ref }}
         run: |
           [ -s /tmp/fix.patch ] || { echo "Empty patch"; exit 0; }
           if grep -qE '(sk-[A-Za-z0-9_-]{16,}|ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|AKIA[A-Z0-9]{16})' /tmp/fix.patch; then

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -69,6 +69,9 @@ jobs:
         with:
           node-version: '24.x'
 
+      - name: Typecheck review scripts
+        run: npx -y typescript@5.9.3 tsc -p scripts/pr-review
+
       - name: Run plugin PR gate
         run: node --experimental-strip-types scripts/pr-review/gate-main.ts
         env:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      - name: Typecheck review scripts
+        run: pnpm exec tsc -p scripts/pr-review
+
       - name: Build
         run: pnpm build
 
@@ -68,9 +71,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '24.x'
-
-      - name: Typecheck review scripts
-        run: npx -y -p typescript@5.9.3 -p @types/node tsc -p scripts/pr-review
 
       - name: Run plugin PR gate
         run: node --experimental-strip-types scripts/pr-review/gate-main.ts

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -70,7 +70,7 @@ jobs:
           node-version: '24.x'
 
       - name: Typecheck review scripts
-        run: npx -y -p typescript@5.9.3 tsc -p scripts/pr-review
+        run: npx -y -p typescript@5.9.3 -p @types/node tsc -p scripts/pr-review
 
       - name: Run plugin PR gate
         run: node --experimental-strip-types scripts/pr-review/gate-main.ts

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -70,7 +70,7 @@ jobs:
           node-version: '24.x'
 
       - name: Typecheck review scripts
-        run: npx -y typescript@5.9.3 tsc -p scripts/pr-review
+        run: npx -y -p typescript@5.9.3 tsc -p scripts/pr-review
 
       - name: Run plugin PR gate
         run: node --experimental-strip-types scripts/pr-review/gate-main.ts

--- a/scripts/pr-review/gate-main.ts
+++ b/scripts/pr-review/gate-main.ts
@@ -1,12 +1,9 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import type { GateResult } from './gate.ts';
-import { detectPlugin, runGate } from './gate.ts';
+import { detectPlugin, renderScorecard, runGate } from './gate.ts';
 
 const MARKER = '<!-- corsair-pr-gate -->';
-const STATUS_ICON = { pass: '✅', warn: '⚠️', fail: '❌' } as const;
-
 function gh(args: string[]): string {
 	return execFileSync('gh', args, {
 		encoding: 'utf8',
@@ -38,26 +35,6 @@ export function countTests(pluginDir: string): {
 		assertionCount += content.match(/\b(expect|assert)\s*\(/g)?.length ?? 0;
 	}
 	return { testFileCount, assertionCount };
-}
-
-function renderComment(result: GateResult): string {
-	const lines = [
-		MARKER,
-		`### Plugin PR scorecard — \`packages/${result.plugin}\``,
-		'',
-		'| Check | Status | Notes |',
-		'| --- | --- | --- |',
-	];
-	for (const c of result.checks) {
-		lines.push(
-			`| ${c.rule} — ${c.label} | ${STATUS_ICON[c.status]} | ${c.detail ?? ''} |`,
-		);
-	}
-	lines.push(
-		'',
-		`Rules: [PLUGIN_PR_RULES.md](https://github.com/${process.env.GITHUB_REPOSITORY}/blob/main/.github/PLUGIN_PR_RULES.md) · re-runs on every push`,
-	);
-	return lines.join('\n');
 }
 
 function upsertComment(repo: string, pr: string, body: string): void {
@@ -146,8 +123,20 @@ if (!result.isPluginPr) {
 	process.exit(0);
 }
 
-upsertComment(repo, pr, renderComment(result));
-setLabel(repo, pr, result.failures.length > 0);
+// Fork PRs get a read-only GITHUB_TOKEN regardless of workflow permissions;
+// degrade to log-only there — the loop workflow (base context) posts the
+// scorecard on each review, and this job's exit code enforces the check.
+try {
+	upsertComment(repo, pr, renderScorecard(result));
+	setLabel(repo, pr, result.failures.length > 0);
+} catch (error) {
+	console.log(
+		`::notice::Could not post scorecard (read-only token on fork PRs): ${
+			error instanceof Error ? error.message.split('\n')[0] : error
+		}`,
+	);
+	console.log(renderScorecard(result));
+}
 
 if (result.failures.length > 0) {
 	for (const f of result.failures) {

--- a/scripts/pr-review/gate.ts
+++ b/scripts/pr-review/gate.ts
@@ -34,9 +34,9 @@ export interface GateResult {
 }
 
 function pluginOf(file: string): string | null {
-	const m = file.match(/^packages\/([^/]+)\//);
-	if (!m) return null;
-	return IGNORED_PACKAGES.includes(m[1]) ? null : m[1];
+	const name = file.match(/^packages\/([^/]+)\//)?.[1];
+	if (!name) return null;
+	return IGNORED_PACKAGES.includes(name) ? null : name;
 }
 
 /** The plugin a PR targets, or null if it touches no plugin packages. */
@@ -184,7 +184,7 @@ export function runGate(input: GateInput): GateResult {
 		.filter((c) => c.status === 'fail')
 		.map((c) => ({ rule: c.rule, message: c.detail ?? c.label }));
 
-	return { isPluginPr: true, plugin, checks, failures };
+	return { isPluginPr: true, plugin: plugin ?? null, checks, failures };
 }
 
 const STATUS_ICON = { pass: '✅', warn: '⚠️', fail: '❌' } as const;

--- a/scripts/pr-review/gate.ts
+++ b/scripts/pr-review/gate.ts
@@ -186,3 +186,26 @@ export function runGate(input: GateInput): GateResult {
 
 	return { isPluginPr: true, plugin, checks, failures };
 }
+
+const STATUS_ICON = { pass: '✅', warn: '⚠️', fail: '❌' } as const;
+
+/** Renders the sticky scorecard comment body (marker included). */
+export function renderScorecard(result: GateResult): string {
+	const lines = [
+		'<!-- corsair-pr-gate -->',
+		`### Plugin PR scorecard — \`packages/${result.plugin}\``,
+		'',
+		'| Check | Status | Notes |',
+		'| --- | --- | --- |',
+	];
+	for (const c of result.checks) {
+		lines.push(
+			`| ${c.rule} — ${c.label} | ${STATUS_ICON[c.status]} | ${c.detail ?? ''} |`,
+		);
+	}
+	lines.push(
+		'',
+		`Rules: [PLUGIN_PR_RULES.md](https://github.com/${process.env.GITHUB_REPOSITORY ?? 'corsairdev/corsair'}/blob/main/.github/PLUGIN_PR_RULES.md) · re-runs on every push`,
+	);
+	return lines.join('\n');
+}

--- a/scripts/pr-review/loop-main.ts
+++ b/scripts/pr-review/loop-main.ts
@@ -110,6 +110,18 @@ if (!gate.isPluginPr) {
 	process.exit(0);
 }
 
+// Fork PRs: the pull_request-triggered gate job has a read-only token and
+// cannot post; this workflow runs in base context, so it owns the scorecard
+// comment and the gate:failed label on every review.
+if (!dryRun) {
+	upsert('<!-- corsair-pr-gate -->', renderScorecard(gate));
+	if (gate.failures.length > 0) {
+		label('gate:failed');
+	} else {
+		unlabel('gate:failed');
+	}
+}
+
 const reviewComments = JSON.parse(
 	gh(['api', `repos/${repo}/pulls/${pr}/comments`, '--paginate']),
 ) as ReviewComment[];

--- a/scripts/pr-review/loop-main.ts
+++ b/scripts/pr-review/loop-main.ts
@@ -27,10 +27,47 @@ const event = JSON.parse(
 	fs.readFileSync(process.env.GITHUB_EVENT_PATH ?? '', 'utf8'),
 );
 const repo = process.env.GITHUB_REPOSITORY ?? '';
-const dryRun = process.env.PR_BOT_DRY_RUN === 'true';
+
+// Triggered either by pull_request_review (same-repo PRs) or issue_comment
+// (Greptile edits its summary comment each review; this event runs with
+// base-repo permissions even for fork PRs). Normalize to a PR object.
+if (!event.pull_request && event.issue?.pull_request) {
+	event.pull_request = JSON.parse(
+		gh(['api', `repos/${repo}/pulls/${event.issue.number}`]),
+	);
+}
+if (!event.pull_request) {
+	console.log('No pull request in event — skipped.');
+	process.exit(0);
+}
+if (!event.review) {
+	const latest = JSON.parse(
+		gh([
+			'api',
+			`repos/${repo}/pulls/${event.pull_request.number}/reviews`,
+			'--paginate',
+		]),
+	)
+		.filter(
+			(r: { user: { login: string } }) => r.user.login === 'greptile-apps[bot]',
+		)
+		.pop();
+	if (!latest) {
+		console.log('No greptile review yet — skipped.');
+		process.exit(0);
+	}
+	event.review = latest;
+}
+// Fail closed: fork-triggered runs don't receive repo variables, so an
+// unset flag must mean dry-run, never live.
+const dryRun = process.env.PR_BOT_DRY_RUN !== 'false';
 const pr = event.pull_request.number as number;
 const reviewId = event.review.id as number;
 const author = event.pull_request.user.login as string;
+
+setOutput('pr_number', String(event.pull_request.number));
+setOutput('head_repo', event.pull_request.head.repo.full_name);
+setOutput('head_ref', event.pull_request.head.ref);
 
 const changedFiles = gh([
 	'api',

--- a/scripts/pr-review/loop-main.ts
+++ b/scripts/pr-review/loop-main.ts
@@ -1,6 +1,11 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
-import { ASSERTION_WARN_FLOOR, detectPlugin, runGate } from './gate.ts';
+import {
+	ASSERTION_WARN_FLOOR,
+	detectPlugin,
+	renderScorecard,
+	runGate,
+} from './gate.ts';
 import {
 	buildEscalationComment,
 	buildRoundOneComment,

--- a/scripts/pr-review/parse-greptile.test.ts
+++ b/scripts/pr-review/parse-greptile.test.ts
@@ -69,7 +69,9 @@ const ruleFixture = JSON.parse(
 test('rule-based finding gets a real title, not "Rule Used:"', () => {
 	const findings = parseFindings(ruleFixture);
 	assert.equal(findings.length, 1);
-	assert.equal(findings[0].severity, 'P0');
-	assert.ok(!findings[0].title.includes('Rule Used'));
-	assert.ok(findings[0].title.includes('new Function()'));
+	const finding = findings[0];
+	assert.ok(finding);
+	assert.equal(finding.severity, 'P0');
+	assert.ok(!finding.title.includes('Rule Used'));
+	assert.ok(finding.title.includes('new Function()'));
 });

--- a/scripts/pr-review/tsconfig.json
+++ b/scripts/pr-review/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["node"],
+    "skipLibCheck": true
+  },
+  "include": ["./*.ts"]
+}

--- a/scripts/pr-review/tsconfig.json
+++ b/scripts/pr-review/tsconfig.json
@@ -1,10 +1,13 @@
 {
-  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true,
-    "allowImportingTsExtensions": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "target": "esnext",
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
     "types": ["node"],
     "skipLibCheck": true
   },


### PR DESCRIPTION
## Description
The wiza rehearsal (#427, first real fork PR through the pipeline) exposed that `pull_request` workflows get a read-only GITHUB_TOKEN on fork PRs regardless of the permissions block — the gate crashed trying to post its scorecard, failing the required check for reasons unrelated to PR quality. Every contributor plugin PR hits this today.

- Gate job now degrades gracefully: posting failures log a notice + print the scorecard to the job log; the exit code still enforces the required check (works on forks).
- The review-loop triage (base context, write token on any PR) now owns the scorecard comment and `gate:failed` label, refreshed on every Greptile review.
- Scorecard renderer moved to the pure module (`gate.ts`) and shared, since `gate-main.ts` is a side-effecting script that must not be imported.

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)
Failing evidence: run 29023571261 on #427.