### PR TITLE
Collapse delivery URL resolution to one env knob

### DIFF
--- a/packages/corsair/hub/resolve-delivery-url.ts
+++ b/packages/corsair/hub/resolve-delivery-url.ts
@@ -16,7 +16,7 @@ export function resolveHubDeliveryUrl(input?: {
 	const explicit =
 		input?.deliveryUrl?.trim() || process.env.CORSAIR_DELIVERY_URL?.trim();
 	if (explicit) {
-		const absolute = explicit.startsWith('http')
+		const absolute = /^https?:\/\//i.test(explicit)
 			? explicit
 			: `https://${explicit}`;
 		return stripTrailingSlash(absolute);

--- a/packages/corsair/hub/resolve-delivery-url.ts
+++ b/packages/corsair/hub/resolve-delivery-url.ts
@@ -1,44 +1,27 @@
 const DEFAULT_LOCAL_PORT = '3000';
-const DEFAULT_DELIVERY_PATH = '/api/corsair';
+const DELIVERY_PATH = '/api/corsair';
 
 function stripTrailingSlash(url: string) {
 	return url.replace(/\/$/, '');
 }
 
-function withDeliveryPath(baseUrl: string, path: string) {
-	return `${stripTrailingSlash(baseUrl)}${path}`;
-}
-
-function toAbsoluteUrl(value: string) {
-	return value.startsWith('http') ? value : `https://${value}`;
-}
-
+/**
+ * One knob: `CORSAIR_DELIVERY_URL` (full endpoint, wins over everything).
+ * Without it, auto-detects `http://localhost:{PORT}/api/corsair` — PORT is
+ * set by the runtime, not something users configure for Corsair.
+ */
 export function resolveHubDeliveryUrl(input?: {
 	deliveryUrl?: string;
-	deliveryPath?: string;
 }): string {
-	const explicit = input?.deliveryUrl?.trim();
+	const explicit =
+		input?.deliveryUrl?.trim() || process.env.CORSAIR_DELIVERY_URL?.trim();
 	if (explicit) {
-		return stripTrailingSlash(explicit);
-	}
-
-	const deliveryPath = input?.deliveryPath?.trim() || DEFAULT_DELIVERY_PATH;
-	const path = deliveryPath.startsWith('/') ? deliveryPath : `/${deliveryPath}`;
-
-	const corsairDeliveryUrl = process.env.CORSAIR_DELIVERY_URL?.trim();
-	if (corsairDeliveryUrl) {
-		return stripTrailingSlash(toAbsoluteUrl(corsairDeliveryUrl));
-	}
-
-	const appBaseUrl =
-		process.env.APP_URL?.trim() ||
-		process.env.NEXT_PUBLIC_APP_URL?.trim() ||
-		process.env.VERCEL_URL?.trim();
-
-	if (appBaseUrl) {
-		return withDeliveryPath(toAbsoluteUrl(appBaseUrl), path);
+		const absolute = explicit.startsWith('http')
+			? explicit
+			: `https://${explicit}`;
+		return stripTrailingSlash(absolute);
 	}
 
 	const port = process.env.PORT?.trim() || DEFAULT_LOCAL_PORT;
-	return `http://localhost:${port}${path}`;
+	return `http://localhost:${port}${DELIVERY_PATH}`;
 }

--- a/packages/corsair/tests/hub-environment.test.ts
+++ b/packages/corsair/tests/hub-environment.test.ts
@@ -101,6 +101,14 @@ describe('hub environment delivery', () => {
 		);
 	});
 
+	it('does not double-prefix uppercase schemes', () => {
+		expect(
+			resolveHubDeliveryUrl({
+				deliveryUrl: 'HTTPS://app.example.com/api/corsair',
+			}),
+		).toBe('HTTPS://app.example.com/api/corsair');
+	});
+
 	it('ignores APP_URL — CORSAIR_DELIVERY_URL is the only env knob', () => {
 		withEnv(
 			{

--- a/packages/corsair/tests/hub-environment.test.ts
+++ b/packages/corsair/tests/hub-environment.test.ts
@@ -101,25 +101,12 @@ describe('hub environment delivery', () => {
 		);
 	});
 
-	it('appends delivery path for APP_URL base URLs', () => {
+	it('ignores APP_URL — CORSAIR_DELIVERY_URL is the only env knob', () => {
 		withEnv(
 			{
 				CORSAIR_DELIVERY_URL: undefined,
-				APP_URL: 'http://localhost:3000',
-			},
-			() => {
-				expect(resolveHubDeliveryUrl()).toBe(
-					'http://localhost:3000/api/corsair',
-				);
-			},
-		);
-	});
-
-	it('handles APP_URL with a trailing slash', () => {
-		withEnv(
-			{
-				CORSAIR_DELIVERY_URL: undefined,
-				APP_URL: 'http://localhost:3000/',
+				APP_URL: 'http://localhost:9999',
+				PORT: undefined,
 			},
 			() => {
 				expect(resolveHubDeliveryUrl()).toBe(


### PR DESCRIPTION
PR #453 follow-up. Users saw three ways to point Hub at their app: PORT, APP_URL, and CORSAIR_DELIVERY_URL. Now there is one: CORSAIR_DELIVERY_URL. Without it the SDK auto-detects http://localhost:{PORT}/api/corsair — PORT comes from the runtime, not something anyone sets for Corsair. Removes the APP_URL/NEXT_PUBLIC_APP_URL/VERCEL_URL sniffing (VERCEL_URL pointed at per-deployment URLs anyway) and the unused deliveryPath option.