### PR TITLE
fix(www): make OSS integration claims race-safe

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -15,7 +15,7 @@
     "db:sync-show": "tsx src/db/sync-written-integration-show.ts",
     "db:seed-tags": "tsx src/db/seed-integration-tags.ts",
     "corsair": "tsx src/server/corsair.ts",
-    "test": "node --import tsx --test src/server/integrations/claim-integration.test.ts",
+    "test": "node --import tsx --test 'src/**/*.test.ts'",
     "sanity:schema": "sanity schema deploy",
     "sanity:deploy": "sanity deploy",
     "blog:migrate": "tsx scripts/migrate-blog-to-sanity.ts"

--- a/www/package.json
+++ b/www/package.json
@@ -15,6 +15,7 @@
     "db:sync-show": "tsx src/db/sync-written-integration-show.ts",
     "db:seed-tags": "tsx src/db/seed-integration-tags.ts",
     "corsair": "tsx src/server/corsair.ts",
+    "test": "node --import tsx --test src/server/integrations/claim-integration.test.ts",
     "sanity:schema": "sanity schema deploy",
     "sanity:deploy": "sanity deploy",
     "blog:migrate": "tsx scripts/migrate-blog-to-sanity.ts"

--- a/www/src/server/api/routers/integrations.ts
+++ b/www/src/server/api/routers/integrations.ts
@@ -23,12 +23,9 @@ import {
 	getLatestStatusForIntegration,
 	getUserActiveDeadlineClaim,
 	getUserClaimEligibility,
-	ISSUE_DEADLINE_MS,
 	insertIntegrationStatus,
 	isIntegrationActivelyClaimed,
-	isIntegrationAvailable,
 	legacyStatusFromPhase,
-	MAX_USER_BUILT_INTEGRATIONS,
 	PR_DEADLINE_MS,
 	releaseIntegrationClaim,
 } from '@/db/integration-status';
@@ -60,6 +57,7 @@ import {
 	sendIssueLinkedEvent,
 	sendPrLinkedEvent,
 } from '@/server/inngest/events';
+import { claimIntegrationAtomically } from '@/server/integrations/claim-integration';
 
 import { createTRPCRouter, protectedProcedure, publicProcedure } from '../trpc';
 
@@ -1055,84 +1053,31 @@ export const integrationsRouter = createTRPCRouter({
 	claim: protectedProcedure
 		.input(z.object({ integrationId: z.string().min(1) }))
 		.mutation(async ({ ctx, input }) => {
-			const claimEligibility = await getUserClaimEligibility(
-				ctx.db,
-				ctx.user.id,
-			);
-
-			if (!claimEligibility.canClaim) {
-				if (claimEligibility.blockReason === 'limit_reached') {
-					throw new TRPCError({
-						code: 'PRECONDITION_FAILED',
-						message: `You've built the maximum of ${MAX_USER_BUILT_INTEGRATIONS} integrations and can't claim another`,
-					});
-				}
-
-				throw new TRPCError({
-					code: 'PRECONDITION_FAILED',
-					message:
-						'Finish your current integration or mark it ready to review before claiming another',
-				});
-			}
-
-			const [integration] = await ctx.db
-				.select({ id: integrations.id, slug: integrations.slug })
-				.from(integrations)
-				.where(
-					and(
-						eq(integrations.id, input.integrationId),
-						eq(integrations.show, true),
-					),
-				)
-				.limit(1);
-
-			if (!integration) {
-				throw new TRPCError({
-					code: 'NOT_FOUND',
-					message: 'Integration not found',
-				});
-			}
-
-			const latestStatus = await getLatestStatusForIntegration(
-				ctx.db,
-				input.integrationId,
-			);
-
-			if (latestStatus && !isIntegrationAvailable(latestStatus.phase)) {
-				if (latestStatus.userId === ctx.user.id) {
-					return {
-						integrationId: input.integrationId,
-						slug: integration.slug,
-						phase: latestStatus.phase,
-					};
-				}
-
-				throw new TRPCError({
-					code: 'CONFLICT',
-					message: 'This integration has already been claimed',
-				});
-			}
-
-			const issueDeadlineAt = new Date(Date.now() + ISSUE_DEADLINE_MS);
-			const status = await insertIntegrationStatus(ctx.db, {
+			const result = await claimIntegrationAtomically(ctx.db, {
 				integrationId: input.integrationId,
 				userId: ctx.user.id,
-				phase: 'awaiting_issue',
-				issueDeadlineAt,
 			});
 
+			if (result.kind === 'already_owned') {
+				return {
+					integrationId: result.integrationId,
+					slug: result.slug,
+					phase: result.phase,
+				};
+			}
+
 			await sendClaimCreatedEvent({
-				statusId: status.id,
-				integrationId: input.integrationId,
-				userId: ctx.user.id,
-				slug: integration.slug,
+				statusId: result.statusId,
+				integrationId: result.integrationId,
+				userId: result.userId,
+				slug: result.slug,
 			});
 
 			return {
-				integrationId: input.integrationId,
-				slug: integration.slug,
-				phase: status.phase,
-				issueDeadlineAt: status.issueDeadlineAt,
+				integrationId: result.integrationId,
+				slug: result.slug,
+				phase: result.phase,
+				issueDeadlineAt: result.issueDeadlineAt,
 			};
 		}),
 

--- a/www/src/server/integrations/claim-decision.ts
+++ b/www/src/server/integrations/claim-decision.ts
@@ -1,0 +1,43 @@
+/**
+ * Pure claim decision helpers (no DB / Next.js imports) so they can be
+ * unit-tested with node:test without path-alias bootstrapping.
+ */
+
+export type ClaimPhase =
+	| 'awaiting_issue'
+	| 'awaiting_pr'
+	| 'building'
+	| 'ready_to_review'
+	| 'finished'
+	| 'released';
+
+export type ClaimDecision =
+	| { action: 'insert' }
+	| { action: 'return_existing'; phase: ClaimPhase }
+	| { action: 'conflict' };
+
+export function isClaimPhaseAvailable(
+	phase: ClaimPhase | null | undefined,
+): boolean {
+	return phase == null || phase === 'released';
+}
+
+/**
+ * Encodes: available → insert; same user active claim → idempotent return;
+ * other user / non-released phase → conflict.
+ */
+export function resolveClaimDecision(input: {
+	latestPhase: ClaimPhase | null;
+	latestUserId: string | null;
+	claimantUserId: string;
+}): ClaimDecision {
+	if (isClaimPhaseAvailable(input.latestPhase)) {
+		return { action: 'insert' };
+	}
+
+	if (input.latestUserId === input.claimantUserId && input.latestPhase) {
+		return { action: 'return_existing', phase: input.latestPhase };
+	}
+
+	return { action: 'conflict' };
+}

--- a/www/src/server/integrations/claim-integration.test.ts
+++ b/www/src/server/integrations/claim-integration.test.ts
@@ -106,34 +106,54 @@ describe('claimLockKeys', () => {
 });
 
 describe('resolveClaimOutcome', () => {
-	it('returns an existing same-user claim even when the user is otherwise ineligible', () => {
-		assert.deepEqual(
-			resolveClaimOutcome(
-				{ action: 'return_existing', phase: 'awaiting_issue' },
-				{ canClaim: false },
-			),
+	it('returns an existing claim without querying eligibility', async () => {
+		let queried = false;
+		const outcome = await resolveClaimOutcome(
 			{ action: 'return_existing', phase: 'awaiting_issue' },
+			async () => {
+				queried = true;
+				return { canClaim: true, blockReason: null };
+			},
 		);
+		assert.deepEqual(outcome, {
+			action: 'return_existing',
+			phase: 'awaiting_issue',
+		});
+		assert.equal(queried, false);
 	});
 
-	it('reports a conflict ahead of the eligibility gate', () => {
-		assert.deepEqual(
-			resolveClaimOutcome({ action: 'conflict' }, { canClaim: false }),
+	it('reports a conflict without querying eligibility', async () => {
+		let queried = false;
+		const outcome = await resolveClaimOutcome(
 			{ action: 'conflict' },
+			async () => {
+				queried = true;
+				return { canClaim: true, blockReason: null };
+			},
 		);
+		assert.deepEqual(outcome, { action: 'conflict' });
+		assert.equal(queried, false);
 	});
 
-	it('blocks a genuinely new claim when the user is ineligible', () => {
-		assert.deepEqual(
-			resolveClaimOutcome({ action: 'insert' }, { canClaim: false }),
-			{ action: 'blocked' },
-		);
-	});
-
-	it('allows a new claim when the user is eligible', () => {
-		assert.deepEqual(
-			resolveClaimOutcome({ action: 'insert' }, { canClaim: true }),
+	it('blocks a genuinely new claim when the user is ineligible', async () => {
+		const outcome = await resolveClaimOutcome(
 			{ action: 'insert' },
+			async () => ({
+				canClaim: false,
+				blockReason: 'wip',
+			}),
 		);
+		assert.deepEqual(outcome, { action: 'blocked', blockReason: 'wip' });
+	});
+
+	it('allows a new claim when the user is eligible', async () => {
+		const outcome = await resolveClaimOutcome(
+			{ action: 'insert' },
+			async () => ({
+				canClaim: true,
+				blockReason: null,
+			}),
+		);
+		assert.deepEqual(outcome, { action: 'insert' });
 	});
 });

--- a/www/src/server/integrations/claim-integration.test.ts
+++ b/www/src/server/integrations/claim-integration.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import { isClaimPhaseAvailable, resolveClaimDecision } from './claim-decision';
+import { claimLockKeys } from './claim-integration';
 
 describe('isClaimPhaseAvailable', () => {
 	it('treats null and released as available', () => {
@@ -76,5 +77,30 @@ describe('resolveClaimDecision', () => {
 				{ action: 'conflict' },
 			);
 		}
+	});
+});
+
+describe('claimLockKeys', () => {
+	it('serializes one user across different integrations (user key ignores integration)', () => {
+		const [userKeyA] = claimLockKeys('user-a', 'integration-1');
+		const [userKeyB] = claimLockKeys('user-a', 'integration-2');
+		assert.equal(userKeyA, userKeyB);
+	});
+
+	it('serializes different users on the same integration (integration key ignores user)', () => {
+		const [, intKeyA] = claimLockKeys('user-a', 'integration-1');
+		const [, intKeyB] = claimLockKeys('user-b', 'integration-1');
+		assert.equal(intKeyA, intKeyB);
+	});
+
+	it('keeps user and integration locks in distinct namespaces', () => {
+		const [userKey, intKey] = claimLockKeys('same-id', 'same-id');
+		assert.notEqual(userKey, intKey);
+	});
+
+	it('returns keys user-first then integration (fixed order prevents deadlock)', () => {
+		const [first, second] = claimLockKeys('u', 'i');
+		assert.match(first, /^claim:user:/);
+		assert.match(second, /^claim:integration:/);
 	});
 });

--- a/www/src/server/integrations/claim-integration.test.ts
+++ b/www/src/server/integrations/claim-integration.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { isClaimPhaseAvailable, resolveClaimDecision } from './claim-decision';
+
+describe('isClaimPhaseAvailable', () => {
+	it('treats null and released as available', () => {
+		assert.equal(isClaimPhaseAvailable(null), true);
+		assert.equal(isClaimPhaseAvailable(undefined), true);
+		assert.equal(isClaimPhaseAvailable('released'), true);
+	});
+
+	it('treats active phases as unavailable', () => {
+		assert.equal(isClaimPhaseAvailable('awaiting_issue'), false);
+		assert.equal(isClaimPhaseAvailable('finished'), false);
+	});
+});
+
+describe('resolveClaimDecision', () => {
+	it('allows insert when there is no prior status', () => {
+		assert.deepEqual(
+			resolveClaimDecision({
+				latestPhase: null,
+				latestUserId: null,
+				claimantUserId: 'user-a',
+			}),
+			{ action: 'insert' },
+		);
+	});
+
+	it('allows insert when the latest phase is released', () => {
+		assert.deepEqual(
+			resolveClaimDecision({
+				latestPhase: 'released',
+				latestUserId: 'user-b',
+				claimantUserId: 'user-a',
+			}),
+			{ action: 'insert' },
+		);
+	});
+
+	it('returns the existing claim when the same user re-claims', () => {
+		assert.deepEqual(
+			resolveClaimDecision({
+				latestPhase: 'awaiting_issue',
+				latestUserId: 'user-a',
+				claimantUserId: 'user-a',
+			}),
+			{ action: 'return_existing', phase: 'awaiting_issue' },
+		);
+
+		assert.deepEqual(
+			resolveClaimDecision({
+				latestPhase: 'building',
+				latestUserId: 'user-a',
+				claimantUserId: 'user-a',
+			}),
+			{ action: 'return_existing', phase: 'building' },
+		);
+	});
+
+	it('conflicts when another user holds a non-released claim', () => {
+		for (const phase of [
+			'awaiting_issue',
+			'awaiting_pr',
+			'building',
+			'ready_to_review',
+			'finished',
+		] as const) {
+			assert.deepEqual(
+				resolveClaimDecision({
+					latestPhase: phase,
+					latestUserId: 'user-b',
+					claimantUserId: 'user-a',
+				}),
+				{ action: 'conflict' },
+			);
+		}
+	});
+});

--- a/www/src/server/integrations/claim-integration.test.ts
+++ b/www/src/server/integrations/claim-integration.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import { isClaimPhaseAvailable, resolveClaimDecision } from './claim-decision';
-import { claimLockKeys } from './claim-integration';
+import { claimLockKeys, resolveClaimOutcome } from './claim-integration';
 
 describe('isClaimPhaseAvailable', () => {
 	it('treats null and released as available', () => {
@@ -81,26 +81,59 @@ describe('resolveClaimDecision', () => {
 });
 
 describe('claimLockKeys', () => {
-	it('serializes one user across different integrations (user key ignores integration)', () => {
-		const [userKeyA] = claimLockKeys('user-a', 'integration-1');
-		const [userKeyB] = claimLockKeys('user-a', 'integration-2');
-		assert.equal(userKeyA, userKeyB);
+	it('serializes one user across different integrations (user lock ignores integration)', () => {
+		const [userLockA] = claimLockKeys('user-a', 'integration-1');
+		const [userLockB] = claimLockKeys('user-a', 'integration-2');
+		assert.deepEqual(userLockA, userLockB);
 	});
 
-	it('serializes different users on the same integration (integration key ignores user)', () => {
-		const [, intKeyA] = claimLockKeys('user-a', 'integration-1');
-		const [, intKeyB] = claimLockKeys('user-b', 'integration-1');
-		assert.equal(intKeyA, intKeyB);
+	it('serializes different users on the same integration (integration lock ignores user)', () => {
+		const [, intLockA] = claimLockKeys('user-a', 'integration-1');
+		const [, intLockB] = claimLockKeys('user-b', 'integration-1');
+		assert.deepEqual(intLockA, intLockB);
 	});
 
-	it('keeps user and integration locks in distinct namespaces', () => {
-		const [userKey, intKey] = claimLockKeys('same-id', 'same-id');
-		assert.notEqual(userKey, intKey);
+	it('locks user and integration in distinct classes', () => {
+		const [[userClass], [intClass]] = claimLockKeys('same-id', 'same-id');
+		assert.notEqual(userClass, intClass);
 	});
 
-	it('returns keys user-first then integration (fixed order prevents deadlock)', () => {
-		const [first, second] = claimLockKeys('u', 'i');
-		assert.match(first, /^claim:user:/);
-		assert.match(second, /^claim:integration:/);
+	it('returns the user lock first then integration (fixed order prevents deadlock)', () => {
+		const [userLock, intLock] = claimLockKeys('u', 'i');
+		assert.equal(userLock[1], 'u');
+		assert.equal(intLock[1], 'i');
+	});
+});
+
+describe('resolveClaimOutcome', () => {
+	it('returns an existing same-user claim even when the user is otherwise ineligible', () => {
+		assert.deepEqual(
+			resolveClaimOutcome(
+				{ action: 'return_existing', phase: 'awaiting_issue' },
+				{ canClaim: false },
+			),
+			{ action: 'return_existing', phase: 'awaiting_issue' },
+		);
+	});
+
+	it('reports a conflict ahead of the eligibility gate', () => {
+		assert.deepEqual(
+			resolveClaimOutcome({ action: 'conflict' }, { canClaim: false }),
+			{ action: 'conflict' },
+		);
+	});
+
+	it('blocks a genuinely new claim when the user is ineligible', () => {
+		assert.deepEqual(
+			resolveClaimOutcome({ action: 'insert' }, { canClaim: false }),
+			{ action: 'blocked' },
+		);
+	});
+
+	it('allows a new claim when the user is eligible', () => {
+		assert.deepEqual(
+			resolveClaimOutcome({ action: 'insert' }, { canClaim: true }),
+			{ action: 'insert' },
+		);
 	});
 });

--- a/www/src/server/integrations/claim-integration.ts
+++ b/www/src/server/integrations/claim-integration.ts
@@ -39,12 +39,22 @@ export type AtomicClaimResult =
 	  };
 
 /**
- * Atomically claim an integration.
- *
- * Serializes concurrent claimants with a transaction-scoped advisory lock keyed
- * by integration id, then re-checks eligibility + latest status before insert.
- * Prevents the classic check-then-insert race that allowed two users to both
- * land `awaiting_issue` rows for the same integration.
+ * Advisory-lock keys for a claim, user first then integration. The user key
+ * serializes one user claiming two integrations at once (eligibility is a
+ * per-user rule, so per-integration locks alone don't); the fixed order avoids
+ * deadlock.
+ */
+export function claimLockKeys(
+	userId: string,
+	integrationId: string,
+): [userKey: string, integrationKey: string] {
+	return [`claim:user:${userId}`, `claim:integration:${integrationId}`];
+}
+
+/**
+ * Atomically claim an integration. Locks on both the user and the integration
+ * (see claimLockKeys), then re-checks eligibility + latest status before insert
+ * to close the check-then-insert race.
  */
 export async function claimIntegrationAtomically(
 	db: DB,
@@ -56,9 +66,16 @@ export async function claimIntegrationAtomically(
 	return db.transaction(async (tx) => {
 		const claimDb = tx as unknown as DB;
 
-		// hashtext → int4 advisory key; xact lock auto-releases on commit/rollback.
+		// hashtext → int4 advisory key; xact locks auto-release on commit/rollback.
+		const [userLockKey, integrationLockKey] = claimLockKeys(
+			params.userId,
+			params.integrationId,
+		);
 		await tx.execute(
-			sql`SELECT pg_advisory_xact_lock(hashtext(${params.integrationId}))`,
+			sql`SELECT pg_advisory_xact_lock(hashtext(${userLockKey}))`,
+		);
+		await tx.execute(
+			sql`SELECT pg_advisory_xact_lock(hashtext(${integrationLockKey}))`,
 		);
 
 		const eligibility = await getUserClaimEligibility(claimDb, params.userId);

--- a/www/src/server/integrations/claim-integration.ts
+++ b/www/src/server/integrations/claim-integration.ts
@@ -2,7 +2,10 @@ import { TRPCError } from '@trpc/server';
 import { and, eq, sql } from 'drizzle-orm';
 
 import type { DB } from '@/db';
-import type { LatestIntegrationStatus } from '@/db/integration-status';
+import type {
+	LatestIntegrationStatus,
+	UserClaimEligibility,
+} from '@/db/integration-status';
 import {
 	getLatestStatusForIntegration,
 	getUserClaimEligibility,
@@ -63,27 +66,32 @@ export function claimLockKeys(
 	];
 }
 
+type ClaimEligibility = Pick<UserClaimEligibility, 'canClaim' | 'blockReason'>;
+
 /**
  * Claim precedence: an existing same-user claim or a conflict on this
  * integration is resolved before the per-user eligibility gate, so re-claiming
  * an in-progress integration returns already_owned instead of a 'wip' rejection.
+ * Eligibility is passed as a thunk and only queried for a genuinely new insert.
  */
-export function resolveClaimOutcome(
+export async function resolveClaimOutcome(
 	decision: ClaimDecision,
-	eligibility: { canClaim: boolean },
-):
+	getEligibility: () => Promise<ClaimEligibility>,
+): Promise<
 	| { action: 'return_existing'; phase: ClaimPhase }
 	| { action: 'conflict' }
-	| { action: 'blocked' }
-	| { action: 'insert' } {
+	| { action: 'blocked'; blockReason: ClaimEligibility['blockReason'] }
+	| { action: 'insert' }
+> {
 	if (decision.action === 'return_existing') {
 		return { action: 'return_existing', phase: decision.phase };
 	}
 	if (decision.action === 'conflict') {
 		return { action: 'conflict' };
 	}
+	const eligibility = await getEligibility();
 	if (!eligibility.canClaim) {
-		return { action: 'blocked' };
+		return { action: 'blocked', blockReason: eligibility.blockReason };
 	}
 	return { action: 'insert' };
 }
@@ -145,8 +153,9 @@ export async function claimIntegrationAtomically(
 			claimantUserId: params.userId,
 		});
 
-		const eligibility = await getUserClaimEligibility(claimDb, params.userId);
-		const outcome = resolveClaimOutcome(decision, eligibility);
+		const outcome = await resolveClaimOutcome(decision, () =>
+			getUserClaimEligibility(claimDb, params.userId),
+		);
 
 		if (outcome.action === 'return_existing') {
 			return {
@@ -168,7 +177,7 @@ export async function claimIntegrationAtomically(
 			throw new TRPCError({
 				code: 'PRECONDITION_FAILED',
 				message:
-					eligibility.blockReason === 'limit_reached'
+					outcome.blockReason === 'limit_reached'
 						? `You've built the maximum of ${MAX_USER_BUILT_INTEGRATIONS} integrations and can't claim another`
 						: 'Finish your current integration or mark it ready to review before claiming another',
 			});

--- a/www/src/server/integrations/claim-integration.ts
+++ b/www/src/server/integrations/claim-integration.ts
@@ -12,7 +12,10 @@ import {
 } from '@/db/integration-status';
 import type { IntegrationPhase } from '@/db/schema';
 import { integrations } from '@/db/schema';
-import type { ClaimPhase } from '@/server/integrations/claim-decision';
+import type {
+	ClaimDecision,
+	ClaimPhase,
+} from '@/server/integrations/claim-decision';
 import { resolveClaimDecision } from '@/server/integrations/claim-decision';
 
 export type {
@@ -38,17 +41,51 @@ export type AtomicClaimResult =
 			phase: IntegrationPhase;
 	  };
 
+// Advisory-lock classes for the two-arg pg_advisory_xact_lock(class, id) form —
+// a key space separate from the single-arg form. Distinct classes keep user and
+// integration locks from ever colliding.
+const USER_LOCK_CLASS = 1;
+const INTEGRATION_LOCK_CLASS = 2;
+
 /**
- * Advisory-lock keys for a claim, user first then integration. The user key
- * serializes one user claiming two integrations at once (eligibility is a
- * per-user rule, so per-integration locks alone don't); the fixed order avoids
+ * Advisory-lock (class, id) pairs for a claim, user first then integration. The
+ * user lock serializes one user claiming two integrations at once (eligibility
+ * is per-user, so per-integration locks alone don't); the fixed order avoids
  * deadlock.
  */
 export function claimLockKeys(
 	userId: string,
 	integrationId: string,
-): [userKey: string, integrationKey: string] {
-	return [`claim:user:${userId}`, `claim:integration:${integrationId}`];
+): [userLock: [number, string], integrationLock: [number, string]] {
+	return [
+		[USER_LOCK_CLASS, userId],
+		[INTEGRATION_LOCK_CLASS, integrationId],
+	];
+}
+
+/**
+ * Claim precedence: an existing same-user claim or a conflict on this
+ * integration is resolved before the per-user eligibility gate, so re-claiming
+ * an in-progress integration returns already_owned instead of a 'wip' rejection.
+ */
+export function resolveClaimOutcome(
+	decision: ClaimDecision,
+	eligibility: { canClaim: boolean },
+):
+	| { action: 'return_existing'; phase: ClaimPhase }
+	| { action: 'conflict' }
+	| { action: 'blocked' }
+	| { action: 'insert' } {
+	if (decision.action === 'return_existing') {
+		return { action: 'return_existing', phase: decision.phase };
+	}
+	if (decision.action === 'conflict') {
+		return { action: 'conflict' };
+	}
+	if (!eligibility.canClaim) {
+		return { action: 'blocked' };
+	}
+	return { action: 'insert' };
 }
 
 /**
@@ -66,33 +103,19 @@ export async function claimIntegrationAtomically(
 	return db.transaction(async (tx) => {
 		const claimDb = tx as unknown as DB;
 
-		// hashtext → int4 advisory key; xact locks auto-release on commit/rollback.
-		const [userLockKey, integrationLockKey] = claimLockKeys(
+		// Two-arg pg_advisory_xact_lock(class, id) — a key space separate from the
+		// single-arg form; xact locks auto-release on commit/rollback. User lock
+		// first (see claimLockKeys) so concurrent claims can't deadlock.
+		const [userLock, integrationLock] = claimLockKeys(
 			params.userId,
 			params.integrationId,
 		);
 		await tx.execute(
-			sql`SELECT pg_advisory_xact_lock(hashtext(${userLockKey}))`,
+			sql`SELECT pg_advisory_xact_lock(${userLock[0]}, hashtext(${userLock[1]}))`,
 		);
 		await tx.execute(
-			sql`SELECT pg_advisory_xact_lock(hashtext(${integrationLockKey}))`,
+			sql`SELECT pg_advisory_xact_lock(${integrationLock[0]}, hashtext(${integrationLock[1]}))`,
 		);
-
-		const eligibility = await getUserClaimEligibility(claimDb, params.userId);
-		if (!eligibility.canClaim) {
-			if (eligibility.blockReason === 'limit_reached') {
-				throw new TRPCError({
-					code: 'PRECONDITION_FAILED',
-					message: `You've built the maximum of ${MAX_USER_BUILT_INTEGRATIONS} integrations and can't claim another`,
-				});
-			}
-
-			throw new TRPCError({
-				code: 'PRECONDITION_FAILED',
-				message:
-					'Finish your current integration or mark it ready to review before claiming another',
-			});
-		}
 
 		const [integration] = await tx
 			.select({ id: integrations.id, slug: integrations.slug })
@@ -122,19 +145,32 @@ export async function claimIntegrationAtomically(
 			claimantUserId: params.userId,
 		});
 
-		if (decision.action === 'return_existing') {
+		const eligibility = await getUserClaimEligibility(claimDb, params.userId);
+		const outcome = resolveClaimOutcome(decision, eligibility);
+
+		if (outcome.action === 'return_existing') {
 			return {
 				kind: 'already_owned',
 				integrationId: params.integrationId,
 				slug: integration.slug,
-				phase: decision.phase,
+				phase: outcome.phase,
 			};
 		}
 
-		if (decision.action === 'conflict') {
+		if (outcome.action === 'conflict') {
 			throw new TRPCError({
 				code: 'CONFLICT',
 				message: 'This integration has already been claimed',
+			});
+		}
+
+		if (outcome.action === 'blocked') {
+			throw new TRPCError({
+				code: 'PRECONDITION_FAILED',
+				message:
+					eligibility.blockReason === 'limit_reached'
+						? `You've built the maximum of ${MAX_USER_BUILT_INTEGRATIONS} integrations and can't claim another`
+						: 'Finish your current integration or mark it ready to review before claiming another',
 			});
 		}
 

--- a/www/src/server/integrations/claim-integration.ts
+++ b/www/src/server/integrations/claim-integration.ts
@@ -1,0 +1,142 @@
+import { TRPCError } from '@trpc/server';
+import { and, eq, sql } from 'drizzle-orm';
+
+import type { DB } from '@/db';
+import type { LatestIntegrationStatus } from '@/db/integration-status';
+import {
+	getLatestStatusForIntegration,
+	getUserClaimEligibility,
+	ISSUE_DEADLINE_MS,
+	insertIntegrationStatus,
+	MAX_USER_BUILT_INTEGRATIONS,
+} from '@/db/integration-status';
+import type { IntegrationPhase } from '@/db/schema';
+import { integrations } from '@/db/schema';
+import type { ClaimPhase } from '@/server/integrations/claim-decision';
+import { resolveClaimDecision } from '@/server/integrations/claim-decision';
+
+export type {
+	ClaimDecision,
+	ClaimPhase,
+} from '@/server/integrations/claim-decision';
+export { resolveClaimDecision } from '@/server/integrations/claim-decision';
+
+export type AtomicClaimResult =
+	| {
+			kind: 'claimed';
+			integrationId: string;
+			slug: string;
+			phase: IntegrationPhase;
+			issueDeadlineAt: Date | null;
+			statusId: string;
+			userId: string;
+	  }
+	| {
+			kind: 'already_owned';
+			integrationId: string;
+			slug: string;
+			phase: IntegrationPhase;
+	  };
+
+/**
+ * Atomically claim an integration.
+ *
+ * Serializes concurrent claimants with a transaction-scoped advisory lock keyed
+ * by integration id, then re-checks eligibility + latest status before insert.
+ * Prevents the classic check-then-insert race that allowed two users to both
+ * land `awaiting_issue` rows for the same integration.
+ */
+export async function claimIntegrationAtomically(
+	db: DB,
+	params: {
+		integrationId: string;
+		userId: string;
+	},
+): Promise<AtomicClaimResult> {
+	return db.transaction(async (tx) => {
+		const claimDb = tx as unknown as DB;
+
+		// hashtext → int4 advisory key; xact lock auto-releases on commit/rollback.
+		await tx.execute(
+			sql`SELECT pg_advisory_xact_lock(hashtext(${params.integrationId}))`,
+		);
+
+		const eligibility = await getUserClaimEligibility(claimDb, params.userId);
+		if (!eligibility.canClaim) {
+			if (eligibility.blockReason === 'limit_reached') {
+				throw new TRPCError({
+					code: 'PRECONDITION_FAILED',
+					message: `You've built the maximum of ${MAX_USER_BUILT_INTEGRATIONS} integrations and can't claim another`,
+				});
+			}
+
+			throw new TRPCError({
+				code: 'PRECONDITION_FAILED',
+				message:
+					'Finish your current integration or mark it ready to review before claiming another',
+			});
+		}
+
+		const [integration] = await tx
+			.select({ id: integrations.id, slug: integrations.slug })
+			.from(integrations)
+			.where(
+				and(
+					eq(integrations.id, params.integrationId),
+					eq(integrations.show, true),
+				),
+			)
+			.for('update')
+			.limit(1);
+
+		if (!integration) {
+			throw new TRPCError({
+				code: 'NOT_FOUND',
+				message: 'Integration not found',
+			});
+		}
+
+		const latestStatus: LatestIntegrationStatus | null =
+			await getLatestStatusForIntegration(claimDb, params.integrationId);
+
+		const decision = resolveClaimDecision({
+			latestPhase: (latestStatus?.phase ?? null) as ClaimPhase | null,
+			latestUserId: latestStatus?.userId ?? null,
+			claimantUserId: params.userId,
+		});
+
+		if (decision.action === 'return_existing') {
+			return {
+				kind: 'already_owned',
+				integrationId: params.integrationId,
+				slug: integration.slug,
+				phase: decision.phase,
+			};
+		}
+
+		if (decision.action === 'conflict') {
+			throw new TRPCError({
+				code: 'CONFLICT',
+				message: 'This integration has already been claimed',
+			});
+		}
+
+		const issueDeadlineAt = new Date(Date.now() + ISSUE_DEADLINE_MS);
+		const status = await insertIntegrationStatus(claimDb, {
+			integrationId: params.integrationId,
+			userId: params.userId,
+			phase: 'awaiting_issue',
+			issueDeadlineAt,
+		});
+
+		return {
+			kind: 'claimed',
+			integrationId: params.integrationId,
+			slug: integration.slug,
+			phase: status.phase,
+			issueDeadlineAt: status.issueDeadlineAt,
+			statusId: status.id,
+			userId: params.userId,
+		};
+	});
+}


### PR DESCRIPTION
## Summary
- Replaces the check-then-insert OSS claim path with an atomic transaction that takes `pg_advisory_xact_lock(hashtext(integrationId))` and `FOR UPDATE` on the integration row
- Re-checks user claim eligibility inside the transaction so concurrent claimants cannot both pass the old pre-check
- Extracts a pure claim-decision helper with unit tests covering insert / idempotent re-claim / conflict cases

## Why
`integrations.claim` previously did `getLatestStatus` → if available → `insert`. Two concurrent requests could both observe an available integration and both insert `awaiting_issue`, leaving ambiguous ownership in the append-only status history.

## Test plan
- [x] `pnpm --filter @corsair/www test` (6/6 pass)
- [x] Decision matrix: null/released → insert; same user → return existing; other user → conflict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable integration claiming that prevents conflicting claims during simultaneous requests.
  * Existing owners can reclaim their integration without creating duplicate claim records.
  * Released integrations can be claimed again when available.

* **Bug Fixes**
  * Improved handling of active claim conflicts and ineligible claim attempts.
  * Ensured claim deadlines and status updates remain consistent.

* **Tests**
  * Added coverage for claim availability, ownership, conflicts, eligibility, and concurrent claim scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->