### PR TITLE
chore(readme): add missing imports to root README snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ You can also override individual endpoints within any mode. For example, set Sla
 Corsair is built for production. Set `multiTenancy: true` and every tenant gets isolated credentials, isolated data storage, and isolated permissions handling. You can scope a request to a tenant id and Corsair ensures there is no cross-contamination.
 
 ```typescript
+import { createCorsair } from 'corsair';
+import { slack } from '@corsair-dev/slack';
+import { github } from '@corsair-dev/github';
+
 const corsair = createCorsair({
   multiTenancy: true,
   plugins: [slack(), github()],
@@ -78,6 +82,9 @@ await client.slack.api.messages.post({ channel: '#alerts', text: 'Deploy complet
 Every plugin is shipped with typed, signature-verified webhook handlers. All webhooks point to a single endpoint. Set it and forget it.
 
 ```typescript
+import { processWebhook } from 'corsair';
+import { corsair } from '@/server/corsair';
+
 app.post('/webhooks', async (req, res) => {
   const webhook = processWebhook(corsair, req.headers, req.body)
   


### PR DESCRIPTION
## Description

Fixes #539 the Multi-tenancy and Webhooks code examples in the root `README.md`.

## Changes

- Added the missing imports to the Multi-tenancy example in `README.md`
- Added the missing imports to the Webhooks example in `README.md`
- Verified no unused or fake imports were introduced

## Tests

Skimmed both sections and checked each TypeScript fence for imports, per the issue's verify step.

- [x] Multi-tenancy snippet has imports
- [x] Webhooks snippet has imports
- [x] No unused or fake imports


## Screenshots / Demo

N/A — documentation-only change to code snippets in `README.md`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added import examples for Corsair, Slack, and GitHub integrations in the multi-tenancy guide.
  * Added webhook processing and configured Corsair instance imports to the webhook example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->