### PR TITLE
fix(jira): sanitize trailing slashes in cloudUrl to prevent double-slash HTTP request paths 

### DIFF
--- a/packages/jira/client.test.ts
+++ b/packages/jira/client.test.ts
@@ -1,0 +1,74 @@
+import {
+	makeJiraAgileRequest,
+	makeJiraRequest,
+	uploadJiraAttachment,
+} from './client';
+
+describe('Jira Client URL Sanitization', () => {
+	const originalFetch = globalThis.fetch;
+	let fetchSpy: jest.Mock;
+
+	beforeEach(() => {
+		fetchSpy = jest.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({}),
+			text: async () => '{}',
+			arrayBuffer: async () => new ArrayBuffer(0),
+			headers: new Headers({ 'content-type': 'application/json' }),
+		});
+		globalThis.fetch = fetchSpy;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it('should not contain double slashes when cloudUrl has a trailing slash in makeJiraRequest', async () => {
+		await makeJiraRequest(
+			'myself',
+			'user@example.com:token',
+			'https://test.atlassian.net/',
+			{
+				method: 'GET',
+			},
+		);
+
+		const calledUrl = fetchSpy.mock.calls[0][0];
+		expect(calledUrl).not.toContain('atlassian.net//');
+		expect(calledUrl).toBe('https://test.atlassian.net/rest/api/3/myself');
+	});
+
+	it('should not contain double slashes when cloudUrl has a trailing slash in uploadJiraAttachment', async () => {
+		await uploadJiraAttachment(
+			'PROJ-1',
+			'user@example.com:token',
+			'https://test.atlassian.net/',
+			{
+				name: 'test.txt',
+				content: 'aGVsbG8=',
+			},
+		);
+
+		const calledUrl = fetchSpy.mock.calls[0][0];
+		expect(calledUrl).not.toContain('atlassian.net//');
+		expect(calledUrl).toBe(
+			'https://test.atlassian.net/rest/api/3/issue/PROJ-1/attachments',
+		);
+	});
+
+	it('should not contain double slashes when cloudUrl has a trailing slash in makeJiraAgileRequest', async () => {
+		await makeJiraAgileRequest(
+			'board',
+			'user@example.com:token',
+			'https://test.atlassian.net/',
+			{
+				method: 'GET',
+			},
+		);
+
+		const calledUrl = fetchSpy.mock.calls[0][0];
+		expect(calledUrl).not.toContain('atlassian.net//');
+		expect(calledUrl).toBe('https://test.atlassian.net/rest/agile/1.0/board');
+	});
+});

--- a/packages/jira/client.ts
+++ b/packages/jira/client.ts
@@ -25,6 +25,10 @@ const JIRA_RATE_LIMIT_CONFIG: RateLimitConfig = {
 	},
 };
 
+function sanitizeCloudUrl(url: string): string {
+	return url.trim().replace(/\/+$/, '');
+}
+
 /**
  * Makes a request to the Jira REST API v3.
  * The apiKey should be in "email:apiToken" format for Basic auth (Jira Cloud).
@@ -40,9 +44,10 @@ export async function makeJiraRequest<T>(
 	} = {},
 ): Promise<T> {
 	const { method = 'GET', body, query } = options;
+	const cleanUrl = sanitizeCloudUrl(cloudUrl);
 
 	const config: OpenAPIConfig = {
-		BASE: `${cloudUrl}/rest/api/3`,
+		BASE: `${cleanUrl}/rest/api/3`,
 		VERSION: '3',
 		WITH_CREDENTIALS: false,
 		CREDENTIALS: 'omit',
@@ -115,8 +120,9 @@ export async function uploadJiraAttachment<T>(
 	const blob = new Blob([new Uint8Array(buffer)], { type: mimeType });
 	formData.append('file', blob, file.name);
 
+	const cleanUrl = sanitizeCloudUrl(cloudUrl);
 	const response = await fetch(
-		`${cloudUrl}/rest/api/3/issue/${issueIdOrKey}/attachments`,
+		`${cleanUrl}/rest/api/3/issue/${issueIdOrKey}/attachments`,
 		{
 			method: 'POST',
 			headers: {
@@ -156,9 +162,10 @@ export async function makeJiraAgileRequest<T>(
 	} = {},
 ): Promise<T> {
 	const { method = 'GET', body, query } = options;
+	const cleanUrl = sanitizeCloudUrl(cloudUrl);
 
 	const config: OpenAPIConfig = {
-		BASE: `${cloudUrl}/rest/agile/1.0`,
+		BASE: `${cleanUrl}/rest/agile/1.0`,
 		VERSION: '1.0',
 		WITH_CREDENTIALS: false,
 		CREDENTIALS: 'omit',


### PR DESCRIPTION
## Description

This PR fixes a URL path formatting bug in `@corsair-dev/jira` (`packages/jira/client.ts`) where passing a `cloudUrl` containing a trailing slash (e.g., `https://mycompany.atlassian.net/`) produced double-slash request URLs (`https://mycompany.atlassian.net//rest/api/3/...`).
Fixes #502 
### Changes Made:
1. **Trailing Slash Sanitization**: Added a `sanitizeCloudUrl(url: string): string` helper inside `packages/jira/client.ts` using `url.trim().replace(/\/+$/, '')`.
2. **Helper Updates**: Applied `sanitizeCloudUrl` in `makeJiraRequest`, `uploadJiraAttachment`, and `makeJiraAgileRequest`.
3. **Automated Unit Tests**: Created `packages/jira/client.test.ts` to verify URL formatting across standard REST calls, direct attachment uploads, and Agile API calls.

Fixes double-slash HTTP 404 / 301 authorization drop errors when integrating with Jira Cloud.

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation



### Reproduction vs Verification Unit Test Logs (`pnpm jest client.test.ts`)

#### 1. Before Fix (Failing with double slashes `//`):
```text
FAIL ./client.test.ts
  Jira Client URL Sanitization
    × should not contain double slashes when cloudUrl has a trailing slash in makeJiraRequest
      Expected substring: not "atlassian.net//"
      Received string:        "https://test.atlassian.net//rest/api/3/myself"
    × should not contain double slashes when cloudUrl has a trailing slash in uploadJiraAttachment
      Expected substring: not "atlassian.net//"
      Received string:        "https://test.atlassian.net//rest/api/3/issue/PROJ-1/attachments"
    × should not contain double slashes when cloudUrl has a trailing slash in makeJiraAgileRequest
      Expected substring: not "atlassian.net//"
      Received string:        "https://test.atlassian.net//rest/agile/1.0/board"
```

#### 2. After Fix (All 3 Tests Passing Cleanly):
```text
PASS ./client.test.ts
  Jira Client URL Sanitization
    √ should not contain double slashes when cloudUrl has a trailing slash in makeJiraRequest (15 ms)
    √ should not contain double slashes when cloudUrl has a trailing slash in uploadJiraAttachment (2 ms)
    √ should not contain double slashes when cloudUrl has a trailing slash in makeJiraAgileRequest (3 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
```

## Additional Notes
- **Core Engine Bypass**: `packages/corsair/async-core/request.ts` only checks if `config.BASE.endsWith('/')`. When `BASE` was constructed as `${cloudUrl}/rest/api/3`, `config.BASE` ended with `"3"`, embedding the double slash in the middle (`.net//rest`) and bypassing `request.ts` slash checks.
- **Direct `fetch()` Bypass**: `uploadJiraAttachment()` uses native `fetch()` directly for `multipart/form-data`. Because it does not pass through `request.ts`, sanitization in `packages/jira/client.ts` was mandatory.
- **Zero Breaking Changes**: This change is purely additive and non-breaking. Inputs with or without trailing slashes output identical, clean single-slash URLs.```