### PR TITLE
feat(corsair): self-register delivery URL with Hub

### DIFF
--- a/packages/corsair/hub/announce.ts
+++ b/packages/corsair/hub/announce.ts
@@ -1,0 +1,49 @@
+import { deliveryUrlToAdvertise, hubApiPost } from './client/http';
+import { getHubConfig } from './config';
+
+// Keyed by project API key, so multiple Corsair instances in one process each
+// register even when they share a delivery URL.
+const lastAnnouncedByProject = new Map<string, string>();
+
+/**
+ * Self-registration — tells Hub where this app lives so nobody has to type the
+ * delivery URL into the dashboard.
+ *
+ * The URL comes from the app's own trusted config (CORSAIR_DELIVERY_URL,
+ * APP_URL, or PORT via resolveHubDeliveryUrl) — never from inbound request
+ * headers, which an untrusted caller controls. Called from the request handler
+ * so scripts that merely import the app never announce.
+ *
+ * Fire-and-forget: never blocks or fails the request that carried it. Hub
+ * applies it for development keys only.
+ */
+export function announceAppFromRequest(corsair: unknown): void {
+	let hub: ReturnType<typeof getHubConfig>;
+	try {
+		hub = getHubConfig(corsair);
+	} catch {
+		return; // Hub not configured — nothing to announce.
+	}
+
+	const deliveryUrl = deliveryUrlToAdvertise(hub);
+	if (!deliveryUrl) {
+		return; // No trustworthy URL to advertise (e.g. prod without an app URL).
+	}
+
+	if (lastAnnouncedByProject.get(hub.projectApiKey) === deliveryUrl) {
+		return;
+	}
+	lastAnnouncedByProject.set(hub.projectApiKey, deliveryUrl);
+
+	void hubApiPost({
+		hub,
+		path: '/apps/announce',
+		body: { deliveryUrl },
+		parseResponse: () => ({ ok: true as const }),
+	}).catch(() => {
+		// Push-only — hub availability must never affect the app. A failed
+		// announce still leaves the header fallback (appDeliveryUrlHeader) to
+		// register the URL on the next SDK call.
+		lastAnnouncedByProject.delete(hub.projectApiKey);
+	});
+}

--- a/packages/corsair/hub/client/http.ts
+++ b/packages/corsair/hub/client/http.ts
@@ -1,8 +1,37 @@
 import { parseHubApiErrorBody } from '../contracts/connect-api';
+import { resolveHubDeliveryUrl } from '../resolve-delivery-url';
 import type { HubConfig } from '../types';
 
 export function normalizeHubApiUrl(apiUrl: string): string {
 	return apiUrl.replace(/\/$/, '');
+}
+
+/**
+ * The delivery URL this app should advertise to Hub, or null if there's nothing
+ * to send. Only development keys self-register: Hub applies the delivery URL for
+ * development environments only, so advertising anything on a production key is a
+ * no-op. Production delivery URLs are set deliberately in the dashboard.
+ */
+export function deliveryUrlToAdvertise(hub: HubConfig): string | null {
+	if (!hub.projectApiKey.startsWith('ck_dev_')) {
+		return null;
+	}
+	try {
+		return resolveHubDeliveryUrl();
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Every SDK call tells Hub where this app lives, so nobody has to type the
+ * delivery URL into the dashboard. The URL comes from the app's own trusted
+ * config (CORSAIR_DELIVERY_URL / APP_URL / PORT) — never from inbound request
+ * headers. Hub applies it for development keys only.
+ */
+export function appDeliveryUrlHeader(hub: HubConfig): Record<string, string> {
+	const url = deliveryUrlToAdvertise(hub);
+	return url ? { 'x-corsair-delivery-url': url } : {};
 }
 
 export async function readHubJsonResponse(
@@ -61,6 +90,7 @@ export async function hubApiPost<T>(input: {
 		headers: {
 			'content-type': 'application/json',
 			authorization: `Bearer ${input.hub.projectApiKey}`,
+			...appDeliveryUrlHeader(input.hub),
 		},
 		body: JSON.stringify(input.body),
 	});
@@ -87,6 +117,7 @@ export async function hubApiGet<T>(input: {
 		method: 'GET',
 		headers: {
 			authorization: `Bearer ${input.hub.projectApiKey}`,
+			...appDeliveryUrlHeader(input.hub),
 		},
 	});
 

--- a/packages/corsair/hub/delivery.ts
+++ b/packages/corsair/hub/delivery.ts
@@ -10,6 +10,7 @@ import {
 	verifyBrowserDeliveryToken,
 } from '../tunnel';
 import { isConnectionsSyncBrowserDelivery } from '../tunnel/browser-delivery';
+import { announceAppFromRequest } from './announce';
 import { buildClientBridgePostMessageHtml } from './browser-delivery-html';
 import { getHubConfig, HubNotConfiguredError } from './config';
 import { processConnectionsSyncDelivery } from './connections-sync-delivery';
@@ -405,6 +406,10 @@ export async function respondToHubDeliveryFromRequest(
 	corsair: unknown,
 	request: Request,
 ): Promise<Response> {
+	// A request reaching the corsair route proves the app is live and serving —
+	// register its (trusted, config-derived) delivery URL with Hub.
+	announceAppFromRequest(corsair);
+
 	const method = request.method.toUpperCase();
 	const corsHeaders = resolveHubBrowserDeliveryCorsHeaders(
 		request.headers.get('origin'),


### PR DESCRIPTION
On each request to the corsair route, the app tells Hub where it lives, so the Hub dashboard needs no manually typed delivery URL.

Pairs with the Hub change in corsairdev/hub#7.

**Changes**
- `announceAppFromRequest` fires from the delivery handler; the URL comes from the app's own config (`CORSAIR_DELIVERY_URL` / `APP_URL` / `PORT`).
- Every SDK→Hub call carries `x-corsair-delivery-url` as a fallback registration channel.

**Security**
The delivery URL is derived from the app's trusted env config, never from inbound request headers (`Host` / `X-Forwarded-Host`). This prevents an untrusted caller from redirecting Hub's signed credential deliveries to their own host. Fire-and-forget: a Hub outage never affects the app.