### PR TITLE
fix(core): reject signatures with empty secret

### DIFF
--- a/packages/corsair/async-core/webhook-utils.ts
+++ b/packages/corsair/async-core/webhook-utils.ts
@@ -64,7 +64,7 @@ export function verifyHmacSha256Signature(
 	maxAgeSeconds: number = 60 * 5,
 ): boolean {
 	if (!secret) {
-		return true;
+		return false;
 	}
 
 	if (!signature || !timestamp) {

--- a/packages/corsair/tests/webhook-utils.test.ts
+++ b/packages/corsair/tests/webhook-utils.test.ts
@@ -1,0 +1,42 @@
+import * as crypto from 'crypto';
+
+import {
+	verifyHmacSha256Signature,
+	verifySlackSignature,
+} from '../async-core/webhook-utils';
+
+function sign(payload: string, secret: string, timestamp: string): string {
+	const signatureBase = `v0:${timestamp}:${payload}`;
+	return `v0=${crypto
+		.createHmac('sha256', secret)
+		.update(signatureBase)
+		.digest('hex')}`;
+}
+
+describe('verifyHmacSha256Signature', () => {
+	const payload = '{"event":"test"}';
+	const timestamp = Math.floor(Date.now() / 1000).toString();
+
+	it('rejects a signature when the secret is empty', () => {
+		const signature = sign(payload, '', timestamp);
+
+		expect(verifyHmacSha256Signature(payload, '', timestamp, signature)).toBe(
+			false,
+		);
+	});
+
+	it('accepts a signature generated with the configured secret', () => {
+		const secret = 'signing-secret';
+		const signature = sign(payload, secret, timestamp);
+
+		expect(
+			verifyHmacSha256Signature(payload, secret, timestamp, signature),
+		).toBe(true);
+	});
+
+	it('makes the Slack signature alias fail closed on an empty secret', () => {
+		const signature = sign(payload, '', timestamp);
+
+		expect(verifySlackSignature(payload, '', timestamp, signature)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Description

`verifyHmacSha256Signature` returned `true` before checking the signature whenever the shared secret was empty. That made the shared helper, and its Slack alias, fail open for direct callers.

This change:

- returns `false` when the HMAC secret is empty
- keeps valid signature verification, timestamp validation, and caller-level skip behavior unchanged
- adds focused regression tests for the empty-secret path, a valid signature, and the Slack alias

Closes #587

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation (not applicable; no public API change)

## Screenshots / Demos (if applicable)

Not applicable.

## Additional Notes

Regression validation:

- before the implementation change, the new empty-secret tests failed with `Received: true`
- `pnpm --filter corsair test -- --runTestsByPath tests/webhook-utils.test.ts --runInBand` (3 passed)
- `pnpm --filter corsair test -- --runInBand --testPathIgnorePatterns=postgres-js-database.test.ts` (280 passed, 2 skipped)
- GitHub CI completed repository-wide lint, plugin/docs validation, typecheck, build, and tests successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook signature verification now correctly rejects requests when no secret is configured.
  * Slack signature verification now fails closed when the signing secret is missing.

* **Tests**
  * Added coverage for missing secrets, valid signatures, and rejected webhook requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->