### PR TITLE
refactor(perplexityai,notion): error handling to use 'unknown' type in catch block

### DIFF
--- a/packages/notion/client.ts
+++ b/packages/notion/client.ts
@@ -1,5 +1,5 @@
 import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
-import { request } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
 
 export class NotionAPIError extends Error {
 	constructor(
@@ -51,10 +51,11 @@ export async function makeNotionRequest<T>(
 	try {
 		const response = await request<T>(config, requestOptions);
 		return response;
-	} catch (error: any) {
-		// Using any because error type from request() is unknown and varies
-		if (error?.body?.message) {
-			throw new NotionAPIError(error.body.message, error.body.code);
+	} catch (error: unknown) {
+		if (error instanceof ApiError) {
+			if (error?.body?.message) {
+				throw new NotionAPIError(error.body.message, error.body.code);
+			}
 		}
 		if (error instanceof Error) {
 			throw new NotionAPIError(error.message);

--- a/packages/perplexityai/client.ts
+++ b/packages/perplexityai/client.ts
@@ -1,5 +1,5 @@
 import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
-import { request } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
 
 export class PerplexityAiAPIError extends Error {
 	constructor(
@@ -52,9 +52,13 @@ export async function makePerplexityAiRequest<T>(
 
 	try {
 		return await request<T>(config, requestOptions);
-	} catch (error: any) {
-		const status = error?.status;
-		const retryAfter = error?.retryAfter;
+	} catch (error: unknown) {
+		const status = error instanceof ApiError ? error.status : undefined;
+		const retryAfter =
+			error instanceof ApiError && error.retryAfter !== undefined
+				? String(error.retryAfter)
+				: undefined;
+
 		if (error instanceof Error) {
 			throw new PerplexityAiAPIError(
 				error.message,


### PR DESCRIPTION
## Summary

Replace `catch (error: any)` with `catch (error: unknown)` + `instanceof` narrowing in the Perplexity and Notion API clients, as requested in #521.

## Changes

1. `packages/perplexityai/client.ts` — import `ApiError`; `status`/`retryAfter` now only read when `error instanceof ApiError`, falling back to `undefined` otherwise
2. `packages/notion/client.ts` — import `ApiError`; `error?.body?.message` check now nested inside `error instanceof ApiError`, falls through to existing `instanceof Error` branch unchanged otherwise


Fixes #521

## Test plan

- [x] `rg 'catch (error: any)'` returns no matches in either package
- [x] `pnpm --filter @corsair-dev/perplexityai typecheck` passes
- [x] `pnpm --filter @corsair-dev/notion typecheck` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for Notion and Perplexity AI integrations.
  * API errors now provide more accurate messages, status details, and retry guidance.
  * Prevented unrelated errors from being incorrectly interpreted as service-specific API failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->