### PR TITLE
docs: update bug report environment versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,8 +44,8 @@ body:
       render: bash
       placeholder: |
         OS: macOS 14.0
-        Node: v20.x.x
-        Package manager: pnpm 8.x.x
+        Node: v22.x.x
+        Package manager: pnpm 10.x.x
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
## Description

Updates the bug report environment placeholder from Node 20 and pnpm 8 to the repository's current Node 22 and pnpm 10 requirements.

Fixes #535

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and all type checks pass
- [x] I have run `pnpm build` and the build completes successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

N/A — issue template metadata only.

## Additional Notes

The repository's CI-equivalent test command passed all 123 Turbo tasks. Focused YAML parsing and stale-version checks also passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the bug report template to request Node.js 22.x.x and pnpm 10.x.x environment details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->