### PR TITLE
test(corsair): cover formatProviderDisplayName

### DIFF
--- a/packages/corsair/tests/format-provider-display-name.test.ts
+++ b/packages/corsair/tests/format-provider-display-name.test.ts
@@ -1,0 +1,15 @@
+import { formatProviderDisplayName } from '../core/constants';
+
+describe('formatProviderDisplayName', () => {
+	it('returns the mapped display name for a known provider (slack)', () => {
+		expect(formatProviderDisplayName('slack')).toBe('Slack');
+	});
+
+	it('returns the mapped display name for a known provider (github)', () => {
+		expect(formatProviderDisplayName('github')).toBe('GitHub');
+	});
+
+	it('capitalises the first letter as fallback for an unknown provider', () => {
+		expect(formatProviderDisplayName('acme')).toBe('Acme');
+	});
+});


### PR DESCRIPTION
Closes #516

## Summary
Adds focused unit tests for `formatProviderDisplayName` in `packages/corsair/core/constants.ts`:
- Known provider `slack` returns `Slack`
- Known provider `github` returns `GitHub`
- Unknown provider `acme` returns capitalized fallback `Acme`

## Verification
- Tests: `pnpm --filter corsair test -- format-provider-display-name.test.ts` — 3/3 passed
- Typecheck: `tsc --noEmit` — no errors
- Lint: `biome lint` — no errors
- Whitespace: `git diff --check` — clean
- No production code was changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for provider display-name formatting, including known providers and capitalization of unknown provider names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->