### PR TITLE
a11y(studio): add aria attributes to Sidebar and Chat

### DIFF
--- a/packages/studio/src/web/components/Sidebar.tsx
+++ b/packages/studio/src/web/components/Sidebar.tsx
@@ -44,6 +44,7 @@ export function Sidebar({
 						type="button"
 						key={item.id}
 						onClick={() => onNavigate(item.id)}
+						aria-current={current === item.id ? 'page' : undefined}
 						className={`flex items-center gap-2 px-3 py-2 rounded-md text-xs text-left transition-colors ${
 							current === item.id
 								? 'bg-[var(--color-bg-hover)] text-[var(--color-text)]'

--- a/packages/studio/src/web/pages/ChatPage.tsx
+++ b/packages/studio/src/web/pages/ChatPage.tsx
@@ -108,6 +108,7 @@ function ToolCallRow({ tc }: { tc: ToolBlock }) {
 			<button
 				type="button"
 				onClick={() => setOpen((v) => !v)}
+				aria-expanded={open}
 				className="w-full flex items-center gap-2 px-2 py-1 bg-[var(--color-bg-elevated)] text-left hover:bg-[var(--color-bg-hover)] transition-colors"
 			>
 				<span
@@ -448,6 +449,7 @@ export function ChatPage({ tenant }: { tenant: string }) {
 					value={activeChatId ?? ''}
 					onChange={(e) => void switchChat(e.target.value)}
 					disabled={chatLoading || streaming}
+					aria-label="Active chat"
 					className="flex-1 text-xs bg-[var(--color-bg)] border border-[var(--color-border)] rounded-md px-2 h-7 text-[var(--color-text)] focus:outline-none focus:border-[var(--color-accent-dim)] disabled:opacity-40"
 				>
 					{chats.map((c) => (
@@ -565,6 +567,7 @@ export function ChatPage({ tenant }: { tenant: string }) {
 						variant="primary"
 						onClick={() => void send()}
 						disabled={!input.trim() || streaming || chatLoading}
+						aria-label="Send"
 						className="h-auto py-2 self-stretch"
 					>
 						{streaming ? '…' : '↑'}


### PR DESCRIPTION
## Summary

Basic ARIA attributes for studio screen readers as requested in #522.

## Changes

1. `Sidebar.tsx` — `aria-current="page"` on the active nav button
2. `ChatPage.tsx` ToolCallRow — `aria-expanded={open}`
3. `ChatPage.tsx` chat select — `aria-label="Active chat"`
4. `ChatPage.tsx` send button — `aria-label="Send"`

Fixes #522

## Test plan

- [x] Structural check: all four attributes present on the specified elements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader support for sidebar navigation by identifying the active page.
  * Added expanded/collapsed state information to chat tool controls.
  * Added accessible labels for the chat selector and Send button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->