### PR TITLE
fix(core): ApiError.url can leak query-param API secrets

### DIFF
--- a/packages/corsair/async-core/ApiError.ts
+++ b/packages/corsair/async-core/ApiError.ts
@@ -1,7 +1,49 @@
 import type { ApiRequestOptions } from './ApiRequestOptions';
 import type { ApiResult } from './ApiResult';
 
-const SENSITIVE_QUERY_PARAMS = ['api_key', 'key', 'token', 'appid'];
+const SENSITIVE_QUERY_PARAMS = new Set(['api_key', 'key', 'token', 'appid']);
+
+function isSensitiveQueryParam(key: string): boolean {
+	let normalized = key;
+	try {
+		normalized = decodeURIComponent(key);
+	} catch {
+		normalized = key;
+	}
+	return SENSITIVE_QUERY_PARAMS.has(normalized.toLowerCase());
+}
+
+function redactQueryStringFallback(urlStr: string): string {
+	const queryIndex = urlStr.indexOf('?');
+	if (queryIndex === -1) {
+		return urlStr;
+	}
+
+	const hashIndex = urlStr.indexOf('#', queryIndex);
+	const before = urlStr.slice(0, queryIndex + 1);
+	const query =
+		hashIndex === -1
+			? urlStr.slice(queryIndex + 1)
+			: urlStr.slice(queryIndex + 1, hashIndex);
+	const after = hashIndex === -1 ? '' : urlStr.slice(hashIndex);
+
+	let changed = false;
+	const redacted = query
+		.split('&')
+		.map((pair) => {
+			if (!pair) return pair;
+			const eq = pair.indexOf('=');
+			const key = eq === -1 ? pair : pair.slice(0, eq);
+			if (!isSensitiveQueryParam(key)) {
+				return pair;
+			}
+			changed = true;
+			return `${key}=[REDACTED]`;
+		})
+		.join('&');
+
+	return changed ? before + redacted + after : urlStr;
+}
 
 function redactUrl(urlStr: string): string {
 	if (!urlStr) return urlStr;
@@ -11,8 +53,8 @@ function redactUrl(urlStr: string): string {
 		const urlObj = new URL(urlStr, base);
 		let changed = false;
 
-		for (const key of urlObj.searchParams.keys()) {
-			if (SENSITIVE_QUERY_PARAMS.includes(key.toLowerCase())) {
+		for (const key of [...urlObj.searchParams.keys()]) {
+			if (isSensitiveQueryParam(key)) {
 				urlObj.searchParams.set(key, '[REDACTED]');
 				changed = true;
 			}
@@ -24,34 +66,35 @@ function redactUrl(urlStr: string): string {
 				: urlObj.pathname + urlObj.search + urlObj.hash;
 		}
 		return urlStr;
-	} catch (e) {
-		return urlStr;
+	} catch {
+		return redactQueryStringFallback(urlStr);
 	}
 }
 
 function redactRequest(request: ApiRequestOptions): ApiRequestOptions {
-	if (!request.query) {
-		return request;
-	}
+	const redactedUrl = redactUrl(request.url);
+	let queryChanged = false;
+	let redactedQuery = request.query;
 
-	const redactedQuery = { ...request.query };
-	let changed = false;
-
-	for (const key of Object.keys(redactedQuery)) {
-		if (SENSITIVE_QUERY_PARAMS.includes(key.toLowerCase())) {
-			redactedQuery[key] = '[REDACTED]';
-			changed = true;
+	if (request.query) {
+		redactedQuery = { ...request.query };
+		for (const key of Object.keys(redactedQuery)) {
+			if (isSensitiveQueryParam(key)) {
+				redactedQuery[key] = '[REDACTED]';
+				queryChanged = true;
+			}
 		}
 	}
 
-	if (changed) {
-		return {
-			...request,
-			query: redactedQuery,
-		};
+	if (!queryChanged && redactedUrl === request.url) {
+		return request;
 	}
 
-	return request;
+	return {
+		...request,
+		url: redactedUrl,
+		...(queryChanged ? { query: redactedQuery } : {}),
+	};
 }
 
 export class ApiError extends Error {

--- a/packages/corsair/async-core/ApiError.ts
+++ b/packages/corsair/async-core/ApiError.ts
@@ -1,6 +1,59 @@
 import type { ApiRequestOptions } from './ApiRequestOptions';
 import type { ApiResult } from './ApiResult';
 
+const SENSITIVE_QUERY_PARAMS = ['api_key', 'key', 'token', 'appid'];
+
+function redactUrl(urlStr: string): string {
+	if (!urlStr) return urlStr;
+	try {
+		const hasProtocol = /^[a-z]+:\/\//i.test(urlStr);
+		const base = hasProtocol ? undefined : 'http://localhost';
+		const urlObj = new URL(urlStr, base);
+		let changed = false;
+
+		for (const key of urlObj.searchParams.keys()) {
+			if (SENSITIVE_QUERY_PARAMS.includes(key.toLowerCase())) {
+				urlObj.searchParams.set(key, '[REDACTED]');
+				changed = true;
+			}
+		}
+
+		if (changed) {
+			return hasProtocol
+				? urlObj.toString()
+				: urlObj.pathname + urlObj.search + urlObj.hash;
+		}
+		return urlStr;
+	} catch (e) {
+		return urlStr;
+	}
+}
+
+function redactRequest(request: ApiRequestOptions): ApiRequestOptions {
+	if (!request.query) {
+		return request;
+	}
+
+	const redactedQuery = { ...request.query };
+	let changed = false;
+
+	for (const key of Object.keys(redactedQuery)) {
+		if (SENSITIVE_QUERY_PARAMS.includes(key.toLowerCase())) {
+			redactedQuery[key] = '[REDACTED]';
+			changed = true;
+		}
+	}
+
+	if (changed) {
+		return {
+			...request,
+			query: redactedQuery,
+		};
+	}
+
+	return request;
+}
+
 export class ApiError extends Error {
 	public readonly url: string;
 	public readonly status: number;
@@ -26,11 +79,11 @@ export class ApiError extends Error {
 		super(message);
 
 		this.name = 'ApiError';
-		this.url = response.url;
+		this.url = redactUrl(response.url);
 		this.status = response.status;
 		this.statusText = response.statusText;
 		this.body = response.body;
-		this.request = request;
+		this.request = redactRequest(request);
 		this.retryAfter = rateLimitInfo?.retryAfter;
 		this.rateLimitReset = rateLimitInfo?.rateLimitReset;
 		this.rateLimitRemaining = rateLimitInfo?.rateLimitRemaining;

--- a/packages/corsair/tests/api-error.test.ts
+++ b/packages/corsair/tests/api-error.test.ts
@@ -26,7 +26,6 @@ describe('ApiError Redaction', () => {
 
 		const apiError = new ApiError(request, response, 'Unauthorized');
 
-		// Assertions on the URL
 		expect(apiError.url).not.toContain('secret-key-123');
 		expect(apiError.url).not.toContain('secret-token-abc');
 		expect(apiError.url).not.toContain('secret-appid-xyz');
@@ -37,13 +36,17 @@ describe('ApiError Redaction', () => {
 		expect(apiError.url).toContain('key=%5BREDACTED%5D');
 		expect(apiError.url).toContain('normal_param=public-data');
 
-		// Assertions on the Request options query
 		expect(apiError.request.query).toBeDefined();
 		expect(apiError.request.query?.api_key).toBe('[REDACTED]');
 		expect(apiError.request.query?.token).toBe('[REDACTED]');
 		expect(apiError.request.query?.appid).toBe('[REDACTED]');
 		expect(apiError.request.query?.key).toBe('[REDACTED]');
 		expect(apiError.request.query?.normal_param).toBe('public-data');
+
+		expect(request.query?.api_key).toBe('secret-key-123');
+		expect(request.query?.token).toBe('secret-token-abc');
+		expect(apiError.request).not.toBe(request);
+		expect(apiError.request.query).not.toBe(request.query);
 	});
 
 	it('should handle case-insensitive query parameter matching', () => {
@@ -87,6 +90,51 @@ describe('ApiError Redaction', () => {
 		const apiError = new ApiError(request, response, 'Not Found');
 
 		expect(apiError.url).toBe('/v1/test');
+		expect(apiError.request).toBe(request);
 		expect(apiError.request.query).toBeUndefined();
+	});
+
+	it('should redact sensitive params embedded in request.url', () => {
+		const request: ApiRequestOptions = {
+			method: 'GET',
+			url: '/v1/test?token=secret-in-url&normal_param=public-data',
+		};
+
+		const response: ApiResult = {
+			url: 'https://api.example.com/v1/test',
+			ok: false,
+			status: 401,
+			statusText: 'Unauthorized',
+			body: { error: 'Invalid auth' },
+		};
+
+		const apiError = new ApiError(request, response, 'Unauthorized');
+
+		expect(apiError.request.url).not.toContain('secret-in-url');
+		expect(apiError.request.url).toContain('token=%5BREDACTED%5D');
+		expect(apiError.request.url).toContain('normal_param=public-data');
+		expect(request.url).toContain('secret-in-url');
+	});
+
+	it('should redact sensitive params from malformed response URLs', () => {
+		const request: ApiRequestOptions = {
+			method: 'GET',
+			url: '/v1/test',
+		};
+
+		const response: ApiResult = {
+			url: 'http://[::1/?token=secret&normal_param=public-data#frag',
+			ok: false,
+			status: 401,
+			statusText: 'Unauthorized',
+			body: { error: 'Invalid auth' },
+		};
+
+		const apiError = new ApiError(request, response, 'Unauthorized');
+
+		expect(apiError.url).not.toContain('secret');
+		expect(apiError.url).toContain('token=[REDACTED]');
+		expect(apiError.url).toContain('normal_param=public-data');
+		expect(apiError.url).toContain('#frag');
 	});
 });

--- a/packages/corsair/tests/api-error.test.ts
+++ b/packages/corsair/tests/api-error.test.ts
@@ -1,0 +1,92 @@
+import { ApiError } from '../async-core/ApiError';
+import type { ApiRequestOptions } from '../async-core/ApiRequestOptions';
+import type { ApiResult } from '../async-core/ApiResult';
+
+describe('ApiError Redaction', () => {
+	it('should redact sensitive query parameters from both URL and request query', () => {
+		const request: ApiRequestOptions = {
+			method: 'GET',
+			url: '/v1/test',
+			query: {
+				api_key: 'secret-key-123',
+				token: 'secret-token-abc',
+				appid: 'secret-appid-xyz',
+				key: 'secret-key-xyz',
+				normal_param: 'public-data',
+			},
+		};
+
+		const response: ApiResult = {
+			url: 'https://api.example.com/v1/test?api_key=secret-key-123&token=secret-token-abc&appid=secret-appid-xyz&key=secret-key-xyz&normal_param=public-data',
+			ok: false,
+			status: 401,
+			statusText: 'Unauthorized',
+			body: { error: 'Invalid auth' },
+		};
+
+		const apiError = new ApiError(request, response, 'Unauthorized');
+
+		// Assertions on the URL
+		expect(apiError.url).not.toContain('secret-key-123');
+		expect(apiError.url).not.toContain('secret-token-abc');
+		expect(apiError.url).not.toContain('secret-appid-xyz');
+		expect(apiError.url).not.toContain('secret-key-xyz');
+		expect(apiError.url).toContain('api_key=%5BREDACTED%5D');
+		expect(apiError.url).toContain('token=%5BREDACTED%5D');
+		expect(apiError.url).toContain('appid=%5BREDACTED%5D');
+		expect(apiError.url).toContain('key=%5BREDACTED%5D');
+		expect(apiError.url).toContain('normal_param=public-data');
+
+		// Assertions on the Request options query
+		expect(apiError.request.query).toBeDefined();
+		expect(apiError.request.query?.api_key).toBe('[REDACTED]');
+		expect(apiError.request.query?.token).toBe('[REDACTED]');
+		expect(apiError.request.query?.appid).toBe('[REDACTED]');
+		expect(apiError.request.query?.key).toBe('[REDACTED]');
+		expect(apiError.request.query?.normal_param).toBe('public-data');
+	});
+
+	it('should handle case-insensitive query parameter matching', () => {
+		const request: ApiRequestOptions = {
+			method: 'GET',
+			url: '/v1/test',
+			query: {
+				API_KEY: 'secret-key-123',
+			},
+		};
+
+		const response: ApiResult = {
+			url: 'https://api.example.com/v1/test?API_KEY=secret-key-123',
+			ok: false,
+			status: 401,
+			statusText: 'Unauthorized',
+			body: { error: 'Invalid auth' },
+		};
+
+		const apiError = new ApiError(request, response, 'Unauthorized');
+
+		expect(apiError.url).not.toContain('secret-key-123');
+		expect(apiError.url).toContain('API_KEY=%5BREDACTED%5D');
+		expect(apiError.request.query?.API_KEY).toBe('[REDACTED]');
+	});
+
+	it('should handle relative URLs and no query params without crashing', () => {
+		const request: ApiRequestOptions = {
+			method: 'GET',
+			url: '/v1/test',
+		};
+
+		const response: ApiResult = {
+			url: '/v1/test',
+			ok: false,
+			status: 404,
+			statusText: 'Not Found',
+			body: { error: 'Not found' },
+		};
+
+		const apiError = new ApiError(request, response, 'Not Found');
+
+		expect(apiError.url).toBe('/v1/test');
+		expect(apiError.request.query).toBeUndefined();
+	});
+});


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

Fixes https://github.com/corsairdev/corsair/issues/584

When `ApiError` is constructed upon request failure, the constructor saves `response.url` directly to `this.url` and the raw request options to `this.request`. For plugins where credentials are passed via query parameters (such as `api_key` for InsightoAI/Abstract, `key`/`token` for Trello, or `appid` for OpenWeatherMap), these API secrets leak in application logs when the error is serialized or logged.

This PR adds query-parameter credential redaction:
- Added case-insensitive query parameter filtering within the `ApiError` constructor for both `this.url` and `this.request.query`.
- Safe URL parsing that handles both relative and absolute paths without crashing.
- Cloned the query parameters inside the `ApiError` options clone to avoid mutating the original options (preserving status check and request retry behaviors).
- Added a dedicated unit test suite for query redaction.

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)
<img width="810" height="267" alt="Screenshot 2026-08-07 103156" src="https://github.com/user-attachments/assets/4a7896f0-04bc-4a8c-96b3-e96efbb4c8e7" />


<!-- If your changes affect the UI or CLI output, please include screenshots or terminal recordings. -->

## Additional Notes

- Added a new unit test suite: `packages/corsair/tests/api-error.test.ts`
- Verified that all `error-handlers.test.ts` pass after the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive query parameters are now redacted from error URLs and request details.
  * Redaction works regardless of parameter name casing while preserving non-sensitive values.
  * Relative, malformed, and query-free URLs are handled safely.
  * Original request data remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->