### PR TITLE
fix: add missing imports to packages/corsair README

### DIFF
--- a/packages/corsair/README.md
+++ b/packages/corsair/README.md
@@ -12,7 +12,7 @@ Integrations make products capable. Integrations are also frustrating to write. 
 
 Install Corsair:
 ```bash
-npm install corsair @corsair-dev/mcp
+npm install corsair @corsair-dev/mcp @corsair-dev/slack @corsair-dev/github @corsair-dev/gmail @corsair-dev/linear @corsair-dev/googlecalendar
 ```
 
 Declare your integrations in a file you can track and commit to git:

--- a/packages/corsair/README.md
+++ b/packages/corsair/README.md
@@ -18,6 +18,13 @@ npm install corsair @corsair-dev/mcp
 Declare your integrations in a file you can track and commit to git:
 ```typescript
 // corsair.ts
+import { createCorsair } from 'corsair';
+import { slack } from '@corsair-dev/slack';
+import { github } from '@corsair-dev/github';
+import { gmail } from '@corsair-dev/gmail';
+import { linear } from '@corsair-dev/linear';
+import { googlecalendar } from '@corsair-dev/googlecalendar';
+
 export const corsair = createCorsair({
   plugins: [slack(), github(), gmail(), linear(), googlecalendar()],
 });
@@ -25,6 +32,8 @@ export const corsair = createCorsair({
 
 Connect it to your agent and start prompting:
 ```typescript
+import { runStdioMcpServer } from '@corsair-dev/mcp';
+
 const corsairMcpServer = runStdioMcpServer({ corsair })
 
 query({


### PR DESCRIPTION
## Problem

The get-started snippets in \packages/corsair/README.md\ call \createCorsair\, plugin factories, and \unStdioMcpServer\ with no imports. Someone copying the example will get ReferenceErrors.

## Fix

Added import statements above each code snippet:
- \createCorsair\ from \corsair\
- Plugin factories (\slack\, \github\, \gmail\, \linear\, \googlecalendar\) from \@corsair-dev/*\
- \unStdioMcpServer\ from \@corsair-dev/mcp\

## Verify

Each code block in the Get started section would now run if pasted into a file (assuming packages are installed).

Fixes #538

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Corsair setup instructions to install and configure Slack, GitHub, Gmail, Linear, Google Calendar, and MCP integrations.
  * Added guidance for importing integration plugins, starting the standard MCP server, and registering integrations in the Corsair configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->