### PR TITLE
feat(probe): app-side read-only probe tunnel

### DIFF
--- a/packages/corsair/hub.ts
+++ b/packages/corsair/hub.ts
@@ -34,6 +34,7 @@ export {
 	describeDeliveryNetworkError,
 	encodeConnectTokenForPath,
 	extractConnectLinkFromDeliveryAck,
+	extractProbeFromDeliveryAck,
 	extractRunFromDeliveryAck,
 	extractSyncFromDeliveryAck,
 	type FormatServerDeliveryErrorInput,

--- a/packages/corsair/hub/contracts/tunnel.ts
+++ b/packages/corsair/hub/contracts/tunnel.ts
@@ -17,7 +17,8 @@ export type TunnelType =
 	| 'integration.credentials'
 	| 'connect.create_link'
 	| 'connections.sync'
-	| 'run';
+	| 'run'
+	| 'probe';
 
 /** Inbound tunnel types the app accepts (write-only — no credential reads). */
 export const INBOUND_TUNNEL_TYPES = new Set<TunnelType>([
@@ -33,6 +34,9 @@ export const INBOUND_TUNNEL_TYPES = new Set<TunnelType>([
 	// Workflow execution. Only handled when the app opts in via
 	// processCorsair({ allowWorkflowExecution: true }); off by default.
 	'run',
+	// Read-only probe (authoring dry-run / id grounding). Same opt-in gate as
+	// `run`; the app runs it under runReadonly so it can never write.
+	'probe',
 ]);
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -96,6 +100,29 @@ export type RunResultPayload = {
 	/** ISO timestamp when a `sleeping` run should be re-invoked. */
 	sleepUntil?: string;
 };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Read-only probe contract (`type: 'probe'`)
+//
+// Hub's authoring agent asks the app to run a short read-only script against the
+// tenant's client — to ground on real ids/fields or dry-run generated code before
+// saving it. The app runs it under `runReadonly`, so any write/destructive call
+// throws and the probe can never change anything.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Hub → app: one read-only script to run against the tenant's client. */
+export type ProbeTunnelPayload = {
+	tenantId: string;
+	/** Async JS body with `corsair` in scope; `return` the value to hand back. */
+	code: string;
+	/** Max run time in ms; the app applies a default when omitted. */
+	timeoutMs?: number;
+};
+
+/** App → Hub: the script's value, or an error (including a blocked write). */
+export type ProbeResultPayload =
+	| { status: 'ok'; value: unknown }
+	| { status: 'error'; error: string };
 
 /**
  * JSON body of a server-side delivery POST from the hub.

--- a/packages/corsair/hub/contracts/tunnel.ts
+++ b/packages/corsair/hub/contracts/tunnel.ts
@@ -68,7 +68,7 @@ export type RunTunnelPayload = {
 	code: string;
 	/** What fired the run; `payload` is the webhook body (or null for schedule/manual). */
 	trigger: { type: RunTriggerType; payload: unknown };
-	/** Completed steps from prior attempts, keyed by step name (memoization store). */
+	/** Completed steps from prior attempts, keyed by step id (memoization store). */
 	memoizedSteps?: Record<string, { output: unknown }>;
 	/** Replay attempt counter (0 on first execution). */
 	attempt?: number;
@@ -76,6 +76,13 @@ export type RunTunnelPayload = {
 
 /** One step's outcome within an execution (only steps that actually ran this attempt). */
 export type RunStepResult = {
+	/**
+	 * Stable, unique id for this step call — the memoization key and the log
+	 * correlation id. Derived from name + position, so loops / reused names don't
+	 * collide and a changed step at a position gets a new id (no stale replay).
+	 */
+	stepId: string;
+	/** Human-readable step name (may repeat across a run; use stepId for identity). */
 	name: string;
 	/** Execution order across all step() calls in this run (stable across attempts). */
 	seq: number;
@@ -115,7 +122,8 @@ export type ProbeTunnelPayload = {
 	tenantId: string;
 	/** Async JS body with `corsair` in scope; `return` the value to hand back. */
 	code: string;
-	/** Max run time in ms; the app applies a default when omitted. */
+	/** Max run time in ms, clamped app-side to (0, 10_000]; omitted, non-positive,
+	 * or non-finite falls back to the 10s default. */
 	timeoutMs?: number;
 };
 

--- a/packages/corsair/hub/index.ts
+++ b/packages/corsair/hub/index.ts
@@ -199,6 +199,8 @@ export type {
 	HubPermissionSessionInput,
 	HubPermissionSessionResult,
 	HubProjectConnection,
+	ProbeResultPayload,
+	ProbeTunnelPayload,
 	RunResultPayload,
 	RunStepResult,
 	RunTriggerType,

--- a/packages/corsair/hub/index.ts
+++ b/packages/corsair/hub/index.ts
@@ -137,6 +137,7 @@ export {
 	type ExpiringTokenPayload,
 	encodeConnectTokenForPath,
 	extractConnectLinkFromDeliveryAck,
+	extractProbeFromDeliveryAck,
 	extractRunFromDeliveryAck,
 	extractSyncFromDeliveryAck,
 	type FormatServerDeliveryErrorInput,

--- a/packages/corsair/hub/signing/envelope.ts
+++ b/packages/corsair/hub/signing/envelope.ts
@@ -9,6 +9,7 @@
 import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
 import type { ConnectCreateLinkDeliveryResult } from '../connect-link-delivery';
 import type {
+	ProbeResultPayload,
 	RunResultPayload,
 	TunnelEnvelope,
 	TunnelType,
@@ -65,6 +66,8 @@ export type ServerDeliveryAckBody = {
 	};
 	/** Workflow execution outcome returned by `run` deliveries. */
 	run?: RunResultPayload;
+	/** Read-only script outcome returned by `probe` deliveries. */
+	probe?: ProbeResultPayload;
 };
 
 /**
@@ -74,6 +77,15 @@ export function extractRunFromDeliveryAck(
 	body: ServerDeliveryAckBody,
 ): RunResultPayload | null {
 	return body.run ?? null;
+}
+
+/**
+ * Reads the read-only probe outcome from a parsed delivery ack body.
+ */
+export function extractProbeFromDeliveryAck(
+	body: ServerDeliveryAckBody,
+): ProbeResultPayload | null {
+	return body.probe ?? null;
 }
 
 function parseSignatureHeader(

--- a/packages/corsair/hub/signing/index.ts
+++ b/packages/corsair/hub/signing/index.ts
@@ -38,6 +38,7 @@ export {
 	deliverSignedEnvelope,
 	describeDeliveryNetworkError,
 	extractConnectLinkFromDeliveryAck,
+	extractProbeFromDeliveryAck,
 	extractRunFromDeliveryAck,
 	extractSyncFromDeliveryAck,
 	type FormatServerDeliveryErrorInput,

--- a/packages/corsair/hub/types.ts
+++ b/packages/corsair/hub/types.ts
@@ -76,6 +76,8 @@ export type {
 export type { DeliveryTransport } from './contracts/environment';
 export type {
 	BrowserDeliveryMode,
+	ProbeResultPayload,
+	ProbeTunnelPayload,
 	RunResultPayload,
 	RunStepResult,
 	RunTriggerType,

--- a/packages/corsair/tests/execute.test.ts
+++ b/packages/corsair/tests/execute.test.ts
@@ -1,4 +1,4 @@
-import { executeWorkflowRun } from '../workflows/execute';
+import { computeStepId, executeWorkflowRun } from '../workflows/execute';
 
 // A mock tenant client. `db.query` echoes its arg so tests can prove the
 // membrane lets normal calls through and hardens the result.
@@ -30,8 +30,25 @@ describe('executeWorkflowRun — happy path', () => {
 		`);
 		expect(result.status).toBe('completed');
 		expect(result.steps).toEqual([
-			{ name: 'greet', seq: 0, status: 'completed', output: 'hello' },
+			{
+				stepId: computeStepId('greet', 0),
+				name: 'greet',
+				seq: 0,
+				status: 'completed',
+				output: 'hello',
+			},
 		]);
+	});
+
+	it('gives distinct stepIds to reused names (loops) but stable ones across attempts', async () => {
+		const a = computeStepId('sync', 0);
+		const b = computeStepId('sync', 1);
+		expect(a).not.toBe(b);
+		expect(computeStepId('sync', 0)).toBe(a);
+		// Pin the wire format: Hub persists these as cross-version memo keys, so a
+		// change to the hash input/digest/truncation must break this test.
+		expect(a).toMatch(/^st_[0-9a-f]{16}$/);
+		expect(a).toBe('st_db505c3e4b022e6f');
 	});
 
 	it('passes calls through the membrane and hardens the result', async () => {
@@ -104,13 +121,19 @@ describe('executeWorkflowRun — replay / memoization', () => {
 				await step('b', async () => 'B:' + a);
 			};
 		`,
-			{ memoizedSteps: { a: { output: 'memoA' } } },
+			{ memoizedSteps: { [computeStepId('a', 0)]: { output: 'memoA' } } },
 		);
 		expect(result.status).toBe('completed');
 		// Only the freshly-run step is reported; `b` still gets seq 1 because the
 		// replayed `a` advances the counter.
 		expect(result.steps).toEqual([
-			{ name: 'b', seq: 1, status: 'completed', output: 'B:memoA' },
+			{
+				stepId: computeStepId('b', 1),
+				name: 'b',
+				seq: 1,
+				status: 'completed',
+				output: 'B:memoA',
+			},
 		]);
 	});
 
@@ -141,11 +164,20 @@ describe('executeWorkflowRun — sleep', () => {
 		expect(first.steps.map((s) => s.name)).toEqual(['one', 'nap']);
 
 		const second = await run(code, {
-			memoizedSteps: { one: { output: 1 }, nap: { output: null } },
+			memoizedSteps: {
+				[computeStepId('one', 0)]: { output: 1 },
+				[computeStepId('nap', 1)]: { output: null },
+			},
 		});
 		expect(second.status).toBe('completed');
 		expect(second.steps).toEqual([
-			{ name: 'two', seq: 2, status: 'completed', output: 2 },
+			{
+				stepId: computeStepId('two', 2),
+				name: 'two',
+				seq: 2,
+				status: 'completed',
+				output: 2,
+			},
 		]);
 	});
 

--- a/packages/corsair/tests/probe.test.ts
+++ b/packages/corsair/tests/probe.test.ts
@@ -80,6 +80,31 @@ describe('runReadonlyProbe', () => {
 		expect(result.status).toBe('error');
 	});
 
+	it('blocks a write triggered by toJSON during result serialization', async () => {
+		// A returned object with a script-defined toJSON() is invoked by JSON.stringify.
+		// Serialization runs INSIDE the vm's readonly scope, so a write from toJSON is
+		// blocked (assertReadonlyAllowed throws) instead of escaping after the outer
+		// scope resolved — which a host-side JSON.stringify of the returned object would
+		// allow.
+		let wrote = false;
+		const corsair = {
+			slack: {
+				send: () => {
+					assertReadonlyAllowed('slack.messages.post', 'write');
+					wrote = true;
+					return 'sent';
+				},
+			},
+		};
+		const result = await runReadonlyProbe({
+			corsair,
+			code: 'return { toJSON() { corsair.slack.send(); return "x"; } };',
+		});
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(wrote).toBe(false); // write blocked during serialization
+		expect(result.status).toBe('ok'); // probe still completes
+	});
+
 	it('falls back to the default for a non-positive timeoutMs', async () => {
 		// A bad timeoutMs (0/NaN in a payload) must not RangeError the vm — it uses
 		// the default and runs normally.

--- a/packages/corsair/tests/probe.test.ts
+++ b/packages/corsair/tests/probe.test.ts
@@ -1,0 +1,47 @@
+import { isReadonlyScopeActive } from '../core/permissions';
+import { runReadonlyProbe } from '../workflows/probe';
+
+describe('runReadonlyProbe', () => {
+	it('returns the script value, reading through the client', async () => {
+		const corsair = {
+			db: { query: async (x: unknown) => ({ rows: [x] }) },
+		};
+		const result = await runReadonlyProbe({
+			corsair,
+			code: 'const r = await corsair.db.query("ping"); return r.rows[0];',
+		});
+		expect(result).toEqual({ status: 'ok', value: 'ping' });
+	});
+
+	it('runs the client calls inside a readonly scope', async () => {
+		// The endpoint sees the active readonly scope, proving runReadonly reaches
+		// the client calls the script makes (this is what makes writes throw).
+		const corsair = {
+			probe: { check: async () => isReadonlyScopeActive() },
+		};
+		const result = await runReadonlyProbe({
+			corsair,
+			code: 'return await corsair.probe.check();',
+		});
+		expect(result).toEqual({ status: 'ok', value: true });
+	});
+
+	it('has no host globals in scope', async () => {
+		const result = await runReadonlyProbe({
+			corsair: {},
+			code: 'return typeof process + "," + typeof require + "," + typeof fetch;',
+		});
+		expect(result).toEqual({
+			status: 'ok',
+			value: 'undefined,undefined,undefined',
+		});
+	});
+
+	it('returns an error instead of throwing when the script fails', async () => {
+		const result = await runReadonlyProbe({
+			corsair: {},
+			code: 'throw new Error("boom");',
+		});
+		expect(result).toEqual({ status: 'error', error: 'boom' });
+	});
+});

--- a/packages/corsair/tests/probe.test.ts
+++ b/packages/corsair/tests/probe.test.ts
@@ -4,6 +4,18 @@ import {
 } from '../core/permissions';
 import { clampProbeTimeout, runReadonlyProbe } from '../workflows/probe';
 
+// Poll until an observable flag flips instead of sleeping a fixed duration, so a
+// slow runner can't assert before a post-timeout continuation has resumed.
+async function waitFor(
+	predicate: () => boolean,
+	budgetMs = 2_000,
+): Promise<void> {
+	const deadline = Date.now() + budgetMs;
+	while (!predicate() && Date.now() < deadline) {
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+}
+
 describe('runReadonlyProbe', () => {
 	it('returns the script value, reading through the client', async () => {
 		const corsair = {
@@ -100,7 +112,8 @@ describe('runReadonlyProbe', () => {
 			corsair,
 			code: 'return { toJSON() { corsair.slack.send(); return "x"; } };',
 		});
-		await new Promise((resolve) => setTimeout(resolve, 20));
+		// toJSON runs synchronously inside runReadonlyProbe, so the result is
+		// already settled here — no continuation to wait for.
 		expect(wrote).toBe(false); // write blocked during serialization
 		expect(result.status).toBe('error'); // surfaced as an error, not a masked null
 	});
@@ -133,7 +146,7 @@ describe('runReadonlyProbe', () => {
 		});
 		expect(result.status).toBe('error'); // timed out first
 		// Let the detached continuation resume past the now-resolved slow read.
-		await new Promise((resolve) => setTimeout(resolve, 80));
+		await waitFor(() => sendAttempted);
 		expect(sendAttempted).toBe(true); // proves the continuation DID resume post-timeout
 		expect(wrote).toBe(false); // and the write was still blocked by readonly
 	});

--- a/packages/corsair/tests/probe.test.ts
+++ b/packages/corsair/tests/probe.test.ts
@@ -80,6 +80,17 @@ describe('runReadonlyProbe', () => {
 		expect(result.status).toBe('error');
 	});
 
+	it('falls back to the default for a non-positive timeoutMs', async () => {
+		// A bad timeoutMs (0/NaN in a payload) must not RangeError the vm — it uses
+		// the default and runs normally.
+		const result = await runReadonlyProbe({
+			corsair: {},
+			code: 'return 1;',
+			timeoutMs: 0,
+		});
+		expect(result).toEqual({ status: 'ok', value: 1 });
+	});
+
 	it('keeps readonly on a continuation that resumes after the timeout', async () => {
 		// Adversarial: a read resolves AFTER the wall-clock timeout, then the script
 		// tries a write. The timeout settles the delivery, but the detached

--- a/packages/corsair/tests/probe.test.ts
+++ b/packages/corsair/tests/probe.test.ts
@@ -79,4 +79,37 @@ describe('runReadonlyProbe', () => {
 		});
 		expect(result.status).toBe('error');
 	});
+
+	it('keeps readonly on a continuation that resumes after the timeout', async () => {
+		// Adversarial: a read resolves AFTER the wall-clock timeout, then the script
+		// tries a write. The timeout settles the delivery, but the detached
+		// continuation must STILL be under runReadonly — AsyncLocalStorage propagates
+		// the scope to it — so the write throws. No escape past the readonly guard.
+		let sendAttempted = false;
+		let wrote = false;
+		const corsair = {
+			slow: {
+				read: () =>
+					new Promise((resolve) => setTimeout(() => resolve('late'), 40)),
+			},
+			slack: {
+				send: async () => {
+					sendAttempted = true; // the post-timeout continuation actually reached here
+					assertReadonlyAllowed('slack.messages.post', 'write');
+					wrote = true;
+					return 'sent';
+				},
+			},
+		};
+		const result = await runReadonlyProbe({
+			corsair,
+			code: 'await corsair.slow.read(); return await corsair.slack.send();',
+			timeoutMs: 15,
+		});
+		expect(result.status).toBe('error'); // timed out first
+		// Let the detached continuation resume past the now-resolved slow read.
+		await new Promise((resolve) => setTimeout(resolve, 80));
+		expect(sendAttempted).toBe(true); // proves the continuation DID resume post-timeout
+		expect(wrote).toBe(false); // and the write was still blocked by readonly
+	});
 });

--- a/packages/corsair/tests/probe.test.ts
+++ b/packages/corsair/tests/probe.test.ts
@@ -2,7 +2,7 @@ import {
 	assertReadonlyAllowed,
 	isReadonlyScopeActive,
 } from '../core/permissions';
-import { runReadonlyProbe } from '../workflows/probe';
+import { clampProbeTimeout, runReadonlyProbe } from '../workflows/probe';
 
 describe('runReadonlyProbe', () => {
 	it('returns the script value, reading through the client', async () => {
@@ -80,12 +80,12 @@ describe('runReadonlyProbe', () => {
 		expect(result.status).toBe('error');
 	});
 
-	it('blocks a write triggered by toJSON during result serialization', async () => {
-		// A returned object with a script-defined toJSON() is invoked by JSON.stringify.
-		// Serialization runs INSIDE the vm's readonly scope, so a write from toJSON is
-		// blocked (assertReadonlyAllowed throws) instead of escaping after the outer
-		// scope resolved — which a host-side JSON.stringify of the returned object would
-		// allow.
+	it('surfaces a write attempted by toJSON during serialization as an error', async () => {
+		// A returned object with a script-defined toJSON() is invoked by JSON.stringify,
+		// which runs INSIDE the vm's readonly scope — so a write from toJSON is blocked
+		// (assertReadonlyAllowed throws) and surfaces as { status: 'error' }, not a
+		// masked null. A host-side JSON.stringify of the returned object would instead
+		// invoke that callback outside the scope.
 		let wrote = false;
 		const corsair = {
 			slack: {
@@ -102,18 +102,7 @@ describe('runReadonlyProbe', () => {
 		});
 		await new Promise((resolve) => setTimeout(resolve, 20));
 		expect(wrote).toBe(false); // write blocked during serialization
-		expect(result.status).toBe('ok'); // probe still completes
-	});
-
-	it('falls back to the default for a non-positive timeoutMs', async () => {
-		// A bad timeoutMs (0/NaN in a payload) must not RangeError the vm — it uses
-		// the default and runs normally.
-		const result = await runReadonlyProbe({
-			corsair: {},
-			code: 'return 1;',
-			timeoutMs: 0,
-		});
-		expect(result).toEqual({ status: 'ok', value: 1 });
+		expect(result.status).toBe('error'); // surfaced as an error, not a masked null
 	});
 
 	it('keeps readonly on a continuation that resumes after the timeout', async () => {
@@ -147,5 +136,22 @@ describe('runReadonlyProbe', () => {
 		await new Promise((resolve) => setTimeout(resolve, 80));
 		expect(sendAttempted).toBe(true); // proves the continuation DID resume post-timeout
 		expect(wrote).toBe(false); // and the write was still blocked by readonly
+	});
+});
+
+describe('clampProbeTimeout', () => {
+	it('caps a too-large timeout at the default max', () => {
+		expect(clampProbeTimeout(1_000_000_000)).toBe(10_000);
+	});
+
+	it('keeps a valid in-range timeout', () => {
+		expect(clampProbeTimeout(50)).toBe(50);
+	});
+
+	it('falls back to the default for non-positive / non-finite values', () => {
+		expect(clampProbeTimeout(0)).toBe(10_000);
+		expect(clampProbeTimeout(-5)).toBe(10_000);
+		expect(clampProbeTimeout(Number.NaN)).toBe(10_000);
+		expect(clampProbeTimeout(undefined)).toBe(10_000);
 	});
 });

--- a/packages/corsair/tests/probe.test.ts
+++ b/packages/corsair/tests/probe.test.ts
@@ -66,4 +66,17 @@ describe('runReadonlyProbe', () => {
 		});
 		expect(result.status).toBe('error');
 	});
+
+	it('times out an async probe that never settles', async () => {
+		// The vm timeout only bounds synchronous work; this proves the wall-clock
+		// race bounds an async read that never resolves, instead of hanging the
+		// delivery handler forever.
+		const corsair = { slow: { read: () => new Promise(() => {}) } };
+		const result = await runReadonlyProbe({
+			corsair,
+			code: 'return await corsair.slow.read();',
+			timeoutMs: 50,
+		});
+		expect(result.status).toBe('error');
+	});
 });

--- a/packages/corsair/tests/probe.test.ts
+++ b/packages/corsair/tests/probe.test.ts
@@ -1,4 +1,7 @@
-import { isReadonlyScopeActive } from '../core/permissions';
+import {
+	assertReadonlyAllowed,
+	isReadonlyScopeActive,
+} from '../core/permissions';
 import { runReadonlyProbe } from '../workflows/probe';
 
 describe('runReadonlyProbe', () => {
@@ -43,5 +46,24 @@ describe('runReadonlyProbe', () => {
 			code: 'throw new Error("boom");',
 		});
 		expect(result).toEqual({ status: 'error', error: 'boom' });
+	});
+
+	it('returns an error when the script attempts a write', async () => {
+		// A write endpoint calls assertReadonlyAllowed(path, 'write'), which throws
+		// ReadonlyForbiddenError under the active scope — the exact guard bind.ts
+		// applies to every real endpoint. Proves a probe can look, never change.
+		const corsair = {
+			slack: {
+				send: async () => {
+					assertReadonlyAllowed('slack.messages.post', 'write');
+					return 'sent';
+				},
+			},
+		};
+		const result = await runReadonlyProbe({
+			corsair,
+			code: 'return await corsair.slack.send();',
+		});
+		expect(result.status).toBe('error');
 	});
 });

--- a/packages/corsair/tests/tunnel.test.ts
+++ b/packages/corsair/tests/tunnel.test.ts
@@ -367,3 +367,42 @@ describe('processCorsair — permission decisions', () => {
 		expect(record?.status).toBe('denied');
 	});
 });
+
+describe('processCorsair — probe tunnel', () => {
+	beforeEach(() => {
+		resetDeliveryReplayGuardForTests();
+	});
+
+	const secret = 'tunnel-signing-secret';
+
+	function probeRequest(code: string) {
+		const body = JSON.stringify({
+			type: 'probe',
+			payload: { tenantId: 'default', code },
+		});
+		return { headers: signedTunnelHeaders(body, secret), body };
+	}
+
+	it('is gated behind allowWorkflowExecution (off by default)', async () => {
+		const ack = await processCorsair(
+			createMockCorsair(),
+			probeRequest('return 42;'),
+			{ signingSecret: secret },
+		);
+		expect(ack.status).toBe('failed');
+		expect(ack.error).toMatch(/Workflow execution is not enabled/);
+	});
+
+	it('runs the read-only script and returns its value when enabled', async () => {
+		const ack = await processCorsair(
+			createMockCorsair(),
+			probeRequest('return 40 + 2;'),
+			{ signingSecret: secret, allowWorkflowExecution: true },
+		);
+		expect(ack.status).toBe('ok');
+		expect(ack.webhookResponse?.body).toEqual({
+			status: 'ok',
+			probe: { status: 'ok', value: 42 },
+		});
+	});
+});

--- a/packages/corsair/tunnel.ts
+++ b/packages/corsair/tunnel.ts
@@ -31,3 +31,8 @@ export {
 	executeWorkflowRun,
 	type WorkflowStep,
 } from './workflows/execute';
+export {
+	type ReadonlyProbeInput,
+	type ReadonlyProbeResult,
+	runReadonlyProbe,
+} from './workflows/probe';

--- a/packages/corsair/tunnel/index.ts
+++ b/packages/corsair/tunnel/index.ts
@@ -508,25 +508,35 @@ async function handleProbeTunnel(
 	corsair: unknown,
 	payload: ProbeTunnelPayload,
 ): Promise<TunnelAck> {
-	// Same tenant scoping as a run: the read-only script resolves the right
-	// tenant's credentials. `runReadonlyProbe` runs it under runReadonly, so a
-	// write/destructive call throws and comes back as `{ status: 'error' }`.
-	const tenantScopedCorsair = scopeCorsairToTenant(corsair, payload.tenantId);
-	const probe = await runReadonlyProbe({
-		corsair: tenantScopedCorsair,
-		code: payload.code,
-		timeoutMs: payload.timeoutMs,
-	});
-	// Envelope succeeded regardless of the script outcome — Hub reads `probe` from
-	// the ack. Nested so the ack's own `status: 'ok'` doesn't collide with the
-	// probe's `status: 'ok' | 'error'`.
-	return {
-		status: 'ok',
-		webhookResponse: {
-			status: 200,
-			body: { status: 'ok', probe } satisfies ServerDeliveryAckBody,
-		},
-	};
+	try {
+		// Same tenant scoping as a run: the read-only script resolves the right
+		// tenant's credentials. `runReadonlyProbe` runs it under runReadonly, so a
+		// write/destructive call throws and comes back as `{ status: 'error' }`.
+		const tenantScopedCorsair = scopeCorsairToTenant(corsair, payload.tenantId);
+		const probe = await runReadonlyProbe({
+			corsair: tenantScopedCorsair,
+			code: payload.code,
+			timeoutMs: payload.timeoutMs,
+		});
+		// Envelope succeeded regardless of the script outcome — Hub reads `probe` from
+		// the ack. Nested so the ack's own `status: 'ok'` doesn't collide with the
+		// probe's `status: 'ok' | 'error'`.
+		return {
+			status: 'ok',
+			webhookResponse: {
+				status: 200,
+				body: { status: 'ok', probe } satisfies ServerDeliveryAckBody,
+			},
+		};
+	} catch (error) {
+		// runReadonlyProbe never throws; this only fires if tenant scoping fails,
+		// which is deterministic — not worth retrying.
+		return {
+			status: 'failed',
+			retryable: false,
+			error: error instanceof Error ? error.message : 'Probe failed',
+		};
+	}
 }
 
 export type ProcessCorsairOptions = {

--- a/packages/corsair/tunnel/index.ts
+++ b/packages/corsair/tunnel/index.ts
@@ -6,6 +6,7 @@ import {
 	processConnectionsSyncDelivery,
 } from '../hub/connections-sync-delivery';
 import type {
+	ProbeTunnelPayload,
 	RunResultPayload,
 	RunTunnelPayload,
 	TunnelEnvelope,
@@ -26,6 +27,7 @@ import {
 	setWebhookTenantLink,
 } from '../webhooks/tenant-links';
 import { executeWorkflowRun } from '../workflows/execute';
+import { runReadonlyProbe } from '../workflows/probe';
 
 export {
 	resolveAccountFromWebhookLink,
@@ -502,6 +504,31 @@ async function handleRunTunnel(
 	}
 }
 
+async function handleProbeTunnel(
+	corsair: unknown,
+	payload: ProbeTunnelPayload,
+): Promise<TunnelAck> {
+	// Same tenant scoping as a run: the read-only script resolves the right
+	// tenant's credentials. `runReadonlyProbe` runs it under runReadonly, so a
+	// write/destructive call throws and comes back as `{ status: 'error' }`.
+	const tenantScopedCorsair = scopeCorsairToTenant(corsair, payload.tenantId);
+	const probe = await runReadonlyProbe({
+		corsair: tenantScopedCorsair,
+		code: payload.code,
+		timeoutMs: payload.timeoutMs,
+	});
+	// Envelope succeeded regardless of the script outcome — Hub reads `probe` from
+	// the ack. Nested so the ack's own `status: 'ok'` doesn't collide with the
+	// probe's `status: 'ok' | 'error'`.
+	return {
+		status: 'ok',
+		webhookResponse: {
+			status: 200,
+			body: { status: 'ok', probe } satisfies ServerDeliveryAckBody,
+		},
+	};
+}
+
 export type ProcessCorsairOptions = {
 	/** HMAC signing secret shared with the tunnel relay. Required unless allowUnsignedTunnel is true. */
 	signingSecret?: string;
@@ -660,6 +687,19 @@ export async function processCorsair(
 				};
 			}
 			return handleRunTunnel(corsair, envelope.payload as RunTunnelPayload);
+		case 'probe':
+			// ponytail: gated by the same flag as `run` — a probe still executes
+			// Hub-authored code (read-only). Split into its own flag if a tenant
+			// ever needs authoring probes without enabling full execution.
+			if (!options.allowWorkflowExecution) {
+				return {
+					status: 'failed',
+					retryable: false,
+					error:
+						'Workflow execution is not enabled (set allowWorkflowExecution: true)',
+				};
+			}
+			return handleProbeTunnel(corsair, envelope.payload as ProbeTunnelPayload);
 		default:
 			return {
 				status: 'failed',

--- a/packages/corsair/tunnel/index.ts
+++ b/packages/corsair/tunnel/index.ts
@@ -698,9 +698,9 @@ export async function processCorsair(
 			}
 			return handleRunTunnel(corsair, envelope.payload as RunTunnelPayload);
 		case 'probe':
-			// ponytail: gated by the same flag as `run` — a probe still executes
-			// Hub-authored code (read-only). Split into its own flag if a tenant
-			// ever needs authoring probes without enabling full execution.
+			// Same gate as `run`: a probe still executes Hub-authored code (read-only).
+			// Could be split into its own flag if a tenant ever needs authoring probes
+			// without enabling full execution.
 			if (!options.allowWorkflowExecution) {
 				return {
 					status: 'failed',

--- a/packages/corsair/workflows/execute.ts
+++ b/packages/corsair/workflows/execute.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import * as vm from 'node:vm';
 import type { RunResultPayload, RunStepResult } from '../hub/contracts/tunnel';
 
@@ -64,6 +65,18 @@ function isSleepInterrupt(value: unknown): value is SleepInterrupt {
 		value !== null &&
 		(value as { __corsairSleep?: unknown }).__corsairSleep === true
 	);
+}
+
+/**
+ * Stable, position-anchored id for one step call. Deterministic across attempts
+ * (same name + seq → same id) and unique per call (seq disambiguates loops and
+ * reused names), so it doubles as the memoization key and the correlation id in
+ * run logs. The name is folded in so a code edit that changes the step at a given
+ * position yields a new id instead of replaying a stale output under the old name.
+ */
+export function computeStepId(name: string, seq: number): string {
+	const hash = createHash('sha256').update(`${seq} ${name}`).digest('hex');
+	return `st_${hash.slice(0, 16)}`;
 }
 
 /** Robust message extraction, including cross-realm errors (not `instanceof Error`). */
@@ -295,7 +308,7 @@ export type ExecuteWorkflowRunInput = {
 	code: string;
 	/** Webhook body (or null for schedule/manual triggers). */
 	payload: unknown;
-	/** Outputs of steps that already completed on prior attempts, keyed by name. */
+	/** Outputs of steps that already completed on prior attempts, keyed by stepId. */
 	memoizedSteps?: Record<string, { output: unknown }>;
 	/** Max run time (sync + wall-clock) in ms. Defaults to {@link WORKFLOW_TIMEOUT_MS}. */
 	timeoutMs?: number;
@@ -320,22 +333,30 @@ export async function executeWorkflowRun(
 		// work this attempt.
 		if (pendingSleep) throw pendingSleep;
 		const current = seq++;
+		const stepId = computeStepId(name, current);
 
 		// Replay: a completed step from a prior attempt is not re-executed and not
-		// re-reported (Hub already has it persisted). Harden the stored output so
-		// the sandbox gets a safe view rather than a bare host object.
-		if (Object.hasOwn(memo, name)) {
-			return harden(memo[name]!.output, undefined) as T;
+		// re-reported (Hub already has it persisted). Keyed by stepId so loops /
+		// reused names don't collide. Harden the stored output so the sandbox gets
+		// a safe view rather than a bare host object.
+		if (Object.hasOwn(memo, stepId)) {
+			return harden(memo[stepId]!.output, undefined) as T;
 		}
 
 		try {
 			const output = await fn();
-			steps.push({ name, seq: current, status: 'completed', output });
+			steps.push({ stepId, name, seq: current, status: 'completed', output });
 			return output;
 		} catch (err) {
 			if (isSleepInterrupt(err)) throw err;
 			const message = toMessage(err);
-			steps.push({ name, seq: current, status: 'failed', error: message });
+			steps.push({
+				stepId,
+				name,
+				seq: current,
+				status: 'failed',
+				error: message,
+			});
 			const wrapped = new Error(message);
 			(wrapped as unknown as Record<string, unknown>)[FAILED_STEP_MARKER] =
 				name;
@@ -346,11 +367,18 @@ export async function executeWorkflowRun(
 	step.sleep = async (name: string, ms: number): Promise<void> => {
 		if (pendingSleep) throw pendingSleep;
 		const current = seq++;
+		const stepId = computeStepId(name, current);
 		// Already slept on a prior attempt — the pause is satisfied, continue.
-		if (Object.hasOwn(memo, name)) return;
+		if (Object.hasOwn(memo, stepId)) return;
 		// First encounter: record the sleep as a completed step (so the next attempt
 		// replays past it) and unwind to hand control back to Hub.
-		steps.push({ name, seq: current, status: 'completed', output: null });
+		steps.push({
+			stepId,
+			name,
+			seq: current,
+			status: 'completed',
+			output: null,
+		});
 		// Guard non-finite ms: `Date.now() + NaN` → `new Date(NaN).toISOString()`
 		// throws, turning a sleep into an infra failure.
 		const delay = Number.isFinite(ms) ? Math.max(0, ms) : 0;

--- a/packages/corsair/workflows/execute.ts
+++ b/packages/corsair/workflows/execute.ts
@@ -42,8 +42,8 @@ export interface WorkflowStep {
 
 const FAILED_STEP_MARKER = '__corsairFailedStep';
 
-// ponytail: one 30s cap covers both guards below; the deploy targets short,
-// gated workflows. Promote to a per-run config knob if long workflows land.
+// One 30s cap covers both guards below; the deploy targets short, gated
+// workflows. Promote to a per-run config knob if long workflows land.
 const WORKFLOW_TIMEOUT_MS = 30_000;
 
 /**

--- a/packages/corsair/workflows/execute.ts
+++ b/packages/corsair/workflows/execute.ts
@@ -92,7 +92,7 @@ const BLOCKED_KEYS = new Set<PropertyKey>([
 	'__proto__',
 ]);
 
-function harden(value: unknown, thisArg: unknown): unknown {
+export function harden(value: unknown, thisArg: unknown): unknown {
 	if (value === null) return null;
 	const type = typeof value;
 	if (type === 'function') {

--- a/packages/corsair/workflows/execute.ts
+++ b/packages/corsair/workflows/execute.ts
@@ -67,7 +67,7 @@ function isSleepInterrupt(value: unknown): value is SleepInterrupt {
 }
 
 /** Robust message extraction, including cross-realm errors (not `instanceof Error`). */
-function toMessage(err: unknown): string {
+export function toMessage(err: unknown): string {
 	if (err instanceof Error) return err.message;
 	if (err !== null && typeof err === 'object' && 'message' in err) {
 		const message = (err as { message?: unknown }).message;

--- a/packages/corsair/workflows/probe.ts
+++ b/packages/corsair/workflows/probe.ts
@@ -64,11 +64,14 @@ export async function runReadonlyProbe(
 				context,
 				{ filename: 'corsair:probe', timeout: timeoutMs },
 			) as Promise<unknown>;
-			// The vm `timeout` only bounds synchronous execution; once the script
-			// yields at its first `await` it no longer applies. Bound the async
-			// remainder with a wall-clock race so a slow or never-settling read can't
-			// hang the delivery handler. A detached, timed-out script can't write
-			// (readonly), so it is harmless; clearTimeout frees a finished probe's timer.
+			// The vm `timeout` only bounds synchronous execution up to the first
+			// `await`. Bound the async remainder with a wall-clock race so a slow or
+			// never-settling *async* read can't hang the handler. Note the ceiling: a
+			// post-await synchronous CPU loop can still block this timer on the same
+			// event loop — an in-thread limit shared with the run executor; fully
+			// bounding it needs worker/process isolation (tracked separately). A
+			// detached, timed-out script can't write (readonly); clearTimeout frees a
+			// finished probe's timer.
 			void script.catch(() => {});
 			let timer: ReturnType<typeof setTimeout>;
 			const wallClock = new Promise<never>((_resolve, reject) => {

--- a/packages/corsair/workflows/probe.ts
+++ b/packages/corsair/workflows/probe.ts
@@ -52,22 +52,21 @@ export async function runReadonlyProbe(
 	// The only capability in scope is the hardened client, exposed as `corsair`.
 	sandbox.corsair = harden(input.corsair, undefined);
 
-	// Clamp: a non-positive / non-finite timeout would make vm's `timeout` throw a
-	// RangeError. Fall back to the default instead.
-	const requested = input.timeoutMs;
-	const timeoutMs =
-		typeof requested === 'number' && Number.isFinite(requested) && requested > 0
-			? requested
-			: PROBE_TIMEOUT_MS;
+	// Clamp into (0, PROBE_TIMEOUT_MS]: non-positive / non-finite falls back to the
+	// default, and anything larger is capped so a payload can't extend the synchronous
+	// vm deadline and hold the host event loop.
+	const timeoutMs = clampProbeTimeout(input.timeoutMs);
 
-	// Serialize INSIDE the vm, in the script's own readonly context: a toJSON()/
-	// getter that reaches a write endpoint during stringify throws there (blocked),
-	// and the host only ever parses a plain string — it never runs script callbacks.
+	// Serialize INSIDE the vm, in the script's own readonly context: a toJSON()/getter
+	// that reaches a write endpoint during stringify throws there (blocked) and
+	// surfaces as { status: 'error' } — never a masked null. A genuine serialization
+	// failure (e.g. a circular value) likewise surfaces as an error, not a null. The
+	// host only ever parses a plain string, so it never runs script-defined callbacks.
 	const wrapped = `(async () => {
 const __result = await (async () => {
 ${input.code}
 })();
-try { return JSON.stringify(__result) ?? 'null'; } catch { return 'null'; }
+return JSON.stringify(__result) ?? 'null';
 })()`;
 
 	try {
@@ -114,4 +113,16 @@ function parseProbeJson(raw: unknown): unknown {
 	} catch {
 		return null;
 	}
+}
+
+/**
+ * Clamps a caller-supplied timeout into (0, {@link PROBE_TIMEOUT_MS}]. Non-finite or
+ * non-positive values fall back to the default; a larger value is capped so a probe
+ * payload can't extend the synchronous vm deadline and block the host event loop.
+ */
+export function clampProbeTimeout(ms: number | undefined): number {
+	if (typeof ms !== 'number' || !Number.isFinite(ms) || ms <= 0) {
+		return PROBE_TIMEOUT_MS;
+	}
+	return Math.min(ms, PROBE_TIMEOUT_MS);
 }

--- a/packages/corsair/workflows/probe.ts
+++ b/packages/corsair/workflows/probe.ts
@@ -51,18 +51,36 @@ export async function runReadonlyProbe(
 	// The only capability in scope is the hardened client, exposed as `corsair`.
 	sandbox.corsair = harden(input.corsair, undefined);
 
+	const timeoutMs = input.timeoutMs ?? PROBE_TIMEOUT_MS;
+
 	try {
 		// Run inside the readonly scope: vm.runInContext executes the script
 		// synchronously up to its first `await` (the first client call), so the
 		// scope must already be active when the promise is created — later
 		// continuations inherit it. assertReadonlyAllowed runs host-side per call.
-		const value = await runReadonly(
-			() =>
-				vm.runInContext(`(async () => {\n${input.code}\n})()`, context, {
-					filename: 'corsair:probe',
-					timeout: input.timeoutMs ?? PROBE_TIMEOUT_MS,
-				}) as Promise<unknown>,
-		);
+		const value = await runReadonly(() => {
+			const script = vm.runInContext(
+				`(async () => {\n${input.code}\n})()`,
+				context,
+				{ filename: 'corsair:probe', timeout: timeoutMs },
+			) as Promise<unknown>;
+			// The vm `timeout` only bounds synchronous execution; once the script
+			// yields at its first `await` it no longer applies. Bound the async
+			// remainder with a wall-clock race so a slow or never-settling read can't
+			// hang the delivery handler. A detached, timed-out script can't write
+			// (readonly), so it is harmless; clearTimeout frees a finished probe's timer.
+			void script.catch(() => {});
+			let timer: ReturnType<typeof setTimeout>;
+			const wallClock = new Promise<never>((_resolve, reject) => {
+				timer = setTimeout(
+					() => reject(new Error(`Probe exceeded ${timeoutMs}ms time limit`)),
+					timeoutMs,
+				);
+			});
+			return Promise.race([script, wallClock]).finally(() =>
+				clearTimeout(timer),
+			);
+		});
 
 		// Flatten realm-native / proxied values to plain host JSON for the wire.
 		return { status: 'ok', value: toSerializable(value) };

--- a/packages/corsair/workflows/probe.ts
+++ b/packages/corsair/workflows/probe.ts
@@ -16,8 +16,9 @@ import { harden, toMessage } from './execute';
 //     globals (process/require/fetch), and `corsair` is the hardened Proxy, so
 //     the script can navigate the client but can't reach the host Function ctor.
 //
-// The script's return value is the probe result. Unlike a workflow run there is
-// no step/memoization/durability — it's a synchronous lookup.
+// The result is serialized to a JSON string INSIDE the vm, under the script's own
+// readonly scope, and only the string is handed back — the host never invokes
+// script-defined toJSON()/getters (which would otherwise run outside the scope).
 // ─────────────────────────────────────────────────────────────────────────────
 
 const PROBE_TIMEOUT_MS = 10_000;
@@ -59,25 +60,33 @@ export async function runReadonlyProbe(
 			? requested
 			: PROBE_TIMEOUT_MS;
 
+	// Serialize INSIDE the vm, in the script's own readonly context: a toJSON()/
+	// getter that reaches a write endpoint during stringify throws there (blocked),
+	// and the host only ever parses a plain string — it never runs script callbacks.
+	const wrapped = `(async () => {
+const __result = await (async () => {
+${input.code}
+})();
+try { return JSON.stringify(__result) ?? 'null'; } catch { return 'null'; }
+})()`;
+
 	try {
-		// Run inside the readonly scope: vm.runInContext executes the script
-		// synchronously up to its first `await` (the first client call), so the
-		// scope must already be active when the promise is created — later
-		// continuations inherit it. assertReadonlyAllowed runs host-side per call.
-		const value = await runReadonly(() => {
-			const script = vm.runInContext(
-				`(async () => {\n${input.code}\n})()`,
-				context,
-				{ filename: 'corsair:probe', timeout: timeoutMs },
-			) as Promise<unknown>;
+		// vm.runInContext executes the script synchronously up to its first `await`
+		// (the first client call), so the readonly scope must already be active when
+		// the promise is created — later continuations inherit it. assertReadonlyAllowed
+		// runs host-side per call.
+		const raw = await runReadonly(() => {
+			const script = vm.runInContext(wrapped, context, {
+				filename: 'corsair:probe',
+				timeout: timeoutMs,
+			}) as Promise<unknown>;
 			// The vm `timeout` only bounds synchronous execution up to the first
 			// `await`. Bound the async remainder with a wall-clock race so a slow or
-			// never-settling *async* read can't hang the handler. Note the ceiling: a
-			// post-await synchronous CPU loop can still block this timer on the same
-			// event loop — an in-thread limit shared with the run executor; fully
-			// bounding it needs worker/process isolation (tracked separately). A
-			// detached, timed-out script can't write (readonly); clearTimeout frees a
-			// finished probe's timer.
+			// never-settling *async* read can't hang the handler. Ceiling: a post-await
+			// synchronous CPU loop can still block this timer on the same event loop —
+			// an in-thread limit shared with the run executor; fully bounding it needs
+			// worker/process isolation (tracked separately). A detached, timed-out
+			// script stays read-only; clearTimeout frees a finished probe's timer.
 			void script.catch(() => {});
 			let timer: ReturnType<typeof setTimeout>;
 			const wallClock = new Promise<never>((_resolve, reject) => {
@@ -91,18 +100,17 @@ export async function runReadonlyProbe(
 			);
 		});
 
-		// Flatten realm-native / proxied values to plain host JSON for the wire.
-		return { status: 'ok', value: toSerializable(value) };
+		return { status: 'ok', value: parseProbeJson(raw) };
 	} catch (err) {
 		return { status: 'error', error: toMessage(err) };
 	}
 }
 
-/** JSON round-trip so the result is plain, wire-safe host data (no realm proxies). */
-function toSerializable(value: unknown): unknown {
-	if (value === undefined) return null;
+/** The vm returns a JSON string (serialized in-scope); parse it to host data. */
+function parseProbeJson(raw: unknown): unknown {
+	if (typeof raw !== 'string') return null;
 	try {
-		return JSON.parse(JSON.stringify(value));
+		return JSON.parse(raw);
 	} catch {
 		return null;
 	}

--- a/packages/corsair/workflows/probe.ts
+++ b/packages/corsair/workflows/probe.ts
@@ -51,7 +51,13 @@ export async function runReadonlyProbe(
 	// The only capability in scope is the hardened client, exposed as `corsair`.
 	sandbox.corsair = harden(input.corsair, undefined);
 
-	const timeoutMs = input.timeoutMs ?? PROBE_TIMEOUT_MS;
+	// Clamp: a non-positive / non-finite timeout would make vm's `timeout` throw a
+	// RangeError. Fall back to the default instead.
+	const requested = input.timeoutMs;
+	const timeoutMs =
+		typeof requested === 'number' && Number.isFinite(requested) && requested > 0
+			? requested
+			: PROBE_TIMEOUT_MS;
 
 	try {
 		// Run inside the readonly scope: vm.runInContext executes the script

--- a/packages/corsair/workflows/probe.ts
+++ b/packages/corsair/workflows/probe.ts
@@ -105,14 +105,14 @@ return JSON.stringify(__result) ?? 'null';
 	}
 }
 
-/** The vm returns a JSON string (serialized in-scope); parse it to host data. */
+/** The vm returns a JSON string (serialized in-scope); parse it to host data. A
+ * non-string or unparseable value means the runner itself is broken — throw so
+ * it surfaces as `{ status: 'error' }` instead of masking a bug as a null value. */
 function parseProbeJson(raw: unknown): unknown {
-	if (typeof raw !== 'string') return null;
-	try {
-		return JSON.parse(raw);
-	} catch {
-		return null;
+	if (typeof raw !== 'string') {
+		throw new Error(`Probe returned a non-string result (${typeof raw})`);
 	}
+	return JSON.parse(raw);
 }
 
 /**

--- a/packages/corsair/workflows/probe.ts
+++ b/packages/corsair/workflows/probe.ts
@@ -1,6 +1,7 @@
 import * as vm from 'node:vm';
 import { runReadonly } from '../core/permissions';
-import { harden } from './execute';
+import type { ProbeResultPayload } from '../hub/contracts/tunnel';
+import { harden, toMessage } from './execute';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Read-only probe runner (app side)
@@ -30,19 +31,8 @@ export type ReadonlyProbeInput = {
 	timeoutMs?: number;
 };
 
-export type ReadonlyProbeResult =
-	| { status: 'ok'; value: unknown }
-	| { status: 'error'; error: string };
-
-/** Message extraction that survives cross-realm errors (not `instanceof Error`). */
-function toMessage(err: unknown): string {
-	if (err instanceof Error) return err.message;
-	if (err !== null && typeof err === 'object' && 'message' in err) {
-		const message = (err as { message?: unknown }).message;
-		if (typeof message === 'string') return message;
-	}
-	return String(err);
-}
+/** The runner's result IS the wire contract — one source of truth (no drift). */
+export type ReadonlyProbeResult = ProbeResultPayload;
 
 /**
  * Runs `input.code` read-only against `input.corsair` in a locked-down vm realm

--- a/packages/corsair/workflows/probe.ts
+++ b/packages/corsair/workflows/probe.ts
@@ -1,0 +1,92 @@
+import * as vm from 'node:vm';
+import { runReadonly } from '../core/permissions';
+import { harden } from './execute';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Read-only probe runner (app side)
+//
+// Runs a short, agent-authored script against the tenant's Corsair client purely
+// to READ real data — so the authoring agent can ground on real ids/values
+// instead of guessing them. Two guarantees stack:
+//   • runReadonly(): any write/destructive endpoint the script touches throws
+//     ReadonlyForbiddenError (enforced in core/endpoints/bind.ts). A probe can
+//     look, never change.
+//   • node:vm realm + membrane: same host-isolation as the executor — no host
+//     globals (process/require/fetch), and `corsair` is the hardened Proxy, so
+//     the script can navigate the client but can't reach the host Function ctor.
+//
+// The script's return value is the probe result. Unlike a workflow run there is
+// no step/memoization/durability — it's a synchronous lookup.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PROBE_TIMEOUT_MS = 10_000;
+
+export type ReadonlyProbeInput = {
+	/** Tenant-scoped Corsair client the script reads through (as `corsair`). */
+	corsair: unknown;
+	/** Async JS body with `corsair` in scope; `return` the value to hand back. */
+	code: string;
+	/** Max run time in ms. Defaults to {@link PROBE_TIMEOUT_MS}. */
+	timeoutMs?: number;
+};
+
+export type ReadonlyProbeResult =
+	| { status: 'ok'; value: unknown }
+	| { status: 'error'; error: string };
+
+/** Message extraction that survives cross-realm errors (not `instanceof Error`). */
+function toMessage(err: unknown): string {
+	if (err instanceof Error) return err.message;
+	if (err !== null && typeof err === 'object' && 'message' in err) {
+		const message = (err as { message?: unknown }).message;
+		if (typeof message === 'string') return message;
+	}
+	return String(err);
+}
+
+/**
+ * Runs `input.code` read-only against `input.corsair` in a locked-down vm realm
+ * and returns its value. Never throws — failures (including a write attempt) come
+ * back as `{ status: 'error' }`.
+ */
+export async function runReadonlyProbe(
+	input: ReadonlyProbeInput,
+): Promise<ReadonlyProbeResult> {
+	// Null-proto global → the script's prototype chain can't reach host intrinsics.
+	const sandbox = Object.create(null) as Record<string, unknown>;
+	const context = vm.createContext(sandbox, {
+		name: 'corsair-probe',
+		codeGeneration: { strings: false, wasm: false },
+	});
+	// The only capability in scope is the hardened client, exposed as `corsair`.
+	sandbox.corsair = harden(input.corsair, undefined);
+
+	try {
+		// Run inside the readonly scope: vm.runInContext executes the script
+		// synchronously up to its first `await` (the first client call), so the
+		// scope must already be active when the promise is created — later
+		// continuations inherit it. assertReadonlyAllowed runs host-side per call.
+		const value = await runReadonly(
+			() =>
+				vm.runInContext(`(async () => {\n${input.code}\n})()`, context, {
+					filename: 'corsair:probe',
+					timeout: input.timeoutMs ?? PROBE_TIMEOUT_MS,
+				}) as Promise<unknown>,
+		);
+
+		// Flatten realm-native / proxied values to plain host JSON for the wire.
+		return { status: 'ok', value: toSerializable(value) };
+	} catch (err) {
+		return { status: 'error', error: toMessage(err) };
+	}
+}
+
+/** JSON round-trip so the result is plain, wire-safe host data (no realm proxies). */
+function toSerializable(value: unknown): unknown {
+	if (value === undefined) return null;
+	try {
+		return JSON.parse(JSON.stringify(value));
+	} catch {
+		return null;
+	}
+}


### PR DESCRIPTION
Adds the read-only probe tunnel to the SDK so Hub can run a short, agent-authored script against a tenant's Corsair client to READ real data — letting the authoring agent ground on real ids/values and dry-run generated code before saving, instead of guessing.

## What
- `workflows/probe.ts` — app-side runner. Executes the script in a `node:vm` realm (null-proto global, hardened `corsair` proxy, code-gen disabled) under `runReadonly`, so any write/destructive endpoint the script touches throws and comes back as `{ status: 'error' }`.
- `probe` tunnel type + `ProbeTunnelPayload` / `ProbeResultPayload` contract + inbound `case 'probe'` handler, gated behind `allowWorkflowExecution` (off by default), verified through the existing signed tunnel.
- Exports for Hub: `extractProbeFromDeliveryAck` (via `corsair/hub`), `runReadonlyProbe` (via `corsair/tunnel`).

## Safety
- Read-only enforced host-side via `assertReadonlyAllowed`; no `eval`/`new Function`; no new unsigned entry point (reuses tunnel signature + nonce replay).

## Tests
- probe + tunnel suites (18 passing), including: reads through the client, runs inside the readonly scope, no host globals, script error returns `{ status: 'error' }`, and a write attempt returns `{ status: 'error' }`.
- Not yet covered: the `timeoutMs` path (follow-up).

## Consumer
The Hub-side sender + agent tool land separately (ENG-42); this is the SDK half only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new inbound **probe** tunnel type to run read-only tenant scripts with clamped timeouts.
  * Probe results are returned as structured `{ status: 'ok' | 'error' }` and exposed via the hub/tunnel public exports.
* **Bug Fixes**
  * Improved workflow replay/memoization by switching memoization and step reporting to deterministic, sequence-aware **stepId** keys (including sleeps and failures).
* **Documentation**
  * Clarified that `memoizedSteps` is keyed by `stepId`, and expanded `stepId` semantics for memo/log correlation.
* **Tests**
  * Added/updated probe, tunnel, and execute workflow tests for readonly blocking, timeout handling, and stepId-based replay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->