### PR TITLE
feat(plugins): add managed authType to Corsair-managed oauth2 providers

### DIFF
--- a/packages/asana/index.ts
+++ b/packages/asana/index.ts
@@ -13,6 +13,7 @@ import type {
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { attachManagedRefreshAuth, getManagedAccessToken } from 'corsair/hub';
 import { getValidAccessToken } from './client';
 import {
 	Projects,
@@ -898,6 +899,9 @@ export const asanaAuthConfig = {
 	oauth_2: {
 		account: ['workspace_gid', 'project_gid'] as const,
 	},
+	managed: {
+		account: ['workspace_gid', 'project_gid'] as const,
+	},
 } as const satisfies PluginAuthConfig;
 
 type AsanaEndpoint<K extends keyof AsanaEndpointOutputs> = CorsairEndpoint<
@@ -921,7 +925,7 @@ export type AsanaWebhooks = {
 export type AsanaBoundWebhooks = BindWebhooks<AsanaWebhooks>;
 
 export type AsanaPluginOptions = {
-	authType?: PickAuth<'api_key' | 'oauth_2'>;
+	authType?: PickAuth<'api_key' | 'oauth_2' | 'managed'>;
 	key?: string;
 	webhookSecret?: string;
 	hooks?: InternalAsanaPlugin['hooks'];
@@ -1094,6 +1098,25 @@ export function asana<const PluginOptions extends AsanaPluginOptions>(
 					return freshResult.accessToken;
 				};
 
+				return result.accessToken;
+			}
+
+			if (ctx.authType === 'managed') {
+				if (!ctx.hub) {
+					throw new Error(
+						'[auth-missing:asana:managed]: Hub config is required for managed auth. Pass hub: { ... } to createCorsair().',
+					);
+				}
+
+				const managedContext = {
+					keys: ctx.keys,
+					hub: ctx.hub,
+					plugin: 'asana',
+					tenantId: ctx.tenantId,
+				};
+
+				const result = await getManagedAccessToken(managedContext);
+				await attachManagedRefreshAuth(ctx, managedContext);
 				return result.accessToken;
 			}
 

--- a/packages/asana/jest.config.cjs
+++ b/packages/asana/jest.config.cjs
@@ -44,6 +44,7 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/hub$': '<rootDir>/../corsair/hub.ts',
 		'^corsair/core$': '<rootDir>/../corsair/core.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',

--- a/packages/asana/package.json
+++ b/packages/asana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/asana",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Asana plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/dropbox/index.ts
+++ b/packages/dropbox/index.ts
@@ -13,6 +13,7 @@ import type {
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { attachManagedRefreshAuth, getManagedAccessToken } from 'corsair/hub';
 import { getValidAccessToken } from './client';
 import { Files, Folders, Search } from './endpoints';
 import type {
@@ -188,7 +189,7 @@ const dropboxEndpointMeta = {
 } satisfies RequiredPluginEndpointMeta<typeof dropboxEndpointsNested>;
 
 export type DropboxPluginOptions = {
-	authType?: PickAuth<'oauth_2'>;
+	authType?: PickAuth<'oauth_2' | 'managed'>;
 	key?: string;
 	webhookSecret?: string;
 	hooks?: InternalDropboxPlugin['hooks'];
@@ -228,6 +229,9 @@ export type DropboxBoundWebhooks = BindWebhooks<DropboxWebhooks>;
 
 export const dropboxAuthConfig = {
 	oauth_2: {
+		account: ['account_id', 'user_id'] as const,
+	},
+	managed: {
 		account: ['account_id', 'user_id'] as const,
 	},
 } as const satisfies PluginAuthConfig;
@@ -297,6 +301,14 @@ export function dropbox<const T extends DropboxPluginOptions>(
 			// See https://www.dropbox.com/developers/reference/webhooks
 			if (source === 'webhook') {
 				if (options.webhookSecret) return options.webhookSecret;
+				if (ctx.authType === 'managed') {
+					throw new Error(
+						'[auth-missing:dropbox:managed]: webhook signature is not available in managed mode',
+					);
+				}
+				if (ctx.authType !== 'oauth_2') {
+					throw new AuthMissingError('dropbox', 'oauth_2');
+				}
 				const creds = await ctx.keys.get_integration_credentials();
 				if (!creds.client_secret) {
 					throw new Error(
@@ -372,6 +384,25 @@ export function dropbox<const T extends DropboxPluginOptions>(
 					return freshResult.accessToken;
 				};
 
+				return result.accessToken;
+			}
+
+			if (ctx.authType === 'managed') {
+				if (!ctx.hub) {
+					throw new Error(
+						'[auth-missing:dropbox:managed]: Hub config is required for managed auth. Pass hub: { ... } to createCorsair().',
+					);
+				}
+
+				const managedContext = {
+					keys: ctx.keys,
+					hub: ctx.hub,
+					plugin: 'dropbox',
+					tenantId: ctx.tenantId,
+				};
+
+				const result = await getManagedAccessToken(managedContext);
+				await attachManagedRefreshAuth(ctx, managedContext);
 				return result.accessToken;
 			}
 

--- a/packages/dropbox/jest.config.cjs
+++ b/packages/dropbox/jest.config.cjs
@@ -44,6 +44,7 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/hub$': '<rootDir>/../corsair/hub.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',
 	},

--- a/packages/dropbox/package.json
+++ b/packages/dropbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/dropbox",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Dropbox plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gitlab/client.test.ts
+++ b/packages/gitlab/client.test.ts
@@ -1,0 +1,29 @@
+import { isManagedGitlabHost } from './client';
+
+describe('isManagedGitlabHost', () => {
+	it('accepts gitlab.com and equivalent origins', () => {
+		for (const url of [
+			'https://gitlab.com',
+			'https://gitlab.com:443',
+			'https://gitlab.com:8443',
+			'https://gitlab.com.',
+			'https://GitLab.com',
+			'https://gitlab.com/',
+			'https://user@gitlab.com',
+		]) {
+			expect(isManagedGitlabHost(url)).toBe(true);
+		}
+	});
+
+	it('rejects custom and malformed hosts', () => {
+		for (const url of [
+			'https://gitlab.example.com',
+			'https://notgitlab.com',
+			'https://gitlab.com.evil.com',
+			'https://gitlab.com@evil.com',
+			'gitlab.com',
+		]) {
+			expect(isManagedGitlabHost(url)).toBe(false);
+		}
+	});
+});

--- a/packages/gitlab/client.test.ts
+++ b/packages/gitlab/client.test.ts
@@ -5,7 +5,6 @@ describe('isManagedGitlabHost', () => {
 		for (const url of [
 			'https://gitlab.com',
 			'https://gitlab.com:443',
-			'https://gitlab.com:8443',
 			'https://gitlab.com.',
 			'https://GitLab.com',
 			'https://gitlab.com/',
@@ -22,6 +21,18 @@ describe('isManagedGitlabHost', () => {
 			'https://gitlab.com.evil.com',
 			'https://gitlab.com@evil.com',
 			'gitlab.com',
+			// Cyrillic 'а' lookalike — new URL() punycodes it, so it is not gitlab.com
+			'https://gitlаb.com',
+		]) {
+			expect(isManagedGitlabHost(url)).toBe(false);
+		}
+	});
+
+	it('rejects non-default ports and non-https schemes (managed token must not reach a noncanonical service)', () => {
+		for (const url of [
+			'https://gitlab.com:8443',
+			'https://gitlab.com:80',
+			'http://gitlab.com',
 		]) {
 			expect(isManagedGitlabHost(url)).toBe(false);
 		}

--- a/packages/gitlab/client.ts
+++ b/packages/gitlab/client.ts
@@ -17,6 +17,20 @@ export function normalizeGitlabBaseUrl(baseUrl?: string): string {
 	return withoutSlash || 'https://gitlab.com';
 }
 
+// Managed auth uses Corsair's gitlab.com OAuth app, so its token is only valid
+// against gitlab.com. Compare on hostname (port-agnostic, case-insensitive,
+// trailing-dot tolerant) rather than the raw string so equivalent origins pass.
+export function isManagedGitlabHost(baseUrl: string): boolean {
+	try {
+		return (
+			new URL(baseUrl).hostname.replace(/\.$/, '').toLowerCase() ===
+			'gitlab.com'
+		);
+	} catch {
+		return false;
+	}
+}
+
 export function gitlabApiBase(baseUrl?: string): string {
 	return `${normalizeGitlabBaseUrl(baseUrl)}/api/v4`;
 }

--- a/packages/gitlab/client.ts
+++ b/packages/gitlab/client.ts
@@ -17,14 +17,18 @@ export function normalizeGitlabBaseUrl(baseUrl?: string): string {
 	return withoutSlash || 'https://gitlab.com';
 }
 
-// Managed auth uses Corsair's gitlab.com OAuth app, so its token is only valid
-// against gitlab.com. Compare on hostname (port-agnostic, case-insensitive,
-// trailing-dot tolerant) rather than the raw string so equivalent origins pass.
+// Managed auth uses Corsair's gitlab.com OAuth app, so its token is valid only
+// against canonical gitlab.com. Match the hostname (case-insensitive,
+// trailing-dot tolerant) but also require https on the default port — a custom
+// port or scheme is a different service and must not receive the managed token.
 export function isManagedGitlabHost(baseUrl: string): boolean {
 	try {
+		const url = new URL(baseUrl);
+		const hostname = url.hostname.replace(/\.$/, '').toLowerCase();
 		return (
-			new URL(baseUrl).hostname.replace(/\.$/, '').toLowerCase() ===
-			'gitlab.com'
+			hostname === 'gitlab.com' &&
+			url.protocol === 'https:' &&
+			(url.port === '' || url.port === '443')
 		);
 	} catch {
 		return false;

--- a/packages/gitlab/index.ts
+++ b/packages/gitlab/index.ts
@@ -15,9 +15,11 @@ import type {
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { attachManagedRefreshAuth, getManagedAccessToken } from 'corsair/hub';
 import {
 	getValidGitlabAccessToken,
 	gitlabOAuthTokenUrl,
+	isManagedGitlabHost,
 	normalizeGitlabBaseUrl,
 } from './client';
 import {
@@ -67,11 +69,14 @@ export const gitlabAuthConfig = {
 	oauth_2: {
 		account: ['project_id', 'group_id'] as const,
 	},
+	managed: {
+		account: ['project_id', 'group_id'] as const,
+	},
 } as const satisfies PluginAuthConfig;
 
 export type GitlabPluginOptions = {
 	baseUrl?: string;
-	authType?: PickAuth<'api_key' | 'oauth_2'>;
+	authType?: PickAuth<'api_key' | 'oauth_2' | 'managed'>;
 	key?: string;
 	webhookSecret?: string;
 	hooks?: InternalGitlabPlugin['hooks'];
@@ -822,6 +827,11 @@ export function gitlab<const T extends GitlabPluginOptions>(
 			}
 
 			if (source === 'webhook') {
+				if (ctx.authType === 'managed') {
+					throw new Error(
+						'[auth-missing:gitlab:managed]: webhook signature is not available in managed mode',
+					);
+				}
 				const res = await ctx.keys.get_webhook_signature();
 				return res ?? '';
 			}
@@ -912,6 +922,32 @@ export function gitlab<const T extends GitlabPluginOptions>(
 					return freshResult.accessToken;
 				};
 
+				return result.accessToken;
+			}
+
+			if (ctx.authType === 'managed') {
+				if (!ctx.hub) {
+					throw new Error(
+						'[auth-missing:gitlab:managed]: Hub config is required for managed auth. Pass hub: { ... } to createCorsair().',
+					);
+				}
+
+				// Managed tokens are gitlab.com-only (Corsair's OAuth app); never send to a custom host.
+				if (!isManagedGitlabHost(baseUrl)) {
+					throw new Error(
+						'[auth-missing:gitlab:managed]: managed auth is only available on gitlab.com; use oauth_2 for a custom baseUrl',
+					);
+				}
+
+				const managedContext = {
+					keys: ctx.keys,
+					hub: ctx.hub,
+					plugin: 'gitlab',
+					tenantId: ctx.tenantId,
+				};
+
+				const result = await getManagedAccessToken(managedContext);
+				await attachManagedRefreshAuth(ctx, managedContext);
 				return result.accessToken;
 			}
 

--- a/packages/gitlab/jest.config.cjs
+++ b/packages/gitlab/jest.config.cjs
@@ -44,6 +44,7 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/hub$': '<rootDir>/../corsair/hub.ts',
 		'^corsair/core$': '<rootDir>/../corsair/core.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',

--- a/packages/gitlab/package.json
+++ b/packages/gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/gitlab",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Gitlab plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/hubspot/index.ts
+++ b/packages/hubspot/index.ts
@@ -14,6 +14,7 @@ import type {
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { attachManagedRefreshAuth, getManagedAccessToken } from 'corsair/hub';
 import { z } from 'zod';
 import type {
 	HubSpotEndpointInputs,
@@ -430,6 +431,9 @@ const defaultAuthType = 'api_key' as const;
 export const hubspotAuthConfig = {
 	api_key: { account: ['portal_id'] as const },
 	oauth_2: { account: ['portal_id'] as const },
+	managed: {
+		account: ['portal_id'] as const,
+	},
 } as const satisfies PluginAuthConfig;
 
 /**
@@ -559,7 +563,7 @@ const hubspotEndpointMeta = {
 } satisfies RequiredPluginEndpointMeta<typeof hubspotEndpointsNested>;
 
 export type HubSpotPluginOptions = {
-	authType?: PickAuth<'api_key' | 'oauth_2'>;
+	authType?: PickAuth<'api_key' | 'oauth_2' | 'managed'>;
 	credentials?: HubSpotCredentials;
 	webhookSecret?: string;
 	hooks?: InternalHubSpotPlugin['hooks'];
@@ -680,6 +684,25 @@ export function hubspot<const PluginOptions extends HubSpotPluginOptions>(
 
 					return res;
 				}
+			}
+
+			if (ctx.authType === 'managed') {
+				if (!ctx.hub) {
+					throw new Error(
+						'[auth-missing:hubspot:managed]: Hub config is required for managed auth. Pass hub: { ... } to createCorsair().',
+					);
+				}
+
+				const managedContext = {
+					keys: ctx.keys,
+					hub: ctx.hub,
+					plugin: 'hubspot',
+					tenantId: ctx.tenantId,
+				};
+
+				const result = await getManagedAccessToken(managedContext);
+				await attachManagedRefreshAuth(ctx, managedContext);
+				return result.accessToken;
 			}
 
 			throw new AuthMissingError('hubspot', 'oauth_2');

--- a/packages/hubspot/jest.config.cjs
+++ b/packages/hubspot/jest.config.cjs
@@ -44,6 +44,7 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/hub$': '<rootDir>/../corsair/hub.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',
 	},

--- a/packages/hubspot/package.json
+++ b/packages/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/hubspot",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Hubspot plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/linear/index.ts
+++ b/packages/linear/index.ts
@@ -13,6 +13,7 @@ import type {
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { attachManagedRefreshAuth, getManagedAccessToken } from 'corsair/hub';
 import { getValidLinearAccessToken } from './client';
 import type { LinearEndpointInputs, LinearEndpointOutputs } from './endpoints';
 import { Comments, Issues, Projects, Teams, Users } from './endpoints';
@@ -51,7 +52,7 @@ import {
 } from './webhooks/types';
 
 export type LinearPluginOptions = {
-	authType?: PickAuth<'api_key' | 'oauth_2'>;
+	authType?: PickAuth<'api_key' | 'oauth_2' | 'managed'>;
 	key?: string;
 	webhookSecret?: string;
 	hooks?: InternalLinearPlugin['hooks'];
@@ -300,6 +301,9 @@ const defaultAuthType = 'api_key' as const;
 export const linearAuthConfig = {
 	api_key: { account: ['organization_id'] as const },
 	oauth_2: { account: ['organization_id'] as const },
+	managed: {
+		account: ['organization_id'] as const,
+	},
 } as const satisfies PluginAuthConfig;
 
 /**
@@ -515,6 +519,25 @@ export function linear<const T extends LinearPluginOptions>(
 					return freshResult.accessToken;
 				};
 
+				return `Bearer ${result.accessToken}`;
+			}
+
+			if (ctx.authType === 'managed') {
+				if (!ctx.hub) {
+					throw new Error(
+						'[auth-missing:linear:managed]: Hub config is required for managed auth. Pass hub: { ... } to createCorsair().',
+					);
+				}
+
+				const managedContext = {
+					keys: ctx.keys,
+					hub: ctx.hub,
+					plugin: 'linear',
+					tenantId: ctx.tenantId,
+				};
+
+				const result = await getManagedAccessToken(managedContext);
+				await attachManagedRefreshAuth(ctx, managedContext);
 				return `Bearer ${result.accessToken}`;
 			}
 

--- a/packages/linear/jest.config.cjs
+++ b/packages/linear/jest.config.cjs
@@ -44,6 +44,7 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/hub$': '<rootDir>/../corsair/hub.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',
 	},

--- a/packages/linear/package.json
+++ b/packages/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/linear",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Linear plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/notion/index.ts
+++ b/packages/notion/index.ts
@@ -14,6 +14,7 @@ import type {
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { attachManagedRefreshAuth, getManagedAccessToken } from 'corsair/hub';
 import { Blocks, DatabasePages, Databases, Pages, Users } from './endpoints';
 import type {
 	NotionEndpointInputs,
@@ -42,7 +43,7 @@ import {
 } from './webhooks/types';
 
 export type NotionPluginOptions = {
-	authType?: PickAuth<'api_key' | 'oauth_2'>;
+	authType?: PickAuth<'api_key' | 'oauth_2' | 'managed'>;
 	key?: string;
 	webhookSecret?: string;
 	hooks?: InternalNotionPlugin['hooks'];
@@ -291,6 +292,9 @@ export const notionAuthConfig = {
 	oauth_2: {
 		account: ['workspace_id'] as const,
 	},
+	managed: {
+		account: ['workspace_id'] as const,
+	},
 } as const satisfies PluginAuthConfig;
 
 export type BaseNotionPlugin<T extends NotionPluginOptions> = CorsairPlugin<
@@ -395,6 +399,25 @@ export function notion<const T extends NotionPluginOptions>(
 				}
 
 				return accessToken;
+			}
+
+			if (ctx.authType === 'managed') {
+				if (!ctx.hub) {
+					throw new Error(
+						'[auth-missing:notion:managed]: Hub config is required for managed auth. Pass hub: { ... } to createCorsair().',
+					);
+				}
+
+				const managedContext = {
+					keys: ctx.keys,
+					hub: ctx.hub,
+					plugin: 'notion',
+					tenantId: ctx.tenantId,
+				};
+
+				const result = await getManagedAccessToken(managedContext);
+				await attachManagedRefreshAuth(ctx, managedContext);
+				return result.accessToken;
 			}
 
 			throw new AuthMissingError('notion', 'oauth_2');

--- a/packages/notion/jest.config.cjs
+++ b/packages/notion/jest.config.cjs
@@ -44,6 +44,7 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/hub$': '<rootDir>/../corsair/hub.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',
 	},

--- a/packages/notion/package.json
+++ b/packages/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/notion",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Notion plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/onedrive/index.ts
+++ b/packages/onedrive/index.ts
@@ -15,6 +15,7 @@ import type {
 	RequiredPluginWebhookSchemas,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { attachManagedRefreshAuth, getManagedAccessToken } from 'corsair/hub';
 import { getValidAccessToken } from './client';
 import {
 	Drive,
@@ -51,7 +52,7 @@ import {
 } from './webhooks/types';
 
 export type OnedrivePluginOptions = {
-	authType?: PickAuth<'oauth_2'>;
+	authType?: PickAuth<'oauth_2' | 'managed'>;
 	key?: string;
 	hooks?: InternalOnedrivePlugin['hooks'];
 	webhookHooks?: InternalOnedrivePlugin['webhookHooks'];
@@ -746,6 +747,9 @@ export const onedriveAuthConfig = {
 	oauth_2: {
 		account: ['subscription_id', 'client_state'] as const,
 	},
+	managed: {
+		account: ['subscription_id', 'client_state'] as const,
+	},
 } as const satisfies PluginAuthConfig;
 
 export type BaseOnedrivePlugin<PluginOptions extends OnedrivePluginOptions> =
@@ -816,6 +820,11 @@ export function onedrive<const PluginOptions extends OnedrivePluginOptions>(
 			}
 
 			if (source === 'webhook') {
+				if (ctx.authType === 'managed') {
+					throw new Error(
+						'[auth-missing:onedrive:managed]: webhook signature is not available in managed mode',
+					);
+				}
 				const res = await ctx.keys.get_webhook_signature();
 				if (!res) {
 					throw new Error(
@@ -902,6 +911,25 @@ export function onedrive<const PluginOptions extends OnedrivePluginOptions>(
 					return freshResult.accessToken;
 				};
 
+				return result.accessToken;
+			}
+
+			if (ctx.authType === 'managed') {
+				if (!ctx.hub) {
+					throw new Error(
+						'[auth-missing:onedrive:managed]: Hub config is required for managed auth. Pass hub: { ... } to createCorsair().',
+					);
+				}
+
+				const managedContext = {
+					keys: ctx.keys,
+					hub: ctx.hub,
+					plugin: 'onedrive',
+					tenantId: ctx.tenantId,
+				};
+
+				const result = await getManagedAccessToken(managedContext);
+				await attachManagedRefreshAuth(ctx, managedContext);
 				return result.accessToken;
 			}
 

--- a/packages/onedrive/jest.config.cjs
+++ b/packages/onedrive/jest.config.cjs
@@ -44,6 +44,7 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/hub$': '<rootDir>/../corsair/hub.ts',
 		'^corsair/core$': '<rootDir>/../corsair/core.ts',
 		'^corsair/orm$': '<rootDir>/../corsair/orm.ts',
 		'^corsair/tests$': '<rootDir>/../corsair/tests.ts',

--- a/packages/onedrive/package.json
+++ b/packages/onedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/onedrive",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "onedrive plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/outlook/index.ts
+++ b/packages/outlook/index.ts
@@ -17,6 +17,7 @@ import type {
 	RequiredPluginWebhookSchemas,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { attachManagedRefreshAuth, getManagedAccessToken } from 'corsair/hub';
 import { getValidAccessToken } from './client';
 import { Calendars, Contacts, Events, Folders, Messages } from './endpoints';
 import type {
@@ -58,7 +59,7 @@ import {
 } from './webhooks/types';
 
 export type OutlookPluginOptions = {
-	authType?: PickAuth<'oauth_2'>;
+	authType?: PickAuth<'oauth_2' | 'managed'>;
 	key?: string;
 	webhookSecret?: string;
 	hooks?: InternalOutlookPlugin['hooks'];
@@ -533,6 +534,9 @@ export const outlookAuthConfig = {
 	oauth_2: {
 		account: ['subscription_id', 'client_state'] as const,
 	},
+	managed: {
+		account: ['subscription_id', 'client_state'] as const,
+	},
 } as const satisfies PluginAuthConfig;
 
 export type BaseOutlookPlugin<T extends OutlookPluginOptions> = CorsairPlugin<
@@ -625,6 +629,11 @@ export function outlook<const T extends OutlookPluginOptions>(
 			}
 
 			if (source === 'webhook') {
+				if (ctx.authType === 'managed') {
+					throw new Error(
+						'[auth-missing:outlook:managed]: webhook signature is not available in managed mode',
+					);
+				}
 				const res = await ctx.keys.get_webhook_signature();
 				if (!res) {
 					throw new Error(
@@ -669,6 +678,25 @@ export function outlook<const T extends OutlookPluginOptions>(
 					]);
 				}
 
+				return result.accessToken;
+			}
+
+			if (ctx.authType === 'managed') {
+				if (!ctx.hub) {
+					throw new Error(
+						'[auth-missing:outlook:managed]: Hub config is required for managed auth. Pass hub: { ... } to createCorsair().',
+					);
+				}
+
+				const managedContext = {
+					keys: ctx.keys,
+					hub: ctx.hub,
+					plugin: 'outlook',
+					tenantId: ctx.tenantId,
+				};
+
+				const result = await getManagedAccessToken(managedContext);
+				await attachManagedRefreshAuth(ctx, managedContext);
 				return result.accessToken;
 			}
 

--- a/packages/outlook/jest.config.cjs
+++ b/packages/outlook/jest.config.cjs
@@ -44,6 +44,7 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/hub$': '<rootDir>/../corsair/hub.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
 		'^corsair/core$': '<rootDir>/../corsair/core.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',

--- a/packages/outlook/package.json
+++ b/packages/outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/outlook",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Outlook plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sharepoint/index.ts
+++ b/packages/sharepoint/index.ts
@@ -14,6 +14,7 @@ import type {
 	RequiredPluginEndpointSchemas,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { attachManagedRefreshAuth, getManagedAccessToken } from 'corsair/hub';
 import { getValidSharepointAccessToken } from './client';
 import {
 	ContentTypes,
@@ -65,10 +66,13 @@ export const sharepointAuthConfig = {
 		// site_id is the Graph API site identifier e.g. "tenant.sharepoint.com:/sites/MySite"
 		account: ['site_id', 'subscription_id', 'client_state'] as const,
 	},
+	managed: {
+		account: ['site_id', 'subscription_id', 'client_state'] as const,
+	},
 } as const satisfies PluginAuthConfig;
 
 export type SharepointPluginOptions = {
-	authType?: PickAuth<'oauth_2'>;
+	authType?: PickAuth<'oauth_2' | 'managed'>;
 	siteId?: string;
 	key?: string;
 	webhookClientState?: string;
@@ -1449,6 +1453,29 @@ export function sharepoint<const T extends SharepointPluginOptions>(
 					return freshResult.accessToken;
 				};
 
+				return result.accessToken;
+			}
+
+			// Unlike the other Graph plugins, sharepoint's webhook path above is
+			// not terminal (it returns only when webhookClientState is set), so a
+			// webhook could otherwise fall through here. Scope managed to endpoint
+			// calls — a webhook must never trigger a Hub token fetch.
+			if (source === 'endpoint' && ctx.authType === 'managed') {
+				if (!ctx.hub) {
+					throw new Error(
+						'[auth-missing:sharepoint:managed]: Hub config is required for managed auth. Pass hub: { ... } to createCorsair().',
+					);
+				}
+
+				const managedContext = {
+					keys: ctx.keys,
+					hub: ctx.hub,
+					plugin: 'sharepoint',
+					tenantId: ctx.tenantId,
+				};
+
+				const result = await getManagedAccessToken(managedContext);
+				await attachManagedRefreshAuth(ctx, managedContext);
 				return result.accessToken;
 			}
 

--- a/packages/sharepoint/jest.config.cjs
+++ b/packages/sharepoint/jest.config.cjs
@@ -44,6 +44,7 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/hub$': '<rootDir>/../corsair/hub.ts',
 		'^corsair/core$': '<rootDir>/../corsair/core.ts',
 		'^corsair/orm$': '<rootDir>/../corsair/orm.ts',
 		'^corsair/tests$': '<rootDir>/../corsair/tests.ts',

--- a/packages/sharepoint/package.json
+++ b/packages/sharepoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/sharepoint",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Sharepoint plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/slack/index.ts
+++ b/packages/slack/index.ts
@@ -13,6 +13,7 @@ import type {
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { attachManagedRefreshAuth, getManagedAccessToken } from 'corsair/hub';
 import type { SlackEndpointInputs, SlackEndpointOutputs } from './endpoints';
 import {
 	Channels,
@@ -643,6 +644,9 @@ export const slackAuthConfig = {
 	oauth_2: {
 		account: ['team_id'] as const,
 	},
+	managed: {
+		account: ['team_id'] as const,
+	},
 } as const satisfies PluginAuthConfig;
 
 /**
@@ -659,7 +663,7 @@ type SlackWebhook<K extends keyof SlackWebhookOutputs, TEvent> = CorsairWebhook<
 export type SlackBoundWebhooks = BindWebhooks<SlackWebhooks>;
 
 export type SlackPluginOptions = {
-	authType?: PickAuth<'api_key' | 'oauth_2'>;
+	authType?: PickAuth<'api_key' | 'oauth_2' | 'managed'>;
 	key?: string;
 	signingSecret?: string;
 	hooks?: InternalSlackPlugin['hooks'];
@@ -801,6 +805,25 @@ export function slack<const PluginOptions extends SlackPluginOptions>(
 				}
 
 				return res;
+			}
+
+			if (ctx.authType === 'managed') {
+				if (!ctx.hub) {
+					throw new Error(
+						'[auth-missing:slack:managed]: Hub config is required for managed auth. Pass hub: { ... } to createCorsair().',
+					);
+				}
+
+				const managedContext = {
+					keys: ctx.keys,
+					hub: ctx.hub,
+					plugin: 'slack',
+					tenantId: ctx.tenantId,
+				};
+
+				const result = await getManagedAccessToken(managedContext);
+				await attachManagedRefreshAuth(ctx, managedContext);
+				return result.accessToken;
 			}
 
 			throw new AuthMissingError('slack', 'oauth_2');

--- a/packages/slack/jest.config.cjs
+++ b/packages/slack/jest.config.cjs
@@ -45,6 +45,7 @@ module.exports = {
 	},
 	moduleNameMapper: {
 		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/hub$': '<rootDir>/../corsair/hub.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',
 	},

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/slack",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Slack plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/spotify/index.ts
+++ b/packages/spotify/index.ts
@@ -13,6 +13,7 @@ import type {
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { attachManagedRefreshAuth, getManagedAccessToken } from 'corsair/hub';
 import { getValidAccessToken } from './client';
 import {
 	Albums,
@@ -53,7 +54,7 @@ import { ExampleEventSchema } from './webhooks/types';
  * - webhookSecret: Optional webhook secret for signature verification
  */
 export type SpotifyPluginOptions = {
-	authType?: PickAuth<'oauth_2' | 'api_key'>;
+	authType?: PickAuth<'oauth_2' | 'api_key' | 'managed'>;
 	key?: string;
 	webhookSecret?: string;
 	hooks?: InternalSpotifyPlugin['hooks'];
@@ -607,6 +608,25 @@ export function spotify<const T extends SpotifyPluginOptions>(
 						`[corsair:spotify] Failed to get access token: ${error instanceof Error ? error.message : String(error)}`,
 					);
 				}
+			}
+
+			if (ctx.authType === 'managed') {
+				if (!ctx.hub) {
+					throw new Error(
+						'[auth-missing:spotify:managed]: Hub config is required for managed auth. Pass hub: { ... } to createCorsair().',
+					);
+				}
+
+				const managedContext = {
+					keys: ctx.keys,
+					hub: ctx.hub,
+					plugin: 'spotify',
+					tenantId: ctx.tenantId,
+				};
+
+				const result = await getManagedAccessToken(managedContext);
+				await attachManagedRefreshAuth(ctx, managedContext);
+				return result.accessToken;
 			}
 
 			throw new AuthMissingError('spotify', 'oauth_2');

--- a/packages/spotify/jest.config.cjs
+++ b/packages/spotify/jest.config.cjs
@@ -44,6 +44,7 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/hub$': '<rootDir>/../corsair/hub.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',
 	},

--- a/packages/spotify/package.json
+++ b/packages/spotify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/spotify",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Spotify plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/teams/index.ts
+++ b/packages/teams/index.ts
@@ -15,6 +15,7 @@ import type {
 	RequiredPluginWebhookSchemas,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
+import { attachManagedRefreshAuth, getManagedAccessToken } from 'corsair/hub';
 import { getValidAccessToken } from './client';
 import { Channels, Chats, Members, Messages, Teams } from './endpoints';
 import type {
@@ -49,7 +50,7 @@ import {
 } from './webhooks/types';
 
 export type TeamsPluginOptions = {
-	authType?: PickAuth<'oauth_2'>;
+	authType?: PickAuth<'oauth_2' | 'managed'>;
 	key?: string;
 	clientState?: string;
 	hooks?: InternalTeamsPlugin['hooks'];
@@ -395,6 +396,9 @@ export const teamsAuthConfig = {
 	oauth_2: {
 		account: ['subscription_id', 'client_state'] as const,
 	},
+	managed: {
+		account: ['subscription_id', 'client_state'] as const,
+	},
 } as const satisfies PluginAuthConfig;
 
 export type BaseTeamsPlugin<T extends TeamsPluginOptions> = CorsairPlugin<
@@ -468,6 +472,11 @@ export function teams<const T extends TeamsPluginOptions>(
 			}
 
 			if (source === 'webhook') {
+				if (ctx.authType === 'managed') {
+					throw new Error(
+						'[auth-missing:teams:managed]: webhook signature is not available in managed mode',
+					);
+				}
 				const res = await ctx.keys.get_webhook_signature();
 				if (!res) {
 					throw new Error(
@@ -511,6 +520,25 @@ export function teams<const T extends TeamsPluginOptions>(
 						ctx.keys.set_expires_at(String(result.expiresAt)),
 					]);
 				}
+				return result.accessToken;
+			}
+
+			if (ctx.authType === 'managed') {
+				if (!ctx.hub) {
+					throw new Error(
+						'[auth-missing:teams:managed]: Hub config is required for managed auth. Pass hub: { ... } to createCorsair().',
+					);
+				}
+
+				const managedContext = {
+					keys: ctx.keys,
+					hub: ctx.hub,
+					plugin: 'teams',
+					tenantId: ctx.tenantId,
+				};
+
+				const result = await getManagedAccessToken(managedContext);
+				await attachManagedRefreshAuth(ctx, managedContext);
 				return result.accessToken;
 			}
 

--- a/packages/teams/jest.config.cjs
+++ b/packages/teams/jest.config.cjs
@@ -45,6 +45,7 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/hub$': '<rootDir>/../corsair/hub.ts',
 		'^corsair/core$': '<rootDir>/../corsair/core.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',

--- a/packages/teams/package.json
+++ b/packages/teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/teams",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Microsoft Teams plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/zohomail/index.ts
+++ b/packages/zohomail/index.ts
@@ -13,6 +13,7 @@ import type {
 	RawWebhookRequest,
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
+import { attachManagedRefreshAuth, getManagedAccessToken } from 'corsair/hub';
 import type { ZohoRegion } from './client';
 import {
 	getValidAccessToken,
@@ -49,6 +50,9 @@ import {
 /** Zoho Mail uses standard OAuth2; no plugin-specific integration fields. */
 export const zohoMailAuthConfig = {
 	oauth_2: {
+		account: ['zuid'] as const,
+	},
+	managed: {
 		account: ['zuid'] as const,
 	},
 } as const satisfies PluginAuthConfig;
@@ -191,7 +195,7 @@ const zohoMailWebhookSchemas = {
 } as const;
 
 export type ZohoMailPluginOptions = {
-	authType?: PickAuth<'oauth_2'>;
+	authType?: PickAuth<'oauth_2' | 'managed'>;
 	/** Zoho datacenter region. Selects the accounts.zoho.* and mail.zoho.* hosts. Default 'us'. */
 	region?: ZohoRegion;
 	key?: string;
@@ -339,6 +343,11 @@ export function zohomail<const T extends ZohoMailPluginOptions>(
 			}
 
 			if (source === 'webhook') {
+				if (ctx.authType === 'managed') {
+					throw new Error(
+						'[auth-missing:zohomail:managed]: webhook signature is not available in managed mode',
+					);
+				}
 				const res = await ctx.keys.get_webhook_signature();
 				return res ?? '';
 			}
@@ -424,6 +433,25 @@ export function zohomail<const T extends ZohoMailPluginOptions>(
 					return freshResult.accessToken;
 				};
 
+				return result.accessToken;
+			}
+
+			if (ctx.authType === 'managed') {
+				if (!ctx.hub) {
+					throw new Error(
+						'[auth-missing:zohomail:managed]: Hub config is required for managed auth. Pass hub: { ... } to createCorsair().',
+					);
+				}
+
+				const managedContext = {
+					keys: ctx.keys,
+					hub: ctx.hub,
+					plugin: 'zohomail',
+					tenantId: ctx.tenantId,
+				};
+
+				const result = await getManagedAccessToken(managedContext);
+				await attachManagedRefreshAuth(ctx, managedContext);
 				return result.accessToken;
 			}
 

--- a/packages/zohomail/jest.config.cjs
+++ b/packages/zohomail/jest.config.cjs
@@ -44,6 +44,7 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/hub$': '<rootDir>/../corsair/hub.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
 		'^corsair/core$': '<rootDir>/../corsair/core/index.ts',
 		'^corsair/orm$': '<rootDir>/../corsair/orm.ts',

--- a/packages/zohomail/package.json
+++ b/packages/zohomail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/zohomail",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Zoho Mail plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Declares the `managed` authType on the 13 plugins Corsair has registered a managed OAuth app for, so tenant end-users can connect them without bringing their own OAuth credentials.

Each plugin gains `'managed'` in its authType union, a `managed:` authConfig block mirroring its `oauth_2` account fields, and a keyBuilder branch that resolves the tenant token from the Hub.

Scoped on purpose: `managed` only enters the union of registered providers, so the SDK never offers it where Corsair doesn't own the OAuth app — `authType: 'managed'` on an unregistered plugin is a compile error.

**Plugins:** asana, dropbox, gitlab, hubspot, linear, notion, onedrive, outlook, sharepoint, slack, spotify, teams, zohomail.

**Excluded:** airtable + jira (api_key-only, need oauth2 support first); google + stripe (not published yet).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added managed authentication support across Asana, Dropbox, GitLab, HubSpot, Linear, Notion, OneDrive, Outlook, SharePoint, Slack, Spotify, Teams, and Zoho Mail.
  * Managed authentication now automatically obtains and refreshes access tokens.
  * Added clear errors when required connection settings are missing.
* **Bug Fixes**
  * Prevented unsupported webhook signing operations when using managed authentication.
  * Restricted managed GitLab connections to valid GitLab.com hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->