### PR TITLE
feat: managed webhook suite for Graph plugins

### DIFF
--- a/packages/corsair/hub/managed-oauth.ts
+++ b/packages/corsair/hub/managed-oauth.ts
@@ -3,6 +3,7 @@ import {
 	getCorsairInternal,
 	requireCorsairPlugin,
 } from '../core/utils/corsair-instance';
+import { subscribeAndReport } from '../oauth/subscribe-report';
 import { resolveOAuthWebhookTenantLink } from '../webhooks/resolve-oauth-tenant-link';
 import { setWebhookTenantLink } from '../webhooks/tenant-links';
 import { ensureCorsairProvisionedForTenant } from './internal/provision';
@@ -161,6 +162,15 @@ export async function processManagedOAuthDelivery(
 			error,
 		);
 	}
+
+	await subscribeAndReport(corsair, plugin, tenantId, accountKm).catch(
+		(error) => {
+			console.warn(
+				`[corsair:managed-oauth] subscribe failed for '${pluginId}' tenant '${tenantId}':`,
+				error,
+			);
+		},
+	);
 
 	return { plugin: pluginId, tenantId };
 }

--- a/packages/corsair/oauth/renewal.ts
+++ b/packages/corsair/oauth/renewal.ts
@@ -1,6 +1,7 @@
 import type { CorsairInternalConfig, CorsairKeyBuilderBase } from '../core';
 import { createAccountKeyManager } from '../core';
 import { getCorsairInternal } from '../core/utils/corsair-instance';
+import { getPluginAuthType } from '../core/utils/plugin-auth';
 import { subscribeAndReport } from './subscribe-report';
 
 export type SubscribableAccountRow = {
@@ -33,13 +34,14 @@ export async function renewAccounts(input: {
 		if (!plugin?.subscribe) continue;
 		const label = `${plugin.id}/${row.tenantId}`;
 		try {
+			const authType = getPluginAuthType(plugin) ?? 'oauth_2';
 			const keys = createAccountKeyManager({
-				authType: 'oauth_2',
+				authType,
 				integrationName: plugin.id,
 				tenantId: row.tenantId,
 				kek: internal.kek,
 				database: internal.database,
-				extraAccountFields: [...(plugin.authConfig?.oauth_2?.account ?? [])],
+				extraAccountFields: [...(plugin.authConfig?.[authType]?.account ?? [])],
 			});
 			// Refresh first: stored access tokens expire (~1h) between renewal
 			// passes, and the bookkept expires_at can drift from the real token
@@ -52,7 +54,7 @@ export async function renewAccounts(input: {
 					get_expires_at: { value: async () => '0' },
 				});
 				await keyBuilder(
-					{ authType: 'oauth_2', keys: primingKeys },
+					{ authType, keys: primingKeys, hub: internal.hub },
 					'endpoint',
 				);
 			}

--- a/packages/corsair/package.json
+++ b/packages/corsair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corsair",
-  "version": "0.1.112",
+  "version": "0.1.113",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/corsair/tests/managed-oauth-report.test.ts
+++ b/packages/corsair/tests/managed-oauth-report.test.ts
@@ -10,8 +10,13 @@ jest.mock('../hub/report-connection-status', () => ({
 	reportPluginConnectionStatus: jest.fn().mockResolvedValue(undefined),
 }));
 
+jest.mock('../oauth/subscribe-report', () => ({
+	subscribeAndReport: jest.fn().mockResolvedValue(undefined),
+}));
+
 import { processManagedOAuthDelivery } from '../hub/managed-oauth';
 import { reportPluginConnectionStatus } from '../hub/report-connection-status';
+import { subscribeAndReport } from '../oauth/subscribe-report';
 
 const KEK = 'test-kek-managed-oauth';
 
@@ -29,6 +34,7 @@ describe('processManagedOAuthDelivery', () => {
 	let env: ReturnType<typeof createTestDatabase>;
 	afterEach(() => {
 		(reportPluginConnectionStatus as jest.Mock).mockClear();
+		(subscribeAndReport as jest.Mock).mockClear();
 		env?.cleanup?.();
 	});
 
@@ -62,5 +68,49 @@ describe('processManagedOAuthDelivery', () => {
 		const [, arg] = (reportPluginConnectionStatus as jest.Mock).mock.calls[0];
 		expect(arg.tenantId).toBe('default');
 		expect(arg.plugin.id).toBe('github');
+	});
+
+	it('arms the provider subscription after storing the token', async () => {
+		env = createTestDatabase();
+		const corsair = createCorsair({
+			plugins: [githubManaged],
+			database: env.db,
+			kek: KEK,
+		} as any);
+		await setupCorsair(corsair);
+
+		await processManagedOAuthDelivery(corsair, {
+			plugin: 'github',
+			tenantId: 'default',
+			accessToken: 'gho_delivered',
+			refreshToken: 'ghr_delivered',
+		});
+
+		expect(subscribeAndReport).toHaveBeenCalledTimes(1);
+		const [, plugin, tenantId] = (subscribeAndReport as jest.Mock).mock
+			.calls[0];
+		expect(plugin.id).toBe('github');
+		expect(tenantId).toBe('default');
+	});
+
+	it('a failing subscribe does not break the delivery', async () => {
+		env = createTestDatabase();
+		(subscribeAndReport as jest.Mock).mockRejectedValueOnce(
+			new Error('graph down'),
+		);
+		const corsair = createCorsair({
+			plugins: [githubManaged],
+			database: env.db,
+			kek: KEK,
+		} as any);
+		await setupCorsair(corsair);
+
+		await expect(
+			processManagedOAuthDelivery(corsair, {
+				plugin: 'github',
+				tenantId: 'default',
+				accessToken: 'gho_delivered',
+			}),
+		).resolves.toEqual({ plugin: 'github', tenantId: 'default' });
 	});
 });

--- a/packages/corsair/tests/subscription-renewal.test.ts
+++ b/packages/corsair/tests/subscription-renewal.test.ts
@@ -83,4 +83,45 @@ describe('renewAccounts (BYO subscription renewal)', () => {
 			failed: ['outlook/bad'],
 		});
 	});
+
+	it('primes a managed plugin with its authType AND hub, expiry forced', async () => {
+		const seen: Array<{
+			authType: string;
+			hasHub: boolean;
+			expiresAt: string;
+		}> = [];
+		const outlook = {
+			id: 'outlook',
+			options: { authType: 'managed' },
+			authConfig: { managed: { account: ['subscription_id', 'client_state'] } },
+			subscribe: async () => ({}),
+			keyBuilder: async (ctx: any) => {
+				// mirror the real managed keyBuilder branch, which throws without hub
+				if (ctx.authType === 'managed' && !ctx.hub) {
+					throw new Error('Hub config is required for managed auth');
+				}
+				seen.push({
+					authType: ctx.authType,
+					hasHub: !!ctx.hub,
+					expiresAt: await ctx.keys.get_expires_at(),
+				});
+				return 'tok';
+			},
+		};
+		const result = await renewAccounts({
+			corsair: {},
+			internal: {
+				...internalBase,
+				hub: { signingSecret: 's' },
+				plugins: [outlook],
+			},
+			rows: [{ tenantId: 't1', integrationName: 'outlook' }],
+			subscribeAndReport: async () => {},
+		});
+
+		expect(seen).toEqual([
+			{ authType: 'managed', hasHub: true, expiresAt: '0' },
+		]);
+		expect(result.renewed).toEqual(['outlook/t1']);
+	});
 });

--- a/packages/onedrive/index.ts
+++ b/packages/onedrive/index.ts
@@ -820,11 +820,6 @@ export function onedrive<const PluginOptions extends OnedrivePluginOptions>(
 			}
 
 			if (source === 'webhook') {
-				if (ctx.authType === 'managed') {
-					throw new Error(
-						'[auth-missing:onedrive:managed]: webhook signature is not available in managed mode',
-					);
-				}
 				const res = await ctx.keys.get_webhook_signature();
 				if (!res) {
 					throw new Error(

--- a/packages/onedrive/managed-webhook.test.ts
+++ b/packages/onedrive/managed-webhook.test.ts
@@ -1,0 +1,28 @@
+import { onedrive } from './index';
+
+describe('onedrive managed webhook verification', () => {
+	it('verifies via the stored clientState (no guard)', async () => {
+		const plugin = onedrive({ authType: 'managed' });
+		const key = await (plugin.keyBuilder as any)(
+			{
+				authType: 'managed',
+				keys: { get_webhook_signature: async () => 'cs' },
+			},
+			'webhook',
+		);
+		expect(key).toBe('cs');
+	});
+
+	it('fails closed when no clientState is stored', async () => {
+		const plugin = onedrive({ authType: 'managed' });
+		await expect(
+			(plugin.keyBuilder as any)(
+				{
+					authType: 'managed',
+					keys: { get_webhook_signature: async () => null },
+				},
+				'webhook',
+			),
+		).rejects.toThrow();
+	});
+});

--- a/packages/onedrive/package.json
+++ b/packages/onedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/onedrive",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "onedrive plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/outlook/index.ts
+++ b/packages/outlook/index.ts
@@ -629,11 +629,6 @@ export function outlook<const T extends OutlookPluginOptions>(
 			}
 
 			if (source === 'webhook') {
-				if (ctx.authType === 'managed') {
-					throw new Error(
-						'[auth-missing:outlook:managed]: webhook signature is not available in managed mode',
-					);
-				}
 				const res = await ctx.keys.get_webhook_signature();
 				if (!res) {
 					throw new Error(

--- a/packages/outlook/managed-webhook.test.ts
+++ b/packages/outlook/managed-webhook.test.ts
@@ -1,0 +1,28 @@
+import { outlook } from './index';
+
+describe('outlook managed webhook verification', () => {
+	it('verifies via the stored clientState (no guard)', async () => {
+		const plugin = outlook({ authType: 'managed' });
+		const key = await (plugin.keyBuilder as any)(
+			{
+				authType: 'managed',
+				keys: { get_webhook_signature: async () => 'cs' },
+			},
+			'webhook',
+		);
+		expect(key).toBe('cs');
+	});
+
+	it('fails closed when no clientState is stored', async () => {
+		const plugin = outlook({ authType: 'managed' });
+		await expect(
+			(plugin.keyBuilder as any)(
+				{
+					authType: 'managed',
+					keys: { get_webhook_signature: async () => null },
+				},
+				'webhook',
+			),
+		).rejects.toThrow();
+	});
+});

--- a/packages/outlook/package.json
+++ b/packages/outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/outlook",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Outlook plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sharepoint/index.ts
+++ b/packages/sharepoint/index.ts
@@ -1381,29 +1381,19 @@ export function sharepoint<const T extends SharepointPluginOptions>(
 				if (options.webhookClientState) {
 					return options.webhookClientState;
 				}
-				const res = await ctx.keys.get_webhook_signature();
-				if (!res) {
-					throw new Error(
-						'[auth-missing:sharepoint:webhook_signature]: SharePoint webhook client state is missing',
-					);
-				}
-				return res;
-			}
-
-			// Hub-managed subscriptions: msGraphSubscribe persists the clientState
-			// through set_webhook_signature, so read it back rather than falling
-			// through to the OAuth branch below (which would hand the webhook an
-			// access token and make every clientState comparison fail).
-			//
-			// Deliberately returns '' rather than throwing when absent, which is where
-			// this differs from the outlook/onedrive key builders: SharePoint answers
-			// the Graph validation handshake inside the webhook handler, and the key
-			// is resolved eagerly before that handler runs, so throwing here would
-			// make subscription creation impossible — the handshake arrives before
-			// set_webhook_signature has been called. An empty key lets the handshake
-			// through and still fails closed on a real notification, because the
-			// verifier now rejects an absent clientState.
-			if (source === 'webhook') {
+				// Hub-managed subscriptions: msGraphSubscribe persists the clientState
+				// through set_webhook_signature, so read it back rather than falling
+				// through to the OAuth branch below (which would hand the webhook an
+				// access token and make every clientState comparison fail).
+				//
+				// Deliberately returns '' rather than throwing when absent, which is
+				// where this differs from the outlook/onedrive key builders: SharePoint
+				// answers the Graph validation handshake inside the webhook handler, and
+				// the key is resolved eagerly before that handler runs, so throwing here
+				// would make subscription creation impossible — the handshake arrives
+				// before set_webhook_signature has been called. An empty key lets the
+				// handshake through and still fails closed on a real notification,
+				// because the verifier rejects an absent clientState.
 				return (await ctx.keys.get_webhook_signature()) ?? '';
 			}
 

--- a/packages/sharepoint/index.ts
+++ b/packages/sharepoint/index.ts
@@ -1377,8 +1377,17 @@ export function sharepoint<const T extends SharepointPluginOptions>(
 		keyBuilder: async (ctx: SharepointKeyBuilderContext, source) => {
 			const authType = ctx.authType;
 
-			if (source === 'webhook' && options.webhookClientState) {
-				return options.webhookClientState;
+			if (source === 'webhook') {
+				if (options.webhookClientState) {
+					return options.webhookClientState;
+				}
+				const res = await ctx.keys.get_webhook_signature();
+				if (!res) {
+					throw new Error(
+						'[auth-missing:sharepoint:webhook_signature]: SharePoint webhook client state is missing',
+					);
+				}
+				return res;
 			}
 
 			// Hub-managed subscriptions: msGraphSubscribe persists the clientState
@@ -1473,10 +1482,8 @@ export function sharepoint<const T extends SharepointPluginOptions>(
 				return result.accessToken;
 			}
 
-			// Unlike the other Graph plugins, sharepoint's webhook path above is
-			// not terminal (it returns only when webhookClientState is set), so a
-			// webhook could otherwise fall through here. Scope managed to endpoint
-			// calls — a webhook must never trigger a Hub token fetch.
+			// The webhook path above is terminal, so source is 'endpoint' here; this
+			// stays scoped as a defensive guard — a webhook must never fetch a Hub token.
 			if (source === 'endpoint' && ctx.authType === 'managed') {
 				if (!ctx.hub) {
 					throw new Error(

--- a/packages/sharepoint/managed-webhook.test.ts
+++ b/packages/sharepoint/managed-webhook.test.ts
@@ -14,17 +14,19 @@ describe('sharepoint managed webhook verification', () => {
 		expect(key).toBe('cs');
 	});
 
-	it('fails closed when no clientState is stored', async () => {
+	it('returns an empty key when no clientState is stored, to let the Graph validation handshake through (the handler fails closed on real notifications)', async () => {
 		const plugin = sharepoint({ authType: 'managed' });
-		await expect(
-			(plugin.keyBuilder as any)(
-				{
-					authType: 'managed',
-					keys: { get_webhook_signature: async () => null },
-				},
-				'webhook',
-			),
-		).rejects.toThrow();
+		const key = await (plugin.keyBuilder as any)(
+			{
+				authType: 'managed',
+				keys: { get_webhook_signature: async () => null },
+			},
+			'webhook',
+		);
+		// Throwing here would break subscription creation — the handshake arrives
+		// before the clientState is persisted. Fail-closed is enforced downstream:
+		// the verifier rejects an empty/absent clientState (see the listChanged tests).
+		expect(key).toBe('');
 	});
 
 	it('honors the static webhookClientState override', async () => {

--- a/packages/sharepoint/managed-webhook.test.ts
+++ b/packages/sharepoint/managed-webhook.test.ts
@@ -1,0 +1,75 @@
+import { sharepoint } from './index';
+import { listChanged } from './webhooks/list-changes';
+
+describe('sharepoint managed webhook verification', () => {
+	it('verifies via the stored clientState when no static override', async () => {
+		const plugin = sharepoint({ authType: 'managed' });
+		const key = await (plugin.keyBuilder as any)(
+			{
+				authType: 'managed',
+				keys: { get_webhook_signature: async () => 'cs' },
+			},
+			'webhook',
+		);
+		expect(key).toBe('cs');
+	});
+
+	it('fails closed when no clientState is stored', async () => {
+		const plugin = sharepoint({ authType: 'managed' });
+		await expect(
+			(plugin.keyBuilder as any)(
+				{
+					authType: 'managed',
+					keys: { get_webhook_signature: async () => null },
+				},
+				'webhook',
+			),
+		).rejects.toThrow();
+	});
+
+	it('honors the static webhookClientState override', async () => {
+		const plugin = sharepoint({
+			authType: 'managed',
+			webhookClientState: 'static',
+		});
+		const key = await (plugin.keyBuilder as any)(
+			{
+				authType: 'managed',
+				keys: { get_webhook_signature: async () => 'cs' },
+			},
+			'webhook',
+		);
+		expect(key).toBe('static');
+	});
+});
+
+describe('sharepoint listChanged handler verifies against ctx.key', () => {
+	const req = (clientState: unknown) =>
+		({
+			headers: {},
+			query: {},
+			payload: {
+				value: [
+					{ clientState, subscriptionId: 'sub', resource: 'r', siteUrl: 's' },
+				],
+			},
+		}) as any;
+
+	it('rejects a notification whose clientState mismatches ctx.key', async () => {
+		const res = await (listChanged.handler as any)(
+			{ key: 'cs', options: {} },
+			req('wrong'),
+		);
+		expect(res.success).toBe(false);
+		expect(res.statusCode).toBe(401);
+	});
+
+	it('rejects when ctx.key is absent (fail closed)', async () => {
+		const res = await (listChanged.handler as any)(
+			{ key: undefined, options: {} },
+			req('cs'),
+		);
+		expect(res.success).toBe(false);
+		expect(res.statusCode).toBe(401);
+	});
+});

--- a/packages/sharepoint/package.json
+++ b/packages/sharepoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/sharepoint",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Sharepoint plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/teams/index.ts
+++ b/packages/teams/index.ts
@@ -472,11 +472,6 @@ export function teams<const T extends TeamsPluginOptions>(
 			}
 
 			if (source === 'webhook') {
-				if (ctx.authType === 'managed') {
-					throw new Error(
-						'[auth-missing:teams:managed]: webhook signature is not available in managed mode',
-					);
-				}
 				const res = await ctx.keys.get_webhook_signature();
 				if (!res) {
 					throw new Error(

--- a/packages/teams/managed-webhook.test.ts
+++ b/packages/teams/managed-webhook.test.ts
@@ -1,0 +1,28 @@
+import { teams } from './index';
+
+describe('teams managed webhook verification', () => {
+	it('verifies via the stored clientState (no guard)', async () => {
+		const plugin = teams({ authType: 'managed' });
+		const key = await (plugin.keyBuilder as any)(
+			{
+				authType: 'managed',
+				keys: { get_webhook_signature: async () => 'cs' },
+			},
+			'webhook',
+		);
+		expect(key).toBe('cs');
+	});
+
+	it('fails closed when no clientState is stored', async () => {
+		const plugin = teams({ authType: 'managed' });
+		await expect(
+			(plugin.keyBuilder as any)(
+				{
+					authType: 'managed',
+					keys: { get_webhook_signature: async () => null },
+				},
+				'webhook',
+			),
+		).rejects.toThrow();
+	});
+});

--- a/packages/teams/package.json
+++ b/packages/teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/teams",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Microsoft Teams plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Extends #469's BYO webhook machine to managed connections on the Graph plugins (outlook, onedrive, teams, sharepoint). For managed the token lives in the Hub, so the subscribe engines never ran; this arms the subscription at connect and renewal by resolving the token from the Hub, then verifies inbound events via the stored clientState.

- **Connect:** `processManagedOAuthDelivery` fires `subscribeAndReport` after storing the delivered token (best-effort — a subscribe failure never breaks the connection).
- **Renewal:** `renewAccounts` primes each row by its plugin authType and passes `hub`, so the managed keyBuilder branch refreshes the token from the Hub before re-subscribe.
- **Verify:** managed webhooks read `webhook_signature` like oauth_2 (the managed guards are removed); sharepoint reads the stored clientState, fail-closed.

Also adds the `corsair/hub` jest moduleNameMapper the four plugin configs were missing since #571 (any test loading their `index.ts` failed to resolve `corsair/hub` without it).

**Stacks on #571** (managed authType declaration). Rebases to a clean diff once that merges.

Tests: renewal (managed prime threads authType + hub, expiry forced), connect subscribe (fires after token store + failure swallowed), per-plugin webhook verify + fail-closed. Typecheck clean across corsair + the four plugins.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added managed authentication support across Asana, Dropbox, GitLab, HubSpot, Linear, Notion, OneDrive, Outlook, SharePoint, Slack, Spotify, Teams, and Zoho Mail.
  * Managed access tokens now support automatic refresh through the connected hub.
* **Bug Fixes**
  * Improved webhook verification and fail-closed behavior when required security details are missing.
  * Subscription reporting failures no longer interrupt OAuth delivery.
* **Tests**
  * Added coverage for managed authentication, token renewal, subscription reporting, and webhook verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->