### PR TITLE
test(cloudflare): cover non-envelope error body in cloudflareErrorFro…

### DIFF
--- a/packages/cloudflare/response.test.ts
+++ b/packages/cloudflare/response.test.ts
@@ -67,4 +67,39 @@ describe('cloudflareErrorFromApiErrorBody', () => {
 		expect(err).toBeInstanceOf(CloudflareAPIError);
 		expect(err?.message).toContain('Unauthorized');
 	});
+
+	it('maps non-envelope single error', () => {
+		const err = cloudflareErrorFromApiErrorBody({
+			errors: [{ code: 10000, message: 'Authentication error' }],
+		});
+		expect(err).toBeInstanceOf(CloudflareAPIError);
+		expect(err?.message).toBe('Authentication error');
+		expect(err?.code).toBe(10000);
+	});
+
+	it('joins multiple non-envelope error messages', () => {
+		const err = cloudflareErrorFromApiErrorBody({
+			errors: [
+				{ code: 10000, message: 'Authentication error' },
+				{ code: 10001, message: 'Invalid API token' },
+			],
+		});
+		expect(err).toBeInstanceOf(CloudflareAPIError);
+		expect(err?.message).toBe('Authentication error; Invalid API token');
+		expect(err?.code).toBe(10000);
+	});
+
+	it('gives null for non-envelope empty errors', () => {
+		const err = cloudflareErrorFromApiErrorBody({
+			errors: [],
+		});
+		expect(err).toBeNull();
+	});
+
+	it('gives null for non-envelope unrelated body', () => {
+		const err = cloudflareErrorFromApiErrorBody({
+			random: [],
+		});
+		expect(err).toBeNull();
+	});
 });


### PR DESCRIPTION
## Description
Adds unit tests for the non-envelope branch of `cloudflareErrorFromApiErrorBody` in `packages/cloudflare/response.test.ts`.

Covers: single error, multiple errors (joined message), empty errors array, and unrelated body

Fixes #515

## Checklist
- [x] pnpm --filter @corsair-dev/cloudflare test -- response.test.ts
- [x] I have added or updated tests where applicable

## Screenshots / Demos
<img width="448" height="308" alt="Screenshot 2026-08-02 at 3 38 54 PM" src="https://github.com/user-attachments/assets/83326faf-5d14-4fed-bd6a-6fe0e0e6c348" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for handling Cloudflare error responses without standard envelopes.
  * Verified single and multiple errors produce expected messages and codes.
  * Confirmed empty or unrelated response bodies are handled appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->