### PR TITLE
fix(github): convert snake_case REST responses to camelCase

### DIFF
--- a/packages/github/client.test.ts
+++ b/packages/github/client.test.ts
@@ -1,0 +1,78 @@
+import { request } from 'corsair/http';
+import { makeGithubRequest } from './client';
+
+jest.mock('corsair/http', () => ({ request: jest.fn() }));
+
+const mockRequest = request as unknown as jest.Mock;
+
+// ENG-34: GitHub's REST API returns snake_case, but the plugin's response
+// types and DB schemas are camelCase. Without conversion, camelCase field
+// access (issue.htmlUrl, pr.createdAt) is undefined at runtime.
+describe('makeGithubRequest response casing (ENG-34)', () => {
+	beforeEach(() => mockRequest.mockReset());
+
+	it('converts snake_case REST fields to camelCase, including nested objects', async () => {
+		mockRequest.mockResolvedValueOnce({
+			id: 1,
+			node_id: 'I_abc',
+			html_url: 'https://github.com/o/r/issues/1',
+			created_at: '2026-01-01T00:00:00Z',
+			user: { id: 2, login: 'octocat', avatar_url: 'https://a/2' },
+		});
+
+		const result = await makeGithubRequest<Record<string, unknown>>(
+			'/repos/o/r/issues/1',
+			'token',
+		);
+
+		expect(result.htmlUrl).toBe('https://github.com/o/r/issues/1');
+		expect(result.nodeId).toBe('I_abc');
+		expect(result.createdAt).toBe('2026-01-01T00:00:00Z');
+		expect((result.user as Record<string, unknown>).avatarUrl).toBe(
+			'https://a/2',
+		);
+		expect(result.html_url).toBeUndefined();
+	});
+
+	it('converts snake_case fields inside array (list) responses', async () => {
+		mockRequest.mockResolvedValueOnce([
+			{ id: 1, full_name: 'o/r', html_url: 'https://github.com/o/r' },
+		]);
+
+		const result = await makeGithubRequest<Record<string, unknown>[]>(
+			'/user/repos',
+			'token',
+		);
+
+		expect(result[0]!.fullName).toBe('o/r');
+		expect(result[0]!.htmlUrl).toBe('https://github.com/o/r');
+	});
+
+	it('camelCases search envelope fields and the nested pull_request marker', async () => {
+		mockRequest.mockResolvedValueOnce({
+			total_count: 1,
+			incomplete_results: false,
+			items: [
+				{
+					id: 10,
+					html_url: 'https://github.com/o/r/issues/10',
+					pull_request: {
+						html_url: 'https://github.com/o/r/pull/10',
+						merged_at: null,
+					},
+				},
+			],
+		});
+
+		const result = await makeGithubRequest<Record<string, unknown>>(
+			'/search/issues',
+			'token',
+		);
+
+		expect(result.totalCount).toBe(1);
+		expect(result.incompleteResults).toBe(false);
+		const items = result.items as Record<string, unknown>[];
+		const marker = items[0]!.pullRequest as Record<string, unknown>;
+		expect(marker.htmlUrl).toBe('https://github.com/o/r/pull/10');
+	});
+});

--- a/packages/github/client.ts
+++ b/packages/github/client.ts
@@ -1,5 +1,6 @@
 import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
 import { request } from 'corsair/http';
+import { convertKeysToCamelCase } from './utils';
 
 export class GithubAPIError extends Error {
 	constructor(
@@ -65,7 +66,8 @@ async function makeGithubRequestWithToken<T>(
 
 	try {
 		const response = await request<T>(config, requestOptions);
-		return response;
+		// GitHub REST returns snake_case; the plugin is camelCase throughout.
+		return convertKeysToCamelCase(response) as T;
 	} catch (error) {
 		if (
 			error &&

--- a/packages/github/endpoints/search.ts
+++ b/packages/github/endpoints/search.ts
@@ -39,11 +39,9 @@ export const issues: GithubEndpoints['searchIssues'] = async (ctx, input) => {
 		try {
 			for (const issue of result.items) {
 				// Strip search-specific enrichment before persisting so the row
-				// matches the canonical Issue entity shape. GitHub sends these
-				// as snake_case at runtime (pull_request, not pullRequest),
-				// so destructure from the raw shape.
+				// matches the canonical Issue entity shape.
 				const raw = issue as Record<string, unknown>;
-				const { score, pull_request, repository, ...issueData } = raw;
+				const { score, pullRequest, repository, ...issueData } = raw;
 				await ctx.db.issues.upsertByEntityId(
 					String(issue.id),
 					issueData as Parameters<typeof ctx.db.issues.upsertByEntityId>[1],

--- a/packages/github/endpoints/types.ts
+++ b/packages/github/endpoints/types.ts
@@ -1019,20 +1019,16 @@ const DiscussionEndpointSchema = z.object({
 const SearchPullRequestMarkerSchema = z
 	.object({
 		url: z.string().optional(),
-		html_url: z.string().optional(),
-		diff_url: z.string().optional(),
-		patch_url: z.string().optional(),
-		merged_at: z.coerce.date().nullable().optional(),
+		htmlUrl: z.string().optional(),
+		diffUrl: z.string().optional(),
+		patchUrl: z.string().optional(),
+		mergedAt: z.coerce.date().nullable().optional(),
 	})
 	.loose();
 
-// Search-specific fields use the wire shape (snake_case) because the github
-// client returns raw JSON with no key transformation. The inherited entity
-// fields (nodeId, htmlUrl, etc.) stay optional + .loose() so they tolerate
-// the camelCase/snake_case mismatch the rest of the plugin already lives with.
 const SearchIssueSchema = IssueSchema.extend({
 	score: z.number(),
-	pull_request: SearchPullRequestMarkerSchema.optional(),
+	pullRequest: SearchPullRequestMarkerSchema.optional(),
 	repository: RepositorySchema.optional(),
 }).loose();
 
@@ -1045,29 +1041,26 @@ const SearchUserSchema = SimpleUserSchema.extend({
 	score: z.number(),
 }).loose();
 
-// GitHub's Search API returns these fields as total_count / incomplete_results.
-// The github client returns raw JSON with no key transformation, so response
-// schemas must match the wire shape (snake_case) or .parse() throws on every call.
 const SearchIssuesResponseSchema = z
 	.object({
-		total_count: z.number(),
-		incomplete_results: z.boolean(),
+		totalCount: z.number(),
+		incompleteResults: z.boolean(),
 		items: z.array(SearchIssueSchema),
 	})
 	.loose();
 
 const SearchRepositoriesResponseSchema = z
 	.object({
-		total_count: z.number(),
-		incomplete_results: z.boolean(),
+		totalCount: z.number(),
+		incompleteResults: z.boolean(),
 		items: z.array(SearchRepositorySchema),
 	})
 	.loose();
 
 const SearchUsersResponseSchema = z
 	.object({
-		total_count: z.number(),
-		incomplete_results: z.boolean(),
+		totalCount: z.number(),
+		incompleteResults: z.boolean(),
 		items: z.array(SearchUserSchema),
 	})
 	.loose();
@@ -1120,7 +1113,6 @@ export const GithubEndpointOutputSchemas = {
 	workflowsList: z
 		.object({
 			totalCount: z.number().optional(),
-			total_count: z.number().optional(),
 			workflows: z.array(WorkflowSchema).optional(),
 		})
 		.loose(),
@@ -1128,9 +1120,7 @@ export const GithubEndpointOutputSchemas = {
 	workflowsListRuns: z
 		.object({
 			totalCount: z.number().optional(),
-			total_count: z.number().optional(),
 			workflowRuns: z.array(WorkflowRunSchema).optional(),
-			workflow_runs: z.array(WorkflowRunSchema).optional(),
 		})
 		.loose(),
 	discussionsList: z.array(DiscussionEndpointSchema),

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/github",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Github plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Fixes ENG-34.

## Description

GitHub's REST API returns snake_case fields (`html_url`, `created_at`, `node_id`, `full_name`), but the plugin's response types (`endpoints/types.ts`) and DB entity schemas (`schema/database.ts`) are camelCase. Responses were returned and stored without key conversion, so camelCase field access (`issue.htmlUrl`, `pr.createdAt`) resolved to `undefined` at runtime across most github operations — breaking workflows that read github data.

The snake→camel bridge (`convertKeysToCamelCase`) already existed but was wired into only 2 of ~11 entity schemas (`GithubUser`, `GithubEvent`) and never applied to endpoint return values.

Note: the endpoint-path scoping/casing in core (`inspect`, `bind`) is not the cause — it resolves correctly for all major plugins on `main`. The failure is github response-body casing specifically.

## Fix

Apply `convertKeysToCamelCase` to the parsed response in `makeGithubRequest`'s transport (`client.ts`) — the single point every github REST response flows through. Every endpoint and entity now sees a consistent camelCase shape matching the declared types.

- The `preprocess` wrappers on `GithubUser`/`GithubEvent` are left in place: they serve the webhook path (webhook payloads are snake_case and do not go through this client), and are idempotent for REST responses.
- Response-only: request params and bodies are unchanged (GitHub expects snake_case input).

## Testing

- New `client.test.ts`: snake_case fixtures (nested object + array) asserting camelCase output; transport mocked, no network or credentials.
- biome + typecheck clean.
- Pre-existing `api.test.ts` / `integration.test.ts` failures are unrelated (live-API calls need `GITHUB_TOKEN`; `integration.test.ts` cannot load `corsair/core` under the github jest config) — confirmed identical on `main`.
- Verified no github handler reads snake_case fields off responses, so the conversion is transparent to handler logic.

## Scope

github only. Spot-checked the other major test plugins: slack (snake_case schema over snake_case API) and notion (snake_case schema over snake_case API) are already consistent; linear is camelCase over GraphQL. github was the sole camelCase-schema-over-snake_case-REST outlier.

## Screenshots / Demos
Non-visual change — this fixes REST response key casing (snake_case → camelCase). There is no UI surface to screenshot; the behavioral evidence is the unit test that asserts the conversion on nested objects and arrays:

https://github.com/corsairdev/corsair/blob/yuvraj/eng-34-fix-plugin-scoping-and-casing-that-break-workflow-runs/packages/github/client.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub API responses now consistently use camelCase field names, including nested objects and arrays.
  * Removed duplicate snake_case fields from returned response data for more predictable usage.
  * Updated search results and workflow responses to use consistent camelCase metadata.
  * Improved handling of pull request fields when saving search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
