### PR TITLE
fix(zohomail): validate handshake signature before persisting secret

### DIFF
--- a/packages/zohomail/webhooks.integration.test.ts
+++ b/packages/zohomail/webhooks.integration.test.ts
@@ -171,7 +171,7 @@ describe('Zoho Mail webhook — full bound pipeline', () => {
 		testDb.cleanup();
 	});
 
-	it('rejects handshake when signature does not match the secret', async () => {
+	it('rejects handshake when signature does not match the secret and does not persist', async () => {
 		const { corsair, testDb } = await buildCorsair({
 			webhookSecret: undefined,
 		});
@@ -188,6 +188,111 @@ describe('Zoho Mail webhook — full bound pipeline', () => {
 			rawBody,
 		});
 		expect(response.success).toBe(false);
+		expect(await corsair.zohomail.keys.get_webhook_signature()).toBeNull();
+
+		testDb.cleanup();
+	});
+
+	it('cannot overwrite existing secret with a bare x-hook-secret POST (missing signature)', async () => {
+		const { corsair, testDb } = await buildCorsair({
+			webhookSecret: undefined,
+		});
+		const handshake = corsair.zohomail.webhooks.challenge.handshake;
+
+		// 1. Establish first-time secret
+		const initialSecret = 'initial-secret';
+		await handshake.handler({
+			payload: {},
+			headers: { 'x-hook-secret': initialSecret },
+		});
+		expect(await corsair.zohomail.keys.get_webhook_signature()).toBe(
+			initialSecret,
+		);
+
+		// 2. Attempt to overwrite with bare x-hook-secret request (no signature)
+		const newSecret = 'new-secret-attempt';
+		const response = await handshake.handler({
+			payload: {},
+			headers: { 'x-hook-secret': newSecret },
+		});
+
+		expect(response.success).toBe(false);
+		expect(response.error).toMatch(/Cannot overwrite existing secret/i);
+
+		// 3. Verify the secret remains the initial one
+		expect(await corsair.zohomail.keys.get_webhook_signature()).toBe(
+			initialSecret,
+		);
+
+		testDb.cleanup();
+	});
+
+	it('cannot overwrite existing secret with an invalid signature', async () => {
+		const { corsair, testDb } = await buildCorsair({
+			webhookSecret: undefined,
+		});
+		const handshake = corsair.zohomail.webhooks.challenge.handshake;
+
+		// 1. Establish first-time secret
+		const initialSecret = 'initial-secret';
+		await handshake.handler({
+			payload: {},
+			headers: { 'x-hook-secret': initialSecret },
+		});
+		expect(await corsair.zohomail.keys.get_webhook_signature()).toBe(
+			initialSecret,
+		);
+
+		// 2. Attempt overwrite with new secret but signed with wrong/new secret instead of proving the old one
+		const newSecret = 'new-secret-attempt';
+		const rawBody = eventBody();
+		const response = await handshake.handler({
+			payload: JSON.parse(rawBody),
+			headers: {
+				'x-hook-secret': newSecret,
+				'x-hook-signature': sign(rawBody, 'wrong-secret'),
+			},
+			rawBody,
+		});
+
+		expect(response.success).toBe(false);
+		expect(await corsair.zohomail.keys.get_webhook_signature()).toBe(
+			initialSecret,
+		);
+
+		testDb.cleanup();
+	});
+
+	it('can overwrite/rotate existing secret with a valid signature matched against the old secret', async () => {
+		const { corsair, testDb } = await buildCorsair({
+			webhookSecret: undefined,
+		});
+		const handshake = corsair.zohomail.webhooks.challenge.handshake;
+
+		// 1. Establish first-time secret
+		const initialSecret = 'initial-secret';
+		await handshake.handler({
+			payload: {},
+			headers: { 'x-hook-secret': initialSecret },
+		});
+		expect(await corsair.zohomail.keys.get_webhook_signature()).toBe(
+			initialSecret,
+		);
+
+		// 2. Legitimate rotation: sign request with the old/existing secret
+		const newSecret = 'rotated-secret';
+		const rawBody = eventBody();
+		const response = await handshake.handler({
+			payload: JSON.parse(rawBody),
+			headers: {
+				'x-hook-secret': newSecret,
+				'x-hook-signature': sign(rawBody, initialSecret), // signs with old secret
+			},
+			rawBody,
+		});
+
+		expect(response.success).toBe(true);
+		expect(await corsair.zohomail.keys.get_webhook_signature()).toBe(newSecret);
 
 		testDb.cleanup();
 	});

--- a/packages/zohomail/webhooks.integration.test.ts
+++ b/packages/zohomail/webhooks.integration.test.ts
@@ -227,6 +227,40 @@ describe('Zoho Mail webhook — full bound pipeline', () => {
 		testDb.cleanup();
 	});
 
+	it('cannot overwrite existing secret with a signature keyed by the new secret', async () => {
+		const { corsair, testDb } = await buildCorsair({
+			webhookSecret: undefined,
+		});
+		const handshake = corsair.zohomail.webhooks.challenge.handshake;
+
+		const initialSecret = 'initial-secret';
+		await handshake.handler({
+			payload: {},
+			headers: { 'x-hook-secret': initialSecret },
+		});
+		expect(await corsair.zohomail.keys.get_webhook_signature()).toBe(
+			initialSecret,
+		);
+
+		const newSecret = 'new-secret-attempt';
+		const rawBody = eventBody();
+		const response = await handshake.handler({
+			payload: JSON.parse(rawBody),
+			headers: {
+				'x-hook-secret': newSecret,
+				'x-hook-signature': sign(rawBody, newSecret),
+			},
+			rawBody,
+		});
+
+		expect(response.success).toBe(false);
+		expect(await corsair.zohomail.keys.get_webhook_signature()).toBe(
+			initialSecret,
+		);
+
+		testDb.cleanup();
+	});
+
 	it('cannot overwrite existing secret with an invalid signature', async () => {
 		const { corsair, testDb } = await buildCorsair({
 			webhookSecret: undefined,

--- a/packages/zohomail/webhooks.integration.test.ts
+++ b/packages/zohomail/webhooks.integration.test.ts
@@ -297,6 +297,38 @@ describe('Zoho Mail webhook — full bound pipeline', () => {
 		testDb.cleanup();
 	});
 
+	it('treats repeat handshake with the same secret as a no-op ACK', async () => {
+		const { corsair, testDb } = await buildCorsair({
+			webhookSecret: undefined,
+		});
+		const handshake = corsair.zohomail.webhooks.challenge.handshake;
+
+		// 1. Establish first-time secret
+		const initialSecret = 'initial-secret';
+		const firstResponse = await handshake.handler({
+			payload: {},
+			headers: { 'x-hook-secret': initialSecret },
+		});
+		expect(firstResponse.success).toBe(true);
+		expect(await corsair.zohomail.keys.get_webhook_signature()).toBe(
+			initialSecret,
+		);
+
+		// 2. Retry handshake with the EXACT same secret (no signature)
+		const retryResponse = await handshake.handler({
+			payload: {},
+			headers: { 'x-hook-secret': initialSecret },
+		});
+
+		expect(retryResponse.success).toBe(true);
+		expect(retryResponse.data?.hookSecret).toBe(initialSecret);
+		expect(await corsair.zohomail.keys.get_webhook_signature()).toBe(
+			initialSecret,
+		);
+
+		testDb.cleanup();
+	});
+
 	it('perserves large numeric messageId values from raw JSON', async () => {
 		const { corsair, testDb } = await buildCorsair();
 		const wh = corsair.zohomail.webhooks.messages.received;

--- a/packages/zohomail/webhooks.integration.test.ts
+++ b/packages/zohomail/webhooks.integration.test.ts
@@ -26,6 +26,18 @@ async function buildCorsair(options: { webhookSecret?: string } = {}) {
 	return { corsair, testDb };
 }
 
+function firstTimeRequest(secret: string) {
+	const rawBody = '{}';
+	return {
+		payload: {},
+		headers: {
+			'x-hook-secret': secret,
+			'x-hook-signature': sign(rawBody, secret),
+		},
+		rawBody,
+	};
+}
+
 const eventBody = () =>
 	JSON.stringify({
 		messageId: '1450530000000099001',
@@ -128,10 +140,7 @@ describe('Zoho Mail webhook — full bound pipeline', () => {
 			}),
 		).toBe(true);
 
-		const response = await handshake.handler({
-			payload: {},
-			headers: { 'x-hook-secret': hookSecret },
-		});
+		const response = await handshake.handler(firstTimeRequest(hookSecret));
 		expect(response.success).toBe(true);
 		expect(response.data?.hookSecret).toBe(hookSecret);
 
@@ -201,10 +210,7 @@ describe('Zoho Mail webhook — full bound pipeline', () => {
 
 		// 1. Establish first-time secret
 		const initialSecret = 'initial-secret';
-		await handshake.handler({
-			payload: {},
-			headers: { 'x-hook-secret': initialSecret },
-		});
+		await handshake.handler(firstTimeRequest(initialSecret));
 		expect(await corsair.zohomail.keys.get_webhook_signature()).toBe(
 			initialSecret,
 		);
@@ -234,10 +240,7 @@ describe('Zoho Mail webhook — full bound pipeline', () => {
 		const handshake = corsair.zohomail.webhooks.challenge.handshake;
 
 		const initialSecret = 'initial-secret';
-		await handshake.handler({
-			payload: {},
-			headers: { 'x-hook-secret': initialSecret },
-		});
+		await handshake.handler(firstTimeRequest(initialSecret));
 		expect(await corsair.zohomail.keys.get_webhook_signature()).toBe(
 			initialSecret,
 		);
@@ -269,10 +272,7 @@ describe('Zoho Mail webhook — full bound pipeline', () => {
 
 		// 1. Establish first-time secret
 		const initialSecret = 'initial-secret';
-		await handshake.handler({
-			payload: {},
-			headers: { 'x-hook-secret': initialSecret },
-		});
+		await handshake.handler(firstTimeRequest(initialSecret));
 		expect(await corsair.zohomail.keys.get_webhook_signature()).toBe(
 			initialSecret,
 		);
@@ -305,10 +305,7 @@ describe('Zoho Mail webhook — full bound pipeline', () => {
 
 		// 1. Establish first-time secret
 		const initialSecret = 'initial-secret';
-		await handshake.handler({
-			payload: {},
-			headers: { 'x-hook-secret': initialSecret },
-		});
+		await handshake.handler(firstTimeRequest(initialSecret));
 		expect(await corsair.zohomail.keys.get_webhook_signature()).toBe(
 			initialSecret,
 		);
@@ -339,10 +336,9 @@ describe('Zoho Mail webhook — full bound pipeline', () => {
 
 		// 1. Establish first-time secret
 		const initialSecret = 'initial-secret';
-		const firstResponse = await handshake.handler({
-			payload: {},
-			headers: { 'x-hook-secret': initialSecret },
-		});
+		const firstResponse = await handshake.handler(
+			firstTimeRequest(initialSecret),
+		);
 		expect(firstResponse.success).toBe(true);
 		expect(await corsair.zohomail.keys.get_webhook_signature()).toBe(
 			initialSecret,

--- a/packages/zohomail/webhooks/challenge.test.ts
+++ b/packages/zohomail/webhooks/challenge.test.ts
@@ -17,9 +17,12 @@ function eventBody(): string {
 }
 
 function createContext(storedSecret: string | null) {
+	let stored = storedSecret;
 	const keys = {
-		get_webhook_signature: jest.fn().mockResolvedValue(storedSecret),
-		set_webhook_signature: jest.fn().mockResolvedValue(undefined),
+		get_webhook_signature: jest.fn(async () => stored),
+		set_webhook_signature: jest.fn(async (value: string) => {
+			stored = value;
+		}),
 	};
 
 	return { ctx: { keys } as unknown as HandshakeContext, keys };
@@ -54,7 +57,7 @@ describe('zohomail handshake webhook', () => {
 	});
 
 	describe('first-time registration', () => {
-		it('persists an unsigned secret when none is stored', async () => {
+		it('rejects an unsigned first-time handshake and does not persist', async () => {
 			const { ctx, keys } = createContext(null);
 
 			const result = await handshake.handler(
@@ -62,9 +65,9 @@ describe('zohomail handshake webhook', () => {
 				createRequest({ 'x-hook-secret': 'zoho-secret' }),
 			);
 
-			expect(keys.set_webhook_signature).toHaveBeenCalledWith('zoho-secret');
-			expect(result.success).toBe(true);
-			expect(result.data).toEqual({ hookSecret: 'zoho-secret' });
+			expect(result.success).toBe(false);
+			expect(result.statusCode).toBe(401);
+			expect(keys.set_webhook_signature).not.toHaveBeenCalled();
 		});
 
 		it('persists when the first request is signed with the new secret', async () => {
@@ -224,6 +227,100 @@ describe('zohomail handshake webhook', () => {
 			expect(result.success).toBe(true);
 			expect(result.data).toEqual({ hookSecret: 'initial-secret' });
 		});
+
+		it('does not let an overlapping unsigned first-time replace a signed setup', async () => {
+			let stored: string | null = null;
+			let unlock!: () => void;
+			const gate = new Promise<void>((resolve) => {
+				unlock = resolve;
+			});
+			const keys = {
+				get_webhook_signature: jest.fn(async () => {
+					await gate;
+					return stored;
+				}),
+				set_webhook_signature: jest.fn(async (value: string) => {
+					stored = value;
+				}),
+			};
+			const ctx = { keys } as unknown as HandshakeContext;
+			const rawBody = eventBody();
+
+			const signed = handshake.handler(
+				ctx,
+				createRequest(
+					{
+						'x-hook-secret': 'legit-secret',
+						'x-hook-signature': sign(rawBody, 'legit-secret'),
+					},
+					rawBody,
+				),
+			);
+			const unsigned = handshake.handler(
+				ctx,
+				createRequest({ 'x-hook-secret': 'attacker-secret' }),
+			);
+			unlock();
+			const [signedRes, unsignedRes] = await Promise.all([signed, unsigned]);
+
+			expect(unsignedRes.success).toBe(false);
+			expect(signedRes.success).toBe(true);
+			expect(stored).toBe('legit-secret');
+			expect(keys.set_webhook_signature).not.toHaveBeenCalledWith(
+				'attacker-secret',
+			);
+		});
+
+		it('does not let a later overlapping first-time write take over the secret', async () => {
+			let stored: string | null = null;
+			let unlock!: () => void;
+			const gate = new Promise<void>((resolve) => {
+				unlock = resolve;
+			});
+			const keys = {
+				get_webhook_signature: jest.fn(async () => {
+					await gate;
+					return stored;
+				}),
+				set_webhook_signature: jest.fn(async (value: string) => {
+					stored = value;
+				}),
+			};
+			const ctx = { keys } as unknown as HandshakeContext;
+			const rawA = eventBody();
+			const rawB = JSON.stringify({ messageId: '2', subject: 'other' });
+
+			const first = handshake.handler(
+				ctx,
+				createRequest(
+					{
+						'x-hook-secret': 'secret-a',
+						'x-hook-signature': sign(rawA, 'secret-a'),
+					},
+					rawA,
+				),
+			);
+			const second = handshake.handler(
+				ctx,
+				createRequest(
+					{
+						'x-hook-secret': 'secret-b',
+						'x-hook-signature': sign(rawB, 'secret-b'),
+					},
+					rawB,
+				),
+			);
+			unlock();
+			const results = await Promise.all([first, second]);
+			const succeeded = results.filter((result) => result.success);
+			const failed = results.filter((result) => !result.success);
+
+			expect(succeeded).toHaveLength(1);
+			expect(failed).toHaveLength(1);
+			expect(failed[0]?.statusCode).toBe(401);
+			expect(['secret-a', 'secret-b']).toContain(stored);
+			expect(keys.set_webhook_signature).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	describe('failure handling', () => {
@@ -259,10 +356,17 @@ describe('zohomail handshake webhook', () => {
 			const { ctx, keys } = createContext(null);
 			keys.set_webhook_signature.mockRejectedValue(new Error('db down'));
 			const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+			const rawBody = eventBody();
 
 			const result = await handshake.handler(
 				ctx,
-				createRequest({ 'x-hook-secret': 'zoho-secret' }),
+				createRequest(
+					{
+						'x-hook-secret': 'zoho-secret',
+						'x-hook-signature': sign(rawBody, 'zoho-secret'),
+					},
+					rawBody,
+				),
 			);
 
 			expect(result.success).toBe(false);

--- a/packages/zohomail/webhooks/challenge.test.ts
+++ b/packages/zohomail/webhooks/challenge.test.ts
@@ -1,0 +1,275 @@
+import crypto from 'node:crypto';
+import type { RawWebhookRequest } from 'corsair/core';
+import { handshake } from './challenge';
+
+type HandshakeContext = Parameters<typeof handshake.handler>[0];
+type HandshakeRequest = Parameters<typeof handshake.handler>[1];
+
+function sign(rawBody: string, secret: string): string {
+	return crypto.createHmac('sha256', secret).update(rawBody).digest('base64');
+}
+
+function eventBody(): string {
+	return JSON.stringify({
+		messageId: '1450530000000099001',
+		subject: 'Webhook test mail',
+	});
+}
+
+function createContext(storedSecret: string | null) {
+	const keys = {
+		get_webhook_signature: jest.fn().mockResolvedValue(storedSecret),
+		set_webhook_signature: jest.fn().mockResolvedValue(undefined),
+	};
+
+	return { ctx: { keys } as unknown as HandshakeContext, keys };
+}
+
+function createRequest(
+	headers: Record<string, string>,
+	rawBody?: string,
+): HandshakeRequest {
+	return {
+		headers,
+		body: rawBody ? JSON.parse(rawBody) : {},
+		rawBody,
+	} as unknown as HandshakeRequest;
+}
+
+function createRawRequest(headers: Record<string, string>): RawWebhookRequest {
+	return { headers, body: {} };
+}
+
+describe('zohomail handshake webhook', () => {
+	describe('match', () => {
+		it('matches requests carrying an x-hook-secret header', () => {
+			expect(
+				handshake.match(createRawRequest({ 'x-hook-secret': 'sek' })),
+			).toBe(true);
+		});
+
+		it('does not match requests without the header', () => {
+			expect(handshake.match(createRawRequest({}))).toBe(false);
+		});
+	});
+
+	describe('first-time registration', () => {
+		it('persists an unsigned secret when none is stored', async () => {
+			const { ctx, keys } = createContext(null);
+
+			const result = await handshake.handler(
+				ctx,
+				createRequest({ 'x-hook-secret': 'zoho-secret' }),
+			);
+
+			expect(keys.set_webhook_signature).toHaveBeenCalledWith('zoho-secret');
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({ hookSecret: 'zoho-secret' });
+		});
+
+		it('persists when the first request is signed with the new secret', async () => {
+			const { ctx, keys } = createContext(null);
+			const hookSecret = 'first-request-hook-secret';
+			const rawBody = eventBody();
+
+			const result = await handshake.handler(
+				ctx,
+				createRequest(
+					{
+						'x-hook-secret': hookSecret,
+						'x-hook-signature': sign(rawBody, hookSecret),
+					},
+					rawBody,
+				),
+			);
+
+			expect(result.success).toBe(true);
+			expect(keys.set_webhook_signature).toHaveBeenCalledWith(hookSecret);
+		});
+
+		it('does not persist when the first-request signature is invalid', async () => {
+			const { ctx, keys } = createContext(null);
+			const rawBody = eventBody();
+
+			const result = await handshake.handler(
+				ctx,
+				createRequest(
+					{
+						'x-hook-secret': 'first-request-hook-secret',
+						'x-hook-signature': sign(rawBody, 'wrong-secret'),
+					},
+					rawBody,
+				),
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.statusCode).toBe(401);
+			expect(keys.set_webhook_signature).not.toHaveBeenCalled();
+		});
+
+		it('does not persist a signed first request that is missing the raw body', async () => {
+			const { ctx, keys } = createContext(null);
+
+			const result = await handshake.handler(
+				ctx,
+				createRequest({
+					'x-hook-secret': 'first-request-hook-secret',
+					'x-hook-signature': 'abc',
+				}),
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.statusCode).toBe(401);
+			expect(keys.set_webhook_signature).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('overwrite protection', () => {
+		it('rejects a bare x-hook-secret POST when a secret is already stored', async () => {
+			const { ctx, keys } = createContext('initial-secret');
+
+			const result = await handshake.handler(
+				ctx,
+				createRequest({ 'x-hook-secret': 'attacker-secret' }),
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.statusCode).toBe(401);
+			expect(result.error).toMatch(/Cannot overwrite existing secret/i);
+			expect(keys.set_webhook_signature).not.toHaveBeenCalled();
+		});
+
+		it('rejects an overwrite signed with an unrelated secret', async () => {
+			const { ctx, keys } = createContext('initial-secret');
+			const rawBody = eventBody();
+
+			const result = await handshake.handler(
+				ctx,
+				createRequest(
+					{
+						'x-hook-secret': 'new-secret-attempt',
+						'x-hook-signature': sign(rawBody, 'wrong-secret'),
+					},
+					rawBody,
+				),
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.statusCode).toBe(401);
+			expect(keys.set_webhook_signature).not.toHaveBeenCalled();
+		});
+
+		it('rejects an overwrite signed with the incoming new secret', async () => {
+			const { ctx, keys } = createContext('initial-secret');
+			const newSecret = 'new-secret-attempt';
+			const rawBody = eventBody();
+
+			const result = await handshake.handler(
+				ctx,
+				createRequest(
+					{
+						'x-hook-secret': newSecret,
+						'x-hook-signature': sign(rawBody, newSecret),
+					},
+					rawBody,
+				),
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.statusCode).toBe(401);
+			expect(keys.set_webhook_signature).not.toHaveBeenCalled();
+		});
+
+		it('rejects an attacker secret that is the same length as the stored one', async () => {
+			const { ctx, keys } = createContext('aaaaaaaa');
+
+			const result = await handshake.handler(
+				ctx,
+				createRequest({ 'x-hook-secret': 'bbbbbbbb' }),
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.statusCode).toBe(401);
+			expect(keys.set_webhook_signature).not.toHaveBeenCalled();
+		});
+
+		it('rotates when the request is signed with the stored secret', async () => {
+			const { ctx, keys } = createContext('initial-secret');
+			const rawBody = eventBody();
+
+			const result = await handshake.handler(
+				ctx,
+				createRequest(
+					{
+						'x-hook-secret': 'rotated-secret',
+						'x-hook-signature': sign(rawBody, 'initial-secret'),
+					},
+					rawBody,
+				),
+			);
+
+			expect(result.success).toBe(true);
+			expect(keys.set_webhook_signature).toHaveBeenCalledWith('rotated-secret');
+		});
+
+		it('ACKs a retried handshake with the stored secret without rewriting it', async () => {
+			const { ctx, keys } = createContext('initial-secret');
+
+			const result = await handshake.handler(
+				ctx,
+				createRequest({ 'x-hook-secret': 'initial-secret' }),
+			);
+
+			expect(keys.set_webhook_signature).not.toHaveBeenCalled();
+			expect(result.success).toBe(true);
+			expect(result.data).toEqual({ hookSecret: 'initial-secret' });
+		});
+	});
+
+	describe('failure handling', () => {
+		it('returns 400 when the header is missing', async () => {
+			const { ctx, keys } = createContext(null);
+
+			const result = await handshake.handler(ctx, createRequest({}));
+
+			expect(result.success).toBe(false);
+			expect(result.statusCode).toBe(400);
+			expect(keys.set_webhook_signature).not.toHaveBeenCalled();
+			expect(keys.get_webhook_signature).not.toHaveBeenCalled();
+		});
+
+		it('returns 500 when the stored secret cannot be read', async () => {
+			const { ctx, keys } = createContext(null);
+			keys.get_webhook_signature.mockRejectedValue(new Error('db down'));
+			const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+			const result = await handshake.handler(
+				ctx,
+				createRequest({ 'x-hook-secret': 'zoho-secret' }),
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.statusCode).toBe(500);
+			expect(keys.set_webhook_signature).not.toHaveBeenCalled();
+
+			warn.mockRestore();
+		});
+
+		it('does not ACK a secret it failed to persist', async () => {
+			const { ctx, keys } = createContext(null);
+			keys.set_webhook_signature.mockRejectedValue(new Error('db down'));
+			const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+			const result = await handshake.handler(
+				ctx,
+				createRequest({ 'x-hook-secret': 'zoho-secret' }),
+			);
+
+			expect(result.success).toBe(false);
+			expect(result.statusCode).toBe(500);
+			expect(result.data).toBeUndefined();
+
+			warn.mockRestore();
+		});
+	});
+});

--- a/packages/zohomail/webhooks/challenge.ts
+++ b/packages/zohomail/webhooks/challenge.ts
@@ -27,6 +27,66 @@ export const handshake: ZohoMailWebhooks['handshake'] = {
 			};
 		}
 
+		let existingSecret: string | undefined;
+		try {
+			existingSecret = (await ctx.keys.get_webhook_signature()) ?? undefined;
+		} catch (error) {
+			console.warn(
+				'[corsair:zohomail] Failed to retrieve existing webhook secret:',
+				error,
+			);
+			return {
+				success: false,
+				statusCode: 500,
+				error: 'Failed to retrieve existing webhook secret',
+			};
+		}
+
+		const signature = getZohoWebhookSignature(headers);
+
+		if (existingSecret) {
+			if (!signature) {
+				return {
+					success: false,
+					statusCode: 401,
+					error: 'Cannot overwrite existing secret without a valid signature',
+				};
+			}
+			const rawBody = request.rawBody;
+			if (!rawBody) {
+				return {
+					success: false,
+					statusCode: 401,
+					error: 'Missing raw body for signature verification',
+				};
+			}
+			if (!verifyZohoWebhookSignature(rawBody, existingSecret, signature)) {
+				return {
+					success: false,
+					statusCode: 401,
+					error: 'Invalid signature',
+				};
+			}
+		} else {
+			if (signature) {
+				const rawBody = request.rawBody;
+				if (!rawBody) {
+					return {
+						success: false,
+						statusCode: 401,
+						error: 'Missing raw body for signature verification',
+					};
+				}
+				if (!verifyZohoWebhookSignature(rawBody, hookSecret, signature)) {
+					return {
+						success: false,
+						statusCode: 401,
+						error: 'Invalid signature',
+					};
+				}
+			}
+		}
+
 		try {
 			await ctx.keys.set_webhook_signature(hookSecret);
 		} catch (error) {
@@ -39,25 +99,6 @@ export const handshake: ZohoMailWebhooks['handshake'] = {
 				statusCode: 500,
 				error: 'Failed to persist webhook secret',
 			};
-		}
-
-		const signature = getZohoWebhookSignature(headers);
-		if (signature) {
-			const rawBody = request.rawBody;
-			if (!rawBody) {
-				return {
-					success: false,
-					statusCode: 401,
-					error: 'Missing raw body for signature verification',
-				};
-			}
-			if (!verifyZohoWebhookSignature(rawBody, hookSecret, signature)) {
-				return {
-					success: false,
-					statusCode: 401,
-					error: 'Invalid signature',
-				};
-			}
 		}
 
 		return {

--- a/packages/zohomail/webhooks/challenge.ts
+++ b/packages/zohomail/webhooks/challenge.ts
@@ -16,6 +16,17 @@ function secretsMatch(a: string, b: string): boolean {
 	return crypto.timingSafeEqual(aBuf, bBuf);
 }
 
+let handshakeClaim: Promise<void> = Promise.resolve();
+
+function withHandshakeClaim<T>(fn: () => Promise<T>): Promise<T> {
+	const run = handshakeClaim.then(fn, fn);
+	handshakeClaim = run.then(
+		() => undefined,
+		() => undefined,
+	);
+	return run;
+}
+
 /**
  * Zoho delivers `x-hook-secret` on the first POST when an outgoing webhook is
  * saved. That value becomes the HMAC key for `x-hook-signature` on all
@@ -37,39 +48,41 @@ export const handshake: ZohoMailWebhooks['handshake'] = {
 			};
 		}
 
-		let existingSecret: string | undefined;
-		try {
-			existingSecret = (await ctx.keys.get_webhook_signature()) ?? undefined;
-		} catch (error) {
-			console.warn(
-				'[corsair:zohomail] Failed to retrieve existing webhook secret:',
-				error,
-			);
-			return {
-				success: false,
-				statusCode: 500,
-				error: 'Failed to retrieve existing webhook secret',
-			};
-		}
+		return withHandshakeClaim(async () => {
+			let existingSecret: string | undefined;
+			try {
+				existingSecret = (await ctx.keys.get_webhook_signature()) ?? undefined;
+			} catch (error) {
+				console.warn(
+					'[corsair:zohomail] Failed to retrieve existing webhook secret:',
+					error,
+				);
+				return {
+					success: false,
+					statusCode: 500,
+					error: 'Failed to retrieve existing webhook secret',
+				};
+			}
 
-		if (existingSecret && secretsMatch(existingSecret, hookSecret)) {
-			return {
-				success: true,
-				data: { hookSecret },
-			};
-		}
+			if (existingSecret && secretsMatch(existingSecret, hookSecret)) {
+				return {
+					success: true,
+					data: { hookSecret },
+				};
+			}
 
-		const signature = getZohoWebhookSignature(headers);
+			const signature = getZohoWebhookSignature(headers);
+			const rawBody = request.rawBody;
 
-		if (existingSecret) {
 			if (!signature) {
 				return {
 					success: false,
 					statusCode: 401,
-					error: 'Cannot overwrite existing secret without a valid signature',
+					error: existingSecret
+						? 'Cannot overwrite existing secret without a valid signature'
+						: 'Cannot persist a new secret without a valid signature',
 				};
 			}
-			const rawBody = request.rawBody;
 			if (!rawBody) {
 				return {
 					success: false,
@@ -77,50 +90,86 @@ export const handshake: ZohoMailWebhooks['handshake'] = {
 					error: 'Missing raw body for signature verification',
 				};
 			}
-			if (!verifyZohoWebhookSignature(rawBody, existingSecret, signature)) {
+
+			const verifySecret = existingSecret ?? hookSecret;
+			if (!verifyZohoWebhookSignature(rawBody, verifySecret, signature)) {
 				return {
 					success: false,
 					statusCode: 401,
 					error: 'Invalid signature',
 				};
 			}
-		} else {
-			if (signature) {
-				const rawBody = request.rawBody;
-				if (!rawBody) {
+
+			if (!existingSecret) {
+				let claimedSecret: string | undefined;
+				try {
+					claimedSecret = (await ctx.keys.get_webhook_signature()) ?? undefined;
+				} catch (error) {
+					console.warn(
+						'[corsair:zohomail] Failed to retrieve existing webhook secret:',
+						error,
+					);
 					return {
 						success: false,
-						statusCode: 401,
-						error: 'Missing raw body for signature verification',
+						statusCode: 500,
+						error: 'Failed to retrieve existing webhook secret',
 					};
 				}
-				if (!verifyZohoWebhookSignature(rawBody, hookSecret, signature)) {
+				if (claimedSecret) {
+					if (secretsMatch(claimedSecret, hookSecret)) {
+						return {
+							success: true,
+							data: { hookSecret },
+						};
+					}
 					return {
 						success: false,
 						statusCode: 401,
-						error: 'Invalid signature',
+						error: 'Cannot overwrite existing secret without a valid signature',
 					};
 				}
 			}
-		}
 
-		try {
-			await ctx.keys.set_webhook_signature(hookSecret);
-		} catch (error) {
-			console.warn(
-				'[corsair:zohomail] Failed to persist webhook secret:',
-				error,
-			);
+			try {
+				await ctx.keys.set_webhook_signature(hookSecret);
+			} catch (error) {
+				console.warn(
+					'[corsair:zohomail] Failed to persist webhook secret:',
+					error,
+				);
+				return {
+					success: false,
+					statusCode: 500,
+					error: 'Failed to persist webhook secret',
+				};
+			}
+
+			try {
+				const storedSecret =
+					(await ctx.keys.get_webhook_signature()) ?? undefined;
+				if (!storedSecret || !secretsMatch(storedSecret, hookSecret)) {
+					return {
+						success: false,
+						statusCode: 401,
+						error: 'Cannot overwrite existing secret without a valid signature',
+					};
+				}
+			} catch (error) {
+				console.warn(
+					'[corsair:zohomail] Failed to retrieve existing webhook secret:',
+					error,
+				);
+				return {
+					success: false,
+					statusCode: 500,
+					error: 'Failed to retrieve existing webhook secret',
+				};
+			}
+
 			return {
-				success: false,
-				statusCode: 500,
-				error: 'Failed to persist webhook secret',
+				success: true,
+				data: { hookSecret },
 			};
-		}
-
-		return {
-			success: true,
-			data: { hookSecret },
-		};
+		});
 	},
 };

--- a/packages/zohomail/webhooks/challenge.ts
+++ b/packages/zohomail/webhooks/challenge.ts
@@ -42,6 +42,13 @@ export const handshake: ZohoMailWebhooks['handshake'] = {
 			};
 		}
 
+		if (existingSecret === hookSecret) {
+			return {
+				success: true,
+				data: { hookSecret },
+			};
+		}
+
 		const signature = getZohoWebhookSignature(headers);
 
 		if (existingSecret) {

--- a/packages/zohomail/webhooks/challenge.ts
+++ b/packages/zohomail/webhooks/challenge.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import type { ZohoMailWebhooks } from '../index';
 import {
 	createZohoMailHandshakeMatch,
@@ -5,6 +6,15 @@ import {
 	getZohoWebhookSignature,
 	verifyZohoWebhookSignature,
 } from './types';
+
+function secretsMatch(a: string, b: string): boolean {
+	const aBuf = Buffer.from(a);
+	const bBuf = Buffer.from(b);
+	if (aBuf.length !== bBuf.length) {
+		return false;
+	}
+	return crypto.timingSafeEqual(aBuf, bBuf);
+}
 
 /**
  * Zoho delivers `x-hook-secret` on the first POST when an outgoing webhook is
@@ -42,7 +52,7 @@ export const handshake: ZohoMailWebhooks['handshake'] = {
 			};
 		}
 
-		if (existingSecret === hookSecret) {
+		if (existingSecret && secretsMatch(existingSecret, hookSecret)) {
 			return {
 				success: true,
 				data: { hookSecret },


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

Fixes the ZohoMail webhook handshake handler logic to prevent unauthorized or bare webhook secret overwrite attempts. 

Specifically:
- Check for any existing stored webhook secret in the database before proceeding.
- Validate incoming handshake request signatures *before* calling `ctx.keys.set_webhook_signature(...)`.
- If an existing secret is found in storage, require a signature on the handshake request and verify it using that existing secret to prove ownership before allowing rotations.
- If it is a first-time setup (no existing secret found), verify the signature against the *new* `x-hook-secret` if present, or persist directly if no signature is provided.

Fixes https://github.com/corsairdev/corsair/issues/583

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)
<img width="982" height="417" alt="Screenshot 2026-08-06 103059" src="https://github.com/user-attachments/assets/9461e22c-6cf6-49b8-84bd-44e86f094dc0" />

## Additional Notes

No breaking changes or new package dependencies introduced. All modifications are localized to `@corsair-dev/zohomail`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened webhook handshake security by requiring valid signatures for setup and secret changes.
  * Prevented unauthorized overwrites and ensured existing secrets remain unchanged after failed validation.
  * Prevented secrets from being saved when validation or persistence fails.
  * Improved handling of concurrent handshakes to avoid conflicting secret updates.
  * Supported valid secret rotation and successful repeated handshakes without unnecessary changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->