### PR TITLE
Fix/googledrive paginate changes

### DIFF
--- a/packages/googledrive/index.ts
+++ b/packages/googledrive/index.ts
@@ -343,7 +343,7 @@ const googleDriveEndpointMeta = {
 
 export const googledriveAuthConfig = {
 	oauth_2: {
-		account: ['channel_id'] as const,
+		account: ['channel_id', 'changes_page_token'] as const,
 	},
 } as const satisfies PluginAuthConfig;
 

--- a/packages/googledrive/subscribe.test.ts
+++ b/packages/googledrive/subscribe.test.ts
@@ -16,12 +16,21 @@ describe('googledriveSubscribe (BYO)', () => {
 			return { ok: true, json: async () => ({ resourceId: 'res-1' }) };
 		}) as unknown as typeof fetch;
 
-		const ctx = { keys: { get_access_token: async () => 'tok' } };
+		const saved: string[] = [];
+		const ctx = {
+			keys: {
+				get_access_token: async () => 'tok',
+				set_changes_page_token: async (value: string | null) => {
+					if (value) saved.push(value);
+				},
+			},
+		};
 		const result = await googledriveSubscribe(ctx, {
 			webhookUrl: 'https://hub.example/webhooks/uuid',
 		});
 
 		expect(result!.webhookLink.linkType).toBe('channel_id');
+		expect(saved).toEqual(['77']);
 		expect(calls[0]!.url).toBe(
 			'https://www.googleapis.com/drive/v3/changes/startPageToken',
 		);

--- a/packages/googledrive/subscribe.ts
+++ b/packages/googledrive/subscribe.ts
@@ -27,6 +27,12 @@ export async function googledriveSubscribe(
 	};
 	if (!startPageToken) return null;
 
+	await (
+		ctx.keys as {
+			set_changes_page_token?: (value: string | null) => Promise<void>;
+		}
+	).set_changes_page_token?.(startPageToken);
+
 	return googleChannelSubscribe(ctx, {
 		webhookUrl: input.webhookUrl,
 		watchUrl: `${GOOGLE_DRIVE_API_BASE}/changes/watch?pageToken=${encodeURIComponent(startPageToken)}`,

--- a/packages/googledrive/webhooks/changes.test.ts
+++ b/packages/googledrive/webhooks/changes.test.ts
@@ -1,0 +1,184 @@
+import type { Change, ChangeList } from '../types';
+import { driveChanged } from './changes';
+
+const FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder';
+
+function encodePushNotification(pageToken: string): string {
+	return Buffer.from(
+		JSON.stringify({
+			resourceId: 'res-1',
+			resourceUri: `https://www.googleapis.com/drive/v3/changes?pageToken=${pageToken}`,
+		}),
+	).toString('base64');
+}
+
+function makeRequest(pageToken = '77') {
+	return {
+		payload: { message: { data: encodePushNotification(pageToken) } },
+	} as any;
+}
+
+function makeChange(fileId: string, ageMs = 0): Change {
+	return {
+		fileId,
+		time: new Date(Date.now() - ageMs).toISOString(),
+		removed: false,
+	};
+}
+
+function jsonResponse(body: unknown) {
+	return {
+		ok: true,
+		status: 200,
+		headers: new Headers({ 'Content-Type': 'application/json' }),
+		json: async () => body,
+		text: async () => JSON.stringify(body),
+	};
+}
+
+function stubFile(fileId: string, mimeType = 'text/plain') {
+	return {
+		id: fileId,
+		name: fileId,
+		mimeType,
+		parents: [],
+		trashed: false,
+	};
+}
+
+/**
+ * Serves the changes feed one page at a time and returns a stub file for any
+ * /files/<id> lookup, so the handler can walk a change through to an event.
+ */
+function mockDriveFetch(
+	pages: ChangeList[],
+	mimeTypeFor: (fileId: string) => string = () => 'text/plain',
+) {
+	const changeRequests: string[] = [];
+
+	global.fetch = (async (url: unknown) => {
+		const href = String(url);
+
+		if (href.includes('/changes')) {
+			const pageToken = new URL(href).searchParams.get('pageToken') ?? '';
+			changeRequests.push(pageToken);
+			return jsonResponse(pages[changeRequests.length - 1] ?? { changes: [] });
+		}
+
+		if (href.includes('alt=media')) {
+			return { ok: false, status: 404, text: async () => 'no binary' };
+		}
+
+		const fileId = href.split('/files/')[1]?.split('?')[0] ?? 'unknown';
+		return jsonResponse(stubFile(fileId, mimeTypeFor(fileId)));
+	}) as unknown as typeof fetch;
+
+	return changeRequests;
+}
+
+describe('driveChanged pagination', () => {
+	const originalFetch = global.fetch;
+	const ctx = { key: 'tok' } as any;
+
+	afterEach(() => {
+		global.fetch = originalFetch;
+	});
+
+	it('follows nextPageToken until the feed is exhausted', async () => {
+		const changeRequests = mockDriveFetch([
+			{ changes: [makeChange('file-1')], nextPageToken: '78' },
+			{ changes: [makeChange('file-2')], nextPageToken: '79' },
+			{ changes: [makeChange('file-3')], newStartPageToken: '80' },
+		]);
+
+		const result = await driveChanged.handler(ctx, makeRequest('77'));
+
+		expect(result.success).toBe(true);
+		expect(changeRequests).toEqual(['77', '78', '79']);
+		expect(result.data?.allFiles).toHaveLength(3);
+		expect(result.data?.allFiles.map((f: any) => f.file.id)).toEqual([
+			'file-1',
+			'file-2',
+			'file-3',
+		]);
+	});
+
+	it('keeps fresh changes on later pages when page 1 is entirely stale', async () => {
+		// The recent-changes window is 60s; page 1 is older than that.
+		mockDriveFetch([
+			{ changes: [makeChange('old-file', 600000)], nextPageToken: '78' },
+			{ changes: [makeChange('fresh-file')], newStartPageToken: '79' },
+		]);
+
+		const result = await driveChanged.handler(ctx, makeRequest('77'));
+
+		expect(result.success).toBe(true);
+		expect(result.data?.allFiles).toHaveLength(1);
+		expect(result.data?.allFiles[0]?.file.id).toBe('fresh-file');
+		expect(result.data?.fileId).toBe('fresh-file');
+	});
+
+	it('stops after a single page when no nextPageToken is returned', async () => {
+		const changeRequests = mockDriveFetch([
+			{ changes: [makeChange('only-file')], newStartPageToken: '78' },
+		]);
+
+		const result = await driveChanged.handler(ctx, makeRequest('77'));
+
+		expect(changeRequests).toEqual(['77']);
+		expect(result.data?.allFiles).toHaveLength(1);
+	});
+
+	it('caps runaway feeds at MAX_CHANGE_PAGES', async () => {
+		const pages: ChangeList[] = Array.from({ length: 20 }, (_, i) => ({
+			changes: [makeChange(`file-${i}`)],
+			nextPageToken: String(100 + i),
+		}));
+		const changeRequests = mockDriveFetch(pages);
+
+		const result = await driveChanged.handler(ctx, makeRequest('77'));
+
+		expect(changeRequests).toHaveLength(10);
+		expect(result.data?.allFiles).toHaveLength(10);
+	});
+
+	it('breaks when nextPageToken does not advance', async () => {
+		const changeRequests = mockDriveFetch([
+			{ changes: [makeChange('file-1')], nextPageToken: '77' },
+			{ changes: [makeChange('file-2')], nextPageToken: '77' },
+		]);
+
+		await driveChanged.handler(ctx, makeRequest('77'));
+
+		expect(changeRequests).toEqual(['77']);
+	});
+
+	it('reports no changes when every page is stale', async () => {
+		mockDriveFetch([
+			{ changes: [makeChange('old-1', 600000)], nextPageToken: '78' },
+			{ changes: [makeChange('old-2', 600000)], newStartPageToken: '79' },
+		]);
+
+		const result = await driveChanged.handler(ctx, makeRequest('77'));
+
+		expect(result.success).toBe(true);
+		expect(result.data?.allFiles).toEqual([]);
+		expect(result.data?.allFolders).toEqual([]);
+	});
+
+	it('separates folders from files across pages', async () => {
+		mockDriveFetch(
+			[
+				{ changes: [makeChange('doc-1')], nextPageToken: '78' },
+				{ changes: [makeChange('dir-1')], newStartPageToken: '79' },
+			],
+			(fileId) => (fileId === 'dir-1' ? FOLDER_MIME_TYPE : 'text/plain'),
+		);
+
+		const result = await driveChanged.handler(ctx, makeRequest('77'));
+
+		expect(result.data?.allFiles).toHaveLength(1);
+		expect(result.data?.allFolders).toHaveLength(1);
+		expect(result.data?.allFolders[0]?.folder.id).toBe('dir-1');
+	});
+});

--- a/packages/googledrive/webhooks/changes.test.ts
+++ b/packages/googledrive/webhooks/changes.test.ts
@@ -18,11 +18,25 @@ function makeRequest(pageToken = '77') {
 	} as any;
 }
 
-function makeChange(fileId: string, ageMs = 0): Change {
+function makeChange(
+	fileId: string,
+	ageMs = 0,
+	overrides: Partial<Change> = {},
+): Change {
 	return {
 		fileId,
 		time: new Date(Date.now() - ageMs).toISOString(),
 		removed: false,
+		...overrides,
+	};
+}
+
+function makeKeys(stored: { token?: string | null } = {}) {
+	return {
+		get_changes_page_token: async () => stored.token ?? null,
+		set_changes_page_token: async (value: string | null) => {
+			stored.token = value;
+		},
 	};
 }
 
@@ -53,6 +67,10 @@ function stubFile(fileId: string, mimeType = 'text/plain') {
 function mockDriveFetch(
 	pages: ChangeList[],
 	mimeTypeFor: (fileId: string) => string = () => 'text/plain',
+	options: {
+		missingFileIds?: ReadonlySet<string>;
+		errorFileIds?: ReadonlyMap<string, number>;
+	} = {},
 ) {
 	const changeRequests: string[] = [];
 
@@ -70,7 +88,41 @@ function mockDriveFetch(
 		}
 
 		const fileId = href.split('/files/')[1]?.split('?')[0] ?? 'unknown';
+		const errorStatus =
+			options.errorFileIds?.get(fileId) ??
+			(options.missingFileIds?.has(fileId) ? 404 : undefined);
+		if (errorStatus !== undefined) {
+			return {
+				ok: false,
+				status: errorStatus,
+				text: async () => 'drive error',
+				json: async () => ({ error: { code: errorStatus } }),
+			};
+		}
 		return jsonResponse(stubFile(fileId, mimeTypeFor(fileId)));
+	}) as unknown as typeof fetch;
+
+	return changeRequests;
+}
+
+function mockDriveByToken(pagesByToken: Record<string, ChangeList>) {
+	const changeRequests: string[] = [];
+
+	global.fetch = (async (url: unknown) => {
+		const href = String(url);
+
+		if (href.includes('/changes')) {
+			const pageToken = new URL(href).searchParams.get('pageToken') ?? '';
+			changeRequests.push(pageToken);
+			return jsonResponse(pagesByToken[pageToken] ?? { changes: [] });
+		}
+
+		if (href.includes('alt=media')) {
+			return { ok: false, status: 404, text: async () => 'no binary' };
+		}
+
+		const fileId = href.split('/files/')[1]?.split('?')[0] ?? 'unknown';
+		return jsonResponse(stubFile(fileId));
 	}) as unknown as typeof fetch;
 
 	return changeRequests;
@@ -78,7 +130,10 @@ function mockDriveFetch(
 
 describe('driveChanged pagination', () => {
 	const originalFetch = global.fetch;
-	const ctx = { key: 'tok' } as any;
+	const ctx = {
+		key: 'tok',
+		$getAccountId: async () => 'account-1',
+	} as any;
 
 	afterEach(() => {
 		global.fetch = originalFetch;
@@ -103,8 +158,7 @@ describe('driveChanged pagination', () => {
 		]);
 	});
 
-	it('keeps fresh changes on later pages when page 1 is entirely stale', async () => {
-		// The recent-changes window is 60s; page 1 is older than that.
+	it('keeps later-page changes even when page 1 is older than 60s', async () => {
 		mockDriveFetch([
 			{ changes: [makeChange('old-file', 600000)], nextPageToken: '78' },
 			{ changes: [makeChange('fresh-file')], newStartPageToken: '79' },
@@ -113,9 +167,10 @@ describe('driveChanged pagination', () => {
 		const result = await driveChanged.handler(ctx, makeRequest('77'));
 
 		expect(result.success).toBe(true);
-		expect(result.data?.allFiles).toHaveLength(1);
-		expect(result.data?.allFiles[0]?.file.id).toBe('fresh-file');
-		expect(result.data?.fileId).toBe('fresh-file');
+		expect(result.data?.allFiles.map((f: any) => f.file.id)).toEqual([
+			'old-file',
+			'fresh-file',
+		]);
 	});
 
 	it('stops after a single page when no nextPageToken is returned', async () => {
@@ -139,7 +194,7 @@ describe('driveChanged pagination', () => {
 		const result = await driveChanged.handler(ctx, makeRequest('77'));
 
 		expect(changeRequests).toHaveLength(10);
-		expect(result.data?.allFiles).toHaveLength(10);
+		expect(result.success).toBe(false);
 	});
 
 	it('breaks when nextPageToken points back at the current page', async () => {
@@ -185,7 +240,7 @@ describe('driveChanged pagination', () => {
 		expect(result.data?.allFiles).toHaveLength(2);
 	});
 
-	it('reports no changes when every page is stale', async () => {
+	it('does not drop old changes that the Drive cursor has not advanced past', async () => {
 		mockDriveFetch([
 			{ changes: [makeChange('old-1', 600000)], nextPageToken: '78' },
 			{ changes: [makeChange('old-2', 600000)], newStartPageToken: '79' },
@@ -194,8 +249,10 @@ describe('driveChanged pagination', () => {
 		const result = await driveChanged.handler(ctx, makeRequest('77'));
 
 		expect(result.success).toBe(true);
-		expect(result.data?.allFiles).toEqual([]);
-		expect(result.data?.allFolders).toEqual([]);
+		expect(result.data?.allFiles.map((f: any) => f.file.id)).toEqual([
+			'old-1',
+			'old-2',
+		]);
 	});
 
 	it('separates folders from files across pages', async () => {
@@ -212,5 +269,213 @@ describe('driveChanged pagination', () => {
 		expect(result.data?.allFiles).toHaveLength(1);
 		expect(result.data?.allFolders).toHaveLength(1);
 		expect(result.data?.allFolders[0]?.folder.id).toBe('dir-1');
+	});
+
+	it('keeps changes older than 60s because the Drive cursor defines what is new', async () => {
+		mockDriveFetch([
+			{ changes: [makeChange('old-file', 600000)], newStartPageToken: '78' },
+		]);
+
+		const result = await driveChanged.handler(ctx, makeRequest('77'));
+
+		expect(result.success).toBe(true);
+		expect(result.data?.allFiles).toHaveLength(1);
+		expect(result.data?.allFiles[0]?.file.id).toBe('old-file');
+	});
+
+	it('deletes removed files without fetching them first', async () => {
+		const deleted: string[] = [];
+		mockDriveFetch(
+			[
+				{
+					changes: [makeChange('gone-file', 0, { removed: true })],
+					newStartPageToken: '78',
+				},
+			],
+			() => 'text/plain',
+			{ missingFileIds: new Set(['gone-file']) },
+		);
+
+		const result = await driveChanged.handler(
+			{
+				...ctx,
+				db: {
+					files: {
+						deleteByEntityId: async (id: string) => {
+							deleted.push(id);
+						},
+					},
+					folders: {
+						deleteByEntityId: async (id: string) => {
+							deleted.push(`folder:${id}`);
+						},
+					},
+				},
+			},
+			makeRequest('77'),
+		);
+
+		expect(result.success).toBe(true);
+		expect(deleted).toContain('gone-file');
+		expect(result.data?.allFiles[0]?.changeType).toBe('deleted');
+		expect(result.data?.allFiles[0]?.file.id).toBe('gone-file');
+	});
+
+	it('persists a continuation cursor and resumes there on the next notification', async () => {
+		const stored: { token?: string | null } = {};
+		const pagesByToken: Record<string, ChangeList> = {};
+		for (let i = 0; i < 12; i++) {
+			const token = String(77 + i);
+			const next = String(77 + i + 1);
+			pagesByToken[token] = {
+				changes: [makeChange(`file-${i}`)],
+				nextPageToken: next,
+			};
+		}
+		pagesByToken['87'] = {
+			changes: [makeChange('file-10')],
+			newStartPageToken: '88',
+		};
+		pagesByToken['88'] = {
+			changes: [makeChange('file-11')],
+			newStartPageToken: '89',
+		};
+
+		const changeRequests = mockDriveByToken(pagesByToken);
+		const keyedCtx = { ...ctx, keys: makeKeys(stored) };
+
+		const first = await driveChanged.handler(keyedCtx, makeRequest('77'));
+		expect(first.success).toBe(true);
+		expect(changeRequests).toEqual([
+			'77',
+			'78',
+			'79',
+			'80',
+			'81',
+			'82',
+			'83',
+			'84',
+			'85',
+			'86',
+		]);
+		expect(stored.token).toBe('87');
+
+		changeRequests.length = 0;
+		const second = await driveChanged.handler(keyedCtx, makeRequest('77'));
+		expect(second.success).toBe(true);
+		expect(changeRequests[0]).toBe('87');
+		expect(second.data?.allFiles.map((f: any) => f.file.id)).toContain(
+			'file-10',
+		);
+	});
+
+	it('persists newStartPageToken after the feed is exhausted', async () => {
+		const stored: { token?: string | null } = {};
+		mockDriveFetch([
+			{ changes: [makeChange('only-file')], newStartPageToken: '80' },
+		]);
+
+		await driveChanged.handler(
+			{ ...ctx, keys: makeKeys(stored) },
+			makeRequest('77'),
+		);
+
+		expect(stored.token).toBe('80');
+	});
+
+	it('does not warn about event logging when $getAccountId is on the context', async () => {
+		const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+		mockDriveFetch([
+			{ changes: [makeChange('file-1')], newStartPageToken: '78' },
+		]);
+
+		await driveChanged.handler(ctx, makeRequest('77'));
+
+		expect(
+			warn.mock.calls.filter((call) =>
+				String(call[0]).includes('Failed to log event'),
+			),
+		).toEqual([]);
+		warn.mockRestore();
+	});
+
+	it('does not persist the cursor when a file fetch fails with 500', async () => {
+		const stored: { token?: string | null } = { token: '77' };
+		mockDriveFetch(
+			[{ changes: [makeChange('flaky-file')], newStartPageToken: '80' }],
+			() => 'text/plain',
+			{ errorFileIds: new Map([['flaky-file', 500]]) },
+		);
+
+		const result = await driveChanged.handler(
+			{ ...ctx, keys: makeKeys(stored) },
+			makeRequest('77'),
+		);
+
+		expect(result.success).toBe(false);
+		expect(stored.token).toBe('77');
+	});
+
+	it('returns failure when the feed is truncated and the cursor cannot be stored', async () => {
+		const pages: ChangeList[] = Array.from({ length: 12 }, (_, i) => ({
+			changes: [makeChange(`file-${i}`)],
+			nextPageToken: String(100 + i),
+		}));
+		mockDriveFetch(pages);
+
+		const result = await driveChanged.handler(ctx, makeRequest('77'));
+
+		expect(result.success).toBe(false);
+		expect(result.error).toMatch(/persist/i);
+	});
+
+	it('falls back to the URI page token when the stored cursor is rejected', async () => {
+		const stored: { token?: string | null } = { token: 'bad' };
+		const changeRequests: string[] = [];
+		global.fetch = (async (url: unknown) => {
+			const href = String(url);
+
+			if (href.includes('/changes')) {
+				const pageToken = new URL(href).searchParams.get('pageToken') ?? '';
+				changeRequests.push(pageToken);
+				if (pageToken === 'bad') {
+					return {
+						ok: false,
+						status: 400,
+						statusText: 'Bad Request',
+						headers: new Headers({ 'Content-Type': 'application/json' }),
+						json: async () => ({
+							error: {
+								code: 400,
+								message: 'Invalid Value',
+								errors: [{ reason: 'invalid', location: 'pageToken' }],
+							},
+						}),
+						text: async () => 'invalidStartPageToken',
+					};
+				}
+				return jsonResponse({
+					changes: [makeChange('file-1')],
+					newStartPageToken: '80',
+				});
+			}
+
+			if (href.includes('alt=media')) {
+				return { ok: false, status: 404, text: async () => 'no binary' };
+			}
+
+			const fileId = href.split('/files/')[1]?.split('?')[0] ?? 'unknown';
+			return jsonResponse(stubFile(fileId));
+		}) as unknown as typeof fetch;
+
+		const result = await driveChanged.handler(
+			{ ...ctx, keys: makeKeys(stored) },
+			makeRequest('77'),
+		);
+
+		expect(result.success).toBe(true);
+		expect(changeRequests).toEqual(['bad', '77']);
+		expect(result.data?.allFiles[0]?.file.id).toBe('file-1');
+		expect(stored.token).toBe('80');
 	});
 });

--- a/packages/googledrive/webhooks/changes.test.ts
+++ b/packages/googledrive/webhooks/changes.test.ts
@@ -142,15 +142,47 @@ describe('driveChanged pagination', () => {
 		expect(result.data?.allFiles).toHaveLength(10);
 	});
 
-	it('breaks when nextPageToken does not advance', async () => {
+	it('breaks when nextPageToken points back at the current page', async () => {
 		const changeRequests = mockDriveFetch([
 			{ changes: [makeChange('file-1')], nextPageToken: '77' },
 			{ changes: [makeChange('file-2')], nextPageToken: '77' },
 		]);
 
-		await driveChanged.handler(ctx, makeRequest('77'));
+		const result = await driveChanged.handler(ctx, makeRequest('77'));
 
 		expect(changeRequests).toEqual(['77']);
+		expect(result.data?.allFiles).toHaveLength(1);
+	});
+
+	it('breaks on a multi-step cycle without refetching pages', async () => {
+		// 77 → 78 → 77: each token advances, so a same-token check alone would
+		// keep looping and duplicate file-1/file-2 until the page cap.
+		const changeRequests: string[] = [];
+		global.fetch = (async (url: unknown) => {
+			const href = String(url);
+
+			if (href.includes('/changes')) {
+				const pageToken = new URL(href).searchParams.get('pageToken') ?? '';
+				changeRequests.push(pageToken);
+				return jsonResponse(
+					pageToken === '77'
+						? { changes: [makeChange('file-1')], nextPageToken: '78' }
+						: { changes: [makeChange('file-2')], nextPageToken: '77' },
+				);
+			}
+
+			if (href.includes('alt=media')) {
+				return { ok: false, status: 404, text: async () => 'no binary' };
+			}
+
+			const fileId = href.split('/files/')[1]?.split('?')[0] ?? 'unknown';
+			return jsonResponse(stubFile(fileId));
+		}) as unknown as typeof fetch;
+
+		const result = await driveChanged.handler(ctx, makeRequest('77'));
+
+		expect(changeRequests).toEqual(['77', '78']);
+		expect(result.data?.allFiles).toHaveLength(2);
 	});
 
 	it('reports no changes when every page is stale', async () => {

--- a/packages/googledrive/webhooks/changes.ts
+++ b/packages/googledrive/webhooks/changes.ts
@@ -1,12 +1,13 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeGoogleDriveRequest } from '../client';
 import type { GoogleDriveWebhooks } from '../index';
-import type { ChangeList, File } from '../types';
+import type { Change, ChangeList, File } from '../types';
 import { createGoogleDriveWebhookMatcher, decodePubSubMessage } from './types';
 
 const PAGE_TOKEN_PATTERN = /[?&]pageToken=([^&]+)/;
 const FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder';
 const RECENT_CHANGES_WINDOW_MS = 60000;
+const MAX_CHANGE_PAGES = 10;
 const FILE_FIELDS = [
 	'id',
 	'name',
@@ -89,6 +90,27 @@ async function fetchChanges(
 	});
 }
 
+async function fetchAllChanges(
+	credentials: string,
+	startPageToken: string,
+): Promise<{ changes: Change[]; newStartPageToken?: string }> {
+	const changes: Change[] = [];
+	let pageToken: string | undefined = startPageToken;
+	let newStartPageToken: string | undefined;
+
+	for (let page = 0; pageToken && page < MAX_CHANGE_PAGES; page++) {
+		const response: ChangeList = await fetchChanges(credentials, pageToken);
+		changes.push(...(response.changes ?? []));
+		newStartPageToken = response.newStartPageToken ?? newStartPageToken;
+
+		// A token that does not advance would loop forever.
+		if (response.nextPageToken === pageToken) break;
+		pageToken = response.nextPageToken;
+	}
+
+	return { changes, newStartPageToken };
+}
+
 async function buildFilePath(
 	credentials: string,
 	file: File,
@@ -162,10 +184,11 @@ export const driveChanged: GoogleDriveWebhooks['driveChanged'] = {
 		}
 
 		try {
-			const changesResponse = await fetchChanges(credentials, pageToken);
-			let changes = changesResponse.changes ?? [];
-
-			changes = filterRecentChanges(changes);
+			const { changes: allChanges } = await fetchAllChanges(
+				credentials,
+				pageToken,
+			);
+			const changes = filterRecentChanges(allChanges);
 
 			let corsairEntityId = '';
 

--- a/packages/googledrive/webhooks/changes.ts
+++ b/packages/googledrive/webhooks/changes.ts
@@ -90,21 +90,33 @@ async function fetchChanges(
 	});
 }
 
+/**
+ * Drives the changes feed to exhaustion. Google returns at most `pageSize`
+ * changes per call and hands back a `nextPageToken` while more are pending;
+ * the final page carries `newStartPageToken` instead, which is the cursor to
+ * watch from next cycle. Capped at MAX_CHANGE_PAGES so a large backlog cannot
+ * stall the webhook response.
+ */
 async function fetchAllChanges(
 	credentials: string,
 	startPageToken: string,
 ): Promise<{ changes: Change[]; newStartPageToken?: string }> {
 	const changes: Change[] = [];
+	// Tokens already requested. A feed that points back at any earlier page
+	// (77 → 78 → 77, not just 77 → 77) would otherwise refetch the same pages
+	// and duplicate their changes until the page cap stopped it.
+	const requestedTokens = new Set<string>();
 	let pageToken: string | undefined = startPageToken;
 	let newStartPageToken: string | undefined;
 
 	for (let page = 0; pageToken && page < MAX_CHANGE_PAGES; page++) {
+		if (requestedTokens.has(pageToken)) break;
+		requestedTokens.add(pageToken);
+
 		const response: ChangeList = await fetchChanges(credentials, pageToken);
 		changes.push(...(response.changes ?? []));
 		newStartPageToken = response.newStartPageToken ?? newStartPageToken;
 
-		// A token that does not advance would loop forever.
-		if (response.nextPageToken === pageToken) break;
 		pageToken = response.nextPageToken;
 	}
 

--- a/packages/googledrive/webhooks/changes.ts
+++ b/packages/googledrive/webhooks/changes.ts
@@ -1,4 +1,5 @@
 import { logEventFromContext } from 'corsair/core';
+import { ApiError } from 'corsair/http';
 import { makeGoogleDriveRequest } from '../client';
 import type { GoogleDriveWebhooks } from '../index';
 import type { Change, ChangeList, File } from '../types';
@@ -6,7 +7,6 @@ import { createGoogleDriveWebhookMatcher, decodePubSubMessage } from './types';
 
 const PAGE_TOKEN_PATTERN = /[?&]pageToken=([^&]+)/;
 const FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder';
-const RECENT_CHANGES_WINDOW_MS = 60000;
 const MAX_CHANGE_PAGES = 10;
 const FILE_FIELDS = [
 	'id',
@@ -27,25 +27,78 @@ const FILE_FIELDS = [
 	'originalFilename',
 ].join(',');
 
+type ChangeCursorKeys = {
+	get_changes_page_token?: () => Promise<string | null>;
+	set_changes_page_token?: (value: string | null) => Promise<void>;
+};
+
+type ChangeType = 'created' | 'updated' | 'deleted' | 'trashed' | 'untrashed';
+
+type FileEvent = {
+	file: File;
+	filePath: string;
+	change: Change;
+	changeType: ChangeType;
+	binaryData: string | null;
+};
+
+type FolderEvent = {
+	folder: File;
+	filePath: string;
+	change: Change;
+	changeType: ChangeType;
+};
+
+type FileFetch =
+	| { status: 'ok'; file: File }
+	| { status: 'missing' }
+	| { status: 'failed' };
+
 function parsePageTokenFromUri(resourceUri: string): string | undefined {
 	return resourceUri.match(PAGE_TOKEN_PATTERN)?.[1];
+}
+
+function isRetryableFetchError(error: unknown): boolean {
+	if (error instanceof ApiError) {
+		return error.status >= 500 || error.status === 429;
+	}
+	return true;
+}
+
+function isInvalidPageTokenError(error: unknown): boolean {
+	if (!(error instanceof ApiError) || error.status !== 400) return false;
+	const haystack = `${error.message} ${JSON.stringify(error.body ?? {})}`;
+	return /invalidStartPageToken|pageToken|Invalid Value/i.test(haystack);
 }
 
 async function fetchFile(
 	credentials: string,
 	fileId: string,
-): Promise<File | null> {
+): Promise<FileFetch> {
 	try {
-		return await makeGoogleDriveRequest<File>(`/files/${fileId}`, credentials, {
-			method: 'GET',
-			query: {
-				supportsAllDrives: true,
-				fields: FILE_FIELDS,
+		const file = await makeGoogleDriveRequest<File>(
+			`/files/${fileId}`,
+			credentials,
+			{
+				method: 'GET',
+				query: {
+					supportsAllDrives: true,
+					fields: FILE_FIELDS,
+				},
 			},
-		});
+		);
+		return { status: 'ok', file };
 	} catch (error) {
+		if (
+			error instanceof ApiError &&
+			(error.status === 404 || error.status === 410)
+		) {
+			return { status: 'missing' };
+		}
 		console.warn(`Failed to fetch file ${fileId}:`, error);
-		return null;
+		return isRetryableFetchError(error)
+			? { status: 'failed' }
+			: { status: 'missing' };
 	}
 }
 
@@ -95,12 +148,14 @@ async function fetchChanges(
  * changes per call and hands back a `nextPageToken` while more are pending;
  * the final page carries `newStartPageToken` instead, which is the cursor to
  * watch from next cycle. Capped at MAX_CHANGE_PAGES so a large backlog cannot
- * stall the webhook response.
+ * stall the webhook response. When the cap hits, `resumeToken` is the next
+ * unread page so the following notification can continue instead of restarting
+ * from the original watch token.
  */
 async function fetchAllChanges(
 	credentials: string,
 	startPageToken: string,
-): Promise<{ changes: Change[]; newStartPageToken?: string }> {
+): Promise<{ changes: Change[]; resumeToken?: string; truncated: boolean }> {
 	const changes: Change[] = [];
 	// Tokens already requested. A feed that points back at any earlier page
 	// (77 → 78 → 77, not just 77 → 77) would otherwise refetch the same pages
@@ -120,7 +175,41 @@ async function fetchAllChanges(
 		pageToken = response.nextPageToken;
 	}
 
-	return { changes, newStartPageToken };
+	const truncated = Boolean(pageToken && !requestedTokens.has(pageToken));
+	const resumeToken = truncated ? pageToken : newStartPageToken;
+
+	return { changes, resumeToken, truncated };
+}
+
+async function readResumeToken(ctx: { keys?: object }): Promise<string | null> {
+	try {
+		const keys = ctx.keys as ChangeCursorKeys | undefined;
+		return (await keys?.get_changes_page_token?.()) ?? null;
+	} catch (error) {
+		console.warn('Failed to read Drive changes cursor:', error);
+		return null;
+	}
+}
+
+async function writeResumeToken(
+	ctx: { keys?: object },
+	token: string | undefined,
+	expectedStart?: string,
+): Promise<'written' | 'cas-lost' | 'failed'> {
+	if (!token) return 'written';
+	const keys = ctx.keys as ChangeCursorKeys | undefined;
+	if (!keys?.set_changes_page_token) return 'failed';
+	try {
+		const current = (await keys.get_changes_page_token?.()) ?? null;
+		if (current && expectedStart && current !== expectedStart) {
+			return 'cas-lost';
+		}
+		await keys.set_changes_page_token(token);
+		return 'written';
+	} catch (error) {
+		console.warn('Failed to persist Drive changes cursor:', error);
+		return 'failed';
+	}
 }
 
 async function buildFilePath(
@@ -135,12 +224,12 @@ async function buildFilePath(
 		const parentId = currentParents[0];
 		if (!parentId) break;
 		const parent = await fetchFile(credentials, parentId);
-		if (!parent?.name) break;
-		if (!parent.parents?.length) {
+		if (parent.status !== 'ok' || !parent.file.name) break;
+		if (!parent.file.parents?.length) {
 			break;
 		}
-		parts.unshift(parent.name);
-		currentParents = parent.parents;
+		parts.unshift(parent.file.name);
+		currentParents = parent.file.parents;
 		depth++;
 	}
 	return '/' + parts.join('/');
@@ -149,25 +238,61 @@ async function buildFilePath(
 function determineChangeType(
 	change: ChangeList['changes'] extends (infer T)[] | undefined ? T : never,
 	file: File,
-	isFirstMatch: boolean,
 ): 'created' | 'updated' | 'deleted' | 'trashed' | 'untrashed' {
 	if (change.removed) return 'deleted';
 	if (file.trashed) return 'trashed';
 	return 'updated';
 }
 
-function filterRecentChanges<T extends { time?: string }>(
-	changes: T[],
-	maxAgeMs: number = RECENT_CHANGES_WINDOW_MS,
-): T[] {
-	if (changes.length === 0) return changes;
+async function applyRemovedChange(
+	ctx: {
+		db?: {
+			files?: { deleteByEntityId: (id: string) => Promise<unknown> };
+			folders?: { deleteByEntityId: (id: string) => Promise<unknown> };
+		};
+	},
+	change: Change,
+	files: FileEvent[],
+	folders: FolderEvent[],
+): Promise<boolean> {
+	const fileId = change.fileId;
+	if (!fileId) return true;
 
-	const now = Date.now();
-	return changes.filter((change) => {
-		if (!change.time) return true;
-		const changeTime = new Date(change.time).getTime();
-		return now - changeTime <= maxAgeMs;
+	const file: File = change.file ?? { id: fileId };
+	const isFolder = file.mimeType === FOLDER_MIME_TYPE;
+
+	try {
+		if (isFolder) {
+			await ctx.db?.folders?.deleteByEntityId(fileId);
+		} else {
+			await ctx.db?.files?.deleteByEntityId(fileId);
+		}
+		if (!file.mimeType) {
+			await ctx.db?.folders?.deleteByEntityId(fileId);
+		}
+	} catch (error) {
+		console.warn(`Failed to delete ${fileId} from database:`, error);
+		return false;
+	}
+
+	if (isFolder) {
+		folders.push({
+			folder: file,
+			filePath: '',
+			change,
+			changeType: 'deleted',
+		});
+		return true;
+	}
+
+	files.push({
+		file,
+		filePath: '',
+		change,
+		changeType: 'deleted',
+		binaryData: null,
 	});
+	return true;
 }
 
 export const driveChanged: GoogleDriveWebhooks['driveChanged'] = {
@@ -186,74 +311,79 @@ export const driveChanged: GoogleDriveWebhooks['driveChanged'] = {
 		}
 
 		const credentials = ctx.key;
-		const pageToken = parsePageTokenFromUri(pushNotification.resourceUri!);
-
-		if (!pageToken) {
-			return {
-				success: false,
-				error: 'Could not parse pageToken from resource URI',
-			};
-		}
+		const uriPageToken = parsePageTokenFromUri(pushNotification.resourceUri!);
 
 		try {
-			const { changes: allChanges } = await fetchAllChanges(
-				credentials,
-				pageToken,
-			);
-			const changes = filterRecentChanges(allChanges);
+			const storedPageToken = await readResumeToken(ctx);
+			const startPageToken = storedPageToken ?? uriPageToken;
 
-			let corsairEntityId = '';
-
-			if (changes.length === 0) {
+			if (!startPageToken) {
 				return {
-					success: true,
-					corsairEntityId: '',
-					data: {
-						type: 'fileChanged' as const,
-						fileId: pushNotification.resourceId ?? '',
-						changeType: 'updated' as const,
-						allFiles: [],
-						allFolders: [],
-					},
+					success: false,
+					error: 'Could not parse pageToken from resource URI',
 				};
 			}
 
-			const files = [];
-			const folders = [];
+			let fetched: {
+				changes: Change[];
+				resumeToken?: string;
+				truncated: boolean;
+			};
+			try {
+				fetched = await fetchAllChanges(credentials, startPageToken);
+			} catch (error) {
+				if (
+					storedPageToken &&
+					uriPageToken &&
+					storedPageToken !== uriPageToken &&
+					isInvalidPageTokenError(error)
+				) {
+					fetched = await fetchAllChanges(credentials, uriPageToken);
+				} else {
+					throw error;
+				}
+			}
+
+			const { changes, resumeToken, truncated } = fetched;
+			let applyFailed = false;
+			let corsairEntityId = '';
+			const files: FileEvent[] = [];
+			const folders: FolderEvent[] = [];
 
 			for (const change of changes) {
 				if (!change.fileId) continue;
 
-				const file = await fetchFile(credentials, change.fileId);
-				if (!file) continue;
+				if (change.removed) {
+					const removed = await applyRemovedChange(ctx, change, files, folders);
+					if (!removed) applyFailed = true;
+					continue;
+				}
 
+				const fetchedFile = await fetchFile(credentials, change.fileId);
+				if (fetchedFile.status === 'failed') {
+					applyFailed = true;
+					continue;
+				}
+				if (fetchedFile.status === 'missing') continue;
+
+				const file = fetchedFile.file;
 				const isFolder = file.mimeType === FOLDER_MIME_TYPE;
-				const filePath = change.removed
-					? ''
-					: await buildFilePath(credentials, file);
-
-				const changeType = determineChangeType(
-					change,
-					file,
-					files.length === 0 && folders.length === 0,
-				);
+				const filePath = await buildFilePath(credentials, file);
+				const changeType = determineChangeType(change, file);
 
 				if (isFolder) {
 					if (ctx.db?.folders && file.id) {
 						try {
-							if (changeType === 'deleted') {
-								await ctx.db.folders.deleteByEntityId(file.id);
-							} else {
-								const entity = await ctx.db.folders.upsertByEntityId(file.id, {
-									...file,
-									id: file.id,
-									filePath,
-								});
-								if (!corsairEntityId && entity?.id) {
-									corsairEntityId = entity.id;
-								}
+							const entity = await ctx.db.folders.upsertByEntityId(file.id, {
+								...file,
+								id: file.id,
+								filePath,
+							});
+							if (!corsairEntityId && entity?.id) {
+								corsairEntityId = entity.id;
 							}
 						} catch (error) {
+							applyFailed = true;
 							console.warn(
 								`Failed to save folder ${file.id} to database:`,
 								error,
@@ -272,20 +402,17 @@ export const driveChanged: GoogleDriveWebhooks['driveChanged'] = {
 
 					if (ctx.db?.files && file.id) {
 						try {
-							if (changeType === 'deleted') {
-								await ctx.db.files.deleteByEntityId(file.id);
-							} else {
-								const entity = await ctx.db.files.upsertByEntityId(file.id, {
-									...file,
-									id: file.id,
-									filePath,
-								});
+							const entity = await ctx.db.files.upsertByEntityId(file.id, {
+								...file,
+								id: file.id,
+								filePath,
+							});
 
-								if (!corsairEntityId && entity?.id) {
-									corsairEntityId = entity.id;
-								}
+							if (!corsairEntityId && entity?.id) {
+								corsairEntityId = entity.id;
 							}
 						} catch (error) {
+							applyFailed = true;
 							console.warn(
 								`Failed to save file ${file.id} to database:`,
 								error,
@@ -301,6 +428,40 @@ export const driveChanged: GoogleDriveWebhooks['driveChanged'] = {
 						binaryData,
 					});
 				}
+			}
+
+			if (applyFailed) {
+				return {
+					success: false,
+					error: 'Failed to apply one or more Drive changes',
+				};
+			}
+
+			const persisted = await writeResumeToken(
+				ctx,
+				resumeToken,
+				startPageToken,
+			);
+			if (truncated && persisted === 'failed') {
+				return {
+					success: false,
+					error:
+						'Truncated changes feed but could not persist continuation cursor',
+				};
+			}
+
+			if (files.length === 0 && folders.length === 0) {
+				return {
+					success: true,
+					corsairEntityId: '',
+					data: {
+						type: 'fileChanged' as const,
+						fileId: pushNotification.resourceId ?? '',
+						changeType: 'updated' as const,
+						allFiles: [],
+						allFolders: [],
+					},
+				};
 			}
 
 			const firstFolder = folders[0];


### PR DESCRIPTION
## Description

`packages/googledrive/webhooks/changes.ts` fetched the changes feed once with `pageSize: 100` and never followed `nextPageToken`, so any backlog beyond the first page was silently dropped.

The recent-changes filter compounded this. Page 1 holds the **oldest** changes, so it could filter down to empty, hit the "no changes" early return, and the fresh changes waiting on later pages were never fetched at all.

**Changes:**

- Added `fetchAllChanges()`, which follows `nextPageToken` until the feed is exhausted, capped at `MAX_CHANGE_PAGES` (10 × `pageSize: 100` = 1,000 changes per ping) so a large backlog cannot stall the webhook response.
- Breaks out of the loop if `nextPageToken` fails to advance, guarding against an infinite loop on a malformed response.
- Moved `filterRecentChanges()` so it runs on the **combined** result rather than per page. This is the core fix — filtering per page is what let a stale page 1 mask fresh changes on page 2.
- Added `webhooks/changes.test.ts` (7 tests) with mocked multi-page responses.

`newStartPageToken` is captured by `fetchAllChanges` but not persisted. Resuming from it requires changes to `schema/database.ts` and `subscribe.ts`; the issue marked this optional, so it is left out to keep the PR in scope. See Additional Notes.

Fixes #588

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

<img width="433" height="202" alt="image" src="https://github.com/user-attachments/assets/06b447f1-dfa6-4b46-9ed8-a7347be9474f" />


## Additional Notes

**On the page cap:** capping at 10 pages means a backlog over 1,000 changes still loses its tail, the same class of bug as the one being fixed, at a 10× higher threshold. The trade is deliberate: without a cap, a large backlog times out the webhook and loses *everything*, since the handler makes up to ~20 sequential requests per change (`fetchFile`, `buildFilePath` walking parents, `fetchFileBinary`). Partial delivery beats total failure.

Persisting `newStartPageToken` would close that gap properly by resuming from the cursor next cycle, turning the cap into a latency cost rather than a data loss. Happy to raise the cap or do the persistence work in this PR if preferred.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google Drive change notifications now process multiple pages of changes, ensuring more recent updates are detected reliably.
  * Added safeguards to prevent pagination loops and limit excessive page retrieval.

* **Bug Fixes**
  * Improved handling of stale changes and multi-page results.
  * Correctly identifies updated files and folders across paginated results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->