### PR TITLE
fix(ci): allow user namespaces so the Codex sandbox works on runners

### DIFF
--- a/.github/workflows/plugin-pr-review-loop.yml
+++ b/.github/workflows/plugin-pr-review-loop.yml
@@ -165,6 +165,10 @@ jobs:
           CORSAIR_LLM_KEY: ${{ secrets.CORSAIR_LLM_KEY }}
         run: codex exec --sandbox workspace-write "$(cat /tmp/fix-prompt.md)"
 
+      - name: Re-enable user namespace guard
+        if: always()
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=1
+
       # This job executed untrusted fork code (the agent's pnpm runs), so it
       # never sees PR_BOT_PAT. It only exports the diff; the push job below
       # runs on a fresh runner where no untrusted code executes.

--- a/.github/workflows/plugin-pr-review-loop.yml
+++ b/.github/workflows/plugin-pr-review-loop.yml
@@ -132,6 +132,13 @@ jobs:
       - name: Install agent
         run: npm install -g @openai/codex@0.143.0
 
+      # Ubuntu 24.04 runners block unprivileged user namespaces via AppArmor,
+      # so Codex's bubblewrap sandbox fails every command with
+      # "bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted".
+      # Relaxing the restriction lets the sandbox itself work as designed.
+      - name: Allow unprivileged user namespaces for the agent sandbox
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
       # The round=2 marker is the once-per-PR LLM ratchet. Posting it here —
       # after all setup succeeded, right before the agent — means infra
       # failures earlier in this job leave the round retryable.


### PR DESCRIPTION
## Why

After #438, round-2 fix runs get through the LLM protocol fine — but Codex can't execute a single shell command. Runs 29042031264 (PR #337) and 29042074057 (PR #427) show every command failing with:

```
bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted
```

so the agent reads no findings, edits nothing, and the job ends green with "No changes produced".

Root cause: GitHub's ubuntu-24.04 runners restrict unprivileged user namespaces via AppArmor (`kernel.apparmor_restrict_unprivileged_userns=1`), which breaks bubblewrap — the sandbox Codex wraps every command in under `--sandbox workspace-write`.

## Fix

One step before the agent runs:

```yaml
sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
```

This is the standard Actions workaround for userns-based sandboxes (bubblewrap, Chrome, Flatpak). It only lifts the AppArmor gate on *creating* user namespaces; Codex's sandbox then applies its own isolation exactly as designed. The alternative — running Codex with `--sandbox danger-full-access` — would actually weaken isolation, which is why this direction was chosen.