### PR TITLE
chore(www): add Microsoft publisher-domain verification file

### DIFF
--- a/www/public/.well-known/microsoft-identity-association.json
+++ b/www/public/.well-known/microsoft-identity-association.json
@@ -1,0 +1,7 @@
+{
+  "associatedApplications": [
+    {
+      "applicationId": "0ef1b1ec-e8ca-4112-b627-531e1f7b94af"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the Microsoft identity-association file so `corsair.dev` can be verified as the publisher domain for the managed-OAuth Entra app (Application ID `0ef1b1ec-e8ca-4112-b627-531e1f7b94af`).

Served by Next.js from `www/public/` at:
`https://corsair.dev/.well-known/microsoft-identity-association.json`

Once merged + deployed, "Verify and save domain" in Entra passes and corsair.dev shows as the publisher on the Microsoft consent screen.

- Static file only — no build/route impact (next.config redirects don't touch `/.well-known`, gitignore doesn't exclude it).
- `applicationId` is a public client ID, not a secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added Microsoft identity association metadata to support application verification and integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->