### PR TITLE
feat: app-outbound connect delivery transport (SDK)

### DIFF
--- a/packages/corsair/core/index.ts
+++ b/packages/corsair/core/index.ts
@@ -154,10 +154,10 @@ function maybeStartConnectLoop(
 	instance: unknown,
 	hub: HubConfig | undefined,
 ): void {
-	if (
-		!hub?.allowWorkflowExecution ||
-		!hub.projectApiKey.startsWith('ck_dev_')
-	) {
+	// Only dev keys use connect; prod is out of scope. Delegate the execution-flag
+	// decision to startConnectLoop (the single owner of the "flag is off" warning) —
+	// short-circuiting on the flag here would swallow that warning silently.
+	if (!hub?.projectApiKey?.startsWith('ck_dev_')) {
 		return;
 	}
 	void import('../hub/connect/loop')

--- a/packages/corsair/core/index.ts
+++ b/packages/corsair/core/index.ts
@@ -97,7 +97,7 @@ export function createCorsair<const Plugins extends readonly CorsairPlugin[]>(
 	const manage = buildManagementNamespace(internalConfig);
 
 	if (config.multiTenancy) {
-		return Object.assign(
+		const tenantWrapper = Object.assign(
 			{
 				withTenant: (tenantId: string) => {
 					if (!tenantId) {
@@ -125,6 +125,8 @@ export function createCorsair<const Plugins extends readonly CorsairPlugin[]>(
 			},
 			{ [CORSAIR_INTERNAL]: internalConfig },
 		);
+		maybeStartConnectLoop(tenantWrapper, internalConfig.hub);
+		return tenantWrapper;
 	}
 
 	const client = buildCorsairClient(config.plugins, {
@@ -138,12 +140,29 @@ export function createCorsair<const Plugins extends readonly CorsairPlugin[]>(
 		internalConfig,
 	});
 
-	return Object.assign({}, client, {
+	const singleTenant = Object.assign({}, client, {
 		keys: integrationKeys,
 		permissions,
 		manage,
 		[CORSAIR_INTERNAL]: internalConfig,
 	}) as CorsairSingleTenantClient<Plugins>;
+	maybeStartConnectLoop(singleTenant, internalConfig.hub);
+	return singleTenant;
+}
+
+function maybeStartConnectLoop(
+	instance: unknown,
+	hub: HubConfig | undefined,
+): void {
+	if (
+		!hub?.allowWorkflowExecution ||
+		!hub.projectApiKey.startsWith('ck_dev_')
+	) {
+		return;
+	}
+	void import('../hub/connect/loop')
+		.then((m) => m.startConnectLoop(instance))
+		.catch(() => {});
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/corsair/hub/connect/loop.ts
+++ b/packages/corsair/hub/connect/loop.ts
@@ -1,4 +1,5 @@
-import type { processCorsair } from '../../tunnel/index';
+import { processCorsair } from '../../tunnel/index';
+import { getHubConfig } from '../config';
 import type { HubConfig } from '../types';
 
 type TunnelAck = Awaited<ReturnType<typeof processCorsair>>;
@@ -55,4 +56,52 @@ export async function pollOnce(
 		body: JSON.stringify({ deliveryId, status, body: ackBody }),
 	});
 	return 'handled';
+}
+
+const BACKOFF_MS = 1_000;
+const MAX_BACKOFF_MS = 5_000;
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function startConnectLoop(corsair: unknown): { stop: () => void } {
+	let hub: HubConfig;
+	try {
+		hub = getHubConfig(corsair);
+	} catch {
+		return { stop: () => {} };
+	}
+	if (!hub.allowWorkflowExecution || !hub.projectApiKey.startsWith('ck_dev_')) {
+		return { stop: () => {} };
+	}
+
+	let stopped = false;
+	let backoff = BACKOFF_MS;
+	const deps: ConnectDeps = { fetch, process: processCorsair };
+
+	const run = async (): Promise<void> => {
+		while (!stopped) {
+			try {
+				const outcome = await pollOnce(corsair, hub, deps);
+				if (outcome === 'error') {
+					if (!stopped) await sleep(backoff);
+					backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+				} else {
+					backoff = BACKOFF_MS;
+				}
+			} catch {
+				if (stopped) break;
+				await sleep(backoff);
+				backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+			}
+		}
+	};
+	void run();
+
+	return {
+		stop: () => {
+			stopped = true;
+		},
+	};
 }

--- a/packages/corsair/hub/connect/loop.ts
+++ b/packages/corsair/hub/connect/loop.ts
@@ -24,14 +24,70 @@ export function deriveAck(ack: TunnelAck): { status: number; body: unknown } {
 	};
 }
 
+const ACK_MAX_ATTEMPTS = 3;
+const ACK_RETRY_MS = 250;
+
+function isAbort(err: unknown): boolean {
+	return (err as { name?: string })?.name === 'AbortError';
+}
+
+async function ackConfirmed(resp: Response): Promise<boolean> {
+	try {
+		const body = (await resp.json()) as { ok?: boolean };
+		return body?.ok !== false;
+	} catch {
+		return true;
+	}
+}
+
+// The run already executed locally by the time we ack, so a lost ack means the
+// hub never records the result and eventually retries the run. Retry transport
+// failures a bounded number of times; a 2xx that the hub couldn't match (its
+// delivery already timed out) is terminal, not retryable.
+async function postAck(
+	hub: HubConfig,
+	deps: ConnectDeps,
+	auth: Record<string, string>,
+	payload: { deliveryId: string; status: number; body: unknown },
+	signal?: AbortSignal,
+): Promise<boolean> {
+	for (let attempt = 1; attempt <= ACK_MAX_ATTEMPTS; attempt++) {
+		try {
+			const resp = await deps.fetch(`${hub.apiUrl}/api/dev/ack`, {
+				method: 'POST',
+				headers: { ...auth, 'content-type': 'application/json' },
+				body: JSON.stringify(payload),
+				signal,
+			});
+			if (resp.ok) {
+				if (!(await ackConfirmed(resp))) {
+					console.warn(
+						`[corsair] hub did not record delivery ${payload.deliveryId} (already timed out); the run may be retried`,
+					);
+				}
+				return true;
+			}
+		} catch (err) {
+			if (isAbort(err)) throw err;
+		}
+		if (attempt < ACK_MAX_ATTEMPTS) await sleep(ACK_RETRY_MS);
+	}
+	console.warn(
+		`[corsair] failed to acknowledge delivery ${payload.deliveryId} after ${ACK_MAX_ATTEMPTS} attempts; the run may be retried`,
+	);
+	return false;
+}
+
 export async function pollOnce(
 	corsair: unknown,
 	hub: HubConfig,
 	deps: ConnectDeps,
+	signal?: AbortSignal,
 ): Promise<'idle' | 'handled' | 'error'> {
 	const auth = { authorization: `Bearer ${hub.projectApiKey}` };
 	const pull = await deps.fetch(`${hub.apiUrl}/api/dev/pull`, {
 		headers: auth,
+		signal,
 	});
 	if (pull.status === 204) return 'idle';
 	if (!pull.ok) return 'error';
@@ -50,16 +106,21 @@ export async function pollOnce(
 		},
 	);
 	const { status, body: ackBody } = deriveAck(ack);
-	await deps.fetch(`${hub.apiUrl}/api/dev/ack`, {
-		method: 'POST',
-		headers: { ...auth, 'content-type': 'application/json' },
-		body: JSON.stringify({ deliveryId, status, body: ackBody }),
-	});
-	return 'handled';
+	const confirmed = await postAck(
+		hub,
+		deps,
+		auth,
+		{ deliveryId, status, body: ackBody },
+		signal,
+	);
+	return confirmed ? 'handled' : 'error';
 }
 
 const BACKOFF_MS = 1_000;
 const MAX_BACKOFF_MS = 5_000;
+// Client-side ceiling above the hub's 25s long-poll hold, so a wedged
+// connection (silent proxy drop) is aborted and retried rather than hanging.
+const PULL_ABORT_MS = 30_000;
 
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
@@ -67,10 +128,14 @@ function sleep(ms: number): Promise<void> {
 
 // One loop per project key, tracked on globalThis so it survives module
 // re-evaluation under watch/HMR — otherwise every createCorsair() (or reload)
-// would spawn another perpetual poll loop against the same environment.
-const activeLoopKeys: Set<string> = ((
-	globalThis as typeof globalThis & { __corsairConnectLoops?: Set<string> }
-).__corsairConnectLoops ??= new Set<string>());
+// would spawn another perpetual poll loop against the same environment. The
+// value is an owner token: only the loop that currently owns a key may release
+// it, so a stop()+restart of the same key never leaves two loops polling.
+const activeLoops: Map<string, symbol> = ((
+	globalThis as typeof globalThis & {
+		__corsairConnectLoops?: Map<string, symbol>;
+	}
+).__corsairConnectLoops ??= new Map<string, symbol>());
 
 export function startConnectLoop(
 	corsair: unknown,
@@ -85,29 +150,51 @@ export function startConnectLoop(
 	if (!hub.allowWorkflowExecution || !hub.projectApiKey.startsWith('ck_dev_')) {
 		return { stop: () => {} };
 	}
-	if (activeLoopKeys.has(hub.projectApiKey)) {
+	const key = hub.projectApiKey;
+	if (activeLoops.has(key)) {
 		return { stop: () => {} };
 	}
-	activeLoopKeys.add(hub.projectApiKey);
+	const token = Symbol('corsair-connect-loop');
+	activeLoops.set(key, token);
+	const releaseKey = (): void => {
+		if (activeLoops.get(key) === token) activeLoops.delete(key);
+	};
 
 	let stopped = false;
-	let backoff = BACKOFF_MS;
+	let controller: AbortController | null = null;
 
 	const run = async (): Promise<void> => {
-		while (!stopped) {
-			try {
-				const outcome = await pollOnce(corsair, hub, deps);
-				if (outcome === 'error') {
-					if (!stopped) await sleep(backoff);
-					backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
-				} else {
-					backoff = BACKOFF_MS;
-				}
-			} catch {
-				if (stopped) break;
-				await sleep(backoff);
-				backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+		let backoff = BACKOFF_MS;
+		let erroring = false;
+		const backOff = async (detail: unknown): Promise<void> => {
+			if (!erroring) {
+				console.warn('[corsair] connect loop error; retrying', detail);
+				erroring = true;
 			}
+			if (!stopped) await sleep(backoff);
+			backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+		};
+		try {
+			while (!stopped) {
+				controller = new AbortController();
+				const timer = setTimeout(() => controller?.abort(), PULL_ABORT_MS);
+				try {
+					const outcome = await pollOnce(corsair, hub, deps, controller.signal);
+					if (outcome === 'error') {
+						await backOff('pull or ack failed');
+					} else {
+						erroring = false;
+						backoff = BACKOFF_MS;
+					}
+				} catch (err) {
+					if (stopped) break;
+					await backOff(err instanceof Error ? err.message : err);
+				} finally {
+					clearTimeout(timer);
+				}
+			}
+		} finally {
+			releaseKey();
 		}
 	};
 	void run();
@@ -115,7 +202,8 @@ export function startConnectLoop(
 	return {
 		stop: () => {
 			stopped = true;
-			activeLoopKeys.delete(hub.projectApiKey);
+			controller?.abort();
+			releaseKey();
 		},
 	};
 }

--- a/packages/corsair/hub/connect/loop.ts
+++ b/packages/corsair/hub/connect/loop.ts
@@ -155,8 +155,8 @@ export function startConnectLoop(
 	}
 	if (!hub.allowWorkflowExecution) {
 		console.warn(
-			'[corsair] connect loop not started: hub.allowWorkflowExecution is off, ' +
-				'so this app will not poll for run/probe delivery.',
+			'[corsair] workflow executions not enabled. ' +
+				'Please set hub: { ..., allowWorkflowExecution: true }',
 		);
 		return { stop: () => {} };
 	}

--- a/packages/corsair/hub/connect/loop.ts
+++ b/packages/corsair/hub/connect/loop.ts
@@ -1,0 +1,58 @@
+import type { processCorsair } from '../../tunnel/index';
+import type { HubConfig } from '../types';
+
+type TunnelAck = Awaited<ReturnType<typeof processCorsair>>;
+
+export type ConnectDeps = {
+	fetch: typeof fetch;
+	process: typeof processCorsair;
+};
+
+export function deriveAck(ack: TunnelAck): { status: number; body: unknown } {
+	const wr = (ack as { webhookResponse?: { status: number; body: unknown } })
+		.webhookResponse;
+	if (ack.status === 'ok') {
+		return { status: wr?.status ?? 200, body: wr?.body ?? { status: 'ok' } };
+	}
+	return {
+		status: wr?.status ?? 502,
+		body: wr?.body ?? {
+			status: 'error',
+			error: (ack as { error?: string }).error ?? 'delivery failed',
+		},
+	};
+}
+
+export async function pollOnce(
+	corsair: unknown,
+	hub: HubConfig,
+	deps: ConnectDeps,
+): Promise<'idle' | 'handled' | 'error'> {
+	const auth = { authorization: `Bearer ${hub.projectApiKey}` };
+	const pull = await deps.fetch(`${hub.apiUrl}/api/dev/pull`, {
+		headers: auth,
+	});
+	if (pull.status === 204) return 'idle';
+	if (!pull.ok) return 'error';
+
+	const { deliveryId, body, headers } = (await pull.json()) as {
+		deliveryId: string;
+		body: string;
+		headers: Record<string, string>;
+	};
+	const ack = await deps.process(
+		corsair,
+		{ headers, body },
+		{
+			signingSecret: hub.signingSecret,
+			allowWorkflowExecution: hub.allowWorkflowExecution ?? true,
+		},
+	);
+	const { status, body: ackBody } = deriveAck(ack);
+	await deps.fetch(`${hub.apiUrl}/api/dev/ack`, {
+		method: 'POST',
+		headers: { ...auth, 'content-type': 'application/json' },
+		body: JSON.stringify({ deliveryId, status, body: ackBody }),
+	});
+	return 'handled';
+}

--- a/packages/corsair/hub/connect/loop.ts
+++ b/packages/corsair/hub/connect/loop.ts
@@ -147,7 +147,17 @@ export function startConnectLoop(
 	} catch {
 		return { stop: () => {} };
 	}
-	if (!hub.allowWorkflowExecution || !hub.projectApiKey.startsWith('ck_dev_')) {
+	// A prod key means connect is out of scope — stay silent. But a dev key with
+	// execution gated off is almost always a mistake (it used to fail silently:
+	// the app just never polls). Say why, and where the flag actually goes.
+	if (!hub.projectApiKey.startsWith('ck_dev_')) {
+		return { stop: () => {} };
+	}
+	if (!hub.allowWorkflowExecution) {
+		console.warn(
+			'[corsair] connect loop not started: hub.allowWorkflowExecution is off, ' +
+				'so this app will not poll for run/probe delivery.',
+		);
 		return { stop: () => {} };
 	}
 	const key = hub.projectApiKey;

--- a/packages/corsair/hub/connect/loop.ts
+++ b/packages/corsair/hub/connect/loop.ts
@@ -46,7 +46,7 @@ export async function pollOnce(
 		{ headers, body },
 		{
 			signingSecret: hub.signingSecret,
-			allowWorkflowExecution: hub.allowWorkflowExecution ?? true,
+			allowWorkflowExecution: hub.allowWorkflowExecution,
 		},
 	);
 	const { status, body: ackBody } = deriveAck(ack);
@@ -65,7 +65,17 @@ function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export function startConnectLoop(corsair: unknown): { stop: () => void } {
+// One loop per project key, tracked on globalThis so it survives module
+// re-evaluation under watch/HMR — otherwise every createCorsair() (or reload)
+// would spawn another perpetual poll loop against the same environment.
+const activeLoopKeys: Set<string> = ((
+	globalThis as typeof globalThis & { __corsairConnectLoops?: Set<string> }
+).__corsairConnectLoops ??= new Set<string>());
+
+export function startConnectLoop(
+	corsair: unknown,
+	deps: ConnectDeps = { fetch, process: processCorsair },
+): { stop: () => void } {
 	let hub: HubConfig;
 	try {
 		hub = getHubConfig(corsair);
@@ -75,10 +85,13 @@ export function startConnectLoop(corsair: unknown): { stop: () => void } {
 	if (!hub.allowWorkflowExecution || !hub.projectApiKey.startsWith('ck_dev_')) {
 		return { stop: () => {} };
 	}
+	if (activeLoopKeys.has(hub.projectApiKey)) {
+		return { stop: () => {} };
+	}
+	activeLoopKeys.add(hub.projectApiKey);
 
 	let stopped = false;
 	let backoff = BACKOFF_MS;
-	const deps: ConnectDeps = { fetch, process: processCorsair };
 
 	const run = async (): Promise<void> => {
 		while (!stopped) {
@@ -102,6 +115,7 @@ export function startConnectLoop(corsair: unknown): { stop: () => void } {
 	return {
 		stop: () => {
 			stopped = true;
+			activeLoopKeys.delete(hub.projectApiKey);
 		},
 	};
 }

--- a/packages/corsair/hub/index.ts
+++ b/packages/corsair/hub/index.ts
@@ -39,6 +39,7 @@ export {
 	resolveHubOAuthCallbackUrl,
 } from './config';
 export { createHubConnectSession } from './connect';
+export { startConnectLoop } from './connect/loop';
 export type {
 	ConnectCreateLinkDeliveryPayload,
 	ConnectCreateLinkDeliveryResult,

--- a/packages/corsair/package.json
+++ b/packages/corsair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corsair",
-  "version": "0.1.113",
+  "version": "0.1.114",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/corsair/tests/connect-loop.test.ts
+++ b/packages/corsair/tests/connect-loop.test.ts
@@ -4,6 +4,9 @@ import { deriveAck, pollOnce, startConnectLoop } from '../hub/connect/loop';
 function mockCorsair(projectApiKey: string): unknown {
 	return {
 		[CORSAIR_INTERNAL]: {
+			plugins: [],
+			kek: 'test-kek-with-at-least-32-characters!!',
+			multiTenancy: false,
 			hub: {
 				apiUrl: 'https://hub.test',
 				projectApiKey,
@@ -28,6 +31,8 @@ function res(status: number, json?: unknown): Response {
 		json: async () => json,
 	} as unknown as Response;
 }
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 describe('deriveAck', () => {
 	it('maps a run success to its webhookResponse', () => {
@@ -119,5 +124,46 @@ describe('startConnectLoop', () => {
 		expect(fetchSpy).not.toHaveBeenCalled();
 		handle.stop();
 		fetchSpy.mockRestore();
+	});
+
+	function countingIdleDeps() {
+		const state = { calls: 0 };
+		const deps = {
+			fetch: (async () => {
+				state.calls++;
+				await sleep(5);
+				return res(204);
+			}) as unknown as typeof fetch,
+			process: (async () => ({ status: 'ok' })) as any,
+		};
+		return { state, deps };
+	}
+
+	it('polls while running and halts on stop()', async () => {
+		const { state, deps } = countingIdleDeps();
+		const handle = startConnectLoop(mockCorsair('ck_dev_runtest'), deps);
+		await sleep(40);
+		expect(state.calls).toBeGreaterThan(0);
+		handle.stop();
+		await sleep(40);
+		const afterStop = state.calls;
+		await sleep(40);
+		expect(state.calls).toBe(afterStop);
+	});
+
+	it('does not spawn a second loop for the same project key', async () => {
+		const { state, deps } = countingIdleDeps();
+		const first = startConnectLoop(mockCorsair('ck_dev_dedupe'), deps);
+		const second = startConnectLoop(mockCorsair('ck_dev_dedupe'), deps);
+		await sleep(40);
+		expect(state.calls).toBeGreaterThan(0);
+		// Stopping the one real loop must halt all polling — proving the second
+		// call did not start its own loop.
+		first.stop();
+		await sleep(40);
+		const afterStop = state.calls;
+		await sleep(40);
+		expect(state.calls).toBe(afterStop);
+		second.stop();
 	});
 });

--- a/packages/corsair/tests/connect-loop.test.ts
+++ b/packages/corsair/tests/connect-loop.test.ts
@@ -34,6 +34,20 @@ function res(status: number, json?: unknown): Response {
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+const pulled = (extra?: Record<string, unknown>) =>
+	res(200, {
+		deliveryId: 'd1',
+		body: '{"type":"run"}',
+		headers: { 'x-corsair-signature': 'sha256=x' },
+		...extra,
+	});
+
+const okRun = () =>
+	jest.fn(async () => ({
+		status: 'ok',
+		webhookResponse: { status: 200, body: { status: 'ok' } },
+	}));
+
 describe('deriveAck', () => {
 	it('maps a run success to its webhookResponse', () => {
 		expect(
@@ -67,18 +81,9 @@ describe('pollOnce', () => {
 	it('processes an envelope and posts the ack', async () => {
 		const fetchMock = jest
 			.fn()
-			.mockResolvedValueOnce(
-				res(200, {
-					deliveryId: 'd1',
-					body: '{"type":"run"}',
-					headers: { 'x-corsair-signature': 'sha256=x' },
-				}),
-			)
+			.mockResolvedValueOnce(pulled())
 			.mockResolvedValueOnce(res(200, { ok: true }));
-		const process = jest.fn(async () => ({
-			status: 'ok',
-			webhookResponse: { status: 200, body: { status: 'ok' } },
-		}));
+		const process = okRun();
 		const out = await pollOnce({}, hub, {
 			fetch: fetchMock as any,
 			process: process as any,
@@ -107,6 +112,47 @@ describe('pollOnce', () => {
 			process: jest.fn() as any,
 		});
 		expect(out).toBe('error');
+	});
+
+	it('treats a stale ack (ok:false) as handled without retrying', async () => {
+		const fetchMock = jest
+			.fn()
+			.mockResolvedValueOnce(pulled())
+			.mockResolvedValueOnce(res(200, { ok: false }));
+		const out = await pollOnce({}, hub, {
+			fetch: fetchMock as any,
+			process: okRun() as any,
+		});
+		expect(out).toBe('handled');
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('retries a transiently failed ack and succeeds', async () => {
+		const fetchMock = jest
+			.fn()
+			.mockResolvedValueOnce(pulled())
+			.mockResolvedValueOnce(res(503))
+			.mockResolvedValueOnce(res(200, { ok: true }));
+		const out = await pollOnce({}, hub, {
+			fetch: fetchMock as any,
+			process: okRun() as any,
+		});
+		expect(out).toBe('handled');
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+	});
+
+	it('returns error when the ack never lands', async () => {
+		const fetchMock = jest
+			.fn()
+			.mockResolvedValueOnce(pulled())
+			.mockResolvedValue(res(500));
+		const out = await pollOnce({}, hub, {
+			fetch: fetchMock as any,
+			process: okRun() as any,
+		});
+		expect(out).toBe('error');
+		// 1 pull + 3 ack attempts
+		expect(fetchMock).toHaveBeenCalledTimes(4);
 	});
 });
 
@@ -139,6 +185,27 @@ describe('startConnectLoop', () => {
 		return { state, deps };
 	}
 
+	// A pull that blocks until its request is aborted, so a stop() can be
+	// observed while a pull is genuinely in flight.
+	function blockingDeps() {
+		const state = { starts: 0, aborts: 0 };
+		const deps = {
+			fetch: ((_url: string, init?: { signal?: AbortSignal }) => {
+				state.starts++;
+				return new Promise<Response>((_resolve, reject) => {
+					init?.signal?.addEventListener('abort', () => {
+						state.aborts++;
+						const err = new Error('aborted');
+						err.name = 'AbortError';
+						reject(err);
+					});
+				});
+			}) as unknown as typeof fetch,
+			process: (async () => ({ status: 'ok' })) as any,
+		};
+		return { state, deps };
+	}
+
 	it('polls while running and halts on stop()', async () => {
 		const { state, deps } = countingIdleDeps();
 		const handle = startConnectLoop(mockCorsair('ck_dev_runtest'), deps);
@@ -157,13 +224,31 @@ describe('startConnectLoop', () => {
 		const second = startConnectLoop(mockCorsair('ck_dev_dedupe'), deps);
 		await sleep(40);
 		expect(state.calls).toBeGreaterThan(0);
-		// Stopping the one real loop must halt all polling — proving the second
-		// call did not start its own loop.
 		first.stop();
 		await sleep(40);
 		const afterStop = state.calls;
 		await sleep(40);
 		expect(state.calls).toBe(afterStop);
 		second.stop();
+	});
+
+	it('frees the key on stop so an immediate restart runs exactly one loop', async () => {
+		const a = blockingDeps();
+		const first = startConnectLoop(mockCorsair('ck_dev_owner'), a.deps);
+		await sleep(10);
+		expect(a.state.starts).toBe(1);
+
+		first.stop();
+		expect(a.state.aborts).toBe(1);
+
+		const b = blockingDeps();
+		const second = startConnectLoop(mockCorsair('ck_dev_owner'), b.deps);
+		await sleep(10);
+		// The restart actually started (the key was freed), and the old loop is
+		// gone — only the new loop is polling.
+		expect(b.state.starts).toBe(1);
+		second.stop();
+		await sleep(10);
+		expect(b.state.aborts).toBe(1);
 	});
 });

--- a/packages/corsair/tests/connect-loop.test.ts
+++ b/packages/corsair/tests/connect-loop.test.ts
@@ -1,0 +1,92 @@
+import { deriveAck, pollOnce } from '../hub/connect/loop';
+
+const hub = {
+	apiUrl: 'https://hub.test',
+	projectApiKey: 'ck_dev_abc',
+	signingSecret: 's',
+	allowWorkflowExecution: true,
+} as any;
+
+function res(status: number, json?: unknown): Response {
+	return {
+		status,
+		ok: status >= 200 && status < 300,
+		json: async () => json,
+	} as unknown as Response;
+}
+
+describe('deriveAck', () => {
+	it('maps a run success to its webhookResponse', () => {
+		expect(
+			deriveAck({
+				status: 'ok',
+				webhookResponse: { status: 200, body: { status: 'ok', run: { x: 1 } } },
+			} as any),
+		).toEqual({ status: 200, body: { status: 'ok', run: { x: 1 } } });
+	});
+
+	it('maps a failure to 502 with the error', () => {
+		expect(deriveAck({ status: 'failed', error: 'boom' } as any)).toEqual({
+			status: 502,
+			body: { status: 'error', error: 'boom' },
+		});
+	});
+});
+
+describe('pollOnce', () => {
+	it('returns idle on 204 and does not call process', async () => {
+		const fetchMock = jest.fn(async () => res(204));
+		const process = jest.fn();
+		const out = await pollOnce({}, hub, {
+			fetch: fetchMock as any,
+			process: process as any,
+		});
+		expect(out).toBe('idle');
+		expect(process).not.toHaveBeenCalled();
+	});
+
+	it('processes an envelope and posts the ack', async () => {
+		const fetchMock = jest
+			.fn()
+			.mockResolvedValueOnce(
+				res(200, {
+					deliveryId: 'd1',
+					body: '{"type":"run"}',
+					headers: { 'x-corsair-signature': 'sha256=x' },
+				}),
+			)
+			.mockResolvedValueOnce(res(200, { ok: true }));
+		const process = jest.fn(async () => ({
+			status: 'ok',
+			webhookResponse: { status: 200, body: { status: 'ok' } },
+		}));
+		const out = await pollOnce({}, hub, {
+			fetch: fetchMock as any,
+			process: process as any,
+		});
+		expect(out).toBe('handled');
+		expect(process).toHaveBeenCalledWith(
+			{},
+			{
+				headers: { 'x-corsair-signature': 'sha256=x' },
+				body: '{"type":"run"}',
+			},
+			{ signingSecret: 's', allowWorkflowExecution: true },
+		);
+		const ackCall = fetchMock.mock.calls[1] as unknown[];
+		expect(ackCall[0]).toBe('https://hub.test/api/dev/ack');
+		expect(JSON.parse((ackCall[1] as { body: string }).body)).toMatchObject({
+			deliveryId: 'd1',
+			status: 200,
+		});
+	});
+
+	it('returns error on a non-204/2xx pull', async () => {
+		const fetchMock = jest.fn(async () => res(500));
+		const out = await pollOnce({}, hub, {
+			fetch: fetchMock as any,
+			process: jest.fn() as any,
+		});
+		expect(out).toBe('error');
+	});
+});

--- a/packages/corsair/tests/connect-loop.test.ts
+++ b/packages/corsair/tests/connect-loop.test.ts
@@ -182,7 +182,7 @@ describe('startConnectLoop', () => {
 		await Promise.resolve();
 		expect(fetchSpy).not.toHaveBeenCalled();
 		expect(warnSpy).toHaveBeenCalledWith(
-			expect.stringContaining('allowWorkflowExecution is off'),
+			expect.stringContaining('workflow executions not enabled'),
 		);
 		handle.stop();
 		warnSpy.mockRestore();

--- a/packages/corsair/tests/connect-loop.test.ts
+++ b/packages/corsair/tests/connect-loop.test.ts
@@ -1,4 +1,18 @@
-import { deriveAck, pollOnce } from '../hub/connect/loop';
+import { CORSAIR_INTERNAL } from '../core';
+import { deriveAck, pollOnce, startConnectLoop } from '../hub/connect/loop';
+
+function mockCorsair(projectApiKey: string): unknown {
+	return {
+		[CORSAIR_INTERNAL]: {
+			hub: {
+				apiUrl: 'https://hub.test',
+				projectApiKey,
+				signingSecret: 's',
+				allowWorkflowExecution: true,
+			},
+		},
+	};
+}
 
 const hub = {
 	apiUrl: 'https://hub.test',
@@ -88,5 +102,22 @@ describe('pollOnce', () => {
 			process: jest.fn() as any,
 		});
 		expect(out).toBe('error');
+	});
+});
+
+describe('startConnectLoop', () => {
+	it('is a no-op when the hub is not configured', () => {
+		const handle = startConnectLoop({});
+		expect(typeof handle.stop).toBe('function');
+		handle.stop();
+	});
+
+	it('does not start the loop for a non-dev (prod) key', async () => {
+		const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(res(204));
+		const handle = startConnectLoop(mockCorsair('ck_prod_abc'));
+		await Promise.resolve();
+		expect(fetchSpy).not.toHaveBeenCalled();
+		handle.stop();
+		fetchSpy.mockRestore();
 	});
 });

--- a/packages/corsair/tests/connect-loop.test.ts
+++ b/packages/corsair/tests/connect-loop.test.ts
@@ -1,7 +1,10 @@
 import { CORSAIR_INTERNAL } from '../core';
 import { deriveAck, pollOnce, startConnectLoop } from '../hub/connect/loop';
 
-function mockCorsair(projectApiKey: string): unknown {
+function mockCorsair(
+	projectApiKey: string,
+	allowWorkflowExecution = true,
+): unknown {
 	return {
 		[CORSAIR_INTERNAL]: {
 			plugins: [],
@@ -11,7 +14,7 @@ function mockCorsair(projectApiKey: string): unknown {
 				apiUrl: 'https://hub.test',
 				projectApiKey,
 				signingSecret: 's',
-				allowWorkflowExecution: true,
+				allowWorkflowExecution,
 			},
 		},
 	};
@@ -169,6 +172,20 @@ describe('startConnectLoop', () => {
 		await Promise.resolve();
 		expect(fetchSpy).not.toHaveBeenCalled();
 		handle.stop();
+		fetchSpy.mockRestore();
+	});
+
+	it('warns and does not poll for a dev key with execution disabled', async () => {
+		const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(res(204));
+		const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+		const handle = startConnectLoop(mockCorsair('ck_dev_noexec', false));
+		await Promise.resolve();
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining('allowWorkflowExecution is off'),
+		);
+		handle.stop();
+		warnSpy.mockRestore();
 		fetchSpy.mockRestore();
 	});
 


### PR DESCRIPTION
## What

App-outbound **connect** delivery transport (SDK side) so a local dev app receives `run`/`probe` envelopes from a deployed hub without being reachable at `localhost`.

## Why

The deployed hub cannot reach `localhost` for any delivery. Interactive flows work via the browser bridge, but headless `run`/`probe` delivery had no localhost path — it POSTed directly to the app and failed with `HTTP 0`. This inverts the direction: the app dials out and long-polls the hub, and the hub hands work back over that connection. The hub never touches `localhost`.

Pairs with the hub side (`corsairdev/hub`) — the two ship together.

## Changes

- `hub/connect/loop.ts` — the connect loop:
  - `pollOnce(corsair, hub, deps)` — one `GET /api/dev/pull` → verify + route via the existing `processCorsair` → `POST /api/dev/ack`. `deriveAck` maps the `TunnelAck` back to the ack wire body. `fetch`/`process` are injected for testing.
  - `startConnectLoop(corsair, deps?)` — background loop, gated to `ck_dev_` keys + `allowWorkflowExecution`, with backoff and a `globalThis`-tracked guard so a project key never spawns more than one loop (survives watch/HMR reloads).
- `core/index.ts` — auto-starts the loop from `createCorsair` (guarded dynamic import to avoid a `core → hub` cycle).
- Reuses `processCorsair`, `signDeliveryEnvelope`/`verifySignedTunnelDelivery`, and `hubApiGet`/`hubApiPost` — no new signing or handler code.

The envelope, signing, and replay are transport-agnostic and unchanged. Only the pipe is new.

## Scope

`run`/`probe` headless delivery only. The interactive browser-bridge path is untouched.

## Testing

- `tests/connect-loop.test.ts` — 9 tests: `deriveAck` mapping, `pollOnce` (idle / handled+ack / error), gating (no hub, prod key), a running loop that halts on `stop()`, and the duplicate-loop guard.
- Full SDK suite green (the pre-existing `postgres-js` integration suite needs a live Postgres and is unrelated).
- `tsc --noEmit` clean; biome clean on changed files.

## Review

Ran an independent adversarial review before opening. Fixes applied: dropped an unreachable `?? true`, added the duplicate-loop guard, and switched the loop to injected deps for deterministic tests.

## Status

Unit-verified. End-to-end validation (local app ↔ deployed hub, no tunnel) is pending — **do not merge until that passes.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hub connectivity for polling, processing, and acknowledging workflow deliveries.
  * Connections start automatically when workflow execution is enabled with an eligible development project key.
  * Added safeguards against duplicate connections and support for clean shutdown.
* **Bug Fixes**
  * Improved resilience with retry backoff and graceful handling of connection or startup failures.
  * Added timeout and cancellation handling to prevent stalled connections.
  * Improved acknowledgement delivery through automatic retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->