### PR TITLE
fix(jira): fail closed when webhook secret or signature is missing

### DIFF
--- a/packages/jira/webhooks/types.test.ts
+++ b/packages/jira/webhooks/types.test.ts
@@ -14,15 +14,19 @@ describe('verifyJiraWebhookSignature', () => {
 	const sign = (key: string): string =>
 		`sha256=${crypto.createHmac('sha256', key).update(rawBody).digest('hex')}`;
 
+	const makeRequest = (
+		headers: Record<string, string | string[] | undefined>,
+	): WebhookRequest<JiraWebhookPayload> => ({
+		payload,
+		headers,
+		rawBody,
+	});
+
 	it('should fail closed when secret is missing', () => {
-		const request: WebhookRequest<unknown> = {
-			payload,
-			headers: {
-				'x-hub-signature': sign(secret),
-			},
-			rawBody,
-		};
-		const result = verifyJiraWebhookSignature(request, '');
+		const result = verifyJiraWebhookSignature(
+			makeRequest({ 'x-hub-signature': sign(secret) }),
+			'',
+		);
 		expect(result).toEqual({
 			valid: false,
 			error: 'Missing webhook secret',
@@ -33,22 +37,15 @@ describe('verifyJiraWebhookSignature', () => {
 		// The regression: omitting the signature header used to return
 		// { valid: true } whenever no secret was configured, so an attacker
 		// could bypass verification entirely by simply not sending a signature.
-		const request: WebhookRequest<unknown> = {
-			payload,
-			headers: {},
-			rawBody,
-		};
-		const result = verifyJiraWebhookSignature(request, '');
-		expect(result.valid).toBe(false);
+		const result = verifyJiraWebhookSignature(makeRequest({}), '');
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
 	});
 
 	it('should return invalid if signature header is missing', () => {
-		const request: WebhookRequest<unknown> = {
-			payload,
-			headers: {},
-			rawBody,
-		};
-		const result = verifyJiraWebhookSignature(request, secret);
+		const result = verifyJiraWebhookSignature(makeRequest({}), secret);
 		expect(result).toEqual({
 			valid: false,
 			error: 'Missing x-hub-signature header',
@@ -58,14 +55,10 @@ describe('verifyJiraWebhookSignature', () => {
 	it('should return invalid if signature does not match', () => {
 		// Signed with a different key, so it has the same length as a real
 		// signature and timingSafeEqual compares it rather than throwing.
-		const request: WebhookRequest<unknown> = {
-			payload,
-			headers: {
-				'x-hub-signature': sign('a-different-secret'),
-			},
-			rawBody,
-		};
-		const result = verifyJiraWebhookSignature(request, secret);
+		const result = verifyJiraWebhookSignature(
+			makeRequest({ 'x-hub-signature': sign('a-different-secret') }),
+			secret,
+		);
 		expect(result).toEqual({
 			valid: false,
 			error: 'Invalid signature',
@@ -73,14 +66,10 @@ describe('verifyJiraWebhookSignature', () => {
 	});
 
 	it('should return invalid if the signature length does not match', () => {
-		const request: WebhookRequest<unknown> = {
-			payload,
-			headers: {
-				'x-hub-signature': 'sha256=too-short',
-			},
-			rawBody,
-		};
-		const result = verifyJiraWebhookSignature(request, secret);
+		const result = verifyJiraWebhookSignature(
+			makeRequest({ 'x-hub-signature': 'sha256=too-short' }),
+			secret,
+		);
 		expect(result).toEqual({
 			valid: false,
 			error: 'Signature length mismatch',
@@ -88,26 +77,18 @@ describe('verifyJiraWebhookSignature', () => {
 	});
 
 	it('should return valid for a correct signature round-trip', () => {
-		const request: WebhookRequest<unknown> = {
-			payload,
-			headers: {
-				'x-hub-signature': sign(secret),
-			},
-			rawBody,
-		};
-		const result = verifyJiraWebhookSignature(request, secret);
+		const result = verifyJiraWebhookSignature(
+			makeRequest({ 'x-hub-signature': sign(secret) }),
+			secret,
+		);
 		expect(result).toEqual({ valid: true, error: undefined });
 	});
 
 	it('should accept the signature header when provided as an array', () => {
-		const request: WebhookRequest<unknown> = {
-			payload,
-			headers: {
-				'x-hub-signature': [sign(secret)],
-			},
-			rawBody,
-		};
-		const result = verifyJiraWebhookSignature(request, secret);
+		const result = verifyJiraWebhookSignature(
+			makeRequest({ 'x-hub-signature': [sign(secret)] }),
+			secret,
+		);
 		expect(result.valid).toBe(true);
 	});
 });

--- a/packages/jira/webhooks/types.test.ts
+++ b/packages/jira/webhooks/types.test.ts
@@ -1,0 +1,113 @@
+import * as crypto from 'node:crypto';
+import type { WebhookRequest } from 'corsair/core';
+import type { JiraWebhookPayload } from './types';
+import { verifyJiraWebhookSignature } from './types';
+
+describe('verifyJiraWebhookSignature', () => {
+	const secret = 'my-super-secret-key';
+	const payload: JiraWebhookPayload = {
+		webhookEvent: 'jira:issue_created',
+		timestamp: 1747872000000,
+	};
+	const rawBody = JSON.stringify(payload);
+
+	const sign = (key: string): string =>
+		`sha256=${crypto.createHmac('sha256', key).update(rawBody).digest('hex')}`;
+
+	it('should fail closed when secret is missing', () => {
+		const request: WebhookRequest<unknown> = {
+			payload,
+			headers: {
+				'x-hub-signature': sign(secret),
+			},
+			rawBody,
+		};
+		const result = verifyJiraWebhookSignature(request, '');
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('should fail closed when both secret and signature header are missing', () => {
+		// The regression: omitting the signature header used to return
+		// { valid: true } whenever no secret was configured, so an attacker
+		// could bypass verification entirely by simply not sending a signature.
+		const request: WebhookRequest<unknown> = {
+			payload,
+			headers: {},
+			rawBody,
+		};
+		const result = verifyJiraWebhookSignature(request, '');
+		expect(result.valid).toBe(false);
+	});
+
+	it('should return invalid if signature header is missing', () => {
+		const request: WebhookRequest<unknown> = {
+			payload,
+			headers: {},
+			rawBody,
+		};
+		const result = verifyJiraWebhookSignature(request, secret);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing x-hub-signature header',
+		});
+	});
+
+	it('should return invalid if signature does not match', () => {
+		// Signed with a different key, so it has the same length as a real
+		// signature and timingSafeEqual compares it rather than throwing.
+		const request: WebhookRequest<unknown> = {
+			payload,
+			headers: {
+				'x-hub-signature': sign('a-different-secret'),
+			},
+			rawBody,
+		};
+		const result = verifyJiraWebhookSignature(request, secret);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid signature',
+		});
+	});
+
+	it('should return invalid if the signature length does not match', () => {
+		const request: WebhookRequest<unknown> = {
+			payload,
+			headers: {
+				'x-hub-signature': 'sha256=too-short',
+			},
+			rawBody,
+		};
+		const result = verifyJiraWebhookSignature(request, secret);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Signature length mismatch',
+		});
+	});
+
+	it('should return valid for a correct signature round-trip', () => {
+		const request: WebhookRequest<unknown> = {
+			payload,
+			headers: {
+				'x-hub-signature': sign(secret),
+			},
+			rawBody,
+		};
+		const result = verifyJiraWebhookSignature(request, secret);
+		expect(result).toEqual({ valid: true, error: undefined });
+	});
+
+	it('should accept the signature header when provided as an array', () => {
+		const request: WebhookRequest<unknown> = {
+			payload,
+			headers: {
+				'x-hub-signature': [sign(secret)],
+			},
+			rawBody,
+		};
+		const result = verifyJiraWebhookSignature(request, secret);
+		expect(result.valid).toBe(true);
+	});
+});

--- a/packages/jira/webhooks/types.ts
+++ b/packages/jira/webhooks/types.ts
@@ -181,7 +181,7 @@ export function createJiraMatch(webhookEvent: string): CorsairWebhookMatcher {
  */
 
 export function verifyJiraWebhookSignature(
-	request: WebhookRequest<unknown>,
+	request: WebhookRequest,
 	secret: string,
 ): { valid: boolean; error?: string } {
 	if (!secret) {
@@ -189,10 +189,9 @@ export function verifyJiraWebhookSignature(
 	}
 
 	const headers = request.headers;
-	// Type assertion: headers value is string | string[] | undefined; we only want the string value
 	const signatureHeader = Array.isArray(headers['x-hub-signature'])
 		? headers['x-hub-signature'][0]
-		: (headers['x-hub-signature'] as string | undefined);
+		: headers['x-hub-signature'];
 
 	if (!signatureHeader) {
 		return { valid: false, error: 'Missing x-hub-signature header' };

--- a/packages/jira/webhooks/types.ts
+++ b/packages/jira/webhooks/types.ts
@@ -184,6 +184,10 @@ export function verifyJiraWebhookSignature(
 	request: WebhookRequest<unknown>,
 	secret: string,
 ): { valid: boolean; error?: string } {
+	if (!secret) {
+		return { valid: false, error: 'Missing webhook secret' };
+	}
+
 	const headers = request.headers;
 	// Type assertion: headers value is string | string[] | undefined; we only want the string value
 	const signatureHeader = Array.isArray(headers['x-hub-signature'])
@@ -191,10 +195,6 @@ export function verifyJiraWebhookSignature(
 		: (headers['x-hub-signature'] as string | undefined);
 
 	if (!signatureHeader) {
-		// Only allow unsigned requests when no secret has been configured
-		if (!secret) {
-			return { valid: true };
-		}
 		return { valid: false, error: 'Missing x-hub-signature header' };
 	}
 


### PR DESCRIPTION
## Description

Fixes #595.

`verifyJiraWebhookSignature` returned `{ valid: true }` for any request with no `x-hub-signature` header, as long as no secret was configured — so omitting the signature header bypassed verification entirely.

```ts
// before
if (!signatureHeader) {
	// Only allow unsigned requests when no secret has been configured
	if (!secret) {
		return { valid: true };   // <-- fail open
	}
	return { valid: false, error: 'Missing x-hub-signature header' };
}
```

Now the secret is checked first and a missing header is never valid, so neither a missing secret nor a missing signature can resolve to `valid: true`:

```ts
// after
if (!secret) {
	return { valid: false, error: 'Missing webhook secret' };
}
...
if (!signatureHeader) {
	return { valid: false, error: 'Missing x-hub-signature header' };
}
```

I deliberately matched the ordering and error strings already used by `verifySpotifyWebhookSignature`, since that verifier was fixed for this same fail-open family (#519, #520, #514) — so all the plugins now read the same way.

Adds `packages/jira/webhooks/types.test.ts`, mirroring the Spotify verifier's test layout:

| case | expected |
|---|---|
| secret missing (header present) | `Missing webhook secret` |
| **secret and header both missing** | `valid: false` — this is the actual bypass |
| header missing (secret present) | `Missing x-hub-signature header` |
| signature signed with a different key | `Invalid signature` |
| signature of the wrong length | `Signature length mismatch` |
| correct signature round-trip | `valid: true` |
| header supplied as `string[]` | `valid: true` |

All four acceptance criteria in the issue are covered.

## Checklist

- [x] I have run `pnpm lint` and all checks pass — `biome check` is clean on both changed files, and the repo's own lint-staged hook (`biome check --write`) ran clean on both commits
- [x] I have run `pnpm typecheck` and there are no TypeScript errors — `tsc --build` exits 0; the repo's pre-push typecheck hook also passed
- [x] I have run `pnpm build` and all packages build successfully — `pnpm --filter @corsair-dev/jira build` succeeds
- [x] I have run `pnpm test` and all tests pass — green in CI; **see note below** for local runs
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation — none required, no public API or plugin option changed

Two notes so the ticks above are not taken on trust:

**Tests.** My new suite passes 7/7, but the pre-existing `packages/jira/api.test.ts` fails 12/12 on a clean checkout of `main` too, because it builds an auth header from an unset API key (`Buffer.from(apiKey)` → `TypeError: ... Received undefined`). Unrelated to this change; I left it alone. Happy to fix it in a separate PR if useful.

**Lint.** I verified `biome check` on the two files I changed rather than repo-wide, because I'm on a Windows checkout where `core.autocrlf` gives every file CRLF and repo-wide `biome check .` therefore fails identically on unmodified `main`. Git normalises to LF on commit, so the diff itself carries no line-ending changes — `git diff --stat` on the branch is `+117 / -4` across exactly two files.

```
# on clean main:            Test Suites: 1 failed, 1 total   Tests: 12 failed, 12 total
# on this branch:           Test Suites: 1 failed, 1 passed  Tests: 12 failed, 7 passed
#                                                     ^ pre-existing        ^ new, all passing
```

## Screenshots / Demos (if applicable)

On R4 in `PLUGIN_PR_RULES.md`: the rule exists because "neither CI nor review bots can call the real third-party API." That doesn't apply here — this changes a pure local HMAC comparison, calls no Jira endpoint, and needs no credentials (the issue notes this too). The unit tests are the verification, and they run in CI. Terminal output:

```
$ npx jest --config packages/jira/jest.config.cjs webhooks/types.test.ts

 PASS  packages/jira/webhooks/types.test.ts
  verifyJiraWebhookSignature
    ✓ should fail closed when secret is missing
    ✓ should fail closed when both secret and signature header are missing
    ✓ should return invalid if signature header is missing
    ✓ should return invalid if signature does not match
    ✓ should return invalid if the signature length does not match
    ✓ should return valid for a correct signature round-trip
    ✓ should accept the signature header when provided as an array

Tests:       7 passed, 7 total
```

**Working proof:** the CI run for this branch, where the suite executes and passes — [`CI Checks`](https://github.com/corsairdev/corsair/actions/runs/30980617048/job/92224037009).

To be straight about it: that is a link to a CI job, not a screen recording. I can't record one, and for this change there is nothing to film — no UI, no CLI output, no third-party call. If a recording is required regardless, say so and I'll arrange it.

## Additional Notes

- Scope is `packages/jira/**` only (R1) — no changes to `constants.ts` or the lockfile were needed.
- No breaking change for correctly-configured webhooks: a request with a valid signature and a configured secret behaves exactly as before. The behaviour that changes is precisely the insecure one — a deployment relying on unsigned webhooks with no secret set will now be rejected, which is the point of the fix.
- #594 is the same fail-open bug in the GitLab verifier; I'll send that as a separate PR to keep one plugin per PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Jira webhook signature validation to fail fast when the webhook secret is missing.
  * Added clearer validation handling for missing, invalid, mismatched, and array-based signature headers.
  * Verified successful validation for correctly signed webhook requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->