### PR TITLE
fix: register youcom plugin in core constants.ts

### DIFF
--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -109,6 +109,7 @@ export const BaseProviders = [
 	'vercel',
 	'whatsapp',
 	'xquik',
+	'youcom',
 	'youtube',
 	'zendesk',
 	'zohomail',
@@ -212,6 +213,7 @@ export const ProviderDisplayNames = {
 	vercel: 'Vercel',
 	whatsapp: 'WhatsApp',
 	xquik: 'XQuik',
+	youcom: 'You.com',
 	youtube: 'YouTube',
 	zendesk: 'Zendesk',
 	zohomail: 'Zoho Mail',
@@ -322,6 +324,7 @@ export type AllProviders =
 	| 'vercel'
 	| 'whatsapp'
 	| 'xquik'
+	| 'youcom'
 	| 'youtube'
 	| 'zendesk'
 	| 'zohomail'


### PR DESCRIPTION
## Description

Fixes #622

The youcom (You.com Web Search) plugin has a fully implemented package at `packages/youcom/` but was never registered in the core provider registry.

This PR adds youcom to all three registration points in `packages/corsair/core/constants.ts`:

- `BaseProviders` array
- `ProviderDisplayNames` map (as `You.com`)
- `AllProviders` union type

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos

N/A — no UI or CLI changes. This is a one-file, three-line registration fix.

## Additional Notes

- Only `packages/corsair/core/constants.ts` is modified (1 file, 3 insertions), which aligns with the plugin PR scope rules (R1).
- `pnpm run validate:plugins` passes successfully.
- No new dependencies added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added You.com as a supported provider.
  - You.com is now available throughout provider selection and displays with its proper name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->