### PR TITLE
ci: enforce plugin folder naming + rebrand review bot identity

### DIFF
--- a/.github/workflows/plugin-pr-review-loop.yml
+++ b/.github/workflows/plugin-pr-review-loop.yml
@@ -242,11 +242,11 @@ jobs:
           if grep -qE '(sk-[A-Za-z0-9_-]{16,}|ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|AKIA[A-Z0-9]{16})' /tmp/fix.patch; then
             echo "::error::Patch contains a credential-shaped string — refusing to push"; exit 1
           fi
-          git config user.name "corsair-review-bot"
-          git config user.email "bot@corsair.dev"
+          git config user.name "corsair-team"
+          git config user.email "team@corsair.dev"
           git apply /tmp/fix.patch
           git add -A
-          git commit -m "fix: address review findings (corsair review bot)"
+          git commit -m "fix: address review findings (@corsair-team)"
           if ! git push "https://x-access-token:${PR_BOT_PAT}@github.com/${HEAD_REPO}.git" "HEAD:${HEAD_REF}"; then
             # Fork without "allow edits by maintainers" — deliver the fix as
             # a patch comment instead of failing silently into escalation.

--- a/scripts/validate-plugins.ts
+++ b/scripts/validate-plugins.ts
@@ -24,6 +24,15 @@ function logError(plugin: string, message: string, fix?: string) {
 for (const plugin of plugins) {
 	const pluginPath = path.join(PACKAGES_DIR, plugin);
 
+	// 0. Folder name must be lowercase alphanumeric (no underscores/hyphens)
+	if (!/^[a-z0-9]+$/.test(plugin)) {
+		logError(
+			plugin,
+			'Plugin folder name must be lowercase alphanumeric only (no underscores or hyphens)',
+			'Rename e.g. active_trail -> activetrail (like googlecalendar, dodopayments)',
+		);
+	}
+
 	// 1. Check package.json
 	const packageJsonPath = path.join(pluginPath, 'package.json');
 	if (!fs.existsSync(packageJsonPath)) {


### PR DESCRIPTION
- Validate plugin folder names are lowercase alphanumeric (`active_trail` → `activetrail`) in `scripts/validate-plugins.ts`
- Review bot commits now as `corsair-team` / `team@corsair.dev` (sticky-comment markers unchanged so open PRs keep round-tracking)

Verified: `pnpm run validate:plugins` — exit 0 clean, exit 1 with a fake `active_trail` package.