### PR TITLE
docs(openai): generate mintlify docs for openai

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -540,6 +540,14 @@
                 ]
               },
               {
+                "group": "Openai",
+                "pages": [
+                  "plugins/openai/overview",
+                  "plugins/openai/api",
+                  "plugins/openai/database"
+                ]
+              },
+              {
                 "group": "Oura",
                 "pages": [
                   "plugins/oura/overview",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -543,6 +543,7 @@
                 "group": "Openai",
                 "pages": [
                   "plugins/openai/overview",
+                  "plugins/openai/get-credentials",
                   "plugins/openai/api",
                   "plugins/openai/database"
                 ]

--- a/docs/plugins/openai/api.mdx
+++ b/docs/plugins/openai/api.mdx
@@ -1,0 +1,8213 @@
+---
+title: API
+description: "API reference for Openai: every `openai.api.*` operation with input and output types."
+---
+
+Every `openai.api.*` operation is listed below with parameter shapes and return types from the plugin Zod schemas.
+
+<Info>
+**New to Corsair?** See [API access](/concepts/api), [authentication](/concepts/auth), and [error handling](/concepts/error-handling).
+</Info>
+
+## Assistants
+
+### create
+
+`assistants.create`
+
+Create an assistant
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.assistants.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `model` | `string` | Yes | — |
+| `name` | `string` | No | — |
+| `description` | `string` | No | — |
+| `instructions` | `string` | No | — |
+| `tools` | `object[]` | No | — |
+| `toolResources` | `object` | No | — |
+| `metadata` | `object` | No | — |
+| `temperature` | `number` | No | — |
+| `topP` | `number` | No | — |
+
+<AccordionGroup>
+<Accordion title="tools full type">
+
+```ts
+(
+  {
+    type: code_interpreter
+  } | {
+    type: file_search,
+    file_search?: {
+      max_num_results?: number,
+      ranking_options?: {
+        ranker?: string,
+        score_threshold?: number
+      }
+    }
+  } | {
+    type: function,
+    function: {
+      name: string,
+      description?: string,
+      parameters?: {
+      },
+      strict?: boolean | null
+    }
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="toolResources full type">
+
+```ts
+{
+  code_interpreter?: {
+    file_ids: string[]
+  },
+  file_search?: {
+    vector_store_ids: string[]
+  }
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `assistant` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `name` | `string` | No | — |
+| `description` | `string` | No | — |
+| `model` | `string` | Yes | — |
+| `instructions` | `string` | No | — |
+| `tools` | `object[]` | Yes | — |
+| `metadata` | `object` | No | — |
+| `temperature` | `number` | No | — |
+| `top_p` | `number` | No | — |
+
+<AccordionGroup>
+<Accordion title="tools full type">
+
+```ts
+(
+  {
+    type: code_interpreter
+  } | {
+    type: file_search,
+    file_search?: {
+      max_num_results?: number,
+      ranking_options?: {
+        ranker?: string,
+        score_threshold?: number
+      }
+    }
+  } | {
+    type: function,
+    function: {
+      name: string,
+      description?: string,
+      parameters?: {
+      },
+      strict?: boolean | null
+    }
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### delete
+
+`assistants.delete`
+
+Delete an assistant
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.assistants.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `assistantId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `assistant.deleted` | Yes | — |
+| `deleted` | `boolean` | Yes | — |
+
+
+
+---
+
+### list
+
+`assistants.list`
+
+List assistants
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.assistants.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+| `after` | `string` | No | — |
+| `before` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: assistant,
+  created_at: number,
+  name?: string | null,
+  description?: string | null,
+  model: string,
+  instructions?: string | null,
+  tools: (
+    {
+      type: code_interpreter
+    } | {
+      type: file_search,
+      file_search?: {
+        max_num_results?: number,
+        ranking_options?: {
+          ranker?: string,
+          score_threshold?: number
+        }
+      }
+    } | {
+      type: function,
+      function: {
+        name: string,
+        description?: string,
+        parameters?: {
+        },
+        strict?: boolean | null
+      }
+    }
+  )[],
+  metadata?: {
+  } | null,
+  temperature?: number | null,
+  top_p?: number | null
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### modify
+
+`assistants.modify`
+
+Modify an assistant
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.assistants.modify({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `assistantId` | `string` | Yes | — |
+| `model` | `string` | No | — |
+| `name` | `string` | No | — |
+| `description` | `string` | No | — |
+| `instructions` | `string` | No | — |
+| `tools` | `object[]` | No | — |
+| `toolResources` | `object` | No | — |
+| `metadata` | `object` | No | — |
+| `temperature` | `number` | No | — |
+| `topP` | `number` | No | — |
+
+<AccordionGroup>
+<Accordion title="tools full type">
+
+```ts
+(
+  {
+    type: code_interpreter
+  } | {
+    type: file_search,
+    file_search?: {
+      max_num_results?: number,
+      ranking_options?: {
+        ranker?: string,
+        score_threshold?: number
+      }
+    }
+  } | {
+    type: function,
+    function: {
+      name: string,
+      description?: string,
+      parameters?: {
+      },
+      strict?: boolean | null
+    }
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="toolResources full type">
+
+```ts
+{
+  code_interpreter?: {
+    file_ids: string[]
+  },
+  file_search?: {
+    vector_store_ids: string[]
+  }
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `assistant` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `name` | `string` | No | — |
+| `description` | `string` | No | — |
+| `model` | `string` | Yes | — |
+| `instructions` | `string` | No | — |
+| `tools` | `object[]` | Yes | — |
+| `metadata` | `object` | No | — |
+| `temperature` | `number` | No | — |
+| `top_p` | `number` | No | — |
+
+<AccordionGroup>
+<Accordion title="tools full type">
+
+```ts
+(
+  {
+    type: code_interpreter
+  } | {
+    type: file_search,
+    file_search?: {
+      max_num_results?: number,
+      ranking_options?: {
+        ranker?: string,
+        score_threshold?: number
+      }
+    }
+  } | {
+    type: function,
+    function: {
+      name: string,
+      description?: string,
+      parameters?: {
+      },
+      strict?: boolean | null
+    }
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieve
+
+`assistants.retrieve`
+
+Retrieve an assistant by id
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.assistants.retrieve({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `assistantId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `assistant` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `name` | `string` | No | — |
+| `description` | `string` | No | — |
+| `model` | `string` | Yes | — |
+| `instructions` | `string` | No | — |
+| `tools` | `object[]` | Yes | — |
+| `metadata` | `object` | No | — |
+| `temperature` | `number` | No | — |
+| `top_p` | `number` | No | — |
+
+<AccordionGroup>
+<Accordion title="tools full type">
+
+```ts
+(
+  {
+    type: code_interpreter
+  } | {
+    type: file_search,
+    file_search?: {
+      max_num_results?: number,
+      ranking_options?: {
+        ranker?: string,
+        score_threshold?: number
+      }
+    }
+  } | {
+    type: function,
+    function: {
+      name: string,
+      description?: string,
+      parameters?: {
+      },
+      strict?: boolean | null
+    }
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Audio
+
+### createSpeech
+
+`audio.createSpeech`
+
+Generate spoken audio from text
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.audio.createSpeech({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `model` | `string` | Yes | — |
+| `input` | `string` | Yes | — |
+| `voice` | `string` | Yes | — |
+| `responseFormat` | `mp3 \| opus \| aac \| flac \| wav \| pcm` | No | — |
+| `speed` | `number` | No | — |
+| `instructions` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `audioBase64` | `string` | Yes | — |
+| `format` | `string` | Yes | — |
+
+
+
+---
+
+### createTranscription
+
+`audio.createTranscription`
+
+Transcribe audio into text
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.audio.createTranscription({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `file` | `custom \| string` | Yes | — |
+| `fileName` | `string` | Yes | — |
+| `model` | `string` | Yes | — |
+| `language` | `string` | No | — |
+| `prompt` | `string` | No | — |
+| `responseFormat` | `json \| text \| srt \| verbose_json \| vtt` | No | — |
+| `temperature` | `number` | No | — |
+| `timestampGranularities` | `word \| segment[]` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `text` | `string` | Yes | — |
+
+
+
+---
+
+### createTranslation
+
+`audio.createTranslation`
+
+Translate audio into English text
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.audio.createTranslation({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `file` | `custom \| string` | Yes | — |
+| `fileName` | `string` | Yes | — |
+| `model` | `string` | Yes | — |
+| `prompt` | `string` | No | — |
+| `responseFormat` | `json \| text \| srt \| verbose_json \| vtt` | No | — |
+| `temperature` | `number` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `text` | `string` | Yes | — |
+
+
+
+---
+
+## Batches
+
+### cancel
+
+`batches.cancel`
+
+Cancel an in-progress batch job
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.batches.cancel({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `batchId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `batch` | Yes | — |
+| `endpoint` | `string` | Yes | — |
+| `input_file_id` | `string` | Yes | — |
+| `completion_window` | `string` | Yes | — |
+| `status` | `validating \| failed \| in_progress \| finalizing \| completed \| expired \| cancelling \| cancelled` | Yes | — |
+| `output_file_id` | `string` | No | — |
+| `error_file_id` | `string` | No | — |
+| `created_at` | `number` | Yes | — |
+| `in_progress_at` | `number` | No | — |
+| `expires_at` | `number` | No | — |
+| `finalizing_at` | `number` | No | — |
+| `completed_at` | `number` | No | — |
+| `failed_at` | `number` | No | — |
+| `expired_at` | `number` | No | — |
+| `cancelling_at` | `number` | No | — |
+| `cancelled_at` | `number` | No | — |
+| `request_counts` | `object` | No | — |
+| `errors` | `object` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="request_counts full type">
+
+```ts
+{
+  total: number,
+  completed: number,
+  failed: number
+}
+```
+</Accordion>
+
+<Accordion title="errors full type">
+
+```ts
+{
+  data?: {
+    code: string,
+    message: string,
+    param?: string | null,
+    line?: number | null
+  }[]
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### create
+
+`batches.create`
+
+Create a batch job
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.batches.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `inputFileId` | `string` | Yes | — |
+| `endpoint` | `/v1/chat/completions \| /v1/completions \| /v1/embeddings \| /v1/responses` | Yes | — |
+| `completionWindow` | `24h` | Yes | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `batch` | Yes | — |
+| `endpoint` | `string` | Yes | — |
+| `input_file_id` | `string` | Yes | — |
+| `completion_window` | `string` | Yes | — |
+| `status` | `validating \| failed \| in_progress \| finalizing \| completed \| expired \| cancelling \| cancelled` | Yes | — |
+| `output_file_id` | `string` | No | — |
+| `error_file_id` | `string` | No | — |
+| `created_at` | `number` | Yes | — |
+| `in_progress_at` | `number` | No | — |
+| `expires_at` | `number` | No | — |
+| `finalizing_at` | `number` | No | — |
+| `completed_at` | `number` | No | — |
+| `failed_at` | `number` | No | — |
+| `expired_at` | `number` | No | — |
+| `cancelling_at` | `number` | No | — |
+| `cancelled_at` | `number` | No | — |
+| `request_counts` | `object` | No | — |
+| `errors` | `object` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="request_counts full type">
+
+```ts
+{
+  total: number,
+  completed: number,
+  failed: number
+}
+```
+</Accordion>
+
+<Accordion title="errors full type">
+
+```ts
+{
+  data?: {
+    code: string,
+    message: string,
+    param?: string | null,
+    line?: number | null
+  }[]
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### list
+
+`batches.list`
+
+List batch jobs
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.batches.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `after` | `string` | No | — |
+| `limit` | `number` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: batch,
+  endpoint: string,
+  input_file_id: string,
+  completion_window: string,
+  status: validating | failed | in_progress | finalizing | completed | expired | cancelling | cancelled,
+  output_file_id?: string,
+  error_file_id?: string,
+  created_at: number,
+  in_progress_at?: number,
+  expires_at?: number,
+  finalizing_at?: number,
+  completed_at?: number,
+  failed_at?: number,
+  expired_at?: number,
+  cancelling_at?: number,
+  cancelled_at?: number,
+  request_counts?: {
+    total: number,
+    completed: number,
+    failed: number
+  },
+  errors?: {
+    data?: {
+      code: string,
+      message: string,
+      param?: string | null,
+      line?: number | null
+    }[]
+  },
+  metadata?: {
+  } | null
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieve
+
+`batches.retrieve`
+
+Retrieve a batch job
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.batches.retrieve({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `batchId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `batch` | Yes | — |
+| `endpoint` | `string` | Yes | — |
+| `input_file_id` | `string` | Yes | — |
+| `completion_window` | `string` | Yes | — |
+| `status` | `validating \| failed \| in_progress \| finalizing \| completed \| expired \| cancelling \| cancelled` | Yes | — |
+| `output_file_id` | `string` | No | — |
+| `error_file_id` | `string` | No | — |
+| `created_at` | `number` | Yes | — |
+| `in_progress_at` | `number` | No | — |
+| `expires_at` | `number` | No | — |
+| `finalizing_at` | `number` | No | — |
+| `completed_at` | `number` | No | — |
+| `failed_at` | `number` | No | — |
+| `expired_at` | `number` | No | — |
+| `cancelling_at` | `number` | No | — |
+| `cancelled_at` | `number` | No | — |
+| `request_counts` | `object` | No | — |
+| `errors` | `object` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="request_counts full type">
+
+```ts
+{
+  total: number,
+  completed: number,
+  failed: number
+}
+```
+</Accordion>
+
+<Accordion title="errors full type">
+
+```ts
+{
+  data?: {
+    code: string,
+    message: string,
+    param?: string | null,
+    line?: number | null
+  }[]
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Chat
+
+### createCompletion
+
+`chat.createCompletion`
+
+Create a chat completion for the given messages
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.chat.createCompletion({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `model` | `string` | Yes | — |
+| `messages` | `object[]` | Yes | — |
+| `frequencyPenalty` | `number` | No | — |
+| `logitBias` | `object` | No | — |
+| `logprobs` | `boolean` | No | — |
+| `topLogprobs` | `number` | No | — |
+| `maxCompletionTokens` | `number` | No | — |
+| `n` | `number` | No | — |
+| `presencePenalty` | `number` | No | — |
+| `responseFormat` | `object` | No | — |
+| `seed` | `number` | No | — |
+| `serviceTier` | `auto \| default \| flex \| priority` | No | — |
+| `stop` | `string \| string[]` | No | — |
+| `store` | `boolean` | No | — |
+| `metadata` | `object` | No | — |
+| `temperature` | `number` | No | — |
+| `topP` | `number` | No | — |
+| `tools` | `object[]` | No | — |
+| `toolChoice` | `object` | No | — |
+| `parallelToolCalls` | `boolean` | No | — |
+| `reasoningEffort` | `minimal \| low \| medium \| high` | No | — |
+| `user` | `string` | No | — |
+
+<AccordionGroup>
+<Accordion title="messages full type">
+
+```ts
+{
+  role: system | developer | user | assistant | tool,
+  content?: string | (
+    {
+      type: text,
+      text: string
+    } | {
+      type: image_url,
+      image_url: {
+        url: string,
+        detail?: auto | low | high
+      }
+    } | {
+      type: input_audio,
+      input_audio: {
+        data: string,
+        format: wav | mp3
+      }
+    } | {
+      type: file,
+      file: {
+        file_id?: string,
+        filename?: string,
+        file_data?: string
+      }
+    }
+  )[] | null,
+  name?: string,
+  tool_calls?: {
+    id: string,
+    type: function,
+    function: {
+      name: string,
+      arguments: string
+    }
+  }[],
+  tool_call_id?: string,
+  refusal?: string | null
+}[]
+```
+</Accordion>
+
+<Accordion title="logitBias full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="responseFormat full type">
+
+```ts
+{
+  type: text
+} | {
+  type: json_object
+} | {
+  type: json_schema,
+  json_schema: {
+    name: string,
+    description?: string,
+    schema?: {
+    },
+    strict?: boolean | null
+  }
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="tools full type">
+
+```ts
+{
+  type: function,
+  function: {
+    name: string,
+    description?: string,
+    parameters?: {
+    },
+    strict?: boolean | null
+  }
+}[]
+```
+</Accordion>
+
+<Accordion title="toolChoice full type">
+
+```ts
+none | auto | required | {
+  type: function,
+  function: {
+    name: string
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `chat.completion` | Yes | — |
+| `created` | `number` | Yes | — |
+| `model` | `string` | Yes | — |
+| `choices` | `object[]` | Yes | — |
+| `system_fingerprint` | `string` | No | — |
+| `service_tier` | `string` | No | — |
+| `usage` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="choices full type">
+
+```ts
+{
+  index: number,
+  message: {
+    role: assistant,
+    content?: string | null,
+    refusal?: string | null,
+    tool_calls?: {
+      id: string,
+      type: function,
+      function: {
+        name: string,
+        arguments: string
+      }
+    }[]
+  },
+  logprobs?: {
+  } | null,
+  finish_reason: stop | length | tool_calls | content_filter | function_call
+}[]
+```
+</Accordion>
+
+<Accordion title="usage full type">
+
+```ts
+{
+  prompt_tokens: number,
+  completion_tokens: number,
+  total_tokens: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Chat Completions
+
+### delete
+
+`chatCompletions.delete`
+
+Delete a stored chat completion
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.chatCompletions.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `completionId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `chat.completion.deleted` | Yes | — |
+| `deleted` | `boolean` | Yes | — |
+
+
+
+---
+
+### list
+
+`chatCompletions.list`
+
+List stored chat completions
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.chatCompletions.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `model` | `string` | No | — |
+| `metadata` | `object` | No | — |
+| `after` | `string` | No | — |
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+
+<AccordionGroup>
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### listMessages
+
+`chatCompletions.listMessages`
+
+List messages of a stored chat completion
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.chatCompletions.listMessages({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `completionId` | `string` | Yes | — |
+| `after` | `string` | No | — |
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieve
+
+`chatCompletions.retrieve`
+
+Retrieve a stored chat completion
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.chatCompletions.retrieve({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `completionId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `chat.completion` | Yes | — |
+| `created` | `number` | Yes | — |
+| `model` | `string` | Yes | — |
+
+
+
+---
+
+### update
+
+`chatCompletions.update`
+
+Update a stored chat completion's metadata
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.chatCompletions.update({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `completionId` | `string` | Yes | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `chat.completion` | Yes | — |
+| `created` | `number` | Yes | — |
+| `model` | `string` | Yes | — |
+
+
+
+---
+
+## Chatkit
+
+### getThread
+
+`chatkit.getThread`
+
+Retrieve a ChatKit thread
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.chatkit.getThread({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `threadId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `chatkit.thread` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `status` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="status full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### listThreadItems
+
+`chatkit.listThreadItems`
+
+List items in a ChatKit thread
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.chatkit.listThreadItems({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `threadId` | `string` | Yes | — |
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+| `after` | `string` | No | — |
+| `before` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### listThreads
+
+`chatkit.listThreads`
+
+List ChatKit threads
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.chatkit.listThreads({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+| `after` | `string` | No | — |
+| `before` | `string` | No | — |
+| `user` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: chatkit.thread,
+  created_at: number,
+  status?: {
+  }
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Completions
+
+### create
+
+`completions.create`
+
+Create a legacy text completion
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.completions.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `model` | `string` | Yes | — |
+| `prompt` | `string \| string[]` | Yes | — |
+| `maxTokens` | `number` | No | — |
+| `temperature` | `number` | No | — |
+| `topP` | `number` | No | — |
+| `n` | `number` | No | — |
+| `stop` | `string \| string[]` | No | — |
+| `presencePenalty` | `number` | No | — |
+| `frequencyPenalty` | `number` | No | — |
+| `logprobs` | `number` | No | — |
+| `echo` | `boolean` | No | — |
+| `bestOf` | `number` | No | — |
+| `logitBias` | `object` | No | — |
+| `user` | `string` | No | — |
+| `suffix` | `string` | No | — |
+
+<AccordionGroup>
+<Accordion title="logitBias full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `text_completion` | Yes | — |
+| `created` | `number` | Yes | — |
+| `model` | `string` | Yes | — |
+| `choices` | `object[]` | Yes | — |
+| `usage` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="choices full type">
+
+```ts
+{
+  text: string,
+  index: number,
+  logprobs?: {
+  } | null,
+  finish_reason: string
+}[]
+```
+</Accordion>
+
+<Accordion title="usage full type">
+
+```ts
+{
+  prompt_tokens: number,
+  completion_tokens: number,
+  total_tokens: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Container Files
+
+### create
+
+`containerFiles.create`
+
+Add a file to a container
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.containerFiles.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `containerId` | `string` | Yes | — |
+| `file` | `custom \| string` | No | — |
+| `fileName` | `string` | No | — |
+| `fileId` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `container.file` | Yes | — |
+| `container_id` | `string` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `bytes` | `number` | No | — |
+| `path` | `string` | No | — |
+| `source` | `string` | No | — |
+
+
+
+---
+
+### delete
+
+`containerFiles.delete`
+
+Delete a container file
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.containerFiles.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `containerId` | `string` | Yes | — |
+| `fileId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `container.file.deleted` | Yes | — |
+| `deleted` | `boolean` | Yes | — |
+
+
+
+---
+
+### list
+
+`containerFiles.list`
+
+List files in a container
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.containerFiles.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `containerId` | `string` | Yes | — |
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+| `after` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: container.file,
+  container_id: string,
+  created_at: number,
+  bytes?: number,
+  path?: string,
+  source?: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieve
+
+`containerFiles.retrieve`
+
+Retrieve a container file
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.containerFiles.retrieve({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `containerId` | `string` | Yes | — |
+| `fileId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `container.file` | Yes | — |
+| `container_id` | `string` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `bytes` | `number` | No | — |
+| `path` | `string` | No | — |
+| `source` | `string` | No | — |
+
+
+
+---
+
+### retrieveContent
+
+`containerFiles.retrieveContent`
+
+Download the contents of a container file
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.containerFiles.retrieveContent({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `containerId` | `string` | Yes | — |
+| `fileId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `containerId` | `string` | Yes | — |
+| `fileId` | `string` | Yes | — |
+| `contentBase64` | `string` | Yes | — |
+
+
+
+---
+
+## Containers
+
+### create
+
+`containers.create`
+
+Create a code interpreter container
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.containers.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | `string` | No | — |
+| `fileIds` | `string[]` | No | — |
+| `expiresAfter` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="expiresAfter full type">
+
+```ts
+{
+  anchor: string,
+  minutes: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `container` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `name` | `string` | No | — |
+| `status` | `string` | No | — |
+| `expires_after` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="expires_after full type">
+
+```ts
+{
+  anchor: string,
+  minutes: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### delete
+
+`containers.delete`
+
+Delete a container
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.containers.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `containerId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `container.deleted` | Yes | — |
+| `deleted` | `boolean` | Yes | — |
+
+
+
+---
+
+### list
+
+`containers.list`
+
+List containers
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.containers.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+| `after` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: container,
+  created_at: number,
+  name?: string,
+  status?: string,
+  expires_after?: {
+    anchor: string,
+    minutes: number
+  } | null
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieve
+
+`containers.retrieve`
+
+Retrieve a container
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.containers.retrieve({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `containerId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `container` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `name` | `string` | No | — |
+| `status` | `string` | No | — |
+| `expires_after` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="expires_after full type">
+
+```ts
+{
+  anchor: string,
+  minutes: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Conversations
+
+### create
+
+`conversations.create`
+
+Create a conversation
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.conversations.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `items` | `object[]` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="items full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `conversation` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### createItems
+
+`conversations.createItems`
+
+Add items to a conversation
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.conversations.createItems({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `conversationId` | `string` | Yes | — |
+| `items` | `object[]` | Yes | — |
+| `include` | `string[]` | No | — |
+
+<AccordionGroup>
+<Accordion title="items full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### delete
+
+`conversations.delete`
+
+Delete a conversation
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.conversations.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `conversationId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `conversation.deleted` | Yes | — |
+| `deleted` | `boolean` | Yes | — |
+
+
+
+---
+
+### deleteItem
+
+`conversations.deleteItem`
+
+Delete a conversation item
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.conversations.deleteItem({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `conversationId` | `string` | Yes | — |
+| `itemId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `conversation` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### getItem
+
+`conversations.getItem`
+
+Retrieve a conversation item
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.conversations.getItem({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `conversationId` | `string` | Yes | — |
+| `itemId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `type` | `string` | Yes | — |
+
+
+
+---
+
+### listItems
+
+`conversations.listItems`
+
+List items in a conversation
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.conversations.listItems({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `conversationId` | `string` | Yes | — |
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+| `after` | `string` | No | — |
+| `include` | `string[]` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### update
+
+`conversations.update`
+
+Update a conversation's metadata
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.conversations.update({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `conversationId` | `string` | Yes | — |
+| `metadata` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `conversation` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Embeddings
+
+### create
+
+`embeddings.create`
+
+Create embeddings for the given input
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.embeddings.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `model` | `string` | Yes | — |
+| `input` | `string \| string[] \| number[] \| number[][]` | Yes | — |
+| `encodingFormat` | `float \| base64` | No | — |
+| `dimensions` | `number` | No | — |
+| `user` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `model` | `string` | Yes | — |
+| `usage` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  object: embedding,
+  embedding: number[] | string,
+  index: number
+}[]
+```
+</Accordion>
+
+<Accordion title="usage full type">
+
+```ts
+{
+  prompt_tokens: number,
+  total_tokens: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Engines
+
+### list
+
+`engines.list`
+
+List available engines (legacy, deprecated)
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.engines.list({});
+```
+
+**Input:** _empty object_
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: engine,
+  owner?: string,
+  ready?: boolean
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieve
+
+`engines.retrieve`
+
+Retrieve an engine by id (legacy, deprecated)
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.engines.retrieve({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `engineId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `engine` | Yes | — |
+| `owner` | `string` | No | — |
+| `ready` | `boolean` | No | — |
+
+
+
+---
+
+## Eval Runs
+
+### cancel
+
+`evalRuns.cancel`
+
+Cancel an in-progress eval run
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.evalRuns.cancel({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `evalId` | `string` | Yes | — |
+| `runId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `eval.run` | Yes | — |
+| `eval_id` | `string` | Yes | — |
+| `name` | `string` | No | — |
+| `created_at` | `number` | Yes | — |
+| `status` | `string` | Yes | — |
+| `model` | `string` | No | — |
+| `data_source` | `object` | No | — |
+| `metadata` | `object` | No | — |
+| `result_counts` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="data_source full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="result_counts full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### create
+
+`evalRuns.create`
+
+Create an eval run
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.evalRuns.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `evalId` | `string` | Yes | — |
+| `name` | `string` | No | — |
+| `dataSource` | `object` | Yes | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="dataSource full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `eval.run` | Yes | — |
+| `eval_id` | `string` | Yes | — |
+| `name` | `string` | No | — |
+| `created_at` | `number` | Yes | — |
+| `status` | `string` | Yes | — |
+| `model` | `string` | No | — |
+| `data_source` | `object` | No | — |
+| `metadata` | `object` | No | — |
+| `result_counts` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="data_source full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="result_counts full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### delete
+
+`evalRuns.delete`
+
+Delete an eval run
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.evalRuns.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `evalId` | `string` | Yes | — |
+| `runId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `eval.run.deleted` | Yes | — |
+| `deleted` | `boolean` | Yes | — |
+| `run_id` | `string` | Yes | — |
+
+
+
+---
+
+### get
+
+`evalRuns.get`
+
+Retrieve an eval run
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.evalRuns.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `evalId` | `string` | Yes | — |
+| `runId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `eval.run` | Yes | — |
+| `eval_id` | `string` | Yes | — |
+| `name` | `string` | No | — |
+| `created_at` | `number` | Yes | — |
+| `status` | `string` | Yes | — |
+| `model` | `string` | No | — |
+| `data_source` | `object` | No | — |
+| `metadata` | `object` | No | — |
+| `result_counts` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="data_source full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="result_counts full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### getOutputItem
+
+`evalRuns.getOutputItem`
+
+Retrieve an eval run output item
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.evalRuns.getOutputItem({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `evalId` | `string` | Yes | — |
+| `runId` | `string` | Yes | — |
+| `outputItemId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `eval.run.output_item` | Yes | — |
+
+
+
+---
+
+### list
+
+`evalRuns.list`
+
+List eval runs
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.evalRuns.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `evalId` | `string` | Yes | — |
+| `after` | `string` | No | — |
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+| `status` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: eval.run,
+  eval_id: string,
+  name?: string | null,
+  created_at: number,
+  status: string,
+  model?: string,
+  data_source?: {
+  },
+  metadata?: {
+  } | null,
+  result_counts?: {
+  }
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### listOutputItems
+
+`evalRuns.listOutputItems`
+
+List output items for an eval run
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.evalRuns.listOutputItems({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `evalId` | `string` | Yes | — |
+| `runId` | `string` | Yes | — |
+| `after` | `string` | No | — |
+| `limit` | `number` | No | — |
+| `status` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Evals
+
+### create
+
+`evals.create`
+
+Create an eval
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.evals.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | `string` | No | — |
+| `dataSourceConfig` | `object` | Yes | — |
+| `testingCriteria` | `object[]` | Yes | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="dataSourceConfig full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="testingCriteria full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `eval` | Yes | — |
+| `name` | `string` | No | — |
+| `created_at` | `number` | Yes | — |
+| `data_source_config` | `object` | Yes | — |
+| `testing_criteria` | `object[]` | Yes | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="data_source_config full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="testing_criteria full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### delete
+
+`evals.delete`
+
+Delete an eval
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.evals.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `evalId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `eval.deleted` | Yes | — |
+| `deleted` | `boolean` | Yes | — |
+| `eval_id` | `string` | Yes | — |
+
+
+
+---
+
+### get
+
+`evals.get`
+
+Retrieve an eval
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.evals.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `evalId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `eval` | Yes | — |
+| `name` | `string` | No | — |
+| `created_at` | `number` | Yes | — |
+| `data_source_config` | `object` | Yes | — |
+| `testing_criteria` | `object[]` | Yes | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="data_source_config full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="testing_criteria full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### list
+
+`evals.list`
+
+List evals
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.evals.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `after` | `string` | No | — |
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+| `orderBy` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: eval,
+  name?: string | null,
+  created_at: number,
+  data_source_config: {
+  },
+  testing_criteria: {
+  }[],
+  metadata?: {
+  } | null
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### update
+
+`evals.update`
+
+Update an eval
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.evals.update({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `evalId` | `string` | Yes | — |
+| `name` | `string` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `eval` | Yes | — |
+| `name` | `string` | No | — |
+| `created_at` | `number` | Yes | — |
+| `data_source_config` | `object` | Yes | — |
+| `testing_criteria` | `object[]` | Yes | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="data_source_config full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="testing_criteria full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Files
+
+### delete
+
+`files.delete`
+
+Delete a file
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.files.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `fileId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `file` | Yes | — |
+| `deleted` | `boolean` | Yes | — |
+
+
+
+---
+
+### downloadContent
+
+`files.downloadContent`
+
+Download the contents of a file
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.files.downloadContent({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `fileId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `fileId` | `string` | Yes | — |
+| `contentBase64` | `string` | Yes | — |
+
+
+
+---
+
+### list
+
+`files.list`
+
+List uploaded files
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.files.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `purpose` | `assistants \| assistants_output \| batch \| batch_output \| fine-tune \| fine-tune-results \| vision \| user_data \| evals` | No | — |
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+| `after` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `has_more` | `boolean` | No | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: file,
+  bytes: number,
+  created_at: number,
+  expires_at?: number,
+  filename: string,
+  purpose: assistants | assistants_output | batch | batch_output | fine-tune | fine-tune-results | vision | user_data | evals
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieve
+
+`files.retrieve`
+
+Retrieve file metadata
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.files.retrieve({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `fileId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `file` | Yes | — |
+| `bytes` | `number` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `expires_at` | `number` | No | — |
+| `filename` | `string` | Yes | — |
+| `purpose` | `assistants \| assistants_output \| batch \| batch_output \| fine-tune \| fine-tune-results \| vision \| user_data \| evals` | Yes | — |
+
+
+
+---
+
+### upload
+
+`files.upload`
+
+Upload a file to OpenAI
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.files.upload({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `file` | `custom \| string` | Yes | — |
+| `fileName` | `string` | Yes | — |
+| `purpose` | `assistants \| assistants_output \| batch \| batch_output \| fine-tune \| fine-tune-results \| vision \| user_data \| evals` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `file` | Yes | — |
+| `bytes` | `number` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `expires_at` | `number` | No | — |
+| `filename` | `string` | Yes | — |
+| `purpose` | `assistants \| assistants_output \| batch \| batch_output \| fine-tune \| fine-tune-results \| vision \| user_data \| evals` | Yes | — |
+
+
+
+---
+
+## Fine Tuning
+
+### cancelJob
+
+`fineTuning.cancelJob`
+
+Cancel an in-progress fine-tuning job
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.fineTuning.cancelJob({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `jobId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `fine_tuning.job` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `model` | `string` | Yes | — |
+| `fine_tuned_model` | `string` | No | — |
+| `status` | `validating_files \| queued \| running \| succeeded \| failed \| cancelled` | Yes | — |
+| `training_file` | `string` | Yes | — |
+| `validation_file` | `string` | No | — |
+| `hyperparameters` | `object` | No | — |
+| `result_files` | `string[]` | No | — |
+| `trained_tokens` | `number` | No | — |
+| `error` | `object` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="hyperparameters full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="error full type">
+
+```ts
+{
+  code: string,
+  message: string
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### createJob
+
+`fineTuning.createJob`
+
+Create a fine-tuning job
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.fineTuning.createJob({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `model` | `string` | Yes | — |
+| `trainingFile` | `string` | Yes | — |
+| `validationFile` | `string` | No | — |
+| `hyperparameters` | `object` | No | — |
+| `suffix` | `string` | No | — |
+| `integrations` | `object[]` | No | — |
+| `seed` | `number` | No | — |
+| `method` | `object` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="hyperparameters full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="integrations full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+
+<Accordion title="method full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `fine_tuning.job` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `model` | `string` | Yes | — |
+| `fine_tuned_model` | `string` | No | — |
+| `status` | `validating_files \| queued \| running \| succeeded \| failed \| cancelled` | Yes | — |
+| `training_file` | `string` | Yes | — |
+| `validation_file` | `string` | No | — |
+| `hyperparameters` | `object` | No | — |
+| `result_files` | `string[]` | No | — |
+| `trained_tokens` | `number` | No | — |
+| `error` | `object` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="hyperparameters full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="error full type">
+
+```ts
+{
+  code: string,
+  message: string
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### listCheckpoints
+
+`fineTuning.listCheckpoints`
+
+List checkpoints for a fine-tuning job
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.fineTuning.listCheckpoints({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `jobId` | `string` | Yes | — |
+| `after` | `string` | No | — |
+| `limit` | `number` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: fine_tuning.job.checkpoint,
+  created_at: number,
+  fine_tuned_model_checkpoint: string,
+  step_number: number,
+  metrics?: {
+  }
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### listEvents
+
+`fineTuning.listEvents`
+
+List events for a fine-tuning job
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.fineTuning.listEvents({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `jobId` | `string` | Yes | — |
+| `after` | `string` | No | — |
+| `limit` | `number` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: fine_tuning.job.event,
+  created_at: number,
+  level: string,
+  message: string,
+  data?: {
+  }
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### listJobs
+
+`fineTuning.listJobs`
+
+List fine-tuning jobs
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.fineTuning.listJobs({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `after` | `string` | No | — |
+| `limit` | `number` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: fine_tuning.job,
+  created_at: number,
+  model: string,
+  fine_tuned_model?: string | null,
+  status: validating_files | queued | running | succeeded | failed | cancelled,
+  training_file: string,
+  validation_file?: string | null,
+  hyperparameters?: {
+  },
+  result_files?: string[],
+  trained_tokens?: number | null,
+  error?: {
+    code: string,
+    message: string
+  } | null,
+  metadata?: {
+  } | null
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieveJob
+
+`fineTuning.retrieveJob`
+
+Retrieve a fine-tuning job
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.fineTuning.retrieveJob({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `jobId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `fine_tuning.job` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `model` | `string` | Yes | — |
+| `fine_tuned_model` | `string` | No | — |
+| `status` | `validating_files \| queued \| running \| succeeded \| failed \| cancelled` | Yes | — |
+| `training_file` | `string` | Yes | — |
+| `validation_file` | `string` | No | — |
+| `hyperparameters` | `object` | No | — |
+| `result_files` | `string[]` | No | — |
+| `trained_tokens` | `number` | No | — |
+| `error` | `object` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="hyperparameters full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="error full type">
+
+```ts
+{
+  code: string,
+  message: string
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Graders
+
+### run
+
+`graders.run`
+
+Run a grader against a model sample
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.graders.run({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `grader` | `object` | Yes | — |
+| `item` | `object` | No | — |
+| `modelSample` | `string` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="grader full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="item full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `reward` | `number` | No | — |
+
+
+
+---
+
+### validate
+
+`graders.validate`
+
+Validate a grader configuration
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.graders.validate({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `grader` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="grader full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `grader` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="grader full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Images
+
+### create
+
+`images.create`
+
+Generate images from a prompt
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.images.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `model` | `string` | No | — |
+| `prompt` | `string` | Yes | — |
+| `n` | `number` | No | — |
+| `size` | `string` | No | — |
+| `quality` | `string` | No | — |
+| `style` | `string` | No | — |
+| `responseFormat` | `url \| b64_json` | No | — |
+| `background` | `string` | No | — |
+| `user` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `created` | `number` | Yes | — |
+| `data` | `object[]` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  url?: string,
+  b64_json?: string,
+  revised_prompt?: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### createEdit
+
+`images.createEdit`
+
+Edit an image given a prompt and mask
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.images.createEdit({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `image` | `custom \| string` | Yes | — |
+| `imageFileName` | `string` | Yes | — |
+| `mask` | `custom \| string` | No | — |
+| `maskFileName` | `string` | No | — |
+| `prompt` | `string` | Yes | — |
+| `model` | `string` | No | — |
+| `n` | `number` | No | — |
+| `size` | `string` | No | — |
+| `responseFormat` | `url \| b64_json` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `created` | `number` | Yes | — |
+| `data` | `object[]` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  url?: string,
+  b64_json?: string,
+  revised_prompt?: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### createVariation
+
+`images.createVariation`
+
+Create variations of an image
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.images.createVariation({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `image` | `custom \| string` | Yes | — |
+| `imageFileName` | `string` | Yes | — |
+| `model` | `string` | No | — |
+| `n` | `number` | No | — |
+| `size` | `string` | No | — |
+| `responseFormat` | `url \| b64_json` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `created` | `number` | Yes | — |
+| `data` | `object[]` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  url?: string,
+  b64_json?: string,
+  revised_prompt?: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Messages
+
+### create
+
+`messages.create`
+
+Create a message on a thread
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.messages.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `threadId` | `string` | Yes | — |
+| `role` | `user \| assistant` | Yes | — |
+| `content` | `object[]` | Yes | — |
+| `attachments` | `object[]` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="content full type">
+
+```ts
+string | (
+  {
+    type: text,
+    text: {
+      value: string,
+      annotations: {
+      }[]
+    }
+  } | {
+    type: image_file,
+    image_file: {
+      file_id: string,
+      detail?: auto | low | high
+    }
+  } | {
+    type: image_url,
+    image_url: {
+      url: string,
+      detail?: auto | low | high
+    }
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="attachments full type">
+
+```ts
+{
+  file_id?: string,
+  tools?: (
+    {
+      type: code_interpreter
+    } | {
+      type: file_search
+    }
+  )[]
+}[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `thread.message` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `thread_id` | `string` | Yes | — |
+| `status` | `in_progress \| incomplete \| completed` | No | — |
+| `role` | `user \| assistant` | Yes | — |
+| `content` | `object[]` | Yes | — |
+| `assistant_id` | `string` | No | — |
+| `run_id` | `string` | No | — |
+| `attachments` | `object[]` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="content full type">
+
+```ts
+(
+  {
+    type: text,
+    text: {
+      value: string,
+      annotations: {
+      }[]
+    }
+  } | {
+    type: image_file,
+    image_file: {
+      file_id: string,
+      detail?: auto | low | high
+    }
+  } | {
+    type: image_url,
+    image_url: {
+      url: string,
+      detail?: auto | low | high
+    }
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="attachments full type">
+
+```ts
+{
+  file_id?: string,
+  tools?: (
+    {
+      type: code_interpreter
+    } | {
+      type: file_search
+    }
+  )[]
+}[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### delete
+
+`messages.delete`
+
+Delete a message
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.messages.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `threadId` | `string` | Yes | — |
+| `messageId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `thread.message.deleted` | Yes | — |
+| `deleted` | `boolean` | Yes | — |
+
+
+
+---
+
+### list
+
+`messages.list`
+
+List messages on a thread
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.messages.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `threadId` | `string` | Yes | — |
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+| `after` | `string` | No | — |
+| `before` | `string` | No | — |
+| `runId` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: thread.message,
+  created_at: number,
+  thread_id: string,
+  status?: in_progress | incomplete | completed,
+  role: user | assistant,
+  content: (
+    {
+      type: text,
+      text: {
+        value: string,
+        annotations: {
+        }[]
+      }
+    } | {
+      type: image_file,
+      image_file: {
+        file_id: string,
+        detail?: auto | low | high
+      }
+    } | {
+      type: image_url,
+      image_url: {
+        url: string,
+        detail?: auto | low | high
+      }
+    }
+  )[],
+  assistant_id?: string | null,
+  run_id?: string | null,
+  attachments?: {
+    file_id?: string,
+    tools?: (
+      {
+        type: code_interpreter
+      } | {
+        type: file_search
+      }
+    )[]
+  }[] | null,
+  metadata?: {
+  } | null
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### modify
+
+`messages.modify`
+
+Modify a message
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.messages.modify({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `threadId` | `string` | Yes | — |
+| `messageId` | `string` | Yes | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `thread.message` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `thread_id` | `string` | Yes | — |
+| `status` | `in_progress \| incomplete \| completed` | No | — |
+| `role` | `user \| assistant` | Yes | — |
+| `content` | `object[]` | Yes | — |
+| `assistant_id` | `string` | No | — |
+| `run_id` | `string` | No | — |
+| `attachments` | `object[]` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="content full type">
+
+```ts
+(
+  {
+    type: text,
+    text: {
+      value: string,
+      annotations: {
+      }[]
+    }
+  } | {
+    type: image_file,
+    image_file: {
+      file_id: string,
+      detail?: auto | low | high
+    }
+  } | {
+    type: image_url,
+    image_url: {
+      url: string,
+      detail?: auto | low | high
+    }
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="attachments full type">
+
+```ts
+{
+  file_id?: string,
+  tools?: (
+    {
+      type: code_interpreter
+    } | {
+      type: file_search
+    }
+  )[]
+}[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieve
+
+`messages.retrieve`
+
+Retrieve a message
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.messages.retrieve({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `threadId` | `string` | Yes | — |
+| `messageId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `thread.message` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `thread_id` | `string` | Yes | — |
+| `status` | `in_progress \| incomplete \| completed` | No | — |
+| `role` | `user \| assistant` | Yes | — |
+| `content` | `object[]` | Yes | — |
+| `assistant_id` | `string` | No | — |
+| `run_id` | `string` | No | — |
+| `attachments` | `object[]` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="content full type">
+
+```ts
+(
+  {
+    type: text,
+    text: {
+      value: string,
+      annotations: {
+      }[]
+    }
+  } | {
+    type: image_file,
+    image_file: {
+      file_id: string,
+      detail?: auto | low | high
+    }
+  } | {
+    type: image_url,
+    image_url: {
+      url: string,
+      detail?: auto | low | high
+    }
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="attachments full type">
+
+```ts
+{
+  file_id?: string,
+  tools?: (
+    {
+      type: code_interpreter
+    } | {
+      type: file_search
+    }
+  )[]
+}[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Models
+
+### list
+
+`models.list`
+
+List available models
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.models.list({});
+```
+
+**Input:** _empty object_
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: model,
+  created: number,
+  owned_by: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieve
+
+`models.retrieve`
+
+Retrieve a model by id
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.models.retrieve({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `model` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `model` | Yes | — |
+| `created` | `number` | Yes | — |
+| `owned_by` | `string` | Yes | — |
+
+
+
+---
+
+## Moderation
+
+### create
+
+`moderation.create`
+
+Classify text/image input against usage policies
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.moderation.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `input` | `object[]` | Yes | — |
+| `model` | `string` | No | — |
+
+<AccordionGroup>
+<Accordion title="input full type">
+
+```ts
+string | string[] | {
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `model` | `string` | Yes | — |
+| `results` | `object[]` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="results full type">
+
+```ts
+{
+  flagged: boolean,
+  categories: {
+  },
+  category_scores: {
+  },
+  category_applied_input_types?: {
+  }
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Realtime
+
+### createCall
+
+`realtime.createCall`
+
+Create a realtime call
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.realtime.createCall({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `sdp` | `string` | No | — |
+| `session` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="session full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | No | — |
+| `sdp` | `string` | No | — |
+
+
+
+---
+
+### createClientSecret
+
+`realtime.createClientSecret`
+
+Create an ephemeral client secret for the Realtime API
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.realtime.createClientSecret({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `session` | `object` | No | — |
+| `expiresAfter` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="session full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="expiresAfter full type">
+
+```ts
+{
+  anchor: string,
+  seconds: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `value` | `string` | Yes | — |
+| `expires_at` | `number` | Yes | — |
+
+
+
+---
+
+### createSession
+
+`realtime.createSession`
+
+Create a realtime session
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.realtime.createSession({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `model` | `string` | No | — |
+| `voice` | `string` | No | — |
+| `modalities` | `string[]` | No | — |
+| `instructions` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | No | — |
+
+
+
+---
+
+### createTranscriptionSession
+
+`realtime.createTranscriptionSession`
+
+Create a realtime transcription session
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.realtime.createTranscriptionSession({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `inputAudioFormat` | `string` | No | — |
+| `inputAudioTranscription` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="inputAudioTranscription full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | No | — |
+
+
+
+---
+
+## Responses
+
+### cancel
+
+`responses.cancel`
+
+Cancel an in-progress background response
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.responses.cancel({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `responseId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `response` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `status` | `completed \| failed \| in_progress \| cancelled \| queued \| incomplete` | Yes | — |
+| `model` | `string` | Yes | — |
+| `output` | `object[]` | Yes | — |
+| `previous_response_id` | `string` | No | — |
+| `usage` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="output full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+
+<Accordion title="usage full type">
+
+```ts
+{
+  input_tokens: number,
+  output_tokens: number,
+  total_tokens: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### compact
+
+`responses.compact`
+
+Compact response input to reduce token usage
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.responses.compact({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `model` | `string` | Yes | — |
+| `input` | `object[]` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="input full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `response.compaction` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `output` | `object[]` | Yes | — |
+| `usage` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="output full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+
+<Accordion title="usage full type">
+
+```ts
+{
+  input_tokens: number,
+  output_tokens: number,
+  total_tokens: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### create
+
+`responses.create`
+
+Create a model response via the Responses API
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.responses.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `model` | `string` | Yes | — |
+| `input` | `object[]` | Yes | — |
+| `instructions` | `string` | No | — |
+| `tools` | `object[]` | No | — |
+| `toolChoice` | `object` | No | — |
+| `temperature` | `number` | No | — |
+| `topP` | `number` | No | — |
+| `maxOutputTokens` | `number` | No | — |
+| `previousResponseId` | `string` | No | — |
+| `store` | `boolean` | No | — |
+| `metadata` | `object` | No | — |
+| `truncation` | `auto \| disabled` | No | — |
+| `parallelToolCalls` | `boolean` | No | — |
+| `background` | `boolean` | No | — |
+| `reasoning` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="input full type">
+
+```ts
+string | {
+}[]
+```
+</Accordion>
+
+<Accordion title="tools full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+
+<Accordion title="toolChoice full type">
+
+```ts
+none | auto | required | {
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="reasoning full type">
+
+```ts
+{
+  effort?: minimal | low | medium | high
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `response` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `status` | `completed \| failed \| in_progress \| cancelled \| queued \| incomplete` | Yes | — |
+| `model` | `string` | Yes | — |
+| `output` | `object[]` | Yes | — |
+| `previous_response_id` | `string` | No | — |
+| `usage` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="output full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+
+<Accordion title="usage full type">
+
+```ts
+{
+  input_tokens: number,
+  output_tokens: number,
+  total_tokens: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### delete
+
+`responses.delete`
+
+Delete a stored model response
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.responses.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `responseId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `response.deleted` | Yes | — |
+| `deleted` | `boolean` | Yes | — |
+
+
+
+---
+
+### listInputItems
+
+`responses.listInputItems`
+
+List input items for a response
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.responses.listInputItems({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `responseId` | `string` | Yes | — |
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+| `after` | `string` | No | — |
+| `before` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieve
+
+`responses.retrieve`
+
+Retrieve a model response
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.responses.retrieve({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `responseId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `response` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `status` | `completed \| failed \| in_progress \| cancelled \| queued \| incomplete` | Yes | — |
+| `model` | `string` | Yes | — |
+| `output` | `object[]` | Yes | — |
+| `previous_response_id` | `string` | No | — |
+| `usage` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="output full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+
+<Accordion title="usage full type">
+
+```ts
+{
+  input_tokens: number,
+  output_tokens: number,
+  total_tokens: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Runs
+
+### cancel
+
+`runs.cancel`
+
+Cancel an in-progress run
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.runs.cancel({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `threadId` | `string` | Yes | — |
+| `runId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `thread.run` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `thread_id` | `string` | Yes | — |
+| `assistant_id` | `string` | Yes | — |
+| `status` | `queued \| in_progress \| requires_action \| cancelling \| cancelled \| failed \| completed \| incomplete \| expired` | Yes | — |
+| `required_action` | `object` | No | — |
+| `last_error` | `object` | No | — |
+| `model` | `string` | Yes | — |
+| `instructions` | `string` | No | — |
+| `tools` | `object[]` | Yes | — |
+| `metadata` | `object` | No | — |
+| `usage` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="required_action full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="last_error full type">
+
+```ts
+{
+  code: string,
+  message: string
+}
+```
+</Accordion>
+
+<Accordion title="tools full type">
+
+```ts
+(
+  {
+    type: code_interpreter
+  } | {
+    type: file_search,
+    file_search?: {
+      max_num_results?: number,
+      ranking_options?: {
+        ranker?: string,
+        score_threshold?: number
+      }
+    }
+  } | {
+    type: function,
+    function: {
+      name: string,
+      description?: string,
+      parameters?: {
+      },
+      strict?: boolean | null
+    }
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="usage full type">
+
+```ts
+{
+  prompt_tokens: number,
+  completion_tokens: number,
+  total_tokens: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### create
+
+`runs.create`
+
+Create a run on a thread
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.runs.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `threadId` | `string` | Yes | — |
+| `assistantId` | `string` | Yes | — |
+| `model` | `string` | No | — |
+| `instructions` | `string` | No | — |
+| `additionalInstructions` | `string` | No | — |
+| `tools` | `object[]` | No | — |
+| `metadata` | `object` | No | — |
+| `temperature` | `number` | No | — |
+| `topP` | `number` | No | — |
+| `maxPromptTokens` | `number` | No | — |
+| `maxCompletionTokens` | `number` | No | — |
+| `truncationStrategy` | `object` | No | — |
+| `toolChoice` | `object` | No | — |
+| `parallelToolCalls` | `boolean` | No | — |
+
+<AccordionGroup>
+<Accordion title="tools full type">
+
+```ts
+(
+  {
+    type: code_interpreter
+  } | {
+    type: file_search,
+    file_search?: {
+      max_num_results?: number,
+      ranking_options?: {
+        ranker?: string,
+        score_threshold?: number
+      }
+    }
+  } | {
+    type: function,
+    function: {
+      name: string,
+      description?: string,
+      parameters?: {
+      },
+      strict?: boolean | null
+    }
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="truncationStrategy full type">
+
+```ts
+{
+  type: auto | last_messages,
+  last_messages?: number | null
+}
+```
+</Accordion>
+
+<Accordion title="toolChoice full type">
+
+```ts
+none | auto | required | {
+  type: function | code_interpreter | file_search,
+  function?: {
+    name: string
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `thread.run` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `thread_id` | `string` | Yes | — |
+| `assistant_id` | `string` | Yes | — |
+| `status` | `queued \| in_progress \| requires_action \| cancelling \| cancelled \| failed \| completed \| incomplete \| expired` | Yes | — |
+| `required_action` | `object` | No | — |
+| `last_error` | `object` | No | — |
+| `model` | `string` | Yes | — |
+| `instructions` | `string` | No | — |
+| `tools` | `object[]` | Yes | — |
+| `metadata` | `object` | No | — |
+| `usage` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="required_action full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="last_error full type">
+
+```ts
+{
+  code: string,
+  message: string
+}
+```
+</Accordion>
+
+<Accordion title="tools full type">
+
+```ts
+(
+  {
+    type: code_interpreter
+  } | {
+    type: file_search,
+    file_search?: {
+      max_num_results?: number,
+      ranking_options?: {
+        ranker?: string,
+        score_threshold?: number
+      }
+    }
+  } | {
+    type: function,
+    function: {
+      name: string,
+      description?: string,
+      parameters?: {
+      },
+      strict?: boolean | null
+    }
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="usage full type">
+
+```ts
+{
+  prompt_tokens: number,
+  completion_tokens: number,
+  total_tokens: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### list
+
+`runs.list`
+
+List runs on a thread
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.runs.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `threadId` | `string` | Yes | — |
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+| `after` | `string` | No | — |
+| `before` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: thread.run,
+  created_at: number,
+  thread_id: string,
+  assistant_id: string,
+  status: queued | in_progress | requires_action | cancelling | cancelled | failed | completed | incomplete | expired,
+  required_action?: {
+  } | null,
+  last_error?: {
+    code: string,
+    message: string
+  } | null,
+  model: string,
+  instructions?: string | null,
+  tools: (
+    {
+      type: code_interpreter
+    } | {
+      type: file_search,
+      file_search?: {
+        max_num_results?: number,
+        ranking_options?: {
+          ranker?: string,
+          score_threshold?: number
+        }
+      }
+    } | {
+      type: function,
+      function: {
+        name: string,
+        description?: string,
+        parameters?: {
+        },
+        strict?: boolean | null
+      }
+    }
+  )[],
+  metadata?: {
+  } | null,
+  usage?: {
+    prompt_tokens: number,
+    completion_tokens: number,
+    total_tokens: number
+  } | null
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### modify
+
+`runs.modify`
+
+Modify a run
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.runs.modify({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `threadId` | `string` | Yes | — |
+| `runId` | `string` | Yes | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `thread.run` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `thread_id` | `string` | Yes | — |
+| `assistant_id` | `string` | Yes | — |
+| `status` | `queued \| in_progress \| requires_action \| cancelling \| cancelled \| failed \| completed \| incomplete \| expired` | Yes | — |
+| `required_action` | `object` | No | — |
+| `last_error` | `object` | No | — |
+| `model` | `string` | Yes | — |
+| `instructions` | `string` | No | — |
+| `tools` | `object[]` | Yes | — |
+| `metadata` | `object` | No | — |
+| `usage` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="required_action full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="last_error full type">
+
+```ts
+{
+  code: string,
+  message: string
+}
+```
+</Accordion>
+
+<Accordion title="tools full type">
+
+```ts
+(
+  {
+    type: code_interpreter
+  } | {
+    type: file_search,
+    file_search?: {
+      max_num_results?: number,
+      ranking_options?: {
+        ranker?: string,
+        score_threshold?: number
+      }
+    }
+  } | {
+    type: function,
+    function: {
+      name: string,
+      description?: string,
+      parameters?: {
+      },
+      strict?: boolean | null
+    }
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="usage full type">
+
+```ts
+{
+  prompt_tokens: number,
+  completion_tokens: number,
+  total_tokens: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieve
+
+`runs.retrieve`
+
+Retrieve a run
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.runs.retrieve({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `threadId` | `string` | Yes | — |
+| `runId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `thread.run` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `thread_id` | `string` | Yes | — |
+| `assistant_id` | `string` | Yes | — |
+| `status` | `queued \| in_progress \| requires_action \| cancelling \| cancelled \| failed \| completed \| incomplete \| expired` | Yes | — |
+| `required_action` | `object` | No | — |
+| `last_error` | `object` | No | — |
+| `model` | `string` | Yes | — |
+| `instructions` | `string` | No | — |
+| `tools` | `object[]` | Yes | — |
+| `metadata` | `object` | No | — |
+| `usage` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="required_action full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="last_error full type">
+
+```ts
+{
+  code: string,
+  message: string
+}
+```
+</Accordion>
+
+<Accordion title="tools full type">
+
+```ts
+(
+  {
+    type: code_interpreter
+  } | {
+    type: file_search,
+    file_search?: {
+      max_num_results?: number,
+      ranking_options?: {
+        ranker?: string,
+        score_threshold?: number
+      }
+    }
+  } | {
+    type: function,
+    function: {
+      name: string,
+      description?: string,
+      parameters?: {
+      },
+      strict?: boolean | null
+    }
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="usage full type">
+
+```ts
+{
+  prompt_tokens: number,
+  completion_tokens: number,
+  total_tokens: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### submitToolOutputs
+
+`runs.submitToolOutputs`
+
+Submit tool outputs to a run awaiting action
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.runs.submitToolOutputs({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `threadId` | `string` | Yes | — |
+| `runId` | `string` | Yes | — |
+| `toolOutputs` | `object[]` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="toolOutputs full type">
+
+```ts
+{
+  toolCallId?: string,
+  output?: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `thread.run` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `thread_id` | `string` | Yes | — |
+| `assistant_id` | `string` | Yes | — |
+| `status` | `queued \| in_progress \| requires_action \| cancelling \| cancelled \| failed \| completed \| incomplete \| expired` | Yes | — |
+| `required_action` | `object` | No | — |
+| `last_error` | `object` | No | — |
+| `model` | `string` | Yes | — |
+| `instructions` | `string` | No | — |
+| `tools` | `object[]` | Yes | — |
+| `metadata` | `object` | No | — |
+| `usage` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="required_action full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="last_error full type">
+
+```ts
+{
+  code: string,
+  message: string
+}
+```
+</Accordion>
+
+<Accordion title="tools full type">
+
+```ts
+(
+  {
+    type: code_interpreter
+  } | {
+    type: file_search,
+    file_search?: {
+      max_num_results?: number,
+      ranking_options?: {
+        ranker?: string,
+        score_threshold?: number
+      }
+    }
+  } | {
+    type: function,
+    function: {
+      name: string,
+      description?: string,
+      parameters?: {
+      },
+      strict?: boolean | null
+    }
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="usage full type">
+
+```ts
+{
+  prompt_tokens: number,
+  completion_tokens: number,
+  total_tokens: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Run Steps
+
+### list
+
+`runSteps.list`
+
+List steps of a run
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.runSteps.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `threadId` | `string` | Yes | — |
+| `runId` | `string` | Yes | — |
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+| `after` | `string` | No | — |
+| `before` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: thread.run.step,
+  created_at: number,
+  run_id: string,
+  assistant_id: string,
+  thread_id: string,
+  type: message_creation | tool_calls,
+  status: in_progress | cancelled | failed | completed | expired,
+  step_details: {
+  },
+  last_error?: {
+    code: string,
+    message: string
+  } | null,
+  usage?: {
+    prompt_tokens: number,
+    completion_tokens: number,
+    total_tokens: number
+  } | null
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieve
+
+`runSteps.retrieve`
+
+Retrieve a run step
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.runSteps.retrieve({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `threadId` | `string` | Yes | — |
+| `runId` | `string` | Yes | — |
+| `stepId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `thread.run.step` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `run_id` | `string` | Yes | — |
+| `assistant_id` | `string` | Yes | — |
+| `thread_id` | `string` | Yes | — |
+| `type` | `message_creation \| tool_calls` | Yes | — |
+| `status` | `in_progress \| cancelled \| failed \| completed \| expired` | Yes | — |
+| `step_details` | `object` | Yes | — |
+| `last_error` | `object` | No | — |
+| `usage` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="step_details full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="last_error full type">
+
+```ts
+{
+  code: string,
+  message: string
+}
+```
+</Accordion>
+
+<Accordion title="usage full type">
+
+```ts
+{
+  prompt_tokens: number,
+  completion_tokens: number,
+  total_tokens: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Skills
+
+### create
+
+`skills.create`
+
+Upload a skill
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.skills.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `file` | `custom \| string` | Yes | — |
+| `fileName` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `skill` | No | — |
+| `created_at` | `number` | No | — |
+| `default_version` | `number` | No | — |
+| `latest_version` | `number` | No | — |
+| `description` | `string` | No | — |
+| `name` | `string` | No | — |
+
+
+
+---
+
+### delete
+
+`skills.delete`
+
+Delete a skill
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.skills.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `skillId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `skill.deleted` | Yes | — |
+| `deleted` | `boolean` | Yes | — |
+
+
+
+---
+
+### list
+
+`skills.list`
+
+List skills
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.skills.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `limit` | `number` | No | — |
+| `after` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Threads
+
+### create
+
+`threads.create`
+
+Create a thread
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.threads.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `messages` | `object[]` | No | — |
+| `toolResources` | `object` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="messages full type">
+
+```ts
+{
+  role: user | assistant,
+  content: string,
+  metadata?: {
+  } | null
+}[]
+```
+</Accordion>
+
+<Accordion title="toolResources full type">
+
+```ts
+{
+  code_interpreter?: {
+    file_ids: string[]
+  },
+  file_search?: {
+    vector_store_ids: string[]
+  }
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `thread` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### createAndRun
+
+`threads.createAndRun`
+
+Create a thread and run it in one call
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.threads.createAndRun({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `assistantId` | `string` | Yes | — |
+| `thread` | `object` | No | — |
+| `model` | `string` | No | — |
+| `instructions` | `string` | No | — |
+| `tools` | `object[]` | No | — |
+| `toolResources` | `object` | No | — |
+| `metadata` | `object` | No | — |
+| `temperature` | `number` | No | — |
+| `topP` | `number` | No | — |
+| `truncationStrategy` | `object` | No | — |
+| `toolChoice` | `object` | No | — |
+| `parallelToolCalls` | `boolean` | No | — |
+
+<AccordionGroup>
+<Accordion title="thread full type">
+
+```ts
+{
+  messages?: {
+    role: user | assistant,
+    content: string,
+    metadata?: {
+    } | null
+  }[],
+  toolResources?: {
+    code_interpreter?: {
+      file_ids: string[]
+    },
+    file_search?: {
+      vector_store_ids: string[]
+    }
+  },
+  metadata?: {
+  } | null
+}
+```
+</Accordion>
+
+<Accordion title="tools full type">
+
+```ts
+(
+  {
+    type: code_interpreter
+  } | {
+    type: file_search,
+    file_search?: {
+      max_num_results?: number,
+      ranking_options?: {
+        ranker?: string,
+        score_threshold?: number
+      }
+    }
+  } | {
+    type: function,
+    function: {
+      name: string,
+      description?: string,
+      parameters?: {
+      },
+      strict?: boolean | null
+    }
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="toolResources full type">
+
+```ts
+{
+  code_interpreter?: {
+    file_ids: string[]
+  },
+  file_search?: {
+    vector_store_ids: string[]
+  }
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="truncationStrategy full type">
+
+```ts
+{
+  type: auto | last_messages,
+  last_messages?: number | null
+}
+```
+</Accordion>
+
+<Accordion title="toolChoice full type">
+
+```ts
+none | auto | required | {
+  type: function | code_interpreter | file_search,
+  function?: {
+    name: string
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `thread.run` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `thread_id` | `string` | Yes | — |
+| `assistant_id` | `string` | Yes | — |
+| `status` | `queued \| in_progress \| requires_action \| cancelling \| cancelled \| failed \| completed \| incomplete \| expired` | Yes | — |
+| `required_action` | `object` | No | — |
+| `last_error` | `object` | No | — |
+| `model` | `string` | Yes | — |
+| `instructions` | `string` | No | — |
+| `tools` | `object[]` | Yes | — |
+| `metadata` | `object` | No | — |
+| `usage` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="required_action full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="last_error full type">
+
+```ts
+{
+  code: string,
+  message: string
+}
+```
+</Accordion>
+
+<Accordion title="tools full type">
+
+```ts
+(
+  {
+    type: code_interpreter
+  } | {
+    type: file_search,
+    file_search?: {
+      max_num_results?: number,
+      ranking_options?: {
+        ranker?: string,
+        score_threshold?: number
+      }
+    }
+  } | {
+    type: function,
+    function: {
+      name: string,
+      description?: string,
+      parameters?: {
+      },
+      strict?: boolean | null
+    }
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="usage full type">
+
+```ts
+{
+  prompt_tokens: number,
+  completion_tokens: number,
+  total_tokens: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### delete
+
+`threads.delete`
+
+Delete a thread
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.threads.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `threadId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `thread.deleted` | Yes | — |
+| `deleted` | `boolean` | Yes | — |
+
+
+
+---
+
+### modify
+
+`threads.modify`
+
+Modify a thread
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.threads.modify({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `threadId` | `string` | Yes | — |
+| `toolResources` | `object` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="toolResources full type">
+
+```ts
+{
+  code_interpreter?: {
+    file_ids: string[]
+  },
+  file_search?: {
+    vector_store_ids: string[]
+  }
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `thread` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieve
+
+`threads.retrieve`
+
+Retrieve a thread by id
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.threads.retrieve({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `threadId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `thread` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Tokens
+
+### countInput
+
+`tokens.countInput`
+
+Count input tokens for a prospective request
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.tokens.countInput({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `model` | `string` | Yes | — |
+| `input` | `object[]` | Yes | — |
+| `tools` | `object[]` | No | — |
+
+<AccordionGroup>
+<Accordion title="input full type">
+
+```ts
+string | {
+}[]
+```
+</Accordion>
+
+<Accordion title="tools full type">
+
+```ts
+{
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `input_tokens` | `number` | Yes | — |
+
+
+
+---
+
+## Uploads
+
+### addPart
+
+`uploads.addPart`
+
+Add a part of file data to an upload
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.uploads.addPart({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `uploadId` | `string` | Yes | — |
+| `data` | `custom \| string` | Yes | — |
+| `fileName` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `upload.part` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `upload_id` | `string` | Yes | — |
+
+
+
+---
+
+### cancel
+
+`uploads.cancel`
+
+Cancel an in-progress upload session
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.uploads.cancel({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `uploadId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `upload` | Yes | — |
+| `bytes` | `number` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `filename` | `string` | Yes | — |
+| `purpose` | `string` | Yes | — |
+| `status` | `pending \| completed \| cancelled \| expired` | Yes | — |
+| `expires_at` | `number` | Yes | — |
+| `file` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="file full type">
+
+```ts
+{
+  id: string,
+  object: file,
+  bytes: number,
+  created_at: number,
+  filename: string,
+  purpose: string
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### complete
+
+`uploads.complete`
+
+Complete a multipart upload session
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.uploads.complete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `uploadId` | `string` | Yes | — |
+| `partIds` | `string[]` | Yes | — |
+| `md5` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `upload` | Yes | — |
+| `bytes` | `number` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `filename` | `string` | Yes | — |
+| `purpose` | `string` | Yes | — |
+| `status` | `pending \| completed \| cancelled \| expired` | Yes | — |
+| `expires_at` | `number` | Yes | — |
+| `file` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="file full type">
+
+```ts
+{
+  id: string,
+  object: file,
+  bytes: number,
+  created_at: number,
+  filename: string,
+  purpose: string
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### create
+
+`uploads.create`
+
+Create a multipart upload session
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.uploads.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `filename` | `string` | Yes | — |
+| `purpose` | `assistants \| assistants_output \| batch \| batch_output \| fine-tune \| fine-tune-results \| vision \| user_data \| evals` | Yes | — |
+| `bytes` | `number` | Yes | — |
+| `mimeType` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `upload` | Yes | — |
+| `bytes` | `number` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `filename` | `string` | Yes | — |
+| `purpose` | `string` | Yes | — |
+| `status` | `pending \| completed \| cancelled \| expired` | Yes | — |
+| `expires_at` | `number` | Yes | — |
+| `file` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="file full type">
+
+```ts
+{
+  id: string,
+  object: file,
+  bytes: number,
+  created_at: number,
+  filename: string,
+  purpose: string
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Vector Store File Batches
+
+### create
+
+`vectorStoreFileBatches.create`
+
+Attach a batch of files to a vector store
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.vectorStoreFileBatches.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `vectorStoreId` | `string` | Yes | — |
+| `fileIds` | `string[]` | Yes | — |
+| `chunkingStrategy` | `object` | No | — |
+| `attributes` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="chunkingStrategy full type">
+
+```ts
+{
+  type: auto
+} | {
+  type: static,
+  static: {
+    max_chunk_size_tokens: number,
+    chunk_overlap_tokens: number
+  }
+}
+```
+</Accordion>
+
+<Accordion title="attributes full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `vector_store.file_batch` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `vector_store_id` | `string` | Yes | — |
+| `status` | `in_progress \| completed \| cancelled \| failed` | Yes | — |
+| `file_counts` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="file_counts full type">
+
+```ts
+{
+  in_progress: number,
+  completed: number,
+  failed: number,
+  cancelled: number,
+  total: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### listFiles
+
+`vectorStoreFileBatches.listFiles`
+
+List files in a vector store file batch
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.vectorStoreFileBatches.listFiles({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `vectorStoreId` | `string` | Yes | — |
+| `batchId` | `string` | Yes | — |
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+| `after` | `string` | No | — |
+| `before` | `string` | No | — |
+| `filter` | `in_progress \| completed \| cancelled \| failed` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: vector_store.file,
+  usage_bytes: number,
+  created_at: number,
+  vector_store_id: string,
+  status: in_progress | completed | cancelled | failed,
+  last_error?: {
+    code: string,
+    message: string
+  } | null,
+  attributes?: {
+  } | null
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieve
+
+`vectorStoreFileBatches.retrieve`
+
+Retrieve a vector store file batch
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.vectorStoreFileBatches.retrieve({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `vectorStoreId` | `string` | Yes | — |
+| `batchId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `vector_store.file_batch` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `vector_store_id` | `string` | Yes | — |
+| `status` | `in_progress \| completed \| cancelled \| failed` | Yes | — |
+| `file_counts` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="file_counts full type">
+
+```ts
+{
+  in_progress: number,
+  completed: number,
+  failed: number,
+  cancelled: number,
+  total: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Vector Store Files
+
+### create
+
+`vectorStoreFiles.create`
+
+Attach a file to a vector store
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.vectorStoreFiles.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `vectorStoreId` | `string` | Yes | — |
+| `fileId` | `string` | Yes | — |
+| `chunkingStrategy` | `object` | No | — |
+| `attributes` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="chunkingStrategy full type">
+
+```ts
+{
+  type: auto
+} | {
+  type: static,
+  static: {
+    max_chunk_size_tokens: number,
+    chunk_overlap_tokens: number
+  }
+}
+```
+</Accordion>
+
+<Accordion title="attributes full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `vector_store.file` | Yes | — |
+| `usage_bytes` | `number` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `vector_store_id` | `string` | Yes | — |
+| `status` | `in_progress \| completed \| cancelled \| failed` | Yes | — |
+| `last_error` | `object` | No | — |
+| `attributes` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="last_error full type">
+
+```ts
+{
+  code: string,
+  message: string
+}
+```
+</Accordion>
+
+<Accordion title="attributes full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### delete
+
+`vectorStoreFiles.delete`
+
+Detach a file from a vector store
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.vectorStoreFiles.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `vectorStoreId` | `string` | Yes | — |
+| `fileId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `vector_store.file.deleted` | Yes | — |
+| `deleted` | `boolean` | Yes | — |
+
+
+
+---
+
+### list
+
+`vectorStoreFiles.list`
+
+List files attached to a vector store
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.vectorStoreFiles.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `vectorStoreId` | `string` | Yes | — |
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+| `after` | `string` | No | — |
+| `before` | `string` | No | — |
+| `filter` | `in_progress \| completed \| cancelled \| failed` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: vector_store.file,
+  usage_bytes: number,
+  created_at: number,
+  vector_store_id: string,
+  status: in_progress | completed | cancelled | failed,
+  last_error?: {
+    code: string,
+    message: string
+  } | null,
+  attributes?: {
+  } | null
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieve
+
+`vectorStoreFiles.retrieve`
+
+Retrieve a vector store file
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.vectorStoreFiles.retrieve({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `vectorStoreId` | `string` | Yes | — |
+| `fileId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `vector_store.file` | Yes | — |
+| `usage_bytes` | `number` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `vector_store_id` | `string` | Yes | — |
+| `status` | `in_progress \| completed \| cancelled \| failed` | Yes | — |
+| `last_error` | `object` | No | — |
+| `attributes` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="last_error full type">
+
+```ts
+{
+  code: string,
+  message: string
+}
+```
+</Accordion>
+
+<Accordion title="attributes full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieveContent
+
+`vectorStoreFiles.retrieveContent`
+
+Retrieve the parsed content of a vector store file
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.vectorStoreFiles.retrieveContent({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `vectorStoreId` | `string` | Yes | — |
+| `fileId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `vector_store.file_content.page` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `has_more` | `boolean` | Yes | — |
+| `next_page` | `string` | No | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  type: text,
+  text: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### updateAttributes
+
+`vectorStoreFiles.updateAttributes`
+
+Update attributes on a vector store file
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.vectorStoreFiles.updateAttributes({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `vectorStoreId` | `string` | Yes | — |
+| `fileId` | `string` | Yes | — |
+| `attributes` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="attributes full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `vector_store.file` | Yes | — |
+| `usage_bytes` | `number` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `vector_store_id` | `string` | Yes | — |
+| `status` | `in_progress \| completed \| cancelled \| failed` | Yes | — |
+| `last_error` | `object` | No | — |
+| `attributes` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="last_error full type">
+
+```ts
+{
+  code: string,
+  message: string
+}
+```
+</Accordion>
+
+<Accordion title="attributes full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Vector Stores
+
+### create
+
+`vectorStores.create`
+
+Create a vector store
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.vectorStores.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | `string` | No | — |
+| `fileIds` | `string[]` | No | — |
+| `expiresAfter` | `object` | No | — |
+| `chunkingStrategy` | `object` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="expiresAfter full type">
+
+```ts
+{
+  anchor: last_active_at,
+  days: number
+}
+```
+</Accordion>
+
+<Accordion title="chunkingStrategy full type">
+
+```ts
+{
+  type: auto
+} | {
+  type: static,
+  static: {
+    max_chunk_size_tokens: number,
+    chunk_overlap_tokens: number
+  }
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `vector_store` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `name` | `string` | No | — |
+| `usage_bytes` | `number` | Yes | — |
+| `file_counts` | `object` | Yes | — |
+| `status` | `expired \| in_progress \| completed` | Yes | — |
+| `expires_after` | `object` | No | — |
+| `expires_at` | `number` | No | — |
+| `last_active_at` | `number` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="file_counts full type">
+
+```ts
+{
+  in_progress: number,
+  completed: number,
+  failed: number,
+  cancelled: number,
+  total: number
+}
+```
+</Accordion>
+
+<Accordion title="expires_after full type">
+
+```ts
+{
+  anchor: last_active_at,
+  days: number
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### delete
+
+`vectorStores.delete`
+
+Delete a vector store
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.vectorStores.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `vectorStoreId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `vector_store.deleted` | Yes | — |
+| `deleted` | `boolean` | Yes | — |
+
+
+
+---
+
+### list
+
+`vectorStores.list`
+
+List vector stores
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.vectorStores.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+| `after` | `string` | No | — |
+| `before` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: vector_store,
+  created_at: number,
+  name?: string | null,
+  usage_bytes: number,
+  file_counts: {
+    in_progress: number,
+    completed: number,
+    failed: number,
+    cancelled: number,
+    total: number
+  },
+  status: expired | in_progress | completed,
+  expires_after?: {
+    anchor: last_active_at,
+    days: number
+  },
+  expires_at?: number | null,
+  last_active_at?: number | null,
+  metadata?: {
+  } | null
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### modify
+
+`vectorStores.modify`
+
+Modify a vector store
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.vectorStores.modify({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `vectorStoreId` | `string` | Yes | — |
+| `name` | `string` | No | — |
+| `expiresAfter` | `object` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="expiresAfter full type">
+
+```ts
+{
+  anchor: last_active_at,
+  days: number
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `vector_store` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `name` | `string` | No | — |
+| `usage_bytes` | `number` | Yes | — |
+| `file_counts` | `object` | Yes | — |
+| `status` | `expired \| in_progress \| completed` | Yes | — |
+| `expires_after` | `object` | No | — |
+| `expires_at` | `number` | No | — |
+| `last_active_at` | `number` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="file_counts full type">
+
+```ts
+{
+  in_progress: number,
+  completed: number,
+  failed: number,
+  cancelled: number,
+  total: number
+}
+```
+</Accordion>
+
+<Accordion title="expires_after full type">
+
+```ts
+{
+  anchor: last_active_at,
+  days: number
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieve
+
+`vectorStores.retrieve`
+
+Retrieve a vector store
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.vectorStores.retrieve({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `vectorStoreId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `vector_store` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `name` | `string` | No | — |
+| `usage_bytes` | `number` | Yes | — |
+| `file_counts` | `object` | Yes | — |
+| `status` | `expired \| in_progress \| completed` | Yes | — |
+| `expires_after` | `object` | No | — |
+| `expires_at` | `number` | No | — |
+| `last_active_at` | `number` | No | — |
+| `metadata` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="file_counts full type">
+
+```ts
+{
+  in_progress: number,
+  completed: number,
+  failed: number,
+  cancelled: number,
+  total: number
+}
+```
+</Accordion>
+
+<Accordion title="expires_after full type">
+
+```ts
+{
+  anchor: last_active_at,
+  days: number
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### search
+
+`vectorStores.search`
+
+Search a vector store for relevant chunks
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.vectorStores.search({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `vectorStoreId` | `string` | Yes | — |
+| `query` | `string \| string[]` | Yes | — |
+| `filters` | `object` | No | — |
+| `maxNumResults` | `number` | No | — |
+| `rankingOptions` | `object` | No | — |
+| `rewriteQuery` | `boolean` | No | — |
+
+<AccordionGroup>
+<Accordion title="filters full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="rankingOptions full type">
+
+```ts
+{
+  ranker?: string,
+  score_threshold?: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `vector_store.search_results.page` | Yes | — |
+| `search_query` | `string[]` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `has_more` | `boolean` | Yes | — |
+| `next_page` | `string` | No | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  file_id: string,
+  filename: string,
+  score: number,
+  attributes?: {
+  } | null,
+  content: {
+    type: text,
+    text: string
+  }[]
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Videos
+
+### create
+
+`videos.create`
+
+Generate a video from a prompt
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.videos.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `prompt` | `string` | Yes | — |
+| `model` | `string` | No | — |
+| `size` | `string` | No | — |
+| `seconds` | `string` | No | — |
+| `inputReference` | `custom \| string` | No | — |
+| `inputReferenceFileName` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `video` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `status` | `queued \| in_progress \| completed \| failed` | Yes | — |
+| `model` | `string` | No | — |
+| `progress` | `number` | No | — |
+| `seconds` | `string` | No | — |
+| `size` | `string` | No | — |
+| `remixed_from_video_id` | `string` | No | — |
+| `error` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="error full type">
+
+```ts
+{
+  code: string,
+  message: string
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### createRemix
+
+`videos.createRemix`
+
+Create a remix of an existing video
+
+**Risk:** `write`
+
+```ts
+await corsair.openai.api.videos.createRemix({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `videoId` | `string` | Yes | — |
+| `prompt` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `video` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `status` | `queued \| in_progress \| completed \| failed` | Yes | — |
+| `model` | `string` | No | — |
+| `progress` | `number` | No | — |
+| `seconds` | `string` | No | — |
+| `size` | `string` | No | — |
+| `remixed_from_video_id` | `string` | No | — |
+| `error` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="error full type">
+
+```ts
+{
+  code: string,
+  message: string
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### delete
+
+`videos.delete`
+
+Delete a video
+
+**Risk:** `destructive`
+
+```ts
+await corsair.openai.api.videos.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `videoId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `video.deleted` | Yes | — |
+| `deleted` | `boolean` | Yes | — |
+
+
+
+---
+
+### download
+
+`videos.download`
+
+Download the rendered content of a video
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.videos.download({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `videoId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `videoId` | `string` | Yes | — |
+| `contentBase64` | `string` | Yes | — |
+
+
+
+---
+
+### list
+
+`videos.list`
+
+List generated videos
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.videos.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `limit` | `number` | No | — |
+| `order` | `asc \| desc` | No | — |
+| `after` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `object` | `list` | Yes | — |
+| `data` | `object[]` | Yes | — |
+| `first_id` | `string` | No | — |
+| `last_id` | `string` | No | — |
+| `has_more` | `boolean` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  id: string,
+  object: video,
+  created_at: number,
+  status: queued | in_progress | completed | failed,
+  model?: string,
+  progress?: number,
+  seconds?: string,
+  size?: string,
+  remixed_from_video_id?: string | null,
+  error?: {
+    code: string,
+    message: string
+  } | null
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### retrieve
+
+`videos.retrieve`
+
+Retrieve a video
+
+**Risk:** `read`
+
+```ts
+await corsair.openai.api.videos.retrieve({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `videoId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `object` | `video` | Yes | — |
+| `created_at` | `number` | Yes | — |
+| `status` | `queued \| in_progress \| completed \| failed` | Yes | — |
+| `model` | `string` | No | — |
+| `progress` | `number` | No | — |
+| `seconds` | `string` | No | — |
+| `size` | `string` | No | — |
+| `remixed_from_video_id` | `string` | No | — |
+| `error` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="error full type">
+
+```ts
+{
+  code: string,
+  message: string
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+

--- a/docs/plugins/openai/database.mdx
+++ b/docs/plugins/openai/database.mdx
@@ -1,0 +1,89 @@
+---
+title: Database
+description: "Openai local sync: searchable entities, `.search()` filters, and operators."
+---
+
+The Openai plugin syncs data locally. Use `corsair.openai.db.<entity>.search({ data, limit?, offset? })` with the filters listed per entity.
+
+<Info>
+**New to Corsair?** See [database operations](/concepts/database), [data synchronization](/concepts/integrations), and [multi-tenancy](/concepts/multi-tenancy).
+</Info>
+
+## Assistants
+
+Path: `openai.db.assistants.search`
+
+```ts
+const rows = await corsair.openai.db.assistants.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `id` | `string` | equals, contains, startsWith, endsWith, in |
+| `name` | `string` | equals, contains, startsWith, endsWith, in |
+| `model` | `string` | equals, contains, startsWith, endsWith, in |
+| `description` | `string` | equals, contains, startsWith, endsWith, in |
+| `createdAt` | `date` | equals, before, after, between |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+
+## Threads
+
+Path: `openai.db.threads.search`
+
+```ts
+const rows = await corsair.openai.db.threads.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `id` | `string` | equals, contains, startsWith, endsWith, in |
+| `createdAt` | `date` | equals, before, after, between |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+
+## Vector Stores
+
+Path: `openai.db.vectorStores.search`
+
+```ts
+const rows = await corsair.openai.db.vectorStores.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `id` | `string` | equals, contains, startsWith, endsWith, in |
+| `name` | `string` | equals, contains, startsWith, endsWith, in |
+| `status` | `string` | equals, contains, startsWith, endsWith, in |
+| `usageBytes` | `number` | equals, gt, gte, lt, lte, in |
+| `createdAt` | `date` | equals, before, after, between |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+

--- a/docs/plugins/openai/get-credentials.mdx
+++ b/docs/plugins/openai/get-credentials.mdx
@@ -1,0 +1,32 @@
+---
+title: Get Credentials
+description: Step-by-step instructions for obtaining OpenAI API credentials.
+---
+
+## Authentication Method
+
+- **[`api_key`](/concepts/api-key)** - OpenAI API key
+
+## API Key Setup
+
+### Step 1: Get Your API Key
+
+1. Log in to [OpenAI Platform](https://platform.openai.com)
+2. Open **API keys** from the left sidebar
+3. Select **Create new secret key** and give it a name
+4. Copy the key and store it securely
+5. Add billing and credits as needed — API calls require paid usage
+
+**Storing Credentials:**
+
+```bash
+pnpm corsair setup --plugin=openai api_key=your-api-key
+```
+
+## Required Credentials Summary
+
+| Credential | Required For | Where to Find |
+|-----------|--------------|---------------|
+| API Key | All API calls | OpenAI Platform → API keys |
+
+For general information about how Corsair handles authentication, see [Authentication](/concepts/auth).

--- a/docs/plugins/openai/overview.mdx
+++ b/docs/plugins/openai/overview.mdx
@@ -1,0 +1,141 @@
+---
+title: Overview
+description: "Openai plugin for Corsair"
+---
+
+Use **Openai** through Corsair: one client, typed API calls, optional local DB sync.
+
+**What you get:**
+
+- 129 typed API operations
+- 3 database entities synced for fast `.search()` / `.list()` queries
+
+## Setup
+
+<Steps>
+
+<Step title="Install">
+```bash
+pnpm install @corsair-dev/openai
+```
+
+</Step>
+
+<Step title="Add the plugin">
+<Tabs>
+<Tab title="Solo">
+```ts corsair.ts
+import { createCorsair } from 'corsair';
+import { openai } from '@corsair-dev/openai';
+
+export const corsair = createCorsair({
+	// ... other config options,
+	multiTenancy: false,
+    plugins: [openai()],
+});
+```
+</Tab>
+<Tab title="Multi-Tenant">
+```ts corsair.ts
+import { createCorsair } from 'corsair';
+import { openai } from '@corsair-dev/openai';
+
+export const corsair = createCorsair({
+	// ... other config options,
+    multiTenancy: true,
+    plugins: [openai()],
+});
+```
+
+See [Multi-tenancy](/concepts/multi-tenancy) for account isolation.
+
+</Tab>
+</Tabs>
+
+</Step>
+
+<Step title="Get credentials">
+Follow [Get Credentials](/plugins/openai/get-credentials) if you need help getting keys.
+
+</Step>
+
+<Step title="Store credentials">
+<Tabs>
+<Tab title="Solo">
+```bash
+pnpm corsair setup --plugin=openai
+```
+
+Use the key names documented in [Get Credentials](/plugins/openai/get-credentials) (for example `api_key=`, `bot_token=`, or OAuth client fields).
+</Tab>
+<Tab title="Multi-Tenant">
+```bash
+pnpm corsair setup --plugin=openai --tenant=<tenantId>
+```
+
+Store per-tenant secrets after you create the tenant record. See [Multi-tenancy](/concepts/multi-tenancy).
+</Tab>
+</Tabs>
+
+</Step>
+
+</Steps>
+
+## Authentication
+
+Each tab shows how to register the plugin for that authentication method. The default `authType` from the plugin does not need to appear in the factory call.
+
+<Tabs>
+<Tab title="API Key (Default)">
+
+```ts corsair.ts
+openai()
+```
+
+Store credentials with `pnpm corsair setup --plugin=openai` (see [Get Credentials](/plugins/openai/get-credentials) for field names). For OAuth, you typically store integration keys at the provider level and tokens per account or tenant.
+
+More: [API Key](/concepts/api-key)
+
+</Tab>
+</Tabs>
+
+
+## Query synced data
+
+Synced entities support `corsair.openai.db.<entity>.search()` and `.list()`. See [Database](/plugins/openai/database) for filters and operators.
+
+
+## Example API calls
+
+**Read-style (read):** `assistants.list`
+
+```ts
+await corsair.openai.api.assistants.list({});
+```
+
+
+**Write-style (write):** `assistants.create`
+
+```ts
+await corsair.openai.api.assistants.create({});
+```
+
+
+See the full list on the [API](/plugins/openai/api) page. Use `pnpm corsair list --plugin=openai` and `pnpm corsair schema <path>` locally to inspect schemas.
+
+---
+
+## Hooks
+
+Use `hooks` on API calls and `webhookHooks` on incoming events to add logging, approvals, or side effects. See [Hooks](/concepts/hooks) and [Webhooks](/concepts/webhooks) for routing and payload patterns.
+
+---
+
+## Reference
+
+| Topic | Link |
+|-------|------|
+| API | [API](/plugins/openai/api) |
+| Database | [Database](/plugins/openai/database) |
+| Credentials | [Get credentials](/plugins/openai/get-credentials) |
+


### PR DESCRIPTION
## Description

Adds the missing OpenAI plugin documentation. `packages/openai` has been on `main` for a while, but `docs/plugins/openai` never existed and the plugin wasn't listed in the Mintlify nav — so anyone browsing the docs had no way to find it.

This PR runs the standard doc generator against the `openai` plugin and commits the output, rather than hand-writing a one-off page.

Fixes #541

## Changes

- Ran `pnpm generate:docs -- --plugin=openai` to generate the plugin docs
- Added generated MDX under `docs/plugins/openai/`
- Updated `docs/docs.json` to add the `openai` nav entry under Plugins via script
- Updated `docs/docs.json` to add the `/plugins/openai/get-credentials`

## Tests

Ran the verification steps from the issue:

- [x] `docs/plugins/openai/` exists with the usual pages
- [x] `openai` shows up under Plugins in `docs/docs.json`
- [x] No hand-written one-off layout that ignores the generator

## Screenshots / Demo
<img width="1686" height="934" alt="Screenshot 2026-08-01 at 2 09 17 PM" src="https://github.com/user-attachments/assets/d8005eb4-e1e6-42a6-a890-662b1e26b7e6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

- Added comprehensive OpenAI plugin documentation covering installation, authentication, configuration, hooks, and usage examples.
- Added a complete API reference for assistants, chat, files, images, models, responses, threads, vector stores, and more.
- Documented synchronized data search and listing, including filtering and pagination.
- Added OpenAI documentation to the navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->