### PR TITLE
fix(hub): restore browser delivery replay coverage for live modes

### DIFF
--- a/packages/corsair/hub/internal/delivery-replay-guard.ts
+++ b/packages/corsair/hub/internal/delivery-replay-guard.ts
@@ -46,9 +46,3 @@ export function consumeDeliveryReplayKey(
 export function resetDeliveryReplayGuardForTests(): void {
 	consumedKeys.clear();
 }
-
-/** Test helper: current in-memory key count after pruning. */
-export function countDeliveryReplayKeysForTests(): number {
-	pruneExpired(Date.now());
-	return consumedKeys.size;
-}

--- a/packages/corsair/hub/internal/delivery-replay-guard.ts
+++ b/packages/corsair/hub/internal/delivery-replay-guard.ts
@@ -1,3 +1,10 @@
+/**
+ * Process-local replay set for browser/server delivery JTIs.
+ *
+ * Note: this Map is per Node process. Multi-instance / serverless fleets need a
+ * shared store (Redis/DB) for cross-replica replay protection — this guard still
+ * blocks same-process replays and is the contract exercised by hub delivery tests.
+ */
 const consumedKeys = new Map<string, number>();
 
 function pruneExpired(now: number): void {
@@ -17,10 +24,18 @@ export function consumeDeliveryReplayKey(
 		return { ok: false, error: 'Delivery replay key is required' };
 	}
 
+	if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+		return {
+			ok: false,
+			error: 'Delivery replay TTL must be a positive number',
+		};
+	}
+
 	const now = Date.now();
 	pruneExpired(now);
 
-	if (consumedKeys.has(trimmedKey)) {
+	const existingExpiry = consumedKeys.get(trimmedKey);
+	if (existingExpiry !== undefined && existingExpiry > now) {
 		return { ok: false, error: 'Delivery request already consumed' };
 	}
 
@@ -30,4 +45,10 @@ export function consumeDeliveryReplayKey(
 
 export function resetDeliveryReplayGuardForTests(): void {
 	consumedKeys.clear();
+}
+
+/** Test helper: current in-memory key count after pruning. */
+export function countDeliveryReplayKeysForTests(): number {
+	pruneExpired(Date.now());
+	return consumedKeys.size;
 }

--- a/packages/corsair/tests/delivery-replay-guard.test.ts
+++ b/packages/corsair/tests/delivery-replay-guard.test.ts
@@ -1,0 +1,85 @@
+import {
+	consumeDeliveryReplayKey,
+	resetDeliveryReplayGuardForTests,
+} from '../hub/internal/delivery-replay-guard';
+
+describe('delivery replay guard', () => {
+	beforeEach(() => {
+		resetDeliveryReplayGuardForTests();
+		jest.useFakeTimers();
+		jest.setSystemTime(new Date('2026-07-30T12:00:00.000Z'));
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+		resetDeliveryReplayGuardForTests();
+	});
+
+	it('rejects blank replay keys', () => {
+		expect(consumeDeliveryReplayKey('', 60_000)).toEqual({
+			ok: false,
+			error: 'Delivery replay key is required',
+		});
+		expect(consumeDeliveryReplayKey('   ', 60_000)).toEqual({
+			ok: false,
+			error: 'Delivery replay key is required',
+		});
+	});
+
+	it('accepts a key once and rejects immediate replay', () => {
+		expect(consumeDeliveryReplayKey('browser:jti-1', 60_000)).toEqual({
+			ok: true,
+		});
+		expect(consumeDeliveryReplayKey('browser:jti-1', 60_000)).toEqual({
+			ok: false,
+			error: 'Delivery request already consumed',
+		});
+	});
+
+	it('allows distinct keys independently', () => {
+		expect(consumeDeliveryReplayKey('browser:jti-a', 60_000)).toEqual({
+			ok: true,
+		});
+		expect(consumeDeliveryReplayKey('browser:jti-b', 60_000)).toEqual({
+			ok: true,
+		});
+	});
+
+	it('reclaims a key after its TTL expires', () => {
+		expect(consumeDeliveryReplayKey('browser:jti-ttl', 1_000)).toEqual({
+			ok: true,
+		});
+
+		jest.setSystemTime(new Date('2026-07-30T12:00:00.500Z'));
+		expect(consumeDeliveryReplayKey('browser:jti-ttl', 1_000)).toEqual({
+			ok: false,
+			error: 'Delivery request already consumed',
+		});
+
+		jest.setSystemTime(new Date('2026-07-30T12:00:01.001Z'));
+		expect(consumeDeliveryReplayKey('browser:jti-ttl', 1_000)).toEqual({
+			ok: true,
+		});
+	});
+
+	it('rejects non-positive TTLs', () => {
+		expect(consumeDeliveryReplayKey('browser:jti-bad-ttl', 0)).toEqual({
+			ok: false,
+			error: 'Delivery replay TTL must be a positive number',
+		});
+		expect(consumeDeliveryReplayKey('browser:jti-bad-ttl', -5)).toEqual({
+			ok: false,
+			error: 'Delivery replay TTL must be a positive number',
+		});
+	});
+
+	it('trims surrounding whitespace before storing keys', () => {
+		expect(consumeDeliveryReplayKey('  browser:jti-trim  ', 60_000)).toEqual({
+			ok: true,
+		});
+		expect(consumeDeliveryReplayKey('browser:jti-trim', 60_000)).toEqual({
+			ok: false,
+			error: 'Delivery request already consumed',
+		});
+	});
+});

--- a/packages/corsair/tests/hub-delivery-replay.test.ts
+++ b/packages/corsair/tests/hub-delivery-replay.test.ts
@@ -18,38 +18,31 @@ function signBrowserDeliveryToken(
 	return `${payloadBase64}.${signature}`;
 }
 
+function createReplayTestCorsair(env: ReturnType<typeof createTestDatabase>) {
+	return createCorsair({
+		plugins: [],
+		database: env.db,
+		kek: 'test-kek-hub-browser-delivery-replay-tests',
+		hub: {
+			projectApiKey: 'ck_dev_test_key',
+			signingSecret: 'signing-secret',
+		},
+	});
+}
+
 describe('hub browser delivery replay guard', () => {
 	let env: ReturnType<typeof createTestDatabase>;
 
 	beforeEach(async () => {
 		resetDeliveryReplayGuardForTests();
 		env = createTestDatabase();
-		await setupCorsair(
-			createCorsair({
-				plugins: [],
-				database: env.db,
-				kek: 'test-kek-hub-browser-delivery-replay-tests',
-				hub: {
-					projectApiKey: 'ck_dev_test_key',
-					signingSecret: 'signing-secret',
-				},
-			} as any),
-			{ tenantId: 'default' },
-		);
+		await setupCorsair(createReplayTestCorsair(env), { tenantId: 'default' });
 	});
 
 	afterEach(() => env.cleanup());
 
 	it('rejects replayed auth.credentials browser delivery tokens', async () => {
-		const corsair = createCorsair({
-			plugins: [],
-			database: env.db,
-			kek: 'test-kek-hub-browser-delivery-replay-tests',
-			hub: {
-				projectApiKey: 'ck_dev_test_key',
-				signingSecret: 'signing-secret',
-			},
-		} as any);
+		const corsair = createReplayTestCorsair(env);
 
 		const now = Math.floor(Date.now() / 1000);
 		const token = signBrowserDeliveryToken(
@@ -72,11 +65,11 @@ describe('hub browser delivery replay guard', () => {
 		const url = `http://localhost:3001/api/corsair?d=${encodeURIComponent(token)}`;
 
 		const first = await handleHubDeliveryGet(corsair, url);
-		expect(first.type).toBe('redirect');
-		if (first.type === 'redirect') {
-			const error = new URL(first.url).searchParams.get('error');
-			expect(error).toBe('Credential delivery missing credentials');
+		if (first.type !== 'redirect') {
+			throw new Error(`Expected redirect, received ${first.type}`);
 		}
+		const error = new URL(first.url).searchParams.get('error');
+		expect(error).toBe('Credential delivery missing credentials');
 
 		const second = await handleHubDeliveryGet(corsair, url);
 		expect(second).toEqual({
@@ -87,15 +80,7 @@ describe('hub browser delivery replay guard', () => {
 	});
 
 	it('rejects replayed connections.sync browser delivery tokens', async () => {
-		const corsair = createCorsair({
-			plugins: [],
-			database: env.db,
-			kek: 'test-kek-hub-browser-delivery-replay-tests',
-			hub: {
-				projectApiKey: 'ck_dev_test_key',
-				signingSecret: 'signing-secret',
-			},
-		} as any);
+		const corsair = createReplayTestCorsair(env);
 
 		const now = Math.floor(Date.now() / 1000);
 		const token = signBrowserDeliveryToken(
@@ -134,15 +119,7 @@ describe('hub browser delivery replay guard', () => {
 	});
 
 	it('does not treat stray accessToken as managed OAuth delivery', async () => {
-		const corsair = createCorsair({
-			plugins: [],
-			database: env.db,
-			kek: 'test-kek-hub-browser-delivery-replay-tests',
-			hub: {
-				projectApiKey: 'ck_dev_test_key',
-				signingSecret: 'signing-secret',
-			},
-		} as any);
+		const corsair = createReplayTestCorsair(env);
 
 		const now = Math.floor(Date.now() / 1000);
 		const token = signBrowserDeliveryToken(

--- a/packages/corsair/tests/hub-delivery-replay.test.ts
+++ b/packages/corsair/tests/hub-delivery-replay.test.ts
@@ -40,11 +40,7 @@ describe('hub browser delivery replay guard', () => {
 
 	afterEach(() => env.cleanup());
 
-	// TODO(hub): connect.status is not a BrowserDeliveryMode and
-	// handleHubDeliveryGet has no branch for it (tunnel/index.ts says pull
-	// introspection was disabled in favor of POST /connections/report).
-	// Skipped until the hub owner decides: stale test vs unfinished feature.
-	it.skip('rejects replayed browser delivery tokens', async () => {
+	it('rejects replayed auth.credentials browser delivery tokens', async () => {
 		const corsair = createCorsair({
 			plugins: [],
 			database: env.db,
@@ -58,14 +54,15 @@ describe('hub browser delivery replay guard', () => {
 		const now = Math.floor(Date.now() / 1000);
 		const token = signBrowserDeliveryToken(
 			{
-				jti: 'browser-jti-1',
+				jti: 'browser-jti-credentials-1',
 				connectJti: 'connect-jti-1',
 				projectId: 'proj_test',
 				plugin: 'github',
 				tenantId: 'default',
 				hubSuccessUrl: 'http://localhost:3000/connect/success',
-				deliveryMode: 'connect.status',
-				statusPlugins: ['github'],
+				// Live BrowserDeliveryMode — not the retired connect.status pull path.
+				deliveryMode: 'auth.credentials',
+				// Missing credentials so the first request fails after the jti is burned.
 				iat: now,
 				exp: now + 60,
 			},
@@ -76,6 +73,57 @@ describe('hub browser delivery replay guard', () => {
 
 		const first = await handleHubDeliveryGet(corsair, url);
 		expect(first.type).toBe('redirect');
+		if (first.type === 'redirect') {
+			const error = new URL(first.url).searchParams.get('error');
+			expect(error).toBe('Credential delivery missing credentials');
+		}
+
+		const second = await handleHubDeliveryGet(corsair, url);
+		expect(second).toEqual({
+			type: 'json',
+			status: 400,
+			body: { error: 'Delivery request already consumed' },
+		});
+	});
+
+	it('rejects replayed connections.sync browser delivery tokens', async () => {
+		const corsair = createCorsair({
+			plugins: [],
+			database: env.db,
+			kek: 'test-kek-hub-browser-delivery-replay-tests',
+			hub: {
+				projectApiKey: 'ck_dev_test_key',
+				signingSecret: 'signing-secret',
+			},
+		} as any);
+
+		const now = Math.floor(Date.now() / 1000);
+		const token = signBrowserDeliveryToken(
+			{
+				jti: 'browser-jti-sync-1',
+				connectJti: 'connect-jti-sync',
+				projectId: 'proj_test',
+				plugin: 'github',
+				tenantId: 'default',
+				hubSuccessUrl: 'http://localhost:3000/connect/success',
+				deliveryMode: 'connections.sync',
+				// Intentionally incomplete so the first request fails after consume.
+				iat: now,
+				exp: now + 60,
+			},
+			'signing-secret',
+		);
+
+		const url = `http://localhost:3001/api/corsair?d=${encodeURIComponent(token)}`;
+		const first = await handleHubDeliveryGet(corsair, url);
+		expect(first).toEqual({
+			type: 'json',
+			status: 400,
+			body: {
+				error:
+					'Connections sync delivery requires hubOrigin and requestId for client bridge',
+			},
+		});
 
 		const second = await handleHubDeliveryGet(corsair, url);
 		expect(second).toEqual({


### PR DESCRIPTION
## Summary
- Rewrites the long-skipped hub browser delivery replay test off the retired `connect.status` mode onto live `auth.credentials` and `connections.sync` delivery modes
- Hardens the in-memory replay guard: validates TTL, treats expired keys as reclaimable, and documents process-local limits
- Adds dedicated unit tests for blank keys, single-use consume, TTL expiry, and whitespace trimming

## Why
`packages/corsair/tests/hub-delivery-replay.test.ts` was `it.skip`'d because `connect.status` is no longer a `BrowserDeliveryMode`. Replay protection still runs in production for every `?d=` delivery — without coverage, regressions are silent.

## Test plan
- [x] `pnpm --filter corsair test -- delivery-replay-guard.test.ts hub-delivery-replay.test.ts` (9/9 pass)
- [x] Typecheck via pre-push hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against replayed browser delivery tokens by rejecting previously consumed tokens.
  * Added consistent validation for missing, invalid, or blank delivery details.
  * Delivery tokens can be reused after their configured expiration period.
  * Whitespace around tokens is handled consistently, preventing accidental duplicate use.
  * Improved handling of separate delivery requests so valid tokens do not interfere with one another.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->