### PR TITLE
fix: correct github org links in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,9 +7,9 @@ body:
         Thank you for reporting an issue! The more details you provide, the faster we can help.
 
         **Before submitting:**
-        - Search [existing issues](https://github.com/corsair/corsair/issues) to see if this has already been reported. If so, please add a 👍 reaction or comment with additional details.
-        - For feature requests, please use the [feature request template](https://github.com/corsair/corsair/issues/new?assignees=&labels=&projects=&template=feature_request.yml&title=) instead.
-        - For integration requests, please use the [integration request template](https://github.com/corsair/corsair/issues/new?assignees=&labels=&projects=&template=integration_request.yml&title=) instead.
+        - Search [existing issues](https://github.com/corsairdev/corsair/issues) to see if this has already been reported. If so, please add a 👍 reaction or comment with additional details.
+        - For feature requests, please use the [feature request template](https://github.com/corsairdev/corsair/issues/new?assignees=&labels=&projects=&template=feature_request.yml&title=) instead.
+        - For integration requests, please use the [integration request template](https://github.com/corsairdev/corsair/issues/new?assignees=&labels=&projects=&template=integration_request.yml&title=) instead.
   - type: textarea
     attributes:
       label: Steps to reproduce

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,9 +7,9 @@ body:
         Thanks for taking the time to suggest a new feature! 
 
         **Before submitting:**
-        - Check if a [similar feature request](https://github.com/corsair/corsair/issues) already exists. If it does, please add a 👍 reaction instead of creating a duplicate.
-        - If you're requesting a new integration, please use the [integration request template](https://github.com/corsair/corsair/issues/new?assignees=&labels=&projects=&template=integration_request.yml&title=) instead.
-        - If you're reporting a bug, please use the [bug report template](https://github.com/corsair/corsair/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml) instead.
+        - Check if a [similar feature request](https://github.com/corsairdev/corsair/issues) already exists. If it does, please add a 👍 reaction instead of creating a duplicate.
+        - If you're requesting a new integration, please use the [integration request template](https://github.com/corsairdev/corsair/issues/new?assignees=&labels=&projects=&template=integration_request.yml&title=) instead.
+        - If you're reporting a bug, please use the [bug report template](https://github.com/corsairdev/corsair/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml) instead.
   - type: textarea
     attributes:
       label: What problem does this solve?

--- a/.github/ISSUE_TEMPLATE/integration_request.yml
+++ b/.github/ISSUE_TEMPLATE/integration_request.yml
@@ -8,8 +8,8 @@ body:
 
         **Before submitting:**
         - If you plan to build this integration, check [corsair.dev/oss](https://corsair.dev/oss) first to see whether it is already claimed or in progress. Claim it there before you start so two people do not work on the same plugin.
-        - Check if this integration has already been [requested](https://github.com/corsair/corsair/issues?q=is%3Aissue+label%3Aintegration) or [implemented](https://github.com/corsair/corsair/issues?q=is%3Aissue+label%3Aintegration+is%3Aclosed). If it has, please add a 👍 reaction instead of creating a duplicate.
-        - For general feature requests, please use the [feature request template](https://github.com/corsair/corsair/issues/new?assignees=&labels=&projects=&template=feature_request.yml&title=) instead.
+        - Check if this integration has already been [requested](https://github.com/corsairdev/corsair/issues) or [implemented](https://github.com/corsairdev/corsair/issues?q=is%3Aissue+is%3Aclosed). If it has, please add a 👍 reaction instead of creating a duplicate.
+        - For general feature requests, please use the [feature request template](https://github.com/corsairdev/corsair/issues/new?assignees=&labels=&projects=&template=feature_request.yml&title=) instead.
   - type: input
     attributes:
       label: What API or service would you like integrated?


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description
Fixes #533 . Fixed the issue templates to point at the correct repo (`corsairdev/corsair`) and removed the dead `label:integration` search links from the integration request template.
<!-- Briefly describe the changes you've made and why they're necessary. -->
<!-- Link to any related issues (e.g. "Fixes #123"). -->

## Checklist

Before submitting your PR, please verify the following:

- [X] I have run `pnpm lint` and all checks pass
- [X] I have run `pnpm typecheck` and there are no TypeScript errors
- [X] I have run `pnpm build` and all packages build successfully
- [X] I have run `pnpm test` and all tests pass
- [X] I have added or updated tests where applicable
- [X] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

<!-- If your changes affect the UI or CLI output, please include screenshots or terminal recordings. -->
N/A



<!-- Any other information that reviewers should know? (e.g. breaking changes, new dependencies) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

- Updated issue and feature request templates with current repository links.
- Improved integration request checklist links for requested and implemented integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->