### PR TITLE
fix(spotify): fail closed when webhook secret is missing

### DIFF
--- a/packages/spotify/webhooks/types.test.ts
+++ b/packages/spotify/webhooks/types.test.ts
@@ -1,0 +1,82 @@
+import * as crypto from 'node:crypto';
+import type { WebhookRequest } from 'corsair/core';
+import type { SpotifyWebhookPayload } from './types';
+import { verifySpotifyWebhookSignature } from './types';
+
+describe('verifySpotifyWebhookSignature', () => {
+	const secret = 'my-super-secret-key';
+	const payload: SpotifyWebhookPayload = {
+		type: 'example',
+		created_at: '2026-05-22T00:00:00Z',
+		data: { id: '123' },
+	};
+	const rawBody = JSON.stringify(payload);
+
+	it('should fail closed when secret is missing', () => {
+		const request: WebhookRequest<unknown> = {
+			payload,
+			headers: {
+				'x-spotify-signature': 'some-signature',
+			},
+			rawBody,
+		};
+		const result = verifySpotifyWebhookSignature(request, '');
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('should return invalid if signature header is missing', () => {
+		const request: WebhookRequest<unknown> = {
+			payload,
+			headers: {},
+			rawBody,
+		};
+		const result = verifySpotifyWebhookSignature(request, secret);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing signature header',
+		});
+	});
+
+	it('should return invalid if signature does not match', () => {
+		// Same length as a real hex-encoded HMAC-SHA256 digest so that
+		// timingSafeEqual can compare it (rather than throw) and the
+		// comparison itself fails.
+		const wrongSignature = crypto
+			.createHmac('sha256', 'a-different-secret')
+			.update(rawBody)
+			.digest('hex');
+
+		const request: WebhookRequest<unknown> = {
+			payload,
+			headers: {
+				'x-spotify-signature': wrongSignature,
+			},
+			rawBody,
+		};
+		const result = verifySpotifyWebhookSignature(request, secret);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid signature',
+		});
+	});
+
+	it('should return valid for a correct signature round-trip', () => {
+		const correctSignature = crypto
+			.createHmac('sha256', secret)
+			.update(rawBody)
+			.digest('hex');
+
+		const request: WebhookRequest<unknown> = {
+			payload,
+			headers: {
+				'x-spotify-signature': correctSignature,
+			},
+			rawBody,
+		};
+		const result = verifySpotifyWebhookSignature(request, secret);
+		expect(result).toEqual({ valid: true, error: undefined });
+	});
+});

--- a/packages/spotify/webhooks/types.ts
+++ b/packages/spotify/webhooks/types.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'node:crypto';
 import type {
 	CorsairWebhookMatcher,
 	RawWebhookRequest,
@@ -102,7 +103,7 @@ export function verifySpotifyWebhookSignature(
 	secret: string,
 ): { valid: boolean; error?: string } {
 	if (!secret) {
-		return { valid: true };
+		return { valid: false, error: 'Missing webhook secret' };
 	}
 
 	const signatureHeader = request.headers['x-spotify-signature'];
@@ -124,7 +125,6 @@ export function verifySpotifyWebhookSignature(
 			: JSON.stringify(request.payload));
 
 	try {
-		const crypto = require('crypto');
 		const expectedSignature = crypto
 			.createHmac('sha256', secret)
 			.update(payloadString)


### PR DESCRIPTION
## Description

`verifySpotifyWebhookSignature` (`packages/spotify/webhooks/types.ts`) returned `{ valid: true }` whenever the configured `secret` was missing or empty — meaning a misconfigured Spotify plugin instance (no `webhookSecret` option and nothing in the key manager) would accept **any** inbound webhook with zero signature verification. Every other webhook-verifying plugin in this repo (Zendesk, Cloudinary, WhatsApp, Slack) fails closed in this situation; Spotify was the one exception.

This PR:
- Changes the missing-secret branch to `return { valid: false, error: 'Missing webhook secret' }`, matching the fail-closed pattern used by sibling plugins.
- Replaces the inline `require('crypto')` with a top-level `import * as crypto from 'node:crypto'`, matching the ESM import convention used elsewhere in this package (e.g. `zendesk/webhooks/types.ts`).
- Adds `packages/spotify/webhooks/types.test.ts` with 4 unit tests: missing secret fails closed, missing signature header, invalid signature, and a valid signature round-trip.

Closes #519

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass (the 21 pre-existing `api.test.ts`/`integration.test.ts` failures require live Spotify API credentials and are unrelated — verified identical on `main` before this patch)
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation (none required — no public API or docs changed by this fix)

## Screenshots / Demos (if applicable)

Terminal recording of the test run, showing all 4 tests in `webhooks/types.test.ts` passing including the new fail-closed case:

![test run](https://raw.githubusercontent.com/EngineerOnTravel/corsair/pr-assets/pr-519-test-run.gif)

## Additional Notes

No breaking changes, no new dependencies. Scope is confined to `packages/spotify/webhooks/` per R1.
