### PR TITLE
fix(asana): reject webhook secret overwrite on configured accounts

### DIFF
--- a/packages/asana/endpoints/webhooks-management.ts
+++ b/packages/asana/endpoints/webhooks-management.ts
@@ -35,8 +35,6 @@ export const deleteWebhook: AsanaEndpoints['webhooksDelete'] = async (
 		{ method: 'DELETE', query: { opt_pretty } },
 	);
 
-	await ctx.keys.set_webhook_signature(null);
-
 	await logEventFromContext(
 		ctx,
 		'asana.webhooks.delete',

--- a/packages/asana/endpoints/webhooks-management.ts
+++ b/packages/asana/endpoints/webhooks-management.ts
@@ -35,6 +35,8 @@ export const deleteWebhook: AsanaEndpoints['webhooksDelete'] = async (
 		{ method: 'DELETE', query: { opt_pretty } },
 	);
 
+	await ctx.keys.set_webhook_signature(null);
+
 	await logEventFromContext(
 		ctx,
 		'asana.webhooks.delete',

--- a/packages/asana/webhooks/challenge.test.ts
+++ b/packages/asana/webhooks/challenge.test.ts
@@ -55,6 +55,7 @@ describe('asana challenge webhook', () => {
 	describe('overwrite protection', () => {
 		it('rejects a different secret when one is already configured', async () => {
 			const { ctx, keys } = createContext('real-asana-secret');
+			const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
 			const result = await challenge.handler(
 				ctx,
@@ -67,10 +68,15 @@ describe('asana challenge webhook', () => {
 			// The sender's value must not be echoed back.
 			expect(result.responseHeaders).toBeUndefined();
 			expect(result.data).toBeUndefined();
+			// Operators need a signal; the rejection is otherwise invisible.
+			expect(warn).toHaveBeenCalledTimes(1);
+
+			warn.mockRestore();
 		});
 
 		it('rejects an attacker secret that is the same length as the stored one', async () => {
 			const { ctx, keys } = createContext('aaaaaaaa');
+			const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
 			const result = await challenge.handler(
 				ctx,
@@ -80,6 +86,8 @@ describe('asana challenge webhook', () => {
 			expect(keys.set_webhook_signature).not.toHaveBeenCalled();
 			expect(result.success).toBe(false);
 			expect(result.statusCode).toBe(401);
+
+			warn.mockRestore();
 		});
 
 		it('accepts a retried handshake carrying the stored secret without rewriting it', async () => {

--- a/packages/asana/webhooks/challenge.test.ts
+++ b/packages/asana/webhooks/challenge.test.ts
@@ -1,0 +1,130 @@
+import type { RawWebhookRequest } from 'corsair/core';
+import { challenge } from './challenge';
+
+type ChallengeContext = Parameters<typeof challenge.handler>[0];
+type ChallengeRequest = Parameters<typeof challenge.handler>[1];
+
+function createContext(storedSecret: string | null) {
+	const keys = {
+		get_webhook_signature: jest.fn().mockResolvedValue(storedSecret),
+		set_webhook_signature: jest.fn().mockResolvedValue(undefined),
+	};
+
+	return { ctx: { keys } as unknown as ChallengeContext, keys };
+}
+
+function createRequest(headers: Record<string, string>) {
+	return { headers, body: {} } as unknown as ChallengeRequest;
+}
+
+function createRawRequest(headers: Record<string, string>): RawWebhookRequest {
+	return { headers, body: {} };
+}
+
+describe('asana challenge webhook', () => {
+	describe('match', () => {
+		it('matches requests carrying an x-hook-secret header', () => {
+			expect(
+				challenge.match(createRawRequest({ 'x-hook-secret': 'abc' })),
+			).toBe(true);
+		});
+
+		it('does not match requests without the header', () => {
+			expect(challenge.match(createRawRequest({}))).toBe(false);
+		});
+	});
+
+	describe('first-time registration', () => {
+		it('persists and echoes the secret when none is stored', async () => {
+			const { ctx, keys } = createContext(null);
+
+			const result = await challenge.handler(
+				ctx,
+				createRequest({ 'x-hook-secret': 'asana-secret' }),
+			);
+
+			expect(keys.set_webhook_signature).toHaveBeenCalledWith('asana-secret');
+			expect(result.success).toBe(true);
+			expect(result.responseHeaders).toEqual({
+				'X-Hook-Secret': 'asana-secret',
+			});
+			expect(result.data).toEqual({ hookSecret: 'asana-secret' });
+		});
+	});
+
+	describe('overwrite protection', () => {
+		it('rejects a different secret when one is already configured', async () => {
+			const { ctx, keys } = createContext('real-asana-secret');
+
+			const result = await challenge.handler(
+				ctx,
+				createRequest({ 'x-hook-secret': 'attacker-secret' }),
+			);
+
+			expect(keys.set_webhook_signature).not.toHaveBeenCalled();
+			expect(result.success).toBe(false);
+			expect(result.statusCode).toBe(401);
+			// The sender's value must not be echoed back.
+			expect(result.responseHeaders).toBeUndefined();
+			expect(result.data).toBeUndefined();
+		});
+
+		it('rejects an attacker secret that is the same length as the stored one', async () => {
+			const { ctx, keys } = createContext('aaaaaaaa');
+
+			const result = await challenge.handler(
+				ctx,
+				createRequest({ 'x-hook-secret': 'bbbbbbbb' }),
+			);
+
+			expect(keys.set_webhook_signature).not.toHaveBeenCalled();
+			expect(result.success).toBe(false);
+			expect(result.statusCode).toBe(401);
+		});
+
+		it('accepts a retried handshake carrying the stored secret without rewriting it', async () => {
+			const { ctx, keys } = createContext('asana-secret');
+
+			const result = await challenge.handler(
+				ctx,
+				createRequest({ 'x-hook-secret': 'asana-secret' }),
+			);
+
+			expect(keys.set_webhook_signature).not.toHaveBeenCalled();
+			expect(result.success).toBe(true);
+			expect(result.responseHeaders).toEqual({
+				'X-Hook-Secret': 'asana-secret',
+			});
+		});
+	});
+
+	describe('failure handling', () => {
+		it('returns 400 when the header is missing', async () => {
+			const { ctx, keys } = createContext(null);
+
+			const result = await challenge.handler(ctx, createRequest({}));
+
+			expect(result.success).toBe(false);
+			expect(result.statusCode).toBe(400);
+			expect(keys.set_webhook_signature).not.toHaveBeenCalled();
+			expect(keys.get_webhook_signature).not.toHaveBeenCalled();
+		});
+
+		it('does not echo a secret it failed to persist', async () => {
+			const { ctx, keys } = createContext(null);
+			keys.set_webhook_signature.mockRejectedValue(new Error('db down'));
+			const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+			const result = await challenge.handler(
+				ctx,
+				createRequest({ 'x-hook-secret': 'asana-secret' }),
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.statusCode).toBe(500);
+			expect(result.responseHeaders).toBeUndefined();
+
+			warn.mockRestore();
+		});
+	});
+});

--- a/packages/asana/webhooks/challenge.ts
+++ b/packages/asana/webhooks/challenge.ts
@@ -9,7 +9,18 @@ import type { AsanaWebhooks } from '../index';
 // This handler places the secret in returnToSender['X-Hook-Secret'].
 // The consuming application MUST read this value and set it as the
 // X-Hook-Secret HTTP response header (not in the body).
+//
+// This endpoint is unauthenticated — anything that can reach the webhook URL can
+// send an X-Hook-Secret header. A secret is therefore only persisted when the
+// account has none stored yet; otherwise an attacker could install a signing key
+// they control and forge events the other Asana handlers would accept.
+//
+// Once configured, a secret is never replaced, including for a legitimate
+// re-registration: Corsair stores one webhook_signature per account while Asana
+// issues one per webhook, so there is no safe way to rotate here. Rotation needs
+// per-webhook secret storage in core.
 
+/** Constant-time compare. Length may short-circuit; length is not sensitive. */
 function secretsMatch(a: string, b: string): boolean {
 	const aBuf = Buffer.from(a);
 	const bBuf = Buffer.from(b);
@@ -40,9 +51,16 @@ export const challenge: AsanaWebhooks['challenge'] = {
 		const storedSecret = await ctx.keys.get_webhook_signature();
 
 		if (storedSecret) {
-			// A different value belongs to no handshake Corsair
+			// Asana retries the handshake if it does not get a timely 200, so the
+			// same secret arriving again is legitimate — echo it back without
+			// rewriting storage. A different value belongs to no handshake Corsair
 			// started, so refuse it and do not echo the sender's value back.
 			if (!secretsMatch(storedSecret, hookSecret)) {
+				// Logged so operators can tell an attack from a blocked
+				// re-registration; both land here.
+				console.warn(
+					'[corsair:asana] Rejected X-Hook-Secret for an account that already has one configured',
+				);
 				return {
 					success: false,
 					statusCode: 401,

--- a/packages/asana/webhooks/challenge.ts
+++ b/packages/asana/webhooks/challenge.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import type { AsanaWebhooks } from '../index';
 
 // ── Asana Webhook Challenge ───────────────────────────────────────────────────
@@ -9,6 +10,15 @@ import type { AsanaWebhooks } from '../index';
 // The consuming application MUST read this value and set it as the
 // X-Hook-Secret HTTP response header (not in the body).
 
+function secretsMatch(a: string, b: string): boolean {
+	const aBuf = Buffer.from(a);
+	const bBuf = Buffer.from(b);
+	if (aBuf.length !== bBuf.length) {
+		return false;
+	}
+	return crypto.timingSafeEqual(aBuf, bBuf);
+}
+
 export const challenge: AsanaWebhooks['challenge'] = {
 	match: (request) => {
 		return (
@@ -17,16 +27,53 @@ export const challenge: AsanaWebhooks['challenge'] = {
 		);
 	},
 
-	handler: async (_ctx, request) => {
+	handler: async (ctx, request) => {
 		const hookSecret = request.headers['x-hook-secret'];
 		if (!hookSecret || typeof hookSecret !== 'string') {
 			return {
 				success: false,
+				statusCode: 400,
 				error: 'Missing X-Hook-Secret header',
 			};
 		}
 
-		_ctx.keys.set_webhook_signature(hookSecret);
+		const storedSecret = await ctx.keys.get_webhook_signature();
+
+		if (storedSecret) {
+			// A different value belongs to no handshake Corsair
+			// started, so refuse it and do not echo the sender's value back.
+			if (!secretsMatch(storedSecret, hookSecret)) {
+				return {
+					success: false,
+					statusCode: 401,
+					error: 'Webhook signing secret is already configured',
+				};
+			}
+
+			return {
+				success: true,
+				responseHeaders: {
+					'X-Hook-Secret': storedSecret,
+				},
+				data: { hookSecret: storedSecret },
+			};
+		}
+
+		try {
+			await ctx.keys.set_webhook_signature(hookSecret);
+		} catch (error) {
+			// Echoing a secret we failed to store would leave Asana signing events
+			// with a key this account cannot verify.
+			console.warn(
+				'[corsair:asana] Failed to persist webhook secret:',
+				error instanceof Error ? error.message : String(error),
+			);
+			return {
+				success: false,
+				statusCode: 500,
+				error: 'Failed to persist webhook secret',
+			};
+		}
 
 		return {
 			success: true,


### PR DESCRIPTION
## Description

Fixes #597.

The Asana webhook challenge handler persisted any `X-Hook-Secret` header it received, with no check for an already-configured secret. The webhook URL is public by necessity, so anyone able to reach it could POST their own secret, have it stored as the signing key via `ctx.keys.set_webhook_signature`, and then forge signed events that `taskEvent` accepts. It also silently broke the integration, since genuine Asana events continued to be signed with the original secret and started failing verification.

**`webhooks/challenge.ts`** — the handler now reads the stored secret before writing:

- nothing stored → persist and echo it back (first-time registration unchanged)
- same secret arrives again → echo it back without rewriting storage (Asana retries the handshake if it does not get a timely 200)
- different secret arrives → 401, nothing written, and the sender's value is not echoed back

The comparison uses `crypto.timingSafeEqual` rather than `===`, matching the existing precedent in `core/auth/state.ts`. Rejections are logged, since a blocked handshake is otherwise invisible to operators.

Two smaller defects on the same path are fixed here as well: `set_webhook_signature` was a floating promise, so a storage failure was swallowed and the handler still returned `success: true` while echoing a secret that was never saved; and the missing-header branch carried no `statusCode`, defaulting to 500 for what is a client error.

**`webhooks/challenge.test.ts`** — new, 8 tests covering match behavior, first-time registration, the overwrite attempt the issue asks for, an overwrite attempt at equal secret length (so the comparison is not merely a length check), handshake retry, missing header, and persistence failure. They fail against the previous handler and pass against this one.

**Known limitation (deliberate).** Once a secret is configured, this handler never replaces it — including for a legitimate re-registration. A safe rotation path needs per-webhook secret storage: Corsair keeps one account-level `webhook_signature`, while Asana issues one secret per webhook, so an account with multiple webhooks cannot be represented correctly today. That is a core storage change, out of scope for a plugin PR, and I've opened #NNN to track it. Blocking rotation is the safer failure mode in the meantime — the alternative is the unauthenticated overwrite this PR exists to close.

An earlier revision of this PR cleared the stored secret in `webhookManagement.delete` to keep re-registration working. Greptile correctly flagged that it would wipe a secret shared by an account's other webhooks, so that change has been dropped and `endpoints/webhooks-management.ts` is now identical to `main`.

I deliberately did not tighten `match` to handshake-shaped requests only. It resembles a fix but is not one — an attacker can trivially send an empty body. The storage check is the actual defense.

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

<img width="671" height="295" alt="challenge.test.ts — 8/8 passing" src="https://github.com/user-attachments/assets/478e09ab-8e09-4abd-8a08-4603ad4733d7" />

## Additional Notes

**On the test checkbox.** `pnpm test` at the repo root cannot complete on a local machine: 51 plugins ship credential-gated live-API tests (`api.test.ts`), and turbo halts at the first one it reaches (`@corsair-dev/airtable`, which needs `AIRTABLE_API_KEY`). Scoped results for the package this PR touches:

- `pnpm --filter @corsair-dev/asana test -- challenge.test.ts` → 8/8 pass
- `packages/asana/api.test.ts` → 39 failures, pre-existing on `main`, needs `ASANA_ACCESS_TOKEN`
- `pnpm --filter @corsair-dev/asana typecheck` → clean
- `pnpm lint` → clean
- `pnpm run validate:plugins` → all plugins pass

