### PR TITLE
docs: fix bad github org URLs in docs

### DIFF
--- a/docs/concepts/database.mdx
+++ b/docs/concepts/database.mdx
@@ -414,7 +414,7 @@ entity_type: "messages"
 data: { text: "Hello!", channel: "C01234567", ts: "1234567890.123456" }
 ```
 
-Schema types: [`packages/corsair/db/index.ts`](https://github.com/corsair-dev/corsair/blob/main/packages/corsair/db/index.ts).
+Schema types: [`packages/corsair/db/index.ts`](https://github.com/corsairdev/corsair/blob/main/packages/corsair/db/index.ts).
 
 ---
 

--- a/docs/concepts/integrations.mdx
+++ b/docs/concepts/integrations.mdx
@@ -100,7 +100,7 @@ See the [Creating Custom Integrations](/guides/create-your-own-plugin) guide for
 
 ## Missing an Endpoint?
 
-If an existing integration is missing an endpoint you need, [create an issue](https://github.com/corsair/corsair/issues) and we'll add it ASAP.
+If an existing integration is missing an endpoint you need, [create an issue](https://github.com/corsairdev/corsair/issues) and we'll add it ASAP.
 
 ## Available Integrations
 

--- a/docs/guides/create-your-own-plugin.mdx
+++ b/docs/guides/create-your-own-plugin.mdx
@@ -15,7 +15,7 @@ The fastest way to build a custom plugin is to use the built-in generator. It sc
 Plugins live inside the monorepo alongside the core library.
 
 ```bash
-git clone https://github.com/corsair-dev/corsair.git
+git clone https://github.com/corsairdev/corsair.git
 cd corsair
 pnpm install
 ```


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description
Fixes #536.

This PR keeps only the intended documentation changes from the cleanup branch and removes the unrelated issue-template updates. It corrects the bad GitHub URLs in the docs and clone instructions so they point to corsairdev/corsair.

<!-- Briefly describe the changes you've made and why they're necessary. -->
<!-- Link to any related issues (e.g. "Fixes #123"). -->

## Checklist

Before submitting your PR, please verify the following:

- [X] I have run `pnpm lint` and all checks pass
- [X] I have run `pnpm typecheck` and there are no TypeScript errors
- [X] I have run `pnpm build` and all packages build successfully
- [X] I have run `pnpm test` and all tests pass
- [X] I have added or updated tests where applicable
- [X] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)
NA
<!-- If your changes affect the UI or CLI output, please include screenshots or terminal recordings. -->


## Additional Notes

<!-- Any other information that reviewers should know? (e.g. breaking changes, new dependencies) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub links in the database, integrations, and plugin development guides.
  * Corrected repository references to ensure links point to the current locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->