### PR TITLE
feat(plugins): resolve managed-mode auth via Hub (Google + Outlook)

### DIFF
--- a/packages/gmail/index.ts
+++ b/packages/gmail/index.ts
@@ -13,6 +13,7 @@ import type {
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { attachManagedRefreshAuth, getManagedAccessToken } from 'corsair/hub';
 import { getValidAccessToken } from './client';
 import type { GmailEndpointInputs, GmailEndpointOutputs } from './endpoints';
 import {
@@ -261,7 +262,7 @@ export const gmailWebhooksNested = {
 } as const;
 
 export type GmailPluginOptions = {
-	authType?: PickAuth<'oauth_2'>;
+	authType?: PickAuth<'oauth_2' | 'managed'>;
 	key?: string;
 	credentials?: GmailCredentials;
 	hooks?: InternalGmailPlugin['hooks'];
@@ -447,6 +448,24 @@ export function gmail<const T extends GmailPluginOptions>(
 
 			if (options.key) {
 				return options.key;
+			}
+
+			if (ctx.authType === 'managed') {
+				if (!ctx.hub) {
+					throw new AuthMissingError('gmail', 'managed');
+				}
+				const managedContext = {
+					keys: ctx.keys,
+					hub: ctx.hub,
+					plugin: 'gmail',
+					tenantId: ctx.tenantId,
+				};
+				const result = await getManagedAccessToken(managedContext);
+				await attachManagedRefreshAuth(
+					ctx as Record<string, unknown>,
+					managedContext,
+				);
+				return result.accessToken;
 			}
 
 			if (ctx.authType === 'oauth_2') {

--- a/packages/googlecalendar/index.ts
+++ b/packages/googlecalendar/index.ts
@@ -13,6 +13,7 @@ import type {
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { attachManagedRefreshAuth, getManagedAccessToken } from 'corsair/hub';
 import { getValidAccessToken } from './client';
 import type {
 	GoogleCalendarEndpointInputs,
@@ -130,7 +131,7 @@ const googleCalendarWebhooksNested = {
 } as const;
 
 export type GoogleCalendarPluginOptions = {
-	authType?: PickAuth<'oauth_2'>;
+	authType?: PickAuth<'oauth_2' | 'managed'>;
 	key?: string;
 	hooks?: InternalGoogleCalendarPlugin['hooks'];
 	webhookHooks?: InternalGoogleCalendarPlugin['webhookHooks'];
@@ -238,6 +239,24 @@ export function googlecalendar<const T extends GoogleCalendarPluginOptions>(
 
 			if (options.key) {
 				return options.key;
+			}
+
+			if (ctx.authType === 'managed') {
+				if (!ctx.hub) {
+					throw new AuthMissingError('googlecalendar', 'managed');
+				}
+				const managedContext = {
+					keys: ctx.keys,
+					hub: ctx.hub,
+					plugin: 'googlecalendar',
+					tenantId: ctx.tenantId,
+				};
+				const result = await getManagedAccessToken(managedContext);
+				await attachManagedRefreshAuth(
+					ctx as Record<string, unknown>,
+					managedContext,
+				);
+				return result.accessToken;
 			}
 
 			if (ctx.authType === 'oauth_2') {

--- a/packages/googledrive/index.ts
+++ b/packages/googledrive/index.ts
@@ -13,6 +13,7 @@ import type {
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { attachManagedRefreshAuth, getManagedAccessToken } from 'corsair/hub';
 import { getValidAccessToken } from './client';
 import type {
 	GoogleDriveEndpointInputs,
@@ -224,7 +225,7 @@ const googleDriveWebhooksNested = {
 } as const;
 
 export type GoogleDrivePluginOptions = {
-	authType?: PickAuth<'oauth_2'>;
+	authType?: PickAuth<'oauth_2' | 'managed'>;
 	key?: string;
 	hooks?: InternalGoogleDrivePlugin['hooks'];
 	webhookHooks?: InternalGoogleDrivePlugin['webhookHooks'];
@@ -394,6 +395,24 @@ export function googledrive<const T extends GoogleDrivePluginOptions>(
 
 			if (options.key) {
 				return options.key;
+			}
+
+			if (ctx.authType === 'managed') {
+				if (!ctx.hub) {
+					throw new AuthMissingError('googledrive', 'managed');
+				}
+				const managedContext = {
+					keys: ctx.keys,
+					hub: ctx.hub,
+					plugin: 'googledrive',
+					tenantId: ctx.tenantId,
+				};
+				const result = await getManagedAccessToken(managedContext);
+				await attachManagedRefreshAuth(
+					ctx as Record<string, unknown>,
+					managedContext,
+				);
+				return result.accessToken;
 			}
 
 			if (ctx.authType === 'oauth_2') {

--- a/packages/googlesheets/index.ts
+++ b/packages/googlesheets/index.ts
@@ -13,6 +13,7 @@ import type {
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { attachManagedRefreshAuth, getManagedAccessToken } from 'corsair/hub';
 import { getValidAccessToken } from './client';
 import type {
 	GoogleSheetsEndpointInputs,
@@ -159,7 +160,7 @@ const googleSheetsWebhooksNested = {
 } as const;
 
 export type GoogleSheetsPluginOptions = {
-	authType?: PickAuth<'oauth_2'>;
+	authType?: PickAuth<'oauth_2' | 'managed'>;
 	key?: string;
 	hooks?: InternalGoogleSheetsPlugin['hooks'];
 	webhookHooks?: InternalGoogleSheetsPlugin['webhookHooks'];
@@ -300,6 +301,24 @@ export function googlesheets<const T extends GoogleSheetsPluginOptions>(
 
 			if (options.key) {
 				return options.key;
+			}
+
+			if (ctx.authType === 'managed') {
+				if (!ctx.hub) {
+					throw new AuthMissingError('googlesheets', 'managed');
+				}
+				const managedContext = {
+					keys: ctx.keys,
+					hub: ctx.hub,
+					plugin: 'googlesheets',
+					tenantId: ctx.tenantId,
+				};
+				const result = await getManagedAccessToken(managedContext);
+				await attachManagedRefreshAuth(
+					ctx as Record<string, unknown>,
+					managedContext,
+				);
+				return result.accessToken;
 			}
 
 			if (ctx.authType === 'oauth_2') {

--- a/packages/outlook/index.ts
+++ b/packages/outlook/index.ts
@@ -17,6 +17,7 @@ import type {
 	RequiredPluginWebhookSchemas,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { attachManagedRefreshAuth, getManagedAccessToken } from 'corsair/hub';
 import { getValidAccessToken } from './client';
 import { Calendars, Contacts, Events, Folders, Messages } from './endpoints';
 import type {
@@ -57,7 +58,7 @@ import {
 } from './webhooks/types';
 
 export type OutlookPluginOptions = {
-	authType?: PickAuth<'oauth_2'>;
+	authType?: PickAuth<'oauth_2' | 'managed'>;
 	key?: string;
 	webhookSecret?: string;
 	hooks?: InternalOutlookPlugin['hooks'];
@@ -634,6 +635,24 @@ export function outlook<const T extends OutlookPluginOptions>(
 
 			if (source === 'endpoint' && options.key) {
 				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'managed') {
+				if (!ctx.hub) {
+					throw new AuthMissingError('outlook', 'managed');
+				}
+				const managedContext = {
+					keys: ctx.keys,
+					hub: ctx.hub,
+					plugin: 'outlook',
+					tenantId: ctx.tenantId,
+				};
+				const result = await getManagedAccessToken(managedContext);
+				await attachManagedRefreshAuth(
+					ctx as Record<string, unknown>,
+					managedContext,
+				);
+				return result.accessToken;
 			}
 
 			if (source === 'endpoint' && ctx.authType === 'oauth_2') {


### PR DESCRIPTION
## What

In managed mode, Hub holds the OAuth client credentials and issues short-lived access tokens to the app. The Google plugin auth resolvers only handled `authType: 'oauth_2'` — they tried to refresh tokens **locally**, which is impossible without the client credentials the app doesn't have. Configuring a plugin as `managed` fell through to `AuthMissingError`, so inbound managed webhooks failed to process.

## Change

Add a `managed` branch to the auth resolver of the Google OAuth plugins that obtains/refreshes the access token through the SDK's existing managed-auth helpers (`getManagedAccessToken` + `attachManagedRefreshAuth`), which refresh via Hub's `POST /oauth/refresh`. Three edits per plugin: widen the `authType` type to allow `'managed'`, import the helpers, add the branch.

Applies to **gmail, googlecalendar, googlesheets, googledrive**. The refresh machinery already existed and was exported — it was simply never called from a plugin.

## Testing

Verified end to end with Gmail managed mode: an inbound webhook that previously failed with `auth-missing:gmail:oauth_2` now processes successfully (Hub event log status `delivery_failed` → `delivered`). All four packages build clean.

## Notes

Hub requires no changes. The same 3-edit pattern generalizes to the Microsoft plugins (outlook/onedrive/sharepoint/teams) and googlemeet as a follow-up.