### PR TITLE
fix(ci): read changed files from the pr files api

### DIFF
--- a/scripts/pr-review/gate-main.ts
+++ b/scripts/pr-review/gate-main.ts
@@ -92,13 +92,18 @@ const event = JSON.parse(
 );
 const repo = process.env.GITHUB_REPOSITORY ?? '';
 const pr = String(event.pull_request.number);
-const baseSha = event.pull_request.base.sha as string;
 
-const changedFiles = execFileSync(
-	'git',
-	['diff', '--name-only', `${baseSha}...HEAD`],
-	{ encoding: 'utf8' },
-)
+// The PR files API is the source of truth. Diffing against
+// event.pull_request.base.sha is wrong: that sha is recorded on the PR
+// object and lags behind the base branch, sweeping unrelated main-side
+// changes into the diff (seen live on #427 after #435 merged).
+const changedFiles = gh([
+	'api',
+	`repos/${repo}/pulls/${pr}/files`,
+	'--paginate',
+	'--jq',
+	'.[].filename',
+])
 	.trim()
 	.split('\n')
 	.filter(Boolean);


### PR DESCRIPTION
## Description
The gate computed changed files with `git diff ${event.pull_request.base.sha}...HEAD`, but that sha is recorded on the PR object and lags behind the base branch — after #435 merged, #427's gate swept #435's own files into the diff and false-failed R1. Changed files now come from the PR files API (same source the review loop uses; works with read-only fork tokens).

Evidence: run 29029489770 (R1 lists the #435 file set); `gh api pulls/427/files` returns only the wiza files.

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)
CI-only.