### PR TITLE
fix(ci): disable codex reasoning so Azure responses accepts tool loops

### DIFF
--- a/.github/workflows/plugin-pr-review-loop.yml
+++ b/.github/workflows/plugin-pr-review-loop.yml
@@ -116,6 +116,11 @@ jobs:
           cat > ~/.codex/config.toml <<EOF
           model = "${{ vars.LLM_MODEL }}"
           model_provider = "corsair"
+          # Azure Foundry /openai/v1/responses rejects replayed reasoning items
+          # (Codex sends them without ids; Azure's schema requires ids). With
+          # effort=none the model emits no reasoning items, so tool-call
+          # continuation turns pass. Verified locally end to end 2026-07-10.
+          model_reasoning_effort = "none"
 
           [model_providers.corsair]
           name = "corsair"


### PR DESCRIPTION
## Why

Round-2 fix runs on the review loop fail with \`invalid_payload\` from the gateway (\`The provided data does not match the expected schema\`, e.g. request \`ac6ac148b48553fc0bd0578944abed29\` on #427).

Root cause, isolated by capturing Codex CLI 0.143.0 traffic through a local logging proxy and replaying it against \`llm.corsair.dev\`:

- Turn 1 succeeds. The model (reasoning effort \`medium\`, Codex's default) returns a **reasoning item**.
- On the continuation turn (after a tool call), Codex replays the transcript **with the reasoning item but without its \`id\`** — OpenAI's API accepts this, but Azure Foundry's \`/openai/v1/responses\` schema validation rejects id-less reasoning items (adding a fake id passes validation and instead fails with "Items are not persisted when \`store\` is false", confirming the schema check is the blocker).
- Removing the reasoning item from the same captured payload → HTTP 200.

## Fix

One config line: \`model_reasoning_effort = "none"\`. The model then emits no reasoning items, so continuation turns contain only message/function_call items, which Azure accepts.

Verified locally end to end: \`codex exec\` against the real gateway completed a full tool-call loop (executed a shell command, returned its output; both the initial and continuation requests returned HTTP 200).

Trade-off: the fix agent runs without extended reasoning. Fine for the scoped one-round fix task; if we later want reasoning back, the durable fix is gateway/provider-side (a route that accepts Codex's id-less reasoning replay).