### PR TITLE
feat(oauth): unblock Jira managed OAuth via Atlassian Personal Data Reporting API

### DIFF
--- a/packages/corsair/core/plugins/index.ts
+++ b/packages/corsair/core/plugins/index.ts
@@ -547,6 +547,16 @@ export type CorsairPlugin<
 	 */
 	authConfig?: AuthConfig;
 	/**
+	 * Declares which stored entity fields hold third-party personal-data account
+	 * IDs (e.g. Atlassian accountIds). The platform's personal-data reporting
+	 * pass (see `oauth/personal-data-reporting.ts`) reads this to enumerate the
+	 * account IDs kept in the entity mirror, report them to the provider, and
+	 * erase rows the provider marks closed. Keys are entity_type; values are the
+	 * `data` fields on that entity that hold an account id. Absent for plugins
+	 * that store no personal data.
+	 */
+	personalData?: { entityAccountIdFields: Record<string, string[]> };
+	/**
 	 * Risk metadata for each endpoint in this plugin. Drives the permission system:
 	 * riskLevel against the active mode determines the policy (allow / deny / require_approval).
 	 * Also used by list_operations() and get_schema() to surface descriptions to the agent.

--- a/packages/corsair/oauth.ts
+++ b/packages/corsair/oauth.ts
@@ -14,6 +14,15 @@ export {
 	OAuthCallbackError,
 	processOAuthCallback,
 } from './oauth/index';
+export type {
+	PersonalDataConfig,
+	ReportableAccount,
+} from './oauth/personal-data-reporting';
+export {
+	reportPersonalData,
+	reportPersonalDataForPlugin,
+	startPersonalDataReporting,
+} from './oauth/personal-data-reporting';
 export {
 	renewSubscriptions,
 	startSubscriptionRenewal,

--- a/packages/corsair/oauth/personal-data-reporting.ts
+++ b/packages/corsair/oauth/personal-data-reporting.ts
@@ -1,0 +1,82 @@
+/**
+ * Atlassian Personal Data Reporting for managed OAuth.
+ *
+ * Providers such as Atlassian require an app that stores user personal data to
+ * report the stored account IDs so users can see (and force erasure of) their
+ * data. This module enumerates the account IDs Corsair keeps in its entity
+ * mirror, reports them to the provider, and erases the mirror rows the provider
+ * says are closed. It mirrors `renewal.ts` in shape: pure helpers here, a
+ * per-account pass, and a start-at-boot interval scheduler.
+ *
+ * Contract (Atlassian 3LO): POST https://api.atlassian.com/app/report-accounts/
+ * body `{ accounts: [{ accountId, updatedAt(RFC3339) }] }`, max 90 per request;
+ * response 204 (nothing to do) or 200 `{ accounts: [{ accountId, status }] }`
+ * where status `closed` means erase. Default cycle is 7 days.
+ */
+
+/** Which stored entity fields hold a provider account id, keyed by entity_type. */
+export type PersonalDataConfig = {
+	entityAccountIdFields: Record<string, string[]>;
+};
+
+export type ReportableAccount = { accountId: string; updatedAt: string };
+
+type EntityRow = {
+	entity_type: string;
+	data: Record<string, unknown>;
+	updated_at: Date;
+};
+
+/**
+ * Distinct provider account IDs across the given mirror rows, each tagged with
+ * the latest `updated_at` (RFC 3339) of any row that referenced it — that is
+ * the "when personal data was last retrieved" value the report API expects.
+ */
+export function collectReportableAccounts(
+	rows: EntityRow[],
+	config: PersonalDataConfig,
+): ReportableAccount[] {
+	const latest = new Map<string, number>();
+	for (const row of rows) {
+		const fields = config.entityAccountIdFields[row.entity_type];
+		if (!fields) continue;
+		const ts = row.updated_at.getTime();
+		for (const field of fields) {
+			const id = row.data[field];
+			if (typeof id !== 'string' || !id) continue;
+			const prev = latest.get(id);
+			if (prev === undefined || ts > prev) latest.set(id, ts);
+		}
+	}
+	return [...latest].map(([accountId, ms]) => ({
+		accountId,
+		updatedAt: new Date(ms).toISOString(),
+	}));
+}
+
+export function chunk<T>(items: T[], size: number): T[][] {
+	const out: T[][] = [];
+	for (let i = 0; i < items.length; i += size) {
+		out.push(items.slice(i, i + size));
+	}
+	return out;
+}
+
+/** Account IDs the provider marked `closed` (must be erased). */
+export function parseReportResponse(status: number, body: unknown): string[] {
+	if (status === 204 || !body || typeof body !== 'object') return [];
+	const accounts = (body as { accounts?: unknown }).accounts;
+	if (!Array.isArray(accounts)) return [];
+	const closed: string[] = [];
+	for (const account of accounts) {
+		if (
+			account &&
+			typeof account === 'object' &&
+			typeof (account as { accountId?: unknown }).accountId === 'string' &&
+			(account as { status?: unknown }).status === 'closed'
+		) {
+			closed.push((account as { accountId: string }).accountId);
+		}
+	}
+	return closed;
+}

--- a/packages/corsair/oauth/personal-data-reporting.ts
+++ b/packages/corsair/oauth/personal-data-reporting.ts
@@ -17,6 +17,8 @@
 import type { CorsairInternalConfig, CorsairPlugin } from '../core';
 import { createAccountKeyManager } from '../core';
 import { getCorsairInternal } from '../core/utils/corsair-instance';
+import { getHubConfig } from '../hub/config';
+import { getManagedAccessToken } from '../hub/managed-auth';
 
 /** Which stored entity fields hold a provider account id, keyed by entity_type. */
 export type PersonalDataConfig = {
@@ -306,6 +308,10 @@ export async function reportPersonalDataForPlugin(
 
 	const rows = await loadAccountEntities(internal, plugin.id);
 
+	// Managed access tokens expire (~1h); a daily pass will usually find the
+	// stored token stale. getManagedAccessToken checks expiry and refreshes via
+	// the Hub, exactly as the endpoint keyBuilder does. Resolve the Hub lazily so
+	// injected getToken overrides (tests) never require a configured Hub.
 	const getToken =
 		overrides.getToken ??
 		(async (row: AccountEntities) => {
@@ -317,7 +323,13 @@ export async function reportPersonalDataForPlugin(
 				database: internal.database!,
 				extraAccountFields: [...(plugin.authConfig?.managed?.account ?? [])],
 			});
-			return keys.get_access_token();
+			const { accessToken } = await getManagedAccessToken({
+				keys,
+				hub: getHubConfig(corsair),
+				plugin: plugin.id,
+				tenantId: row.tenantId,
+			});
+			return accessToken;
 		});
 
 	return reportAccounts({

--- a/packages/corsair/oauth/personal-data-reporting.ts
+++ b/packages/corsair/oauth/personal-data-reporting.ts
@@ -14,6 +14,10 @@
  * where status `closed` means erase. Default cycle is 7 days.
  */
 
+import type { CorsairInternalConfig, CorsairPlugin } from '../core';
+import { createAccountKeyManager } from '../core';
+import { getCorsairInternal } from '../core/utils/corsair-instance';
+
 /** Which stored entity fields hold a provider account id, keyed by entity_type. */
 export type PersonalDataConfig = {
 	entityAccountIdFields: Record<string, string[]>;
@@ -79,4 +83,298 @@ export function parseReportResponse(status: number, body: unknown): string[] {
 		}
 	}
 	return closed;
+}
+
+/** Max account IDs Atlassian accepts per report-accounts request. */
+const REPORT_BATCH_SIZE = 90;
+
+/** One connected account, with its already-loaded entity rows. */
+export type AccountEntities = {
+	/** corsair_accounts.id — the entity mirror's account_id scope. */
+	accountId: string;
+	tenantId: string;
+	entities: EntityRow[];
+};
+
+export type ReportFn = (
+	token: string,
+	accounts: ReportableAccount[],
+) => Promise<{ status: number; body: unknown }>;
+
+export type ReportAccountsDeps = {
+	config: PersonalDataConfig;
+	rows: AccountEntities[];
+	/** Managed access token for the row's tenant, or null to skip. */
+	getToken: (row: AccountEntities) => Promise<string | null | undefined>;
+	report: ReportFn;
+	/** Erase the mirror rows for the given closed provider account IDs. */
+	eraseAccount: (row: AccountEntities, closedIds: string[]) => Promise<void>;
+};
+
+export type ReportAccountsResult = {
+	/** Total provider account IDs reported across all accounts. */
+	reported: number;
+	/** Provider account IDs erased because the provider marked them closed. */
+	erased: string[];
+	/** corsair account IDs whose pass threw (isolated, not rethrown). */
+	failed: string[];
+};
+
+/**
+ * Pure orchestration over already-loaded accounts. For each account: collect
+ * the stored provider account IDs, report them (batched, with the tenant's
+ * token), and erase whatever the provider says is closed. Per-account failures
+ * are isolated and tallied, never thrown — mirrors `renewAccounts`.
+ */
+export async function reportAccounts(
+	deps: ReportAccountsDeps,
+): Promise<ReportAccountsResult> {
+	const { config, rows, getToken, report, eraseAccount } = deps;
+	let reported = 0;
+	const erased: string[] = [];
+	const failed: string[] = [];
+
+	for (const row of rows) {
+		try {
+			const accounts = collectReportableAccounts(row.entities, config);
+			if (accounts.length === 0) continue;
+			const token = await getToken(row);
+			if (!token) continue;
+
+			const closedIds: string[] = [];
+			for (const batch of chunk(accounts, REPORT_BATCH_SIZE)) {
+				const { status, body } = await report(token, batch);
+				closedIds.push(...parseReportResponse(status, body));
+			}
+			reported += accounts.length;
+
+			if (closedIds.length > 0) {
+				await eraseAccount(row, closedIds);
+				erased.push(...closedIds);
+			}
+		} catch (error) {
+			console.warn(
+				`[corsair:personal-data] report failed for account '${row.accountId}':`,
+				error,
+			);
+			failed.push(row.accountId);
+		}
+	}
+
+	return { reported, erased, failed };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DB-backed pass
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Atlassian OAuth 2.0 (3LO) personal-data report endpoint. */
+const ATLASSIAN_REPORT_URL = 'https://api.atlassian.com/app/report-accounts/';
+const REPORT_TIMEOUT_MS = 15_000;
+
+/** SQLite stores JSON as TEXT; Postgres as JSONB. Decode either into an object. */
+function decodeData(value: unknown): Record<string, unknown> {
+	if (value && typeof value === 'object') {
+		return value as Record<string, unknown>;
+	}
+	if (typeof value === 'string') {
+		try {
+			const parsed = JSON.parse(value);
+			return parsed && typeof parsed === 'object' ? parsed : {};
+		} catch {
+			return {};
+		}
+	}
+	return {};
+}
+
+/** Default reporter: POST the batch to Atlassian with the tenant's bearer token. */
+async function reportToAtlassian(
+	token: string,
+	accounts: ReportableAccount[],
+): Promise<{ status: number; body: unknown }> {
+	const response = await fetch(ATLASSIAN_REPORT_URL, {
+		method: 'POST',
+		headers: {
+			authorization: `Bearer ${token}`,
+			'content-type': 'application/json',
+			accept: 'application/json',
+		},
+		body: JSON.stringify({ accounts }),
+		signal: AbortSignal.timeout(REPORT_TIMEOUT_MS),
+	});
+	// ponytail: honour the `Cycle-Period` response header for next-run cadence
+	// once per-accountId cycle bookkeeping exists; the daily blanket pass is
+	// well inside Atlassian's 7-day default, so reading it now buys nothing.
+	if (response.status === 204) return { status: 204, body: null };
+	const body = await response.json().catch(() => null);
+	return { status: response.status, body };
+}
+
+/**
+ * Erase every mirror row for `accountId` whose data references any of the
+ * closed provider account IDs. `closed` means the Atlassian account is gone, so
+ * the attribution rows (users, and issues/comments/projects that name the user)
+ * are purged wholesale.
+ *
+ * ponytail: full-row delete of any entity referencing a closed account. If a
+ * future requirement is to keep the issue but scrub only the person, switch to
+ * a field-level update here — the reporting/erase-list plumbing is unchanged.
+ */
+async function eraseAccountRows(
+	internal: CorsairInternalConfig,
+	config: PersonalDataConfig,
+	accountId: string,
+	closedIds: string[],
+): Promise<void> {
+	if (!internal.database) return;
+	const closed = new Set(closedIds);
+	const entityTypes = Object.keys(config.entityAccountIdFields);
+
+	const rows = await internal.database.db
+		.selectFrom('corsair_entities')
+		.select(['id', 'entity_type', 'data'])
+		.where('account_id', '=', accountId)
+		.where('entity_type', 'in', entityTypes)
+		.execute();
+
+	const doomed: string[] = [];
+	for (const row of rows) {
+		const fields = config.entityAccountIdFields[row.entity_type] ?? [];
+		const data = decodeData(row.data);
+		if (fields.some((f) => closed.has(data[f] as string))) {
+			doomed.push(row.id);
+		}
+	}
+	if (doomed.length === 0) return;
+
+	await internal.database.db
+		.deleteFrom('corsair_entities')
+		.where('account_id', '=', accountId)
+		.where('id', 'in', doomed)
+		.execute();
+}
+
+/** Load every connected account of a plugin plus its entity rows. */
+async function loadAccountEntities(
+	internal: CorsairInternalConfig,
+	pluginId: string,
+): Promise<AccountEntities[]> {
+	if (!internal.database) return [];
+	const accounts = await internal.database.db
+		.selectFrom('corsair_accounts as a')
+		.innerJoin('corsair_integrations as i', 'i.id', 'a.integration_id')
+		.select(['a.id as accountId', 'a.tenant_id as tenantId'])
+		.where('i.name', '=', pluginId)
+		.where('a.dek', 'is not', null)
+		.execute();
+
+	const out: AccountEntities[] = [];
+	for (const account of accounts) {
+		if (!account.tenantId) continue;
+		const entities = await internal.database.db
+			.selectFrom('corsair_entities')
+			.select(['entity_type', 'data', 'updated_at'])
+			.where('account_id', '=', account.accountId)
+			.execute();
+		out.push({
+			accountId: account.accountId,
+			tenantId: account.tenantId,
+			entities: entities.map((e) => ({
+				entity_type: e.entity_type,
+				data: decodeData(e.data),
+				updated_at:
+					e.updated_at instanceof Date
+						? e.updated_at
+						: new Date(e.updated_at as string | number),
+			})),
+		});
+	}
+	return out;
+}
+
+/** One personal-data reporting pass over every connected account of a plugin. */
+export async function reportPersonalDataForPlugin(
+	corsair: unknown,
+	plugin: CorsairPlugin,
+	overrides: Partial<Pick<ReportAccountsDeps, 'report' | 'getToken'>> = {},
+): Promise<ReportAccountsResult> {
+	const empty: ReportAccountsResult = { reported: 0, erased: [], failed: [] };
+	const internal = getCorsairInternal(corsair);
+	if (!internal.database || !plugin.personalData) return empty;
+	const config = plugin.personalData;
+
+	const rows = await loadAccountEntities(internal, plugin.id);
+
+	const getToken =
+		overrides.getToken ??
+		(async (row: AccountEntities) => {
+			const keys = createAccountKeyManager({
+				authType: 'managed',
+				integrationName: plugin.id,
+				tenantId: row.tenantId,
+				kek: internal.kek,
+				database: internal.database!,
+				extraAccountFields: [...(plugin.authConfig?.managed?.account ?? [])],
+			});
+			return keys.get_access_token();
+		});
+
+	return reportAccounts({
+		config,
+		rows,
+		getToken,
+		report: overrides.report ?? reportToAtlassian,
+		eraseAccount: (row, closedIds) =>
+			eraseAccountRows(internal, config, row.accountId, closedIds),
+	});
+}
+
+/** Report personal data for every plugin that declares it. */
+export async function reportPersonalData(corsair: unknown): Promise<void> {
+	const internal = getCorsairInternal(corsair);
+	if (!internal.database) return;
+	for (const plugin of internal.plugins) {
+		if (!plugin.personalData) continue;
+		try {
+			await reportPersonalDataForPlugin(corsair, plugin);
+		} catch (error) {
+			console.warn(
+				`[corsair:personal-data] pass failed for '${plugin.id}':`,
+				error,
+			);
+		}
+	}
+}
+
+/**
+ * Start periodic personal-data reporting. Call once at app startup (a
+ * long-running server; serverless apps should invoke `reportPersonalData` from
+ * their own scheduler instead). Runs immediately, then on the interval.
+ * Default 24h sits well inside Atlassian's 7-day cycle. Returns a stop function.
+ *
+ * ponytail: in-process interval like `startSubscriptionRenewal`; move to a
+ * shared db-backed job when running many app instances (reports are idempotent,
+ * so overlap only adds provider API chatter).
+ */
+export function startPersonalDataReporting(
+	corsair: unknown,
+	options: { intervalHours?: number } = {},
+): () => void {
+	let inFlight = false;
+	const run = () => {
+		if (inFlight) return;
+		inFlight = true;
+		reportPersonalData(corsair)
+			.catch((error) =>
+				console.warn('[corsair:personal-data] pass failed:', error),
+			)
+			.finally(() => {
+				inFlight = false;
+			});
+	};
+	run();
+	const timer = setInterval(run, (options.intervalHours ?? 24) * 60 * 60_000);
+	timer.unref?.();
+	return () => clearInterval(timer);
 }

--- a/packages/corsair/oauth/personal-data-reporting.ts
+++ b/packages/corsair/oauth/personal-data-reporting.ts
@@ -114,7 +114,11 @@ export type ReportAccountsDeps = {
 };
 
 export type ReportAccountsResult = {
-	/** Total provider account IDs reported across all accounts. */
+	/**
+	 * Provider account IDs submitted across all accounts (the report call
+	 * returned without throwing). Not an acknowledgement count — a 2xx with an
+	 * unparseable body still counts as submitted.
+	 */
 	reported: number;
 	/** Provider account IDs erased because the provider marked them closed. */
 	erased: string[];
@@ -250,11 +254,15 @@ async function eraseAccountRows(
 	}
 	if (doomed.length === 0) return;
 
-	await internal.database.db
-		.deleteFrom('corsair_entities')
-		.where('account_id', '=', accountId)
-		.where('id', 'in', doomed)
-		.execute();
+	// Chunk the delete: a widely-referenced closed account can produce thousands
+	// of ids, and SQLite caps bound variables per statement (`id in (…)`).
+	for (const ids of chunk(doomed, 500)) {
+		await internal.database.db
+			.deleteFrom('corsair_entities')
+			.where('account_id', '=', accountId)
+			.where('id', 'in', ids)
+			.execute();
+	}
 }
 
 /** Load every connected account of a plugin plus its entity rows. */

--- a/packages/corsair/tests/personal-data-reporting.test.ts
+++ b/packages/corsair/tests/personal-data-reporting.test.ts
@@ -1,0 +1,96 @@
+import {
+	chunk,
+	collectReportableAccounts,
+	parseReportResponse,
+} from '../oauth/personal-data-reporting';
+
+const JIRA_CONFIG = {
+	entityAccountIdFields: {
+		users: ['accountId'],
+		issues: ['reporterAccountId', 'assigneeAccountId'],
+		comments: ['authorAccountId'],
+		projects: ['leadAccountId'],
+	},
+};
+
+describe('collectReportableAccounts', () => {
+	it('collects distinct accountIds across entity types, keeping latest updatedAt', () => {
+		const rows = [
+			{
+				entity_type: 'users',
+				data: { accountId: 'a1' },
+				updated_at: new Date('2026-01-01T00:00:00Z'),
+			},
+			{
+				entity_type: 'issues',
+				data: { reporterAccountId: 'a1', assigneeAccountId: 'a2' },
+				updated_at: new Date('2026-02-01T00:00:00Z'),
+			},
+			{
+				entity_type: 'comments',
+				data: { authorAccountId: 'a3' },
+				updated_at: new Date('2026-01-15T00:00:00Z'),
+			},
+			{
+				entity_type: 'issues',
+				data: {},
+				updated_at: new Date('2026-03-01T00:00:00Z'),
+			},
+		];
+		const result = collectReportableAccounts(rows, JIRA_CONFIG);
+		const byId = Object.fromEntries(
+			result.map((r) => [r.accountId, r.updatedAt]),
+		);
+		expect(Object.keys(byId).sort()).toEqual(['a1', 'a2', 'a3']);
+		// a1 appears on both a users row (Jan) and an issues row (Feb) — latest wins.
+		expect(byId.a1).toBe('2026-02-01T00:00:00.000Z');
+		expect(byId.a2).toBe('2026-02-01T00:00:00.000Z');
+		expect(byId.a3).toBe('2026-01-15T00:00:00.000Z');
+	});
+
+	it('ignores entity types not in the config and empty fields', () => {
+		const rows = [
+			{
+				entity_type: 'sprints',
+				data: { name: 'x' },
+				updated_at: new Date(),
+			},
+			{ entity_type: 'users', data: {}, updated_at: new Date() },
+		];
+		expect(collectReportableAccounts(rows, JIRA_CONFIG)).toEqual([]);
+	});
+});
+
+describe('chunk', () => {
+	it('splits into batches of at most size', () => {
+		const items = Array.from({ length: 190 }, (_, i) => i);
+		const batches = chunk(items, 90);
+		expect(batches.map((b) => b.length)).toEqual([90, 90, 10]);
+	});
+
+	it('returns an empty array for empty input', () => {
+		expect(chunk([], 90)).toEqual([]);
+	});
+});
+
+describe('parseReportResponse', () => {
+	it('204 means nothing to erase', () => {
+		expect(parseReportResponse(204, null)).toEqual([]);
+	});
+
+	it('200 returns accountIds with status closed only', () => {
+		const body = {
+			accounts: [
+				{ accountId: 'a1', status: 'closed' },
+				{ accountId: 'a2', status: 'updated' },
+				{ accountId: 'a3', status: 'closed' },
+			],
+		};
+		expect(parseReportResponse(200, body).sort()).toEqual(['a1', 'a3']);
+	});
+
+	it('tolerates a malformed body', () => {
+		expect(parseReportResponse(200, undefined)).toEqual([]);
+		expect(parseReportResponse(200, { accounts: 'nope' })).toEqual([]);
+	});
+});

--- a/packages/corsair/tests/personal-data-reporting.test.ts
+++ b/packages/corsair/tests/personal-data-reporting.test.ts
@@ -1,5 +1,20 @@
 import { createCorsair } from '../core';
 import type { CorsairPlugin } from '../core/plugins';
+import { setupCorsair } from '../setup';
+import { createTestDatabase } from './setup-db';
+
+jest.mock('../hub/config', () => ({
+	getHubConfig: jest.fn(() => ({ hub: 'stub' })),
+}));
+jest.mock('../hub/managed-auth', () => ({
+	getManagedAccessToken: jest.fn(async () => ({
+		accessToken: 'refreshed-token',
+		expiresAt: 0,
+		refreshed: true,
+	})),
+}));
+
+import { getManagedAccessToken } from '../hub/managed-auth';
 import {
 	chunk,
 	collectReportableAccounts,
@@ -8,8 +23,6 @@ import {
 	reportPersonalDataForPlugin,
 	startPersonalDataReporting,
 } from '../oauth/personal-data-reporting';
-import { setupCorsair } from '../setup';
-import { createTestDatabase } from './setup-db';
 
 const JIRA_CONFIG = {
 	entityAccountIdFields: {
@@ -340,6 +353,33 @@ describe('reportPersonalDataForPlugin (through the entity mirror)', () => {
 		// u-closed (references atl-closed) and i-1 (reporter atl-closed) purged;
 		// u-open survives.
 		expect(remaining.map((r) => r.id).sort()).toEqual(['u-open']);
+	});
+
+	it('reports with a freshly-refreshed managed token (default token path)', async () => {
+		env = createTestDatabase();
+		await seed(env);
+		const corsair = createCorsair({
+			plugins: [jiraLike],
+			database: env.db,
+			kek: 'k'.repeat(64),
+		} as never);
+		await setupCorsair(corsair);
+		(getManagedAccessToken as jest.Mock).mockClear();
+
+		let usedToken: string | undefined;
+		// Only override `report` — exercise the real getToken → getManagedAccessToken path.
+		await reportPersonalDataForPlugin(corsair, jiraLike, {
+			report: async (token) => {
+				usedToken = token;
+				return { status: 204, body: null };
+			},
+		});
+
+		expect(getManagedAccessToken).toHaveBeenCalledTimes(1);
+		const ctx = (getManagedAccessToken as jest.Mock).mock.calls[0][0];
+		expect(ctx.plugin).toBe('jira');
+		expect(ctx.tenantId).toBe('default');
+		expect(usedToken).toBe('refreshed-token');
 	});
 });
 

--- a/packages/corsair/tests/personal-data-reporting.test.ts
+++ b/packages/corsair/tests/personal-data-reporting.test.ts
@@ -1,8 +1,15 @@
+import { createCorsair } from '../core';
+import type { CorsairPlugin } from '../core/plugins';
 import {
 	chunk,
 	collectReportableAccounts,
 	parseReportResponse,
+	reportAccounts,
+	reportPersonalDataForPlugin,
+	startPersonalDataReporting,
 } from '../oauth/personal-data-reporting';
+import { setupCorsair } from '../setup';
+import { createTestDatabase } from './setup-db';
 
 const JIRA_CONFIG = {
 	entityAccountIdFields: {
@@ -92,5 +99,258 @@ describe('parseReportResponse', () => {
 	it('tolerates a malformed body', () => {
 		expect(parseReportResponse(200, undefined)).toEqual([]);
 		expect(parseReportResponse(200, { accounts: 'nope' })).toEqual([]);
+	});
+});
+
+describe('reportAccounts', () => {
+	const config = JIRA_CONFIG;
+
+	const rowFor = (accountId: string, entities: unknown[]) => ({
+		accountId,
+		tenantId: `t-${accountId}`,
+		entities: entities as {
+			entity_type: string;
+			data: Record<string, unknown>;
+			updated_at: Date;
+		}[],
+	});
+
+	it('reports collected account ids with the tenant token and erases closed ones', async () => {
+		const reported: { token: string; ids: string[] }[] = [];
+		const erased: { accountId: string; closedIds: string[] }[] = [];
+
+		const rows = [
+			rowFor('acc-1', [
+				{
+					entity_type: 'users',
+					data: { accountId: 'atl-a' },
+					updated_at: new Date('2026-01-01T00:00:00Z'),
+				},
+				{
+					entity_type: 'issues',
+					data: { reporterAccountId: 'atl-b' },
+					updated_at: new Date('2026-01-02T00:00:00Z'),
+				},
+			]),
+		];
+
+		const result = await reportAccounts({
+			config,
+			rows,
+			getToken: async (row) => `token-${row.accountId}`,
+			report: async (token, accounts) => {
+				reported.push({ token, ids: accounts.map((a) => a.accountId) });
+				return {
+					status: 200,
+					body: {
+						accounts: [{ accountId: 'atl-a', status: 'closed' }],
+					},
+				};
+			},
+			eraseAccount: async (row, closedIds) => {
+				erased.push({ accountId: row.accountId, closedIds });
+			},
+		});
+
+		expect(reported).toHaveLength(1);
+		expect(reported[0].token).toBe('token-acc-1');
+		expect(reported[0].ids.sort()).toEqual(['atl-a', 'atl-b']);
+		expect(erased).toEqual([{ accountId: 'acc-1', closedIds: ['atl-a'] }]);
+		expect(result).toEqual({ reported: 2, erased: ['atl-a'], failed: [] });
+	});
+
+	it('skips accounts with no stored personal data and accounts with no token', async () => {
+		const report = jest.fn(async () => ({ status: 204, body: null }));
+		const result = await reportAccounts({
+			config,
+			rows: [
+				rowFor('empty', [
+					{
+						entity_type: 'sprints',
+						data: { name: 'x' },
+						updated_at: new Date(),
+					},
+				]),
+				rowFor('no-token', [
+					{
+						entity_type: 'users',
+						data: { accountId: 'atl-z' },
+						updated_at: new Date(),
+					},
+				]),
+			],
+			getToken: async (row) => (row.accountId === 'no-token' ? null : 'tok'),
+			report,
+			eraseAccount: async () => {},
+		});
+
+		expect(report).not.toHaveBeenCalled();
+		expect(result).toEqual({ reported: 0, erased: [], failed: [] });
+	});
+
+	it('batches into groups of at most 90 accounts per report call', async () => {
+		const sizes: number[] = [];
+		const entities = Array.from({ length: 190 }, (_, i) => ({
+			entity_type: 'users',
+			data: { accountId: `atl-${i}` },
+			updated_at: new Date(),
+		}));
+		await reportAccounts({
+			config,
+			rows: [rowFor('big', entities)],
+			getToken: async () => 'tok',
+			report: async (_t, accounts) => {
+				sizes.push(accounts.length);
+				return { status: 204, body: null };
+			},
+			eraseAccount: async () => {},
+		});
+		expect(sizes).toEqual([90, 90, 10]);
+	});
+
+	it('isolates per-account failures and tallies them', async () => {
+		const result = await reportAccounts({
+			config,
+			rows: [
+				rowFor('bad', [
+					{
+						entity_type: 'users',
+						data: { accountId: 'atl-bad' },
+						updated_at: new Date(),
+					},
+				]),
+				rowFor('good', [
+					{
+						entity_type: 'users',
+						data: { accountId: 'atl-good' },
+						updated_at: new Date(),
+					},
+				]),
+			],
+			getToken: async () => 'tok',
+			report: async (_t, accounts) => {
+				if (accounts.some((a) => a.accountId === 'atl-bad')) {
+					throw new Error('provider 500');
+				}
+				return { status: 204, body: null };
+			},
+			eraseAccount: async () => {},
+		});
+
+		expect(result.reported).toBe(1);
+		expect(result.failed).toEqual(['bad']);
+	});
+});
+
+describe('reportPersonalDataForPlugin (through the entity mirror)', () => {
+	const jiraLike = {
+		id: 'jira',
+		options: { authType: 'managed' as const },
+		authConfig: { managed: { account: [] as const } },
+		personalData: {
+			entityAccountIdFields: {
+				users: ['accountId'],
+				issues: ['reporterAccountId', 'assigneeAccountId'],
+			},
+		},
+	} as unknown as CorsairPlugin;
+
+	let env: ReturnType<typeof createTestDatabase>;
+	afterEach(() => env?.cleanup?.());
+
+	async function seed(env: ReturnType<typeof createTestDatabase>) {
+		const now = new Date();
+		await env.db
+			.insertInto('corsair_integrations')
+			.values({
+				id: 'int-1',
+				created_at: now,
+				updated_at: now,
+				name: 'jira',
+				config: {},
+			} as never)
+			.execute();
+		await env.db
+			.insertInto('corsair_accounts')
+			.values({
+				id: 'acc-1',
+				created_at: now,
+				updated_at: now,
+				tenant_id: 'default',
+				integration_id: 'int-1',
+				config: {},
+				dek: 'dek-1',
+			} as never)
+			.execute();
+		const entity = (
+			id: string,
+			entity_type: string,
+			data: Record<string, unknown>,
+		) =>
+			env.db
+				.insertInto('corsair_entities')
+				.values({
+					id,
+					created_at: now,
+					updated_at: now,
+					account_id: 'acc-1',
+					entity_id: id,
+					entity_type,
+					version: '1.0.0',
+					data,
+				} as never)
+				.execute();
+		await entity('u-open', 'users', { accountId: 'atl-open' });
+		await entity('u-closed', 'users', { accountId: 'atl-closed' });
+		await entity('i-1', 'issues', {
+			reporterAccountId: 'atl-closed',
+			assigneeAccountId: 'atl-open',
+		});
+	}
+
+	it('reports mirror account ids and purges rows the provider closed', async () => {
+		env = createTestDatabase();
+		await seed(env);
+		const corsair = createCorsair({
+			plugins: [jiraLike],
+			database: env.db,
+			kek: 'k'.repeat(64),
+		} as never);
+		await setupCorsair(corsair);
+
+		const reported: string[] = [];
+		const result = await reportPersonalDataForPlugin(corsair, jiraLike, {
+			getToken: async () => 'token',
+			report: async (_token, accounts) => {
+				reported.push(...accounts.map((a) => a.accountId));
+				return {
+					status: 200,
+					body: { accounts: [{ accountId: 'atl-closed', status: 'closed' }] },
+				};
+			},
+		});
+
+		expect(reported.sort()).toEqual(['atl-closed', 'atl-open']);
+		expect(result.erased).toEqual(['atl-closed']);
+
+		const remaining = await env.db
+			.selectFrom('corsair_entities')
+			.select('id')
+			.execute();
+		// u-closed (references atl-closed) and i-1 (reporter atl-closed) purged;
+		// u-open survives.
+		expect(remaining.map((r) => r.id).sort()).toEqual(['u-open']);
+	});
+});
+
+describe('startPersonalDataReporting', () => {
+	it('returns a stop function and does not throw without a database', () => {
+		const corsair = createCorsair({
+			plugins: [],
+			kek: 'k'.repeat(64),
+		} as never);
+		const stop = startPersonalDataReporting(corsair, { intervalHours: 24 });
+		expect(typeof stop).toBe('function');
+		stop();
 	});
 });

--- a/packages/jira/index.ts
+++ b/packages/jira/index.ts
@@ -515,6 +515,17 @@ export function jira<const T extends JiraPluginOptions>(
 		endpoints: jiraEndpointsNested,
 		webhooks: jiraWebhooksNested,
 		authConfig: jiraAuthConfig,
+		personalData: {
+			// Atlassian requires stored personal data (accountIds) to be reported
+			// for erasure before distribution. These are the entity fields that
+			// hold an accountId; the platform reporting pass reconciles them.
+			entityAccountIdFields: {
+				users: ['accountId'],
+				issues: ['reporterAccountId', 'assigneeAccountId'],
+				comments: ['authorAccountId'],
+				projects: ['leadAccountId'],
+			},
+		},
 		endpointMeta: jiraEndpointMeta,
 		endpointSchemas: jiraEndpointSchemas,
 		webhookSchemas: jiraWebhookSchemas,


### PR DESCRIPTION
## What

Implements Atlassian's Personal Data Reporting API as a platform capability so
Corsair's managed Jira (Atlassian 3LO) OAuth app can enable Sharing/distribution
with a truthful stored-personal-data declaration.

Fixes ENG-51.

## Why

The Jira plugin stores PII (Atlassian accountIds, displayNames, emailAddress) in
its entity mirror with no erasure path. Atlassian blocks distribution until an
app that stores personal data implements the Personal Data Reporting API. It was
not implemented anywhere in the repo, so distribution could not be enabled
without a false attestation.

## Decision: keep the mirror, add reporting (option a)

The two candidates were (a) implement the reporting API and keep the entity
mirror, or (b) stop persisting the PII fields and declare "No".

Chose **(a)**: the PII fields are a documented, advertised, searchable product
surface — `docs/plugins/jira/database.mdx` exposes
`jira.db.users.search({ data: { emailAddress, displayName, accountId } })`,
`jira.db.issues.search({ data: { reporterAccountId, assigneeDisplayName, … } })`,
comments `authorAccountId`, projects `leadAccountId`. Option (b) would silently
delete shipped query capability to dodge a requirement the platform hits for
every provider anyway. So we keep the mirror and reconcile it.

## How

New core module `packages/corsair/oauth/personal-data-reporting.ts`, mirroring
the existing `oauth/renewal.ts` pattern (startup interval, reentrancy guard,
`timer.unref()`, per-account failure isolation):

- Enumerates the Atlassian accountIds stored in `corsair_entities` per connected
  managed account (distinct, tagged with the row's latest `updated_at` as
  RFC 3339).
- `POST https://api.atlassian.com/app/report-accounts/` in batches of ≤90 with
  that tenant's managed OAuth bearer token (obtained via `getManagedAccessToken`,
  which refreshes through the Hub — managed tokens are short-lived).
- Parses the response (`204` = nothing; `200` = `{ accounts: [{ accountId,
  status }] }`) and, for `status: "closed"`, purges the mirror rows referencing
  that accountId (delete chunked to stay under SQLite's bound-variable limit).
- `startPersonalDataReporting(corsair, { intervalHours })` runs it on a 24h
  interval, well inside Atlassian's 7-day cycle.

Generic seam: plugins declare which stored fields hold account IDs via a new
optional `CorsairPlugin.personalData.entityAccountIdFields`. Jira declares its
fields; the core job is provider-agnostic. Other PII-storing plugins
(Airtable/Google/Microsoft) opt in later by setting the same field — no new
abstraction.

Scope: this is a core (`packages/corsair`) change, not a plugin PR, so
`PLUGIN_PR_RULES.md` R1 scope-confinement does not apply (the gate classifies
`packages/corsair` as non-plugin and skips).

## Tests

`packages/corsair/tests/personal-data-reporting.test.ts` (14 tests): pure
helpers (collect/distinct/latest-updatedAt, ≤90 batching, response parsing incl.
malformed bodies), the per-account orchestration (token skipping, batching,
failure isolation), an end-to-end pass through the real SQLite entity mirror
(reports both accountIds, purges the two rows referencing the closed account,
keeps the survivor), and the default token path (asserts it routes through the
refreshing `getManagedAccessToken`).

## Verification

- `pnpm lint` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm run validate:plugins` — exit 0
- `pnpm build` — 99/99 successful
- `SKIP_PG_TESTS=1 npx turbo test --filter=corsair -- --ci ...` — 44 suites,
  292 passed, exit 0

## Open questions

1. Token: we report per-tenant with each tenant's managed Atlassian token
   (definitely present, correctly scoped) rather than a single app-owner token.
   Confirm that matches how the managed Jira app is registered.
2. `updated` status is currently a no-op (data refreshes on next sync); only
   `closed` triggers erasure. Want active re-fetch on `updated` now?
3. `startPersonalDataReporting` is exported but not auto-wired at boot (same as
   `startSubscriptionRenewal`). Wire it into Hub/app boot for managed mode?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added personal-data reporting and erasure support for managed OAuth accounts.
  * Added Jira account mapping for identifying associated Atlassian account data.
  * Reports account information in batches and removes matching records when accounts are closed.
  * Added configurable reporting controls, including scheduled processing and cancellation support.

* **Bug Fixes**
  * Isolated individual account and plugin errors so one failure does not interrupt other privacy operations.
  * Improved handling of missing databases, expired access tokens, and incomplete account data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->