### PR TITLE
docs(hashnode): generate mintlify docs for hashnode

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -431,6 +431,7 @@
                 "group": "Hashnode",
                 "pages": [
                   "plugins/hashnode/overview",
+                  "plugins/hashnode/get-credentials",
                   "plugins/hashnode/api",
                   "plugins/hashnode/database"
                 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -428,6 +428,14 @@
                 ]
               },
               {
+                "group": "Hashnode",
+                "pages": [
+                  "plugins/hashnode/overview",
+                  "plugins/hashnode/api",
+                  "plugins/hashnode/database"
+                ]
+              },
+              {
                 "group": "Hubspot",
                 "pages": [
                   "plugins/hubspot/overview",

--- a/docs/plugins/hashnode/api.mdx
+++ b/docs/plugins/hashnode/api.mdx
@@ -1,0 +1,2216 @@
+---
+title: API
+description: "API reference for Hashnode: every `hashnode.api.*` operation with input and output types."
+---
+
+Every `hashnode.api.*` operation is listed below with parameter shapes and return types from the plugin Zod schemas.
+
+<Info>
+**New to Corsair?** See [API access](/concepts/api), [authentication](/concepts/auth), and [error handling](/concepts/error-handling).
+</Info>
+
+## Comments
+
+### list
+
+`comments.list`
+
+List comments on a post
+
+**Risk:** `read`
+
+```ts
+await corsair.hashnode.api.comments.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `postId` | `string` | Yes | — |
+| `first` | `number` | Yes | — |
+| `after` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `post` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="post full type">
+
+```ts
+{
+  comments: {
+    edges: {
+      node: {
+        id: string,
+        content: {
+          html?: string,
+          markdown?: string,
+          text?: string
+        },
+        author?: {
+          id: string,
+          name: string,
+          username: string,
+          profilePicture?: string | null,
+          coverImage?: string | null,
+          bio?: {
+            text?: string | null,
+            html?: string,
+            markdown?: string
+          } | null,
+          socialMediaLinks?: {
+            twitter?: string | null,
+            github?: string | null,
+            linkedin?: string | null,
+            website?: string | null
+          } | null,
+          location?: string | null,
+          dateJoined?: string | null
+        } | null,
+        totalReactions: number,
+        dateAdded: string
+      },
+      cursor: string
+    }[],
+    pageInfo: {
+      hasNextPage: boolean,
+      endCursor?: string | null
+    }
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Drafts
+
+### create
+
+`drafts.create`
+
+Create a new draft
+
+**Risk:** `write`
+
+```ts
+await corsair.hashnode.api.drafts.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `publicationId` | `string` | Yes | — |
+| `title` | `string` | No | — |
+| `subtitle` | `string` | No | — |
+| `contentMarkdown` | `string` | No | — |
+| `slug` | `string` | No | — |
+| `tags` | `object[]` | No | — |
+| `seriesId` | `string` | No | — |
+| `disableComments` | `boolean` | No | — |
+| `originalArticleURL` | `string` | No | — |
+| `publishedAt` | `string` | No | — |
+| `settings` | `object` | No | — |
+| `metaTags` | `object` | No | — |
+| `coverImageOptions` | `object` | No | — |
+| `publishAs` | `string` | No | — |
+| `coAuthors` | `string[]` | No | — |
+
+<AccordionGroup>
+<Accordion title="tags full type">
+
+```ts
+{
+  slug: string,
+  name?: string
+}[]
+```
+</Accordion>
+
+<Accordion title="settings full type">
+
+```ts
+{
+  enableTableOfContent?: boolean,
+  delist?: boolean,
+  activateNewsletter?: boolean,
+  slugOverridden?: boolean
+}
+```
+</Accordion>
+
+<Accordion title="metaTags full type">
+
+```ts
+{
+  title?: string,
+  description?: string,
+  image?: string
+}
+```
+</Accordion>
+
+<Accordion title="coverImageOptions full type">
+
+```ts
+{
+  coverImageURL?: string,
+  coverImageAttribution?: string,
+  coverImagePhotographer?: string,
+  isCoverAttributionHidden?: boolean,
+  stickCoverToBottom?: boolean
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `createDraft` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="createDraft full type">
+
+```ts
+{
+  draft: {
+    id: string,
+    title?: string | null,
+    subtitle?: string | null,
+    slug?: string | null,
+    content?: {
+      markdown?: string,
+      html?: string,
+      text?: string
+    } | null,
+    author?: {
+      id: string,
+      name: string,
+      username: string,
+      profilePicture?: string | null,
+      coverImage?: string | null,
+      bio?: {
+        text?: string | null,
+        html?: string,
+        markdown?: string
+      } | null,
+      socialMediaLinks?: {
+        twitter?: string | null,
+        github?: string | null,
+        linkedin?: string | null,
+        website?: string | null
+      } | null,
+      location?: string | null,
+      dateJoined?: string | null
+    } | null,
+    coverImage?: {
+      url?: string | null,
+      attribution?: string | null
+    } | null,
+    tags?: {
+      id: string,
+      name: string,
+      slug: string
+    }[] | null,
+    publication?: {
+      id: string,
+      title: string
+    } | null,
+    series?: {
+      id: string,
+      name: string,
+      slug: string
+    } | null,
+    updatedAt: string,
+    scheduledDate?: string | null,
+    readTimeInMinutes?: number,
+    isSubmittedForReview?: boolean
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### delete
+
+`drafts.delete`
+
+Delete a draft [DESTRUCTIVE - IRREVERSIBLE]
+
+**Risk:** `destructive` · **Irreversible**
+
+```ts
+await corsair.hashnode.api.drafts.delete({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `draftId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `deleteDraft` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="deleteDraft full type">
+
+```ts
+{
+  draft?: {
+    id: string
+  } | null
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### get
+
+`drafts.get`
+
+Get a draft by ID
+
+**Risk:** `read`
+
+```ts
+await corsair.hashnode.api.drafts.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `draft` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="draft full type">
+
+```ts
+{
+  id: string,
+  title?: string | null,
+  subtitle?: string | null,
+  slug?: string | null,
+  content?: {
+    markdown?: string,
+    html?: string,
+    text?: string
+  } | null,
+  author?: {
+    id: string,
+    name: string,
+    username: string,
+    profilePicture?: string | null,
+    coverImage?: string | null,
+    bio?: {
+      text?: string | null,
+      html?: string,
+      markdown?: string
+    } | null,
+    socialMediaLinks?: {
+      twitter?: string | null,
+      github?: string | null,
+      linkedin?: string | null,
+      website?: string | null
+    } | null,
+    location?: string | null,
+    dateJoined?: string | null
+  } | null,
+  coverImage?: {
+    url?: string | null,
+    attribution?: string | null
+  } | null,
+  tags?: {
+    id: string,
+    name: string,
+    slug: string
+  }[] | null,
+  publication?: {
+    id: string,
+    title: string
+  } | null,
+  series?: {
+    id: string,
+    name: string,
+    slug: string
+  } | null,
+  updatedAt: string,
+  scheduledDate?: string | null,
+  readTimeInMinutes?: number,
+  isSubmittedForReview?: boolean
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### publish
+
+`drafts.publish`
+
+Publish a draft as a post
+
+**Risk:** `write`
+
+```ts
+await corsair.hashnode.api.drafts.publish({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `draftId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `publishDraft` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="publishDraft full type">
+
+```ts
+{
+  post: {
+    id: string,
+    title: string,
+    subtitle?: string | null,
+    slug: string,
+    brief: string,
+    url: string,
+    coverImage?: {
+      url?: string | null,
+      isPortrait?: boolean,
+      attribution?: string | null
+    } | null,
+    author?: {
+      id: string,
+      name: string,
+      username: string,
+      profilePicture?: string | null,
+      coverImage?: string | null,
+      bio?: {
+        text?: string | null,
+        html?: string,
+        markdown?: string
+      } | null,
+      socialMediaLinks?: {
+        twitter?: string | null,
+        github?: string | null,
+        linkedin?: string | null,
+        website?: string | null
+      } | null,
+      location?: string | null,
+      dateJoined?: string | null
+    } | null,
+    publication?: {
+      id: string,
+      title: string,
+      url?: string | null,
+      displayTitle?: string | null
+    } | null,
+    tags?: {
+      id: string,
+      name: string,
+      slug: string
+    }[] | null,
+    content?: {
+      html?: string,
+      markdown?: string,
+      text?: string
+    } | null,
+    seo?: {
+      title?: string | null,
+      description?: string | null
+    } | null,
+    ogMetaData?: {
+      image?: string | null
+    } | null,
+    publishedAt: string,
+    updatedAt?: string | null,
+    readTimeInMinutes: number,
+    reactionCount: number,
+    responseCount: number,
+    replyCount?: number,
+    series?: {
+      id: string,
+      name: string,
+      slug: string
+    } | null,
+    featured?: boolean
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### update
+
+`drafts.update`
+
+Update an existing draft
+
+**Risk:** `write`
+
+```ts
+await corsair.hashnode.api.drafts.update({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `draftId` | `string` | Yes | — |
+| `title` | `string` | No | — |
+| `subtitle` | `string` | No | — |
+| `contentMarkdown` | `string` | No | — |
+| `slug` | `string` | No | — |
+| `tags` | `object[]` | No | — |
+| `seriesId` | `string` | No | — |
+| `disableComments` | `boolean` | No | — |
+| `originalArticleURL` | `string` | No | — |
+| `publishedAt` | `string` | No | — |
+| `settings` | `object` | No | — |
+| `metaTags` | `object` | No | — |
+| `coverImageOptions` | `object` | No | — |
+| `publishAs` | `string` | No | — |
+| `coAuthors` | `string[]` | No | — |
+
+<AccordionGroup>
+<Accordion title="tags full type">
+
+```ts
+{
+  slug: string,
+  name?: string
+}[]
+```
+</Accordion>
+
+<Accordion title="settings full type">
+
+```ts
+{
+  enableTableOfContent?: boolean,
+  delist?: boolean,
+  activateNewsletter?: boolean,
+  slugOverridden?: boolean
+}
+```
+</Accordion>
+
+<Accordion title="metaTags full type">
+
+```ts
+{
+  title?: string,
+  description?: string,
+  image?: string
+}
+```
+</Accordion>
+
+<Accordion title="coverImageOptions full type">
+
+```ts
+{
+  coverImageURL?: string,
+  coverImageAttribution?: string,
+  coverImagePhotographer?: string,
+  isCoverAttributionHidden?: boolean,
+  stickCoverToBottom?: boolean
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `updateDraft` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="updateDraft full type">
+
+```ts
+{
+  draft: {
+    id: string,
+    title?: string | null,
+    subtitle?: string | null,
+    slug?: string | null,
+    content?: {
+      markdown?: string,
+      html?: string,
+      text?: string
+    } | null,
+    author?: {
+      id: string,
+      name: string,
+      username: string,
+      profilePicture?: string | null,
+      coverImage?: string | null,
+      bio?: {
+        text?: string | null,
+        html?: string,
+        markdown?: string
+      } | null,
+      socialMediaLinks?: {
+        twitter?: string | null,
+        github?: string | null,
+        linkedin?: string | null,
+        website?: string | null
+      } | null,
+      location?: string | null,
+      dateJoined?: string | null
+    } | null,
+    coverImage?: {
+      url?: string | null,
+      attribution?: string | null
+    } | null,
+    tags?: {
+      id: string,
+      name: string,
+      slug: string
+    }[] | null,
+    publication?: {
+      id: string,
+      title: string
+    } | null,
+    series?: {
+      id: string,
+      name: string,
+      slug: string
+    } | null,
+    updatedAt: string,
+    scheduledDate?: string | null,
+    readTimeInMinutes?: number,
+    isSubmittedForReview?: boolean
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Feed
+
+### list
+
+`feed.list`
+
+Get the global feed of posts
+
+**Risk:** `read`
+
+```ts
+await corsair.hashnode.api.feed.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `first` | `number` | Yes | — |
+| `after` | `string` | No | — |
+| `filter` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="filter full type">
+
+```ts
+{
+  tags?: string[],
+  excludeTags?: string[],
+  publications?: string[],
+  excludePublications?: string[]
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `feed` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="feed full type">
+
+```ts
+{
+  edges: {
+    node: {
+      id: string,
+      title: string,
+      subtitle?: string | null,
+      slug: string,
+      brief: string,
+      url: string,
+      coverImage?: {
+        url?: string | null,
+        isPortrait?: boolean,
+        attribution?: string | null
+      } | null,
+      author?: {
+        id: string,
+        name: string,
+        username: string,
+        profilePicture?: string | null,
+        coverImage?: string | null,
+        bio?: {
+          text?: string | null,
+          html?: string,
+          markdown?: string
+        } | null,
+        socialMediaLinks?: {
+          twitter?: string | null,
+          github?: string | null,
+          linkedin?: string | null,
+          website?: string | null
+        } | null,
+        location?: string | null,
+        dateJoined?: string | null
+      } | null,
+      publication?: {
+        id: string,
+        title: string,
+        url?: string | null,
+        displayTitle?: string | null
+      } | null,
+      tags?: {
+        id: string,
+        name: string,
+        slug: string
+      }[] | null,
+      content?: {
+        html?: string,
+        markdown?: string,
+        text?: string
+      } | null,
+      seo?: {
+        title?: string | null,
+        description?: string | null
+      } | null,
+      ogMetaData?: {
+        image?: string | null
+      } | null,
+      publishedAt: string,
+      updatedAt?: string | null,
+      readTimeInMinutes: number,
+      reactionCount: number,
+      responseCount: number,
+      replyCount?: number,
+      series?: {
+        id: string,
+        name: string,
+        slug: string
+      } | null,
+      featured?: boolean
+    },
+    cursor: string
+  }[],
+  pageInfo: {
+    hasNextPage: boolean,
+    endCursor?: string | null
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Images
+
+### createUploadURL
+
+`images.createUploadURL`
+
+Create a presigned image upload URL
+
+**Risk:** `write`
+
+```ts
+await corsair.hashnode.api.images.createUploadURL({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `contentType` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `createImageUploadURL` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="createImageUploadURL full type">
+
+```ts
+{
+  presignedPost: {
+    url: string,
+    fields: {
+    }
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Me
+
+### me
+
+`me`
+
+Get the current authenticated user
+
+**Risk:** `read`
+
+```ts
+await corsair.hashnode.api.me({});
+```
+
+**Input:** _empty object_
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `me` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="me full type">
+
+```ts
+{
+  id: string,
+  name: string,
+  username: string,
+  email: string,
+  profilePicture?: string | null,
+  coverImage?: string | null,
+  bio?: {
+    text?: string | null,
+    html?: string,
+    markdown?: string
+  } | null,
+  socialMediaLinks?: {
+    twitter?: string | null,
+    github?: string | null,
+    linkedin?: string | null,
+    website?: string | null
+  } | null,
+  location?: string | null,
+  dateJoined?: string | null
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Pages
+
+### get
+
+`pages.get`
+
+Get a static page by slug
+
+**Risk:** `read`
+
+```ts
+await corsair.hashnode.api.pages.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `host` | `string` | Yes | — |
+| `slug` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `publication` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="publication full type">
+
+```ts
+{
+  staticPage?: {
+    id: string,
+    title: string,
+    slug: string,
+    content?: {
+      html?: string,
+      markdown?: string,
+      text?: string
+    } | null,
+    hidden?: boolean,
+    ogMetaData?: {
+      image?: string | null
+    } | null,
+    seo?: {
+      title?: string | null,
+      description?: string | null
+    } | null
+  } | null
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### list
+
+`pages.list`
+
+List static pages in a publication
+
+**Risk:** `read`
+
+```ts
+await corsair.hashnode.api.pages.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `host` | `string` | Yes | — |
+| `first` | `number` | Yes | — |
+| `after` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `publication` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="publication full type">
+
+```ts
+{
+  staticPages: {
+    edges: {
+      node: {
+        id: string,
+        title: string,
+        slug: string,
+        content?: {
+          html?: string,
+          markdown?: string,
+          text?: string
+        } | null,
+        hidden?: boolean,
+        ogMetaData?: {
+          image?: string | null
+        } | null,
+        seo?: {
+          title?: string | null,
+          description?: string | null
+        } | null
+      },
+      cursor: string
+    }[],
+    pageInfo: {
+      hasNextPage: boolean,
+      endCursor?: string | null
+    }
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Posts
+
+### get
+
+`posts.get`
+
+Get a single post by ID
+
+**Risk:** `read`
+
+```ts
+await corsair.hashnode.api.posts.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `post` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="post full type">
+
+```ts
+{
+  id: string,
+  title: string,
+  subtitle?: string | null,
+  slug: string,
+  brief: string,
+  url: string,
+  coverImage?: {
+    url?: string | null,
+    isPortrait?: boolean,
+    attribution?: string | null
+  } | null,
+  author?: {
+    id: string,
+    name: string,
+    username: string,
+    profilePicture?: string | null,
+    coverImage?: string | null,
+    bio?: {
+      text?: string | null,
+      html?: string,
+      markdown?: string
+    } | null,
+    socialMediaLinks?: {
+      twitter?: string | null,
+      github?: string | null,
+      linkedin?: string | null,
+      website?: string | null
+    } | null,
+    location?: string | null,
+    dateJoined?: string | null
+  } | null,
+  publication?: {
+    id: string,
+    title: string,
+    url?: string | null,
+    displayTitle?: string | null
+  } | null,
+  tags?: {
+    id: string,
+    name: string,
+    slug: string
+  }[] | null,
+  content?: {
+    html?: string,
+    markdown?: string,
+    text?: string
+  } | null,
+  seo?: {
+    title?: string | null,
+    description?: string | null
+  } | null,
+  ogMetaData?: {
+    image?: string | null
+  } | null,
+  publishedAt: string,
+  updatedAt?: string | null,
+  readTimeInMinutes: number,
+  reactionCount: number,
+  responseCount: number,
+  replyCount?: number,
+  series?: {
+    id: string,
+    name: string,
+    slug: string
+  } | null,
+  featured?: boolean
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### getBySlug
+
+`posts.getBySlug`
+
+Get a post by publication host and slug
+
+**Risk:** `read`
+
+```ts
+await corsair.hashnode.api.posts.getBySlug({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `host` | `string` | Yes | — |
+| `slug` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `publication` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="publication full type">
+
+```ts
+{
+  post?: {
+    id: string,
+    title: string,
+    subtitle?: string | null,
+    slug: string,
+    brief: string,
+    url: string,
+    coverImage?: {
+      url?: string | null,
+      isPortrait?: boolean,
+      attribution?: string | null
+    } | null,
+    author?: {
+      id: string,
+      name: string,
+      username: string,
+      profilePicture?: string | null,
+      coverImage?: string | null,
+      bio?: {
+        text?: string | null,
+        html?: string,
+        markdown?: string
+      } | null,
+      socialMediaLinks?: {
+        twitter?: string | null,
+        github?: string | null,
+        linkedin?: string | null,
+        website?: string | null
+      } | null,
+      location?: string | null,
+      dateJoined?: string | null
+    } | null,
+    publication?: {
+      id: string,
+      title: string,
+      url?: string | null,
+      displayTitle?: string | null
+    } | null,
+    tags?: {
+      id: string,
+      name: string,
+      slug: string
+    }[] | null,
+    content?: {
+      html?: string,
+      markdown?: string,
+      text?: string
+    } | null,
+    seo?: {
+      title?: string | null,
+      description?: string | null
+    } | null,
+    ogMetaData?: {
+      image?: string | null
+    } | null,
+    publishedAt: string,
+    updatedAt?: string | null,
+    readTimeInMinutes: number,
+    reactionCount: number,
+    responseCount: number,
+    replyCount?: number,
+    series?: {
+      id: string,
+      name: string,
+      slug: string
+    } | null,
+    featured?: boolean
+  } | null
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### list
+
+`posts.list`
+
+List posts in a publication
+
+**Risk:** `read`
+
+```ts
+await corsair.hashnode.api.posts.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `host` | `string` | Yes | — |
+| `first` | `number` | Yes | — |
+| `after` | `string` | No | — |
+| `filter` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="filter full type">
+
+```ts
+{
+  tagSlugs?: string[]
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `publication` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="publication full type">
+
+```ts
+{
+  posts: {
+    edges: {
+      node: {
+        id: string,
+        title: string,
+        subtitle?: string | null,
+        slug: string,
+        brief: string,
+        url: string,
+        coverImage?: {
+          url?: string | null,
+          isPortrait?: boolean,
+          attribution?: string | null
+        } | null,
+        author?: {
+          id: string,
+          name: string,
+          username: string,
+          profilePicture?: string | null,
+          coverImage?: string | null,
+          bio?: {
+            text?: string | null,
+            html?: string,
+            markdown?: string
+          } | null,
+          socialMediaLinks?: {
+            twitter?: string | null,
+            github?: string | null,
+            linkedin?: string | null,
+            website?: string | null
+          } | null,
+          location?: string | null,
+          dateJoined?: string | null
+        } | null,
+        publication?: {
+          id: string,
+          title: string,
+          url?: string | null,
+          displayTitle?: string | null
+        } | null,
+        tags?: {
+          id: string,
+          name: string,
+          slug: string
+        }[] | null,
+        content?: {
+          html?: string,
+          markdown?: string,
+          text?: string
+        } | null,
+        seo?: {
+          title?: string | null,
+          description?: string | null
+        } | null,
+        ogMetaData?: {
+          image?: string | null
+        } | null,
+        publishedAt: string,
+        updatedAt?: string | null,
+        readTimeInMinutes: number,
+        reactionCount: number,
+        responseCount: number,
+        replyCount?: number,
+        series?: {
+          id: string,
+          name: string,
+          slug: string
+        } | null,
+        featured?: boolean
+      },
+      cursor: string
+    }[],
+    pageInfo: {
+      hasNextPage: boolean,
+      endCursor?: string | null
+    },
+    totalDocuments?: number
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### publish
+
+`posts.publish`
+
+Publish a new post
+
+**Risk:** `write`
+
+```ts
+await corsair.hashnode.api.posts.publish({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `title` | `string` | Yes | — |
+| `publicationId` | `string` | Yes | — |
+| `contentMarkdown` | `string` | Yes | — |
+| `subtitle` | `string` | No | — |
+| `slug` | `string` | No | — |
+| `coverImage` | `string` | No | — |
+| `tags` | `object[]` | No | — |
+| `originalArticleURL` | `string` | No | — |
+| `metaTitle` | `string` | No | — |
+| `metaDescription` | `string` | No | — |
+| `ogImage` | `string` | No | — |
+| `disableComments` | `boolean` | No | — |
+| `isDelisted` | `boolean` | No | — |
+| `enableToc` | `boolean` | No | — |
+| `publishAs` | `string` | No | — |
+| `coAuthors` | `string[]` | No | — |
+| `seriesId` | `string` | No | — |
+| `publishedAt` | `string` | No | — |
+
+<AccordionGroup>
+<Accordion title="tags full type">
+
+```ts
+{
+  slug: string,
+  name?: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `publishPost` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="publishPost full type">
+
+```ts
+{
+  post: {
+    id: string,
+    title: string,
+    subtitle?: string | null,
+    slug: string,
+    brief: string,
+    url: string,
+    coverImage?: {
+      url?: string | null,
+      isPortrait?: boolean,
+      attribution?: string | null
+    } | null,
+    author?: {
+      id: string,
+      name: string,
+      username: string,
+      profilePicture?: string | null,
+      coverImage?: string | null,
+      bio?: {
+        text?: string | null,
+        html?: string,
+        markdown?: string
+      } | null,
+      socialMediaLinks?: {
+        twitter?: string | null,
+        github?: string | null,
+        linkedin?: string | null,
+        website?: string | null
+      } | null,
+      location?: string | null,
+      dateJoined?: string | null
+    } | null,
+    publication?: {
+      id: string,
+      title: string,
+      url?: string | null,
+      displayTitle?: string | null
+    } | null,
+    tags?: {
+      id: string,
+      name: string,
+      slug: string
+    }[] | null,
+    content?: {
+      html?: string,
+      markdown?: string,
+      text?: string
+    } | null,
+    seo?: {
+      title?: string | null,
+      description?: string | null
+    } | null,
+    ogMetaData?: {
+      image?: string | null
+    } | null,
+    publishedAt: string,
+    updatedAt?: string | null,
+    readTimeInMinutes: number,
+    reactionCount: number,
+    responseCount: number,
+    replyCount?: number,
+    series?: {
+      id: string,
+      name: string,
+      slug: string
+    } | null,
+    featured?: boolean
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### search
+
+`posts.search`
+
+Search posts within a publication
+
+**Risk:** `read`
+
+```ts
+await corsair.hashnode.api.posts.search({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `first` | `number` | Yes | — |
+| `after` | `string` | No | — |
+| `sortBy` | `DATE_PUBLISHED_ASC \| DATE_PUBLISHED_DESC` | No | — |
+| `filter` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="filter full type">
+
+```ts
+{
+  query?: string,
+  publicationId: string,
+  deletedOnly?: boolean,
+  authorIds?: string[],
+  tagIds?: string[]
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `searchPostsOfPublication` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="searchPostsOfPublication full type">
+
+```ts
+{
+  edges: {
+    node: {
+      id: string,
+      title: string,
+      subtitle?: string | null,
+      slug: string,
+      brief: string,
+      url: string,
+      coverImage?: {
+        url?: string | null,
+        isPortrait?: boolean,
+        attribution?: string | null
+      } | null,
+      author?: {
+        id: string,
+        name: string,
+        username: string,
+        profilePicture?: string | null,
+        coverImage?: string | null,
+        bio?: {
+          text?: string | null,
+          html?: string,
+          markdown?: string
+        } | null,
+        socialMediaLinks?: {
+          twitter?: string | null,
+          github?: string | null,
+          linkedin?: string | null,
+          website?: string | null
+        } | null,
+        location?: string | null,
+        dateJoined?: string | null
+      } | null,
+      publication?: {
+        id: string,
+        title: string,
+        url?: string | null,
+        displayTitle?: string | null
+      } | null,
+      tags?: {
+        id: string,
+        name: string,
+        slug: string
+      }[] | null,
+      content?: {
+        html?: string,
+        markdown?: string,
+        text?: string
+      } | null,
+      seo?: {
+        title?: string | null,
+        description?: string | null
+      } | null,
+      ogMetaData?: {
+        image?: string | null
+      } | null,
+      publishedAt: string,
+      updatedAt?: string | null,
+      readTimeInMinutes: number,
+      reactionCount: number,
+      responseCount: number,
+      replyCount?: number,
+      series?: {
+        id: string,
+        name: string,
+        slug: string
+      } | null,
+      featured?: boolean
+    },
+    cursor: string
+  }[],
+  pageInfo: {
+    hasNextPage: boolean,
+    endCursor?: string | null
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### update
+
+`posts.update`
+
+Update an existing post
+
+**Risk:** `write`
+
+```ts
+await corsair.hashnode.api.posts.update({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `title` | `string` | No | — |
+| `subtitle` | `string` | No | — |
+| `contentMarkdown` | `string` | No | — |
+| `slug` | `string` | No | — |
+| `coverImage` | `string` | No | — |
+| `tags` | `object[]` | No | — |
+| `originalArticleURL` | `string` | No | — |
+| `metaTitle` | `string` | No | — |
+| `metaDescription` | `string` | No | — |
+| `ogImage` | `string` | No | — |
+| `disableComments` | `boolean` | No | — |
+| `isDelisted` | `boolean` | No | — |
+| `enableToc` | `boolean` | No | — |
+| `publishAs` | `string` | No | — |
+| `coAuthors` | `string[]` | No | — |
+| `seriesId` | `string` | No | — |
+| `publishedAt` | `string` | No | — |
+
+<AccordionGroup>
+<Accordion title="tags full type">
+
+```ts
+{
+  slug: string,
+  name?: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `updatePost` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="updatePost full type">
+
+```ts
+{
+  post: {
+    id: string,
+    title: string,
+    subtitle?: string | null,
+    slug: string,
+    brief: string,
+    url: string,
+    coverImage?: {
+      url?: string | null,
+      isPortrait?: boolean,
+      attribution?: string | null
+    } | null,
+    author?: {
+      id: string,
+      name: string,
+      username: string,
+      profilePicture?: string | null,
+      coverImage?: string | null,
+      bio?: {
+        text?: string | null,
+        html?: string,
+        markdown?: string
+      } | null,
+      socialMediaLinks?: {
+        twitter?: string | null,
+        github?: string | null,
+        linkedin?: string | null,
+        website?: string | null
+      } | null,
+      location?: string | null,
+      dateJoined?: string | null
+    } | null,
+    publication?: {
+      id: string,
+      title: string,
+      url?: string | null,
+      displayTitle?: string | null
+    } | null,
+    tags?: {
+      id: string,
+      name: string,
+      slug: string
+    }[] | null,
+    content?: {
+      html?: string,
+      markdown?: string,
+      text?: string
+    } | null,
+    seo?: {
+      title?: string | null,
+      description?: string | null
+    } | null,
+    ogMetaData?: {
+      image?: string | null
+    } | null,
+    publishedAt: string,
+    updatedAt?: string | null,
+    readTimeInMinutes: number,
+    reactionCount: number,
+    responseCount: number,
+    replyCount?: number,
+    series?: {
+      id: string,
+      name: string,
+      slug: string
+    } | null,
+    featured?: boolean
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Publications
+
+### get
+
+`publications.get`
+
+Get a publication by host
+
+**Risk:** `read`
+
+```ts
+await corsair.hashnode.api.publications.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `host` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `publication` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="publication full type">
+
+```ts
+{
+  id: string,
+  title: string,
+  displayTitle?: string | null,
+  url?: string | null,
+  favicon?: string | null,
+  about?: {
+    text?: string | null,
+    html?: string,
+    markdown?: string
+  } | null,
+  seo?: {
+    title?: string | null,
+    description?: string | null
+  } | null,
+  author?: {
+    id: string,
+    name: string,
+    username: string,
+    profilePicture?: string | null,
+    coverImage?: string | null,
+    bio?: {
+      text?: string | null,
+      html?: string,
+      markdown?: string
+    } | null,
+    socialMediaLinks?: {
+      twitter?: string | null,
+      github?: string | null,
+      linkedin?: string | null,
+      website?: string | null
+    } | null,
+    location?: string | null,
+    dateJoined?: string | null
+  } | null,
+  ogMetaData?: {
+    image?: string | null
+  } | null,
+  isTeam?: boolean,
+  links?: {
+    twitter?: string | null,
+    github?: string | null,
+    linkedin?: string | null,
+    website?: string | null
+  } | null,
+  followersCount?: number | null
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### list
+
+`publications.list`
+
+List publications for the authenticated user
+
+**Risk:** `read`
+
+```ts
+await corsair.hashnode.api.publications.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `first` | `number` | Yes | — |
+| `after` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `me` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="me full type">
+
+```ts
+{
+  publications: {
+    edges: {
+      node: {
+        id: string,
+        title: string,
+        displayTitle?: string | null,
+        url?: string | null,
+        favicon?: string | null,
+        about?: {
+          text?: string | null,
+          html?: string,
+          markdown?: string
+        } | null,
+        seo?: {
+          title?: string | null,
+          description?: string | null
+        } | null,
+        author?: {
+          id: string,
+          name: string,
+          username: string,
+          profilePicture?: string | null,
+          coverImage?: string | null,
+          bio?: {
+            text?: string | null,
+            html?: string,
+            markdown?: string
+          } | null,
+          socialMediaLinks?: {
+            twitter?: string | null,
+            github?: string | null,
+            linkedin?: string | null,
+            website?: string | null
+          } | null,
+          location?: string | null,
+          dateJoined?: string | null
+        } | null,
+        ogMetaData?: {
+          image?: string | null
+        } | null,
+        isTeam?: boolean,
+        links?: {
+          twitter?: string | null,
+          github?: string | null,
+          linkedin?: string | null,
+          website?: string | null
+        } | null,
+        followersCount?: number | null
+      },
+      cursor: string
+    }[],
+    pageInfo: {
+      hasNextPage: boolean,
+      endCursor?: string | null
+    }
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Series
+
+### get
+
+`series.get`
+
+Get a series by slug
+
+**Risk:** `read`
+
+```ts
+await corsair.hashnode.api.series.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `slug` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `series` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="series full type">
+
+```ts
+{
+  id: string,
+  name: string,
+  slug: string,
+  description?: {
+    text?: string | null,
+    html?: string,
+    markdown?: string
+  } | null,
+  coverImage?: string | null,
+  author?: {
+    id: string,
+    name: string,
+    username: string,
+    profilePicture?: string | null,
+    coverImage?: string | null,
+    bio?: {
+      text?: string | null,
+      html?: string,
+      markdown?: string
+    } | null,
+    socialMediaLinks?: {
+      twitter?: string | null,
+      github?: string | null,
+      linkedin?: string | null,
+      website?: string | null
+    } | null,
+    location?: string | null,
+    dateJoined?: string | null
+  } | null
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### list
+
+`series.list`
+
+List series in a publication
+
+**Risk:** `read`
+
+```ts
+await corsair.hashnode.api.series.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `host` | `string` | Yes | — |
+| `first` | `number` | Yes | — |
+| `after` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `publication` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="publication full type">
+
+```ts
+{
+  seriesList: {
+    edges: {
+      node: {
+        id: string,
+        name: string,
+        slug: string,
+        description?: {
+          text?: string | null,
+          html?: string,
+          markdown?: string
+        } | null,
+        coverImage?: string | null,
+        author?: {
+          id: string,
+          name: string,
+          username: string,
+          profilePicture?: string | null,
+          coverImage?: string | null,
+          bio?: {
+            text?: string | null,
+            html?: string,
+            markdown?: string
+          } | null,
+          socialMediaLinks?: {
+            twitter?: string | null,
+            github?: string | null,
+            linkedin?: string | null,
+            website?: string | null
+          } | null,
+          location?: string | null,
+          dateJoined?: string | null
+        } | null
+      },
+      cursor: string
+    }[],
+    pageInfo: {
+      hasNextPage: boolean,
+      endCursor?: string | null
+    }
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Tags
+
+### get
+
+`tags.get`
+
+Get a tag by slug
+
+**Risk:** `read`
+
+```ts
+await corsair.hashnode.api.tags.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `slug` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `tag` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="tag full type">
+
+```ts
+{
+  id: string,
+  name: string,
+  slug: string,
+  tagline?: string | null,
+  logo?: string | null,
+  postsCount?: number,
+  followersCount?: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Users
+
+### get
+
+`users.get`
+
+Get a user by username
+
+**Risk:** `read`
+
+```ts
+await corsair.hashnode.api.users.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `username` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `user` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="user full type">
+
+```ts
+{
+  id: string,
+  name: string,
+  username: string,
+  profilePicture?: string | null,
+  coverImage?: string | null,
+  bio?: {
+    text?: string | null,
+    html?: string,
+    markdown?: string
+  } | null,
+  socialMediaLinks?: {
+    twitter?: string | null,
+    github?: string | null,
+    linkedin?: string | null,
+    website?: string | null
+  } | null,
+  location?: string | null,
+  dateJoined?: string | null
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+

--- a/docs/plugins/hashnode/database.mdx
+++ b/docs/plugins/hashnode/database.mdx
@@ -1,0 +1,12 @@
+---
+title: Database
+description: "Hashnode local sync: searchable entities, `.search()` filters, and operators."
+---
+
+The Hashnode plugin syncs data locally. Use `corsair.hashnode.db.<entity>.search({ data, limit?, offset? })` with the filters listed per entity.
+
+<Info>
+**New to Corsair?** See [database operations](/concepts/database), [data synchronization](/concepts/integrations), and [multi-tenancy](/concepts/multi-tenancy).
+</Info>
+
+

--- a/docs/plugins/hashnode/get-credentials.mdx
+++ b/docs/plugins/hashnode/get-credentials.mdx
@@ -1,0 +1,32 @@
+---
+title: Get Credentials
+description: Step-by-step instructions for obtaining Hashnode API credentials.
+---
+
+## Authentication Method
+
+- **[`api_key`](/concepts/api-key)** - Hashnode personal access token
+
+## API Key Setup
+
+### Step 1: Get Your API Key
+
+1. Log in to [Hashnode](https://hashnode.com)
+2. Open **Settings** from your profile menu
+3. Navigate to **Developer** → **Personal Access Tokens**
+4. Select **Create token**, give it a name, and copy the generated token
+5. Store it securely
+
+**Storing Credentials:**
+
+```bash
+pnpm corsair setup --plugin=hashnode api_key=your-api-key
+```
+
+## Required Credentials Summary
+
+| Credential | Required For | Where to Find |
+|-----------|--------------|---------------|
+| API Key | All API calls | Hashnode Settings → Developer → Personal Access Tokens |
+
+For general information about how Corsair handles authentication, see [Authentication](/concepts/auth).

--- a/docs/plugins/hashnode/overview.mdx
+++ b/docs/plugins/hashnode/overview.mdx
@@ -1,0 +1,135 @@
+---
+title: Overview
+description: "Hashnode plugin for Corsair"
+---
+
+Use **Hashnode** through Corsair: one client, typed API calls, optional local DB sync.
+
+**What you get:**
+
+- 23 typed API operations
+
+## Setup
+
+<Steps>
+
+<Step title="Install">
+```bash
+pnpm install @corsair-dev/hashnode
+```
+
+</Step>
+
+<Step title="Add the plugin">
+<Tabs>
+<Tab title="Solo">
+```ts corsair.ts
+import { createCorsair } from 'corsair';
+import { hashnode } from '@corsair-dev/hashnode';
+
+export const corsair = createCorsair({
+	// ... other config options,
+	multiTenancy: false,
+    plugins: [hashnode()],
+});
+```
+</Tab>
+<Tab title="Multi-Tenant">
+```ts corsair.ts
+import { createCorsair } from 'corsair';
+import { hashnode } from '@corsair-dev/hashnode';
+
+export const corsair = createCorsair({
+	// ... other config options,
+    multiTenancy: true,
+    plugins: [hashnode()],
+});
+```
+
+See [Multi-tenancy](/concepts/multi-tenancy) for account isolation.
+
+</Tab>
+</Tabs>
+
+</Step>
+
+<Step title="Get credentials">
+Follow [Get Credentials](/plugins/hashnode/get-credentials) if you need help getting keys.
+
+</Step>
+
+<Step title="Store credentials">
+<Tabs>
+<Tab title="Solo">
+```bash
+pnpm corsair setup --plugin=hashnode
+```
+
+Use the key names documented in [Get Credentials](/plugins/hashnode/get-credentials) (for example `api_key=`, `bot_token=`, or OAuth client fields).
+</Tab>
+<Tab title="Multi-Tenant">
+```bash
+pnpm corsair setup --plugin=hashnode --tenant=<tenantId>
+```
+
+Store per-tenant secrets after you create the tenant record. See [Multi-tenancy](/concepts/multi-tenancy).
+</Tab>
+</Tabs>
+
+</Step>
+
+</Steps>
+
+## Authentication
+
+Each tab shows how to register the plugin for that authentication method. The default `authType` from the plugin does not need to appear in the factory call.
+
+<Tabs>
+<Tab title="API Key (Default)">
+
+```ts corsair.ts
+hashnode()
+```
+
+Store credentials with `pnpm corsair setup --plugin=hashnode` (see [Get Credentials](/plugins/hashnode/get-credentials) for field names). For OAuth, you typically store integration keys at the provider level and tokens per account or tenant.
+
+More: [API Key](/concepts/api-key)
+
+</Tab>
+</Tabs>
+
+
+
+## Example API calls
+
+**Read-style (read):** `comments.list`
+
+```ts
+await corsair.hashnode.api.comments.list({});
+```
+
+
+**Write-style (write):** `drafts.create`
+
+```ts
+await corsair.hashnode.api.drafts.create({});
+```
+
+
+See the full list on the [API](/plugins/hashnode/api) page. Use `pnpm corsair list --plugin=hashnode` and `pnpm corsair schema <path>` locally to inspect schemas.
+
+---
+
+## Hooks
+
+Use `hooks` on API calls and `webhookHooks` on incoming events to add logging, approvals, or side effects. See [Hooks](/concepts/hooks) and [Webhooks](/concepts/webhooks) for routing and payload patterns.
+
+---
+
+## Reference
+
+| Topic | Link |
+|-------|------|
+| API | [API](/plugins/hashnode/api) |
+| Credentials | [Get credentials](/plugins/hashnode/get-credentials) |
+

--- a/docs/plugins/hashnode/overview.mdx
+++ b/docs/plugins/hashnode/overview.mdx
@@ -65,7 +65,7 @@ Follow [Get Credentials](/plugins/hashnode/get-credentials) if you need help get
 pnpm corsair setup --plugin=hashnode
 ```
 
-Use the key names documented in [Get Credentials](/plugins/hashnode/get-credentials) (for example `api_key=`, `bot_token=`, or OAuth client fields).
+Use the key names documented in [Get Credentials](/plugins/hashnode/get-credentials) (for example `api_key=`).
 </Tab>
 <Tab title="Multi-Tenant">
 ```bash


### PR DESCRIPTION
## Description

Adds the missing Hashnode plugin documentation. `packages/hashnode` has been on `main` for a while, but `docs/plugins/hashnode` never existed and the plugin wasn't listed in the Mintlify nav — so anyone browsing the docs had no way to find it.

This PR runs the standard doc generator against the `hashnode` plugin and commits the output, rather than hand-writing a one-off page.

Fixes #542

## Changes

- Ran `pnpm generate:docs -- --plugin=hashnode` to generate the plugin docs
- Added generated MDX under `docs/plugins/hashnode/`
- Updated `docs/docs.json` to add the `hashnode` nav entry under Plugins via script
- Updated `docs/docs.json` to add the `/plugins/hashnode/get-credentials`

## Tests

Ran the verification steps from the issue:

- [x] `docs/plugins/hashnode/` exists with the usual pages
- [x] `hashnode` shows up under Plugins in `docs/docs.json`
- [x] No hand-written one-off layout that ignores the generator

## Screenshots / Demo
<img width="1687" height="933" alt="Screenshot 2026-08-01 at 2 35 38 PM" src="https://github.com/user-attachments/assets/24510dab-2d08-4730-b601-1497a6de91e3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Added Hashnode plugin documentation to the navigation.
  * Added setup guidance for single- and multi-tenant configurations, credentials, authentication, hooks, and example API calls.
  * Added a comprehensive API reference covering Hashnode operations, parameters, responses, usage examples, and risk classifications.
  * Documented local database synchronization, entity search, and supported filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->