### PR TITLE
fix(ci): avoid cancelling fork review loop

### DIFF
--- a/.github/workflows/plugin-pr-review-loop.yml
+++ b/.github/workflows/plugin-pr-review-loop.yml
@@ -10,7 +10,7 @@ on:
     types: [created, edited]
 
 concurrency:
-  group: review-loop-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: review-loop-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.full_name != github.repository && 'fork-review' || 'base' }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary
- remove the redundant pull_request_review trigger from the plugin PR review loop
- rely on Greptile summary comment edits, which run in base context for fork PRs
- prevent skipped fork review runs from cancelling the useful issue_comment run

## Test
- git diff --check
- git push pre-push typecheck