### PR TITLE
fix(gitlab): fail closed when the webhook secret is missing

### DIFF
--- a/packages/gitlab/webhooks/types.test.ts
+++ b/packages/gitlab/webhooks/types.test.ts
@@ -1,0 +1,64 @@
+import type { WebhookRequest } from 'corsair/core';
+import type { GitlabWebhookPayload } from './types';
+import { verifyGitlabWebhookSignature } from './types';
+
+describe('verifyGitlabWebhookSignature', () => {
+	const secret = 'my-super-secret-token';
+	const payload: GitlabWebhookPayload = {
+		object_kind: 'push',
+		event_name: 'push',
+	};
+
+	const requestWith = (
+		headers: Record<string, string | string[]>,
+	): WebhookRequest<GitlabWebhookPayload> => ({
+		payload,
+		headers,
+		rawBody: JSON.stringify(payload),
+	});
+
+	it('should fail closed when secret is missing', () => {
+		// The regression: verification returned { valid: true } unconditionally
+		// when no secret was configured, without ever reading the token header.
+		const result = verifyGitlabWebhookSignature(
+			requestWith({ 'x-gitlab-token': secret }),
+			'',
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('should fail closed when both secret and token header are missing', () => {
+		const result = verifyGitlabWebhookSignature(requestWith({}), '');
+		expect(result.valid).toBe(false);
+	});
+
+	it('should return invalid if the token header is missing', () => {
+		const result = verifyGitlabWebhookSignature(requestWith({}), secret);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing X-Gitlab-Token header',
+		});
+	});
+
+	it('should return invalid if the token does not match the secret', () => {
+		const result = verifyGitlabWebhookSignature(
+			requestWith({ 'x-gitlab-token': 'not-the-secret' }),
+			secret,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'X-Gitlab-Token does not match configured secret',
+		});
+	});
+
+	it('should return valid when the token matches the configured secret', () => {
+		const result = verifyGitlabWebhookSignature(
+			requestWith({ 'x-gitlab-token': secret }),
+			secret,
+		);
+		expect(result).toEqual({ valid: true });
+	});
+});

--- a/packages/gitlab/webhooks/types.ts
+++ b/packages/gitlab/webhooks/types.ts
@@ -34,7 +34,7 @@ export function verifyGitlabWebhookSignature(
 	secret: string,
 ): { valid: boolean; error?: string } {
 	if (!secret) {
-		return { valid: true };
+		return { valid: false, error: 'Missing webhook secret' };
 	}
 
 	const token = request.headers['x-gitlab-token'];


### PR DESCRIPTION
## Description

Fixes #594.

`verifyGitlabWebhookSignature` returned `{ valid: true }` whenever no secret was configured. As the issue notes, this one is worse than the Jira/Twitter variants: it short-circuits *unconditionally*, before it ever reads the `X-Gitlab-Token` header, so any unsigned request was accepted outright.

```ts
// before
if (!secret) {
	return { valid: true };   // <-- never even looks at the token
}
```
```ts
// after
if (!secret) {
	return { valid: false, error: 'Missing webhook secret' };
}
```

One line, matching the fail-closed shape and the exact `'Missing webhook secret'` string already used by the Spotify verifier after the same family was fixed there (#519, #520, #514).

Adds `packages/gitlab/webhooks/types.test.ts`:

| case | expected |
|---|---|
| **secret missing** (token present) | `Missing webhook secret` — the bug |
| secret and token both missing | `valid: false` |
| token header missing (secret present) | `Missing X-Gitlab-Token header` |
| token does not match secret | `X-Gitlab-Token does not match configured secret` |
| token matches secret | `valid: true` |

All three acceptance criteria in the issue are covered.

## Checklist

- [x] I have run `pnpm lint` and all checks pass — `biome check` clean on both changed files; the repo's lint-staged hook (`biome check --write`) ran clean on both commits
- [x] I have run `pnpm typecheck` and there are no TypeScript errors — the repo's pre-push typecheck hook passed
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass — green in CI; **see note below** for local runs
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation — none required, no public API or plugin option changed

**On the test box.** My new suite passes 5/5. The package has two pre-existing failing suites that fail identically on a clean checkout of `main`, so this branch changes nothing about them:

```
clean main:   Test Suites: 2 failed, 1 passed, 3 total   Tests: 24 failed,  3 passed, 27 total
this branch:  Test Suites: 2 failed, 2 passed, 4 total   Tests: 24 failed,  8 passed, 32 total
                                     ^ +1 (mine)                 ^ identical   ^ +5 (mine)
```

The two are `api.test.ts` (builds an auth header from an unset API key) and `integration.test.ts` (`Cannot find module 'corsair/orm'` — needs a workspace build). Both unrelated; I left them alone.

## Screenshots / Demos (if applicable)

On R4 in `PLUGIN_PR_RULES.md`: that rule exists because "neither CI nor review bots can call the real third-party API." This change calls no GitLab endpoint and needs no credentials (the issue says so too) — it's a pure local comparison, so the unit tests are the verification and they run in CI:

```
$ pnpm --filter @corsair-dev/gitlab test

 PASS  ./webhooks/types.test.ts
  verifyGitlabWebhookSignature
    √ should fail closed when secret is missing
    √ should fail closed when both secret and token header are missing
    √ should return invalid if the token header is missing
    √ should return invalid if the token does not match the secret
    √ should return valid when the token matches the configured secret
```

**Working proof:** the CI run for this branch, where the suite executes and passes — [`CI Checks`](https://github.com/corsairdev/corsair/actions/runs/30980759047/job/92224458701).

To be straight about it: that is a link to a CI job, not a screen recording. I can't record one, and for this change there is nothing to film — no UI, no CLI output, no third-party call. If a recording is required regardless, say so and I'll arrange it.

## Additional Notes

- Scope is `packages/gitlab/**` only (R1). Companion to #608 (the Jira half of this family) — kept separate to honour one plugin per PR.
- Not a breaking change for correctly-configured webhooks: a request whose token matches a configured secret behaves exactly as before. What stops working is precisely the insecure configuration — a deployment running GitLab webhooks with no secret set will now be rejected, which is the intent.
- Out of scope, but worth flagging: the token check is `token !== secret`, a plain string comparison rather than a timing-safe one. Unlike the HMAC verifiers this compares the shared secret directly, so it is theoretically distinguishable by timing. I left it alone to keep this PR to the one-line fix the issue asks for — happy to send it separately if you want it.
