### PR TITLE
fix(sharepoint): fail closed on missing clientState and use the Hub-stored signature

### DIFF
--- a/packages/sharepoint/index.ts
+++ b/packages/sharepoint/index.ts
@@ -1377,6 +1377,23 @@ export function sharepoint<const T extends SharepointPluginOptions>(
 				return options.webhookClientState;
 			}
 
+			// Hub-managed subscriptions: msGraphSubscribe persists the clientState
+			// through set_webhook_signature, so read it back rather than falling
+			// through to the OAuth branch below (which would hand the webhook an
+			// access token and make every clientState comparison fail).
+			//
+			// Deliberately returns '' rather than throwing when absent, which is where
+			// this differs from the outlook/onedrive key builders: SharePoint answers
+			// the Graph validation handshake inside the webhook handler, and the key
+			// is resolved eagerly before that handler runs, so throwing here would
+			// make subscription creation impossible — the handshake arrives before
+			// set_webhook_signature has been called. An empty key lets the handshake
+			// through and still fails closed on a real notification, because the
+			// verifier now rejects an absent clientState.
+			if (source === 'webhook') {
+				return (await ctx.keys.get_webhook_signature()) ?? '';
+			}
+
 			if (source === 'endpoint' && options.key) {
 				return options.key;
 			}

--- a/packages/sharepoint/webhooks/list-changes.ts
+++ b/packages/sharepoint/webhooks/list-changes.ts
@@ -28,8 +28,10 @@ export const listChanged: SharepointWebhooks['listChanged'] = {
 			};
 		}
 
-		const clientState = ctx.options?.webhookClientState;
-		const verification = verifySharepointWebhookSignature(request, clientState);
+		// ctx.key resolves the plugin option first and then the Hub-stored webhook
+		// signature (see the keyBuilder in ../index.ts), matching the other Graph
+		// plugins. Reading the option directly missed Hub-managed subscriptions.
+		const verification = verifySharepointWebhookSignature(request, ctx.key);
 		if (!verification.valid) {
 			return {
 				success: false,

--- a/packages/sharepoint/webhooks/types.ts
+++ b/packages/sharepoint/webhooks/types.ts
@@ -100,8 +100,7 @@ export function verifySharepointWebhookSignature(
 	clientState?: string,
 ): { valid: boolean; error?: string } {
 	if (!clientState) {
-		// No secret configured; skip verification
-		return { valid: true };
+		return { valid: false, error: 'Missing client state' };
 	}
 
 	const notifications = request.payload?.value;
@@ -109,8 +108,13 @@ export function verifySharepointWebhookSignature(
 		return { valid: false, error: 'Invalid payload: missing value array' };
 	}
 
-	const first = notifications[0];
-	if (first?.clientState !== clientState) {
+	// Every notification must carry the expected clientState, not just the first:
+	// Graph batches notifications into one request, so checking only value[0]
+	// would let unverified entries ride along behind a valid one.
+	const allMatch = notifications.every(
+		(n) => typeof n?.clientState === 'string' && n.clientState === clientState,
+	);
+	if (!allMatch) {
 		return { valid: false, error: 'Client state mismatch' };
 	}
 

--- a/packages/sharepoint/webhooks/webhooks.test.ts
+++ b/packages/sharepoint/webhooks/webhooks.test.ts
@@ -1,0 +1,147 @@
+import type { WebhookRequest } from 'corsair/core';
+import type { SharepointContext } from '../index';
+import { listChanged } from './list-changes';
+import type {
+	SharepointListChangedPayload,
+	SharepointWebhookNotification,
+} from './types';
+import { verifySharepointWebhookSignature } from './types';
+
+const CLIENT_STATE = 'sharepoint-client-state';
+
+function notification(
+	overrides: Partial<SharepointWebhookNotification> = {},
+): SharepointWebhookNotification {
+	return {
+		subscriptionId: 'sub-1',
+		clientState: CLIENT_STATE,
+		resource: 'sites/contoso/lists/tasks',
+		tenantId: 'tenant-1',
+		siteUrl: 'https://contoso.sharepoint.com/sites/team',
+		webId: 'web-1',
+		...overrides,
+	};
+}
+
+function makeRequest(
+	notifications: SharepointWebhookNotification[],
+	headers: Record<string, string> = {},
+): WebhookRequest<SharepointListChangedPayload> {
+	return {
+		payload: { value: notifications },
+		rawBody: JSON.stringify({ value: notifications }),
+		headers,
+	} as unknown as WebhookRequest<SharepointListChangedPayload>;
+}
+
+function makeCtx(key: string): SharepointContext {
+	return { key, db: {} } as unknown as SharepointContext;
+}
+
+describe('verifySharepointWebhookSignature', () => {
+	it('should fail closed when the client state is missing', () => {
+		// The regression: an unset clientState returned { valid: true }, so a
+		// Hub-managed subscription accepted forged Graph notifications outright.
+		const result = verifySharepointWebhookSignature(
+			makeRequest([notification()]),
+			'',
+		);
+		expect(result).toEqual({ valid: false, error: 'Missing client state' });
+	});
+
+	it('should reject a payload with no notifications', () => {
+		const result = verifySharepointWebhookSignature(
+			makeRequest([]),
+			CLIENT_STATE,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid payload: missing value array',
+		});
+	});
+
+	it('should reject when the client state does not match', () => {
+		const result = verifySharepointWebhookSignature(
+			makeRequest([notification({ clientState: 'wrong' })]),
+			CLIENT_STATE,
+		);
+		expect(result).toEqual({ valid: false, error: 'Client state mismatch' });
+	});
+
+	it('should reject a batch where a later notification is forged', () => {
+		// Graph batches notifications into one request. Checking only value[0]
+		// let a forged entry ride along behind a valid one.
+		const result = verifySharepointWebhookSignature(
+			makeRequest([notification(), notification({ clientState: 'forged' })]),
+			CLIENT_STATE,
+		);
+		expect(result).toEqual({ valid: false, error: 'Client state mismatch' });
+	});
+
+	it('should reject a batch where a later notification has no client state', () => {
+		const result = verifySharepointWebhookSignature(
+			makeRequest([notification(), notification({ clientState: null })]),
+			CLIENT_STATE,
+		);
+		expect(result).toEqual({ valid: false, error: 'Client state mismatch' });
+	});
+
+	it('should accept when every notification carries the expected client state', () => {
+		const result = verifySharepointWebhookSignature(
+			makeRequest([notification(), notification({ subscriptionId: 'sub-2' })]),
+			CLIENT_STATE,
+		);
+		expect(result).toEqual({ valid: true });
+	});
+});
+
+describe('listChanged handler', () => {
+	it('rejects a notification with 401 when no client state is configured', async () => {
+		const result = await listChanged.handler(
+			makeCtx(''),
+			makeRequest([notification()]) as never,
+		);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.statusCode).toBe(401);
+		}
+	});
+
+	it('rejects a forged client state with 401', async () => {
+		const result = await listChanged.handler(
+			makeCtx(CLIENT_STATE),
+			makeRequest([notification({ clientState: 'forged' })]) as never,
+		);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.statusCode).toBe(401);
+		}
+	});
+
+	it('still answers the Graph validation handshake when no key is stored yet', async () => {
+		// The handshake arrives during subscription creation, before
+		// set_webhook_signature has run — so it must survive an empty ctx.key.
+		const result = await listChanged.handler(
+			makeCtx(''),
+			makeRequest([], { validationtoken: 'graph-validation-token' }) as never,
+		);
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.returnToSender).toEqual({
+				validationToken: 'graph-validation-token',
+			});
+		}
+	});
+
+	it('accepts a correctly signed notification', async () => {
+		const result = await listChanged.handler(
+			makeCtx(CLIENT_STATE),
+			makeRequest([notification()]) as never,
+		);
+
+		expect(result.success).toBe(true);
+	});
+});


### PR DESCRIPTION
## Description

Fixes #585. All three bullets from the issue's Fix section.

**1. Fail closed when clientState is missing.** `verifySharepointWebhookSignature` returned `{ valid: true }` when no clientState was configured, so forged Graph notifications were accepted outright. Now returns `Missing client state`.

**2. Verify every notification in `value[]`, not just the first.** Graph batches notifications into one request, so comparing only `value[0]` let a forged entry ride along behind a valid one. Now uses `.every()`.

**3. Read the Hub-stored webhook signature, not options-only.** This is the substantive part, and it turned out to need a keyBuilder change too:

`list-changes.ts` read `ctx.options?.webhookClientState` directly, so a Hub-managed subscription — where `msGraphSubscribe` persists the clientState via `set_webhook_signature` — had nothing to compare against unless the secret was *also* set in plugin options. It now reads `ctx.key`, like outlook/onedrive/teams.

But `ctx.key` alone wasn't enough: SharePoint's `keyBuilder` had no `source === 'webhook'` branch, so a webhook key fell through to the OAuth branch and resolved to an **access token** — which no clientState can ever match. Swapping to `ctx.key` without fixing that would have turned the fail-open into a permanent 401. So the branch is added, mirroring outlook.

### One deliberate divergence from outlook — please sanity-check this

Outlook's webhook branch *throws* when no signature is stored. SharePoint returns `''` instead, because the two plugins answer the Graph validation handshake in different places:

- SharePoint answers it **inside the webhook handler** (`extractMicrosoftGraphValidationToken` at the top of `list-changes.ts`).
- `core/webhooks/bind.ts:59` resolves the key **eagerly**, before the handler runs: `const key = keyBuilder ? await keyBuilder(ctx, 'webhook') : undefined;`
- The handshake arrives during subscription creation — *before* `ms-graph-subscribe.ts:99` calls `set_webhook_signature`.

So a throw would run before the handler could answer the handshake, and subscription creation could never complete. `''` lets the handshake through and still fails closed on a real notification, since an absent clientState is now rejected. There's a test pinning exactly that. (The keyBuilder signature is `Promise<string>`, so `''` rather than `undefined`.)

If you'd rather have the throw for consistency and handle the handshake earlier, say so and I'll rework it.

## Tests

`packages/sharepoint/webhooks/webhooks.test.ts`, 10 tests, all passing:

**Verifier** — missing clientState; empty `value[]`; mismatched clientState; **batch where a later notification is forged**; batch where a later notification has `clientState: null`; batch where all match → valid.

**Handler** — no clientState configured → 401; forged clientState → 401; **validation handshake still succeeds with an empty `ctx.key`**; correctly signed → success.

## Checklist

- [x] I have run `pnpm lint` and all checks pass — lint-staged (`biome check --write`) ran clean on all three commits
- [x] I have run `pnpm typecheck` and there are no TypeScript errors — `tsc --build packages/sharepoint` clean
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass — green in CI; **see note** for local runs
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation — none required, no public API or plugin option changed

**On the test box.** My suite passes 10/10. The package's API suite fails 40/40 on clean `main` too (it needs live credentials), unchanged by this branch:

```
clean main:   Test Suites: 1 failed, 3 passed, 4 total   Tests: 40 failed, 18 passed, 58 total
this branch:  Test Suites: 1 failed, 4 passed, 5 total   Tests: 40 failed, 28 passed, 68 total
                                     ^ +1 (mine)                ^ identical  ^ +10 (mine)
```

The existing `subscribe.test.ts` still passes with the keyBuilder change.

## Screenshots / Demos (if applicable)

No UI. Local clientState verification only. Evidence is the unit tests + issue:
https://github.com/corsairdev/corsair/issues/585

## Additional Notes

- Scope is `packages/sharepoint/**` only (R1).
- **Behaviour-changing for live traffic**, worth a release note: a SharePoint deployment currently running webhooks with no clientState anywhere will start getting 401s. That is the intent of the issue, but it is not purely theoretical hardening.
- Companions in the same fail-open family: #608 (Jira), #609 (GitLab), #610 (Monday).
- Not changed here, but noticed while comparing: `verifyOutlookWebhookSignature` uses `.every()` on `payload?.value ?? []`, and `[].every()` is `true` — so an outlook notification with an empty `value[]` passes verification. SharePoint rejects that case explicitly. Happy to file it separately if you agree it's a bug.

