### PR TITLE
refactor(perplexityai): narrow types by replacing any with unknown

### DIFF
--- a/packages/perplexityai/client.ts
+++ b/packages/perplexityai/client.ts
@@ -1,5 +1,5 @@
 import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
-import { request } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
 
 export class PerplexityAiAPIError extends Error {
 	constructor(
@@ -52,9 +52,13 @@ export async function makePerplexityAiRequest<T>(
 
 	try {
 		return await request<T>(config, requestOptions);
-	} catch (error: any) {
-		const status = error?.status;
-		const retryAfter = error?.retryAfter;
+	} catch (error: unknown) {
+		const status = error instanceof ApiError ? error.status : undefined;
+		const retryAfter =
+			error instanceof ApiError && error.retryAfter !== undefined
+				? String(error.retryAfter)
+				: undefined;
+
 		if (error instanceof Error) {
 			throw new PerplexityAiAPIError(
 				error.message,

--- a/packages/perplexityai/client.ts
+++ b/packages/perplexityai/client.ts
@@ -53,6 +53,7 @@ export async function makePerplexityAiRequest<T>(
 	try {
 		return await request<T>(config, requestOptions);
 	} catch (error: unknown) {
+		// replaced 'any' with 'unknown' preventing runtime failures.
 		const status = error instanceof ApiError ? error.status : undefined;
 		const retryAfter =
 			error instanceof ApiError && error.retryAfter !== undefined


### PR DESCRIPTION
## Description
Replace `catch (error: any)` with `catch (error: unknown)` + `instanceof` narrowing in the Perplexity API client, as requested in #521. Split from the original combined PR per the repo's single-plugin scope rule (R1) — see #521 and the companion PR for the Notion half.

## Changes
1. `packages/perplexityai/client.ts` — import `ApiError`; `status`/`retryAfter` now only read when `error instanceof ApiError`, falling back to `undefined` otherwise
No behavior change — same fields read, same fallbacks, same thrown error types.

Fixes #521

## Test plan
- [x] `rg 'catch (error: any)'` returns no matches in `packages/perplexityai`
- [x] `pnpm --filter @corsair-dev/perplexityai typecheck` passes

## Screenshots / Demos
<img width="1446" height="125" alt="Screenshot 2026-07-31 at 2 26 11 PM" src="https://github.com/user-attachments/assets/2d471543-5611-493f-a232-1e1b34779c5e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for Perplexity API requests.
  * Retry information is now handled safely and consistently.
  * Prevented unrelated error details from being exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->