### PR TITLE
fix: resolve corsair source in docs/catalog scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "generate:plugin": "node --experimental-strip-types scripts/generate-plugin.ts",
     "generate:plugin-from-json": "node --experimental-strip-types scripts/generate-plugin-from-json.ts",
     "generate:labeler-config": "node scripts/generate-labeler-config.mjs",
-    "generate:docs": "tsx scripts/generate-plugin-docs.ts",
-    "generate:docs:all": "tsx scripts/generate-plugin-docs.ts --all",
-    "build:explorer-catalog": "tsx scripts/build-explorer-catalog.ts",
+    "generate:docs": "tsx --conditions=dev-source scripts/generate-plugin-docs.ts",
+    "generate:docs:all": "tsx --conditions=dev-source scripts/generate-plugin-docs.ts --all",
+    "build:explorer-catalog": "tsx --conditions=dev-source scripts/build-explorer-catalog.ts",
     "validate:plugins": "tsx scripts/validate-plugins.ts",
     "validate:docs": "tsx scripts/lint-docs-imports.ts",
     "prepare": "simple-git-hooks"


### PR DESCRIPTION
## Summary
- Docs/catalog scripts were importing `corsair/*` through `dist/`, which is gitignored and often stale after core exports land (e.g. subscribe helpers from #469).
- Run `generate:docs`, `generate:docs:all`, and `build:explorer-catalog` with `tsx --conditions=dev-source` so they resolve package source instead.
- Verified: with a pre-#469 stale `dist`, `pnpm run -w generate:docs:all` goes from 6 import failures to `96/96 plugins ok`.

## Test plan
- [ ] `pnpm run -w generate:docs:all` passes without rebuilding `corsair`
- [ ] Optional: delete/replace `packages/corsair/dist` with an older build and confirm docs gen still succeeds
- [ ] `pnpm build:explorer-catalog` still runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability and consistency of documentation and explorer catalog generation.
  * Updated build tooling to use the appropriate development source configuration during generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->