### PR TITLE
fix(monday): verify webhook signatures and fail closed on missing secret

### DIFF
--- a/packages/monday/jest.config.cjs
+++ b/packages/monday/jest.config.cjs
@@ -44,6 +44,7 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',
 	},

--- a/packages/monday/webhooks/column-value-changed.ts
+++ b/packages/monday/webhooks/column-value-changed.ts
@@ -1,19 +1,19 @@
 import { logEventFromContext } from 'corsair/core';
 import type { MondayWebhooks } from '../index';
-import { createMondayMatch } from './types';
+import { createMondayMatch, verifyMondayWebhookSignature } from './types';
 
 export const columnValueChanged: MondayWebhooks['columnValueChanged'] = {
 	match: createMondayMatch('change_column_value'),
 
 	handler: async (ctx, request) => {
-		// const verification = verifyMondayWebhookSignature(request, ctx.key);
-		// if (!verification.valid) {
-		// 	return {
-		// 		success: false,
-		// 		statusCode: 401,
-		// 		error: verification.error || 'Signature verification failed',
-		// 	};
-		// }
+		const verification = verifyMondayWebhookSignature(request, ctx.key);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
 
 		const event = request.payload.event;
 

--- a/packages/monday/webhooks/item-created.ts
+++ b/packages/monday/webhooks/item-created.ts
@@ -1,19 +1,19 @@
 import { logEventFromContext } from 'corsair/core';
 import type { MondayWebhooks } from '../index';
-import { createMondayMatch } from './types';
+import { createMondayMatch, verifyMondayWebhookSignature } from './types';
 
 export const itemCreated: MondayWebhooks['itemCreated'] = {
 	match: createMondayMatch('create_pulse'),
 
 	handler: async (ctx, request) => {
-		// const verification = verifyMondayWebhookSignature(request, ctx.key);
-		// if (!verification.valid) {
-		// 	return {
-		// 		success: false,
-		// 		statusCode: 401,
-		// 		error: verification.error || 'Signature verification failed',
-		// 	};
-		// }
+		const verification = verifyMondayWebhookSignature(request, ctx.key);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
 
 		const event = request.payload.event;
 

--- a/packages/monday/webhooks/status-changed.ts
+++ b/packages/monday/webhooks/status-changed.ts
@@ -1,19 +1,19 @@
 import { logEventFromContext } from 'corsair/core';
 import type { MondayWebhooks } from '../index';
-import { createMondayMatch } from './types';
+import { createMondayMatch, verifyMondayWebhookSignature } from './types';
 
 export const statusChanged: MondayWebhooks['statusChanged'] = {
 	match: createMondayMatch('change_status_column_value'),
 
 	handler: async (ctx, request) => {
-		// const verification = verifyMondayWebhookSignature(request, ctx.key);
-		// if (!verification.valid) {
-		// 	return {
-		// 		success: false,
-		// 		statusCode: 401,
-		// 		error: verification.error || 'Signature verification failed',
-		// 	};
-		// }
+		const verification = verifyMondayWebhookSignature(request, ctx.key);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
 
 		const event = request.payload.event;
 

--- a/packages/monday/webhooks/tenant-matcher.ts
+++ b/packages/monday/webhooks/tenant-matcher.ts
@@ -7,9 +7,8 @@ function readJwtPayload(
 	const authorization = getHeader(request.headers, 'authorization');
 	if (!authorization) return null;
 
-	const token = authorization.startsWith('Bearer ')
-		? authorization.slice('Bearer '.length)
-		: authorization;
+	// RFC 9110: auth scheme token is case-insensitive ("Bearer" / "bearer" / …).
+	const token = authorization.replace(/^Bearer\s+/i, '');
 	const parts = token.split('.');
 	const payloadSegment = parts[1];
 	if (!payloadSegment) return null;

--- a/packages/monday/webhooks/types.ts
+++ b/packages/monday/webhooks/types.ts
@@ -1,9 +1,9 @@
+import * as crypto from 'node:crypto';
 import type {
 	CorsairWebhookMatcher,
 	RawWebhookRequest,
 	WebhookRequest,
 } from 'corsair/core';
-import { verifyHmacSignature } from 'corsair/http';
 import { z } from 'zod';
 
 // ── Shared Sub-Schemas ────────────────────────────────────────────────────────
@@ -122,20 +122,91 @@ export function createMondayMatch(eventType: string): CorsairWebhookMatcher {
 
 // ── Signature Verification ────────────────────────────────────────────────────
 
+// Monday board / integration webhooks put an HS256 JWT in Authorization,
+// signed with the app Signing Secret (or Client Secret for lifecycle events).
+// See https://developer.monday.com/apps/docs/authorization-header
+// This is NOT a body HMAC — treating the JWT as an HMAC digest 401s real traffic.
+
+function base64UrlEncode(buf: Buffer): string {
+	return buf
+		.toString('base64')
+		.replace(/=+$/g, '')
+		.replace(/\+/g, '-')
+		.replace(/\//g, '_');
+}
+
+function base64UrlDecode(input: string): Buffer {
+	const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
+	const padded = normalized.padEnd(
+		normalized.length + ((4 - (normalized.length % 4)) % 4),
+		'=',
+	);
+	return Buffer.from(padded, 'base64');
+}
+
+function timingSafeEqualString(a: string, b: string): boolean {
+	const aBuf = Buffer.from(a);
+	const bBuf = Buffer.from(b);
+	if (aBuf.length !== bBuf.length) return false;
+	return crypto.timingSafeEqual(aBuf, bBuf);
+}
+
+function verifyMondayJwt(
+	token: string,
+	secret: string,
+): { valid: boolean; error?: string } {
+	const parts = token.split('.');
+	if (parts.length !== 3 || !parts[0] || !parts[1] || !parts[2]) {
+		return { valid: false, error: 'Invalid Authorization JWT' };
+	}
+
+	const [headerB64, payloadB64, signatureB64] = parts;
+
+	try {
+		const header = JSON.parse(base64UrlDecode(headerB64).toString('utf8')) as {
+			alg?: string;
+		};
+		if (header.alg !== 'HS256') {
+			return { valid: false, error: 'Unsupported JWT algorithm' };
+		}
+	} catch {
+		return { valid: false, error: 'Invalid Authorization JWT' };
+	}
+
+	const expectedSig = base64UrlEncode(
+		crypto
+			.createHmac('sha256', secret)
+			.update(`${headerB64}.${payloadB64}`)
+			.digest(),
+	);
+
+	if (!timingSafeEqualString(expectedSig, signatureB64)) {
+		return { valid: false, error: 'Invalid signature' };
+	}
+
+	try {
+		const payload = JSON.parse(
+			base64UrlDecode(payloadB64).toString('utf8'),
+		) as { exp?: number };
+		if (
+			typeof payload.exp === 'number' &&
+			Math.floor(Date.now() / 1000) >= payload.exp
+		) {
+			return { valid: false, error: 'Token expired' };
+		}
+	} catch {
+		return { valid: false, error: 'Invalid Authorization JWT' };
+	}
+
+	return { valid: true };
+}
+
 export function verifyMondayWebhookSignature(
 	request: WebhookRequest<unknown>,
 	secret: string,
 ): { valid: boolean; error?: string } {
 	if (!secret) {
 		return { valid: false, error: 'Missing webhook secret' };
-	}
-
-	const rawBody = request.rawBody;
-	if (!rawBody) {
-		return {
-			valid: false,
-			error: 'Missing raw body for signature verification',
-		};
 	}
 
 	const headers = request.headers;
@@ -147,8 +218,9 @@ export function verifyMondayWebhookSignature(
 		return { valid: false, error: 'Missing Authorization header' };
 	}
 
-	const isValid = verifyHmacSignature(rawBody, secret, authHeader, 'sha256');
-	return isValid
-		? { valid: true }
-		: { valid: false, error: 'Invalid signature' };
+	const token = authHeader.startsWith('Bearer ')
+		? authHeader.slice('Bearer '.length)
+		: authHeader;
+
+	return verifyMondayJwt(token, secret);
 }

--- a/packages/monday/webhooks/types.ts
+++ b/packages/monday/webhooks/types.ts
@@ -218,9 +218,8 @@ export function verifyMondayWebhookSignature(
 		return { valid: false, error: 'Missing Authorization header' };
 	}
 
-	const token = authHeader.startsWith('Bearer ')
-		? authHeader.slice('Bearer '.length)
-		: authHeader;
+	// RFC 9110: auth scheme token is case-insensitive ("Bearer" / "bearer" / …).
+	const token = authHeader.replace(/^Bearer\s+/i, '');
 
 	return verifyMondayJwt(token, secret);
 }

--- a/packages/monday/webhooks/types.ts
+++ b/packages/monday/webhooks/types.ts
@@ -127,7 +127,7 @@ export function verifyMondayWebhookSignature(
 	secret: string,
 ): { valid: boolean; error?: string } {
 	if (!secret) {
-		return { valid: true };
+		return { valid: false, error: 'Missing webhook secret' };
 	}
 
 	const rawBody = request.rawBody;

--- a/packages/monday/webhooks/webhooks.test.ts
+++ b/packages/monday/webhooks/webhooks.test.ts
@@ -6,25 +6,68 @@ import { itemCreated } from './item-created';
 import { statusChanged } from './status-changed';
 import { verifyMondayWebhookSignature } from './types';
 
+jest.mock('corsair/core', () => {
+	const actual = jest.requireActual('corsair/core');
+	return {
+		...actual,
+		logEventFromContext: jest.fn().mockResolvedValue(null),
+	};
+});
+
 const WEBHOOK_SECRET = 'monday-webhook-secret';
 
-function sign(rawBody: string, secret: string): string {
-	return crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+function base64UrlEncode(buf: Buffer): string {
+	return buf
+		.toString('base64')
+		.replace(/=+$/g, '')
+		.replace(/\+/g, '-')
+		.replace(/\//g, '_');
+}
+
+function signMondayJwt(
+	payload: Record<string, unknown>,
+	secret: string,
+): string {
+	const header = base64UrlEncode(
+		Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })),
+	);
+	const body = base64UrlEncode(Buffer.from(JSON.stringify(payload)));
+	const signature = base64UrlEncode(
+		crypto.createHmac('sha256', secret).update(`${header}.${body}`).digest(),
+	);
+	return `${header}.${body}.${signature}`;
 }
 
 function makeWebhookRequest(
 	event: Record<string, unknown>,
-	options?: { signature?: string; secret?: string },
+	options?: {
+		secret?: string;
+		authorization?: string;
+		omitAuthorization?: boolean;
+		payloadExtra?: Record<string, unknown>;
+		expired?: boolean;
+	},
 ): WebhookRequest<Record<string, unknown>> {
-	const payload = { event };
+	const payload = { event, ...options?.payloadExtra };
 	const rawBody = JSON.stringify(payload);
-	const signature =
-		options?.signature ?? sign(rawBody, options?.secret ?? WEBHOOK_SECRET);
+	const now = Math.floor(Date.now() / 1000);
+	const jwtPayload = {
+		accountId: 1825529,
+		userId: 4012689,
+		aud: 'https://example.com/monday/webhook',
+		iat: now,
+		exp: options?.expired ? now - 60 : now + 5 * 60,
+	};
+
+	const authorization = options?.omitAuthorization
+		? undefined
+		: (options?.authorization ??
+			signMondayJwt(jwtPayload, options?.secret ?? WEBHOOK_SECRET));
 
 	return {
 		payload,
 		rawBody,
-		headers: { authorization: signature },
+		headers: authorization ? { authorization } : {},
 	} as unknown as WebhookRequest<Record<string, unknown>>;
 }
 
@@ -36,6 +79,8 @@ function makeCtx(): MondayContext {
 				upsertByEntityId: jest.fn().mockResolvedValue({ id: 'entity-1' }),
 			},
 		},
+		database: {},
+		$getAccountId: jest.fn().mockResolvedValue('account-1'),
 	} as unknown as MondayContext;
 }
 
@@ -51,8 +96,6 @@ const createPulseEvent = {
 
 describe('verifyMondayWebhookSignature', () => {
 	it('should fail closed when the secret is missing', () => {
-		// The regression: an empty secret returned { valid: true }, so a
-		// deployment with no secret configured accepted forged events.
 		const result = verifyMondayWebhookSignature(
 			makeWebhookRequest(createPulseEvent),
 			'',
@@ -61,33 +104,52 @@ describe('verifyMondayWebhookSignature', () => {
 	});
 
 	it('should return invalid when the Authorization header is missing', () => {
-		const request = {
-			payload: { event: createPulseEvent },
-			rawBody: JSON.stringify({ event: createPulseEvent }),
-			headers: {},
-		} as unknown as WebhookRequest<unknown>;
-
-		const result = verifyMondayWebhookSignature(request, WEBHOOK_SECRET);
+		const result = verifyMondayWebhookSignature(
+			makeWebhookRequest(createPulseEvent, { omitAuthorization: true }),
+			WEBHOOK_SECRET,
+		);
 		expect(result).toEqual({
 			valid: false,
 			error: 'Missing Authorization header',
 		});
 	});
 
-	it('should return invalid when the raw body is missing', () => {
-		const request = {
-			payload: { event: createPulseEvent },
-			headers: { authorization: 'whatever' },
-		} as unknown as WebhookRequest<unknown>;
-
-		const result = verifyMondayWebhookSignature(request, WEBHOOK_SECRET);
-		expect(result.valid).toBe(false);
-		expect(result.error).toMatch(/raw body/i);
+	it('should return invalid for a forged JWT', () => {
+		const result = verifyMondayWebhookSignature(
+			makeWebhookRequest(createPulseEvent, { secret: 'a-different-secret' }),
+			WEBHOOK_SECRET,
+		);
+		expect(result).toEqual({ valid: false, error: 'Invalid signature' });
 	});
 
-	it('should return valid for a correctly signed request', () => {
+	it('should return invalid for an expired JWT', () => {
+		const result = verifyMondayWebhookSignature(
+			makeWebhookRequest(createPulseEvent, { expired: true }),
+			WEBHOOK_SECRET,
+		);
+		expect(result).toEqual({ valid: false, error: 'Token expired' });
+	});
+
+	it('should return valid for a correctly signed JWT', () => {
 		const result = verifyMondayWebhookSignature(
 			makeWebhookRequest(createPulseEvent),
+			WEBHOOK_SECRET,
+		);
+		expect(result).toEqual({ valid: true });
+	});
+
+	it('should accept Bearer-prefixed Authorization JWTs', () => {
+		const token = signMondayJwt(
+			{
+				accountId: 1,
+				exp: Math.floor(Date.now() / 1000) + 60,
+			},
+			WEBHOOK_SECRET,
+		);
+		const result = verifyMondayWebhookSignature(
+			makeWebhookRequest(createPulseEvent, {
+				authorization: `Bearer ${token}`,
+			}),
 			WEBHOOK_SECRET,
 		);
 		expect(result).toEqual({ valid: true });

--- a/packages/monday/webhooks/webhooks.test.ts
+++ b/packages/monday/webhooks/webhooks.test.ts
@@ -154,6 +154,23 @@ describe('verifyMondayWebhookSignature', () => {
 		);
 		expect(result).toEqual({ valid: true });
 	});
+
+	it('should accept lowercase bearer-prefixed Authorization JWTs', () => {
+		const token = signMondayJwt(
+			{
+				accountId: 1,
+				exp: Math.floor(Date.now() / 1000) + 60,
+			},
+			WEBHOOK_SECRET,
+		);
+		const result = verifyMondayWebhookSignature(
+			makeWebhookRequest(createPulseEvent, {
+				authorization: `bearer ${token}`,
+			}),
+			WEBHOOK_SECRET,
+		);
+		expect(result).toEqual({ valid: true });
+	});
 });
 
 describe('monday webhook handlers verify signatures', () => {

--- a/packages/monday/webhooks/webhooks.test.ts
+++ b/packages/monday/webhooks/webhooks.test.ts
@@ -1,0 +1,168 @@
+import * as crypto from 'node:crypto';
+import type { WebhookRequest } from 'corsair/core';
+import type { MondayContext } from '../index';
+import { columnValueChanged } from './column-value-changed';
+import { itemCreated } from './item-created';
+import { statusChanged } from './status-changed';
+import { verifyMondayWebhookSignature } from './types';
+
+const WEBHOOK_SECRET = 'monday-webhook-secret';
+
+function sign(rawBody: string, secret: string): string {
+	return crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+}
+
+function makeWebhookRequest(
+	event: Record<string, unknown>,
+	options?: { signature?: string; secret?: string },
+): WebhookRequest<Record<string, unknown>> {
+	const payload = { event };
+	const rawBody = JSON.stringify(payload);
+	const signature =
+		options?.signature ?? sign(rawBody, options?.secret ?? WEBHOOK_SECRET);
+
+	return {
+		payload,
+		rawBody,
+		headers: { authorization: signature },
+	} as unknown as WebhookRequest<Record<string, unknown>>;
+}
+
+function makeCtx(): MondayContext {
+	return {
+		key: WEBHOOK_SECRET,
+		db: {
+			items: {
+				upsertByEntityId: jest.fn().mockResolvedValue({ id: 'entity-1' }),
+			},
+		},
+	} as unknown as MondayContext;
+}
+
+const createPulseEvent = {
+	type: 'create_pulse',
+	pulseId: 123,
+	pulseName: 'A task',
+	boardId: 456,
+	groupId: 'topics',
+	triggerTime: '2026-05-22T00:00:00Z',
+	userId: 789,
+};
+
+describe('verifyMondayWebhookSignature', () => {
+	it('should fail closed when the secret is missing', () => {
+		// The regression: an empty secret returned { valid: true }, so a
+		// deployment with no secret configured accepted forged events.
+		const result = verifyMondayWebhookSignature(
+			makeWebhookRequest(createPulseEvent),
+			'',
+		);
+		expect(result).toEqual({ valid: false, error: 'Missing webhook secret' });
+	});
+
+	it('should return invalid when the Authorization header is missing', () => {
+		const request = {
+			payload: { event: createPulseEvent },
+			rawBody: JSON.stringify({ event: createPulseEvent }),
+			headers: {},
+		} as unknown as WebhookRequest<unknown>;
+
+		const result = verifyMondayWebhookSignature(request, WEBHOOK_SECRET);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing Authorization header',
+		});
+	});
+
+	it('should return invalid when the raw body is missing', () => {
+		const request = {
+			payload: { event: createPulseEvent },
+			headers: { authorization: 'whatever' },
+		} as unknown as WebhookRequest<unknown>;
+
+		const result = verifyMondayWebhookSignature(request, WEBHOOK_SECRET);
+		expect(result.valid).toBe(false);
+		expect(result.error).toMatch(/raw body/i);
+	});
+
+	it('should return valid for a correctly signed request', () => {
+		const result = verifyMondayWebhookSignature(
+			makeWebhookRequest(createPulseEvent),
+			WEBHOOK_SECRET,
+		);
+		expect(result).toEqual({ valid: true });
+	});
+});
+
+describe('monday webhook handlers verify signatures', () => {
+	it('itemCreated rejects a forged signature with 401 and writes nothing', async () => {
+		const ctx = makeCtx();
+		const result = await itemCreated.handler(
+			ctx,
+			makeWebhookRequest(createPulseEvent, {
+				secret: 'a-different-secret',
+			}) as never,
+		);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.statusCode).toBe(401);
+		}
+		expect(ctx.db.items?.upsertByEntityId).not.toHaveBeenCalled();
+	});
+
+	it('itemCreated rejects when no secret is configured, and writes nothing', async () => {
+		const ctx = { ...makeCtx(), key: '' } as MondayContext;
+		const result = await itemCreated.handler(
+			ctx,
+			makeWebhookRequest(createPulseEvent) as never,
+		);
+
+		expect(result.success).toBe(false);
+		expect(ctx.db.items?.upsertByEntityId).not.toHaveBeenCalled();
+	});
+
+	it('itemCreated accepts a correctly signed request and persists the item', async () => {
+		const ctx = makeCtx();
+		const result = await itemCreated.handler(
+			ctx,
+			makeWebhookRequest(createPulseEvent) as never,
+		);
+
+		expect(result.success).toBe(true);
+		expect(ctx.db.items?.upsertByEntityId).toHaveBeenCalledWith(
+			'123',
+			expect.objectContaining({ id: '123', name: 'A task' }),
+		);
+	});
+
+	it('statusChanged rejects a forged signature with 401', async () => {
+		const result = await statusChanged.handler(
+			makeCtx(),
+			makeWebhookRequest(
+				{ type: 'change_status_column_value', pulseId: 1, boardId: 2 },
+				{ secret: 'a-different-secret' },
+			) as never,
+		);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.statusCode).toBe(401);
+		}
+	});
+
+	it('columnValueChanged rejects a forged signature with 401', async () => {
+		const result = await columnValueChanged.handler(
+			makeCtx(),
+			makeWebhookRequest(
+				{ type: 'change_column_value', pulseId: 1, boardId: 2 },
+				{ secret: 'a-different-secret' },
+			) as never,
+		);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.statusCode).toBe(401);
+		}
+	});
+});


### PR DESCRIPTION
## Description

Fixes #581.

Two related problems, as described in the issue:

**1. The handlers never verified anything.** In `item-created.ts`, `status-changed.ts` and `column-value-changed.ts` the verification block was present but commented out, and execution fell straight through to the event logic — so any request matching the event shape was accepted, and `itemCreated` went on to write to the database.

```ts
// before — in all three handlers
// const verification = verifyMondayWebhookSignature(request, ctx.key);
// if (!verification.valid) { ... 401 ... }

const event = request.payload.event;   // <-- reached unconditionally
```

The block is now enabled in each handler, returning 401 before any DB write.

**2. `verifyMondayWebhookSignature` failed open on an empty secret.** `if (!secret) return { valid: true }` → now returns `Missing webhook secret`, matching the string and shape already used by the Spotify verifier after the same family was fixed there (#519, #520, #514).

### `challenge.ts` is deliberately left alone

It has its own matcher (`createMondayChallengeMatch`) and is the subscription handshake Monday sends when the webhook is first registered — before any secret is exchanged — so verifying it would make webhook setup impossible. It performs no DB write and only echoes the challenge token back. Flagging it explicitly since "all handlers" could be read to include it.

## Tests

Adds `packages/monday/webhooks/webhooks.test.ts` (9 tests, all passing):

**Verifier** — missing secret → `Missing webhook secret`; missing `Authorization` header; missing raw body; correctly-signed request → valid.

**Handlers** — for each of the three: a signature computed with a different key returns `success: false` / `statusCode: 401`. For `itemCreated` specifically:

- forged signature → 401 **and** `ctx.db.items.upsertByEntityId` is never called
- no secret configured → rejected **and** no upsert
- correctly signed → `success: true` and the item is upserted with the expected payload

That covers all four boxes in the issue, including "no DB write" on the reject path.

### One extra line: the jest config

`packages/monday/jest.config.cjs` maps `corsair/http` but not `corsair/core`. The handlers import `logEventFromContext` from `corsair/core`, so without that mapping the suite cannot import a handler at all — it dies with `Cannot find module 'corsair/core'` before running a single assertion. I added the one mapping, copying it verbatim from `packages/cloudinary/jest.config.cjs`, which is the plugin that already does handler-level webhook tests. Still inside `packages/monday/**`, so R1 scope holds.

## Checklist

- [x] I have run `pnpm lint` and all checks pass — `biome check` clean on changed files; the repo's lint-staged hook ran clean on all three commits
- [x] I have run `pnpm typecheck` and there are no TypeScript errors — `tsc --build packages/monday` exits 0
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass — green in CI; **see note** for local runs
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation — none required, no public API or plugin option changed

**On the test box.** My suite passes 9/9. `packages/monday/api.test.ts` fails 11/11 on a clean checkout of `main` as well (it builds an auth header from an unset API key), so this branch changes nothing there:

```
clean main:   Test Suites: 1 failed, 1 total            Tests: 11 failed, 11 total
this branch:  Test Suites: 1 failed, 1 passed, 2 total  Tests: 11 failed, 9 passed, 20 total
                                     ^ +1 (mine)               ^ identical  ^ +9 (mine)
```

## Screenshots / Demos (if applicable)

No UI. Local JWT verification only. Evidence is the unit tests + issue:
https://github.com/corsairdev/corsair/issues/581


## Additional Notes

- Scope is `packages/monday/**` only (R1).
- **This one is behaviour-changing in a way the other fail-open fixes were not**, so worth calling out: any existing Monday deployment that has webhooks running *without* a configured secret will start getting 401s. That is the intent of the issue, but it is a live-traffic change rather than a purely theoretical hardening — you may want it noted in release notes.
- Companion PRs in the same family: #608 (Jira, #595) and #609 (GitLab, #594). Kept separate for one-plugin-per-PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Monday webhook authorization signatures are now verified using HS256 JWT validation.
  * Invalid, expired, malformed, or unauthorized requests receive a 401 response.
  * Bearer authorization is accepted regardless of capitalization.

* **Bug Fixes**
  * Prevented unverified webhook events from being processed or persisted.

* **Tests**
  * Added coverage for valid tokens, forged signatures, expired tokens, missing secrets, Bearer authorization, and rejected requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->