### PR TITLE
fix(telegram): fail closed when no webhook secret token is configured

### DIFF
--- a/packages/telegram/jest.config.cjs
+++ b/packages/telegram/jest.config.cjs
@@ -44,6 +44,7 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',
 	},

--- a/packages/telegram/webhooks/types.ts
+++ b/packages/telegram/webhooks/types.ts
@@ -265,8 +265,7 @@ export function verifyTelegramWebhookSignature(
 	secretToken: string,
 ): { valid: boolean; error?: string } {
 	if (!secretToken) {
-		// No secret configured — skip verification (valid deployment scenario)
-		return { valid: true };
+		return { valid: false, error: 'Missing webhook secret' };
 	}
 
 	const headers = request.headers;

--- a/packages/telegram/webhooks/webhooks.test.ts
+++ b/packages/telegram/webhooks/webhooks.test.ts
@@ -1,0 +1,140 @@
+import type { WebhookRequest } from 'corsair/core';
+import type { TelegramContext } from '../index';
+import { message } from './message';
+import { verifyTelegramWebhookSignature } from './types';
+
+const SECRET = 'telegram-secret-token';
+
+function makeRequest(
+	payload: unknown,
+	headers: Record<string, string | string[]> = {},
+): WebhookRequest<unknown> {
+	return {
+		payload,
+		rawBody: JSON.stringify(payload),
+		headers,
+	} as unknown as WebhookRequest<unknown>;
+}
+
+function makeCtx(key: string): TelegramContext {
+	return {
+		key,
+		db: {
+			messages: {
+				upsertByEntityId: jest.fn().mockResolvedValue({ id: 'entity-1' }),
+			},
+		},
+	} as unknown as TelegramContext;
+}
+
+const messageUpdate = {
+	update_id: 1,
+	message: {
+		message_id: 42,
+		date: 1747872000,
+		chat: { id: 1234, type: 'private' },
+		from: { id: 9999, is_bot: false, first_name: 'Mallory' },
+		text: 'a forged message',
+	},
+};
+
+describe('verifyTelegramWebhookSignature', () => {
+	it('should fail closed when no secret token is configured', () => {
+		// The regression: an unset secret returned { valid: true }, so any caller
+		// who knew the webhook URL was treated as Telegram.
+		const result = verifyTelegramWebhookSignature(
+			makeRequest(messageUpdate),
+			'',
+		);
+		expect(result).toEqual({ valid: false, error: 'Missing webhook secret' });
+	});
+
+	it('should reject a request with no secret-token header', () => {
+		const result = verifyTelegramWebhookSignature(
+			makeRequest(messageUpdate),
+			SECRET,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing x-telegram-bot-api-secret-token header',
+		});
+	});
+
+	it('should reject a mismatched secret token', () => {
+		const result = verifyTelegramWebhookSignature(
+			makeRequest(messageUpdate, {
+				'x-telegram-bot-api-secret-token': 'wrong',
+			}),
+			SECRET,
+		);
+		expect(result).toEqual({ valid: false, error: 'Invalid secret token' });
+	});
+
+	it('should accept a matching secret token', () => {
+		const result = verifyTelegramWebhookSignature(
+			makeRequest(messageUpdate, {
+				'x-telegram-bot-api-secret-token': SECRET,
+			}),
+			SECRET,
+		);
+		expect(result).toEqual({ valid: true, error: undefined });
+	});
+
+	it('should accept the header when provided as an array', () => {
+		const result = verifyTelegramWebhookSignature(
+			makeRequest(messageUpdate, {
+				'x-telegram-bot-api-secret-token': [SECRET],
+			}),
+			SECRET,
+		);
+		expect(result.valid).toBe(true);
+	});
+});
+
+describe('message handler', () => {
+	it('rejects with 401 and persists nothing when no secret is configured', async () => {
+		// This is the consequence the fix is really about: the handler upserts
+		// attacker-controlled message content, so an unverified request must not
+		// reach the database.
+		const ctx = makeCtx('');
+		const result = await message.handler(
+			ctx,
+			makeRequest(messageUpdate) as never,
+		);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.statusCode).toBe(401);
+		}
+		expect(ctx.db.messages?.upsertByEntityId).not.toHaveBeenCalled();
+	});
+
+	it('rejects a forged secret token with 401 and persists nothing', async () => {
+		const ctx = makeCtx(SECRET);
+		const result = await message.handler(
+			ctx,
+			makeRequest(messageUpdate, {
+				'x-telegram-bot-api-secret-token': 'wrong',
+			}) as never,
+		);
+
+		expect(result.success).toBe(false);
+		expect(ctx.db.messages?.upsertByEntityId).not.toHaveBeenCalled();
+	});
+
+	it('accepts a correctly signed update and persists the message', async () => {
+		const ctx = makeCtx(SECRET);
+		const result = await message.handler(
+			ctx,
+			makeRequest(messageUpdate, {
+				'x-telegram-bot-api-secret-token': SECRET,
+			}) as never,
+		);
+
+		expect(result.success).toBe(true);
+		expect(ctx.db.messages?.upsertByEntityId).toHaveBeenCalledWith(
+			'42',
+			expect.objectContaining({ id: '42', chat_id: '1234' }),
+		);
+	});
+});

--- a/packages/telegram/webhooks/webhooks.test.ts
+++ b/packages/telegram/webhooks/webhooks.test.ts
@@ -1,33 +1,43 @@
 import type { WebhookRequest } from 'corsair/core';
 import type { TelegramContext } from '../index';
 import { message } from './message';
+import type { MessageEvent } from './types';
 import { verifyTelegramWebhookSignature } from './types';
 
 const SECRET = 'telegram-secret-token';
 
-function makeRequest(
-	payload: unknown,
+type MessageContextFixture = Pick<TelegramContext, 'key' | '$getAccountId'> & {
+	db: {
+		messages: Pick<TelegramContext['db']['messages'], 'upsertByEntityId'>;
+	};
+};
+
+function makeRequest<TPayload>(
+	payload: TPayload,
 	headers: Record<string, string | string[]> = {},
-): WebhookRequest<unknown> {
+): WebhookRequest<TPayload> {
 	return {
 		payload,
 		rawBody: JSON.stringify(payload),
 		headers,
-	} as unknown as WebhookRequest<unknown>;
+	};
 }
 
 function makeCtx(key: string): TelegramContext {
-	return {
+	const fixture = {
 		key,
 		db: {
 			messages: {
 				upsertByEntityId: jest.fn().mockResolvedValue({ id: 'entity-1' }),
 			},
 		},
-	} as unknown as TelegramContext;
+		$getAccountId: jest.fn().mockResolvedValue('account-1'),
+	} satisfies MessageContextFixture;
+
+	return fixture as unknown as TelegramContext;
 }
 
-const messageUpdate = {
+const messageUpdate: MessageEvent = {
 	update_id: 1,
 	message: {
 		message_id: 42,
@@ -92,15 +102,16 @@ describe('verifyTelegramWebhookSignature', () => {
 });
 
 describe('message handler', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
 	it('rejects with 401 and persists nothing when no secret is configured', async () => {
 		// This is the consequence the fix is really about: the handler upserts
 		// attacker-controlled message content, so an unverified request must not
 		// reach the database.
 		const ctx = makeCtx('');
-		const result = await message.handler(
-			ctx,
-			makeRequest(messageUpdate) as never,
-		);
+		const result = await message.handler(ctx, makeRequest(messageUpdate));
 
 		expect(result.success).toBe(false);
 		if (!result.success) {
@@ -115,7 +126,7 @@ describe('message handler', () => {
 			ctx,
 			makeRequest(messageUpdate, {
 				'x-telegram-bot-api-secret-token': 'wrong',
-			}) as never,
+			}),
 		);
 
 		expect(result.success).toBe(false);
@@ -123,15 +134,17 @@ describe('message handler', () => {
 	});
 
 	it('accepts a correctly signed update and persists the message', async () => {
+		const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
 		const ctx = makeCtx(SECRET);
 		const result = await message.handler(
 			ctx,
 			makeRequest(messageUpdate, {
 				'x-telegram-bot-api-secret-token': SECRET,
-			}) as never,
+			}),
 		);
 
 		expect(result.success).toBe(true);
+		expect(warnSpy).not.toHaveBeenCalled();
 		expect(ctx.db.messages?.upsertByEntityId).toHaveBeenCalledWith(
 			'42',
 			expect.objectContaining({ id: '42', chat_id: '1234' }),


### PR DESCRIPTION
## Description

Fixes #628.

`verifyTelegramWebhookSignature` returned `{ valid: true }` whenever no secret token was configured, so any caller who knew the webhook URL was treated as Telegram.

```ts
// before
if (!secretToken) {
	// No secret configured — skip verification (valid deployment scenario)
	return { valid: true };
}
```
```ts
// after
if (!secretToken) {
	return { valid: false, error: 'Missing webhook secret' };
}
```

One line, matching the shape and `'Missing webhook secret'` string adopted across this family (#594, #595, #581, #585).

### Why this one has teeth

I found this by grepping the remaining plugins for the same shape after the earlier fixes, and it is the one instance where the fail-open leads somewhere. The other plugins in this family stopped short of acting on the unverified request. `packages/telegram/webhooks/message.ts` does not:

```ts
const entity = await ctx.db.messages.upsertByEntityId(
	event.message.message_id.toString(),
	{
		...event.message,
		id: event.message.message_id.toString(),
		chat_id: event.message.chat.id.toString(),
		authorId: event.message.from?.id.toString(),
		createdAt: new Date(event.message.date * 1000),
	},
);
```

Every value there comes from the request body. Against a deployment with no secret token, an unauthenticated caller can insert rows with an arbitrary `message_id`, `chat_id`, `authorId`, text and timestamp — forging messages attributed to a chosen user in a chosen chat. Because it's an upsert keyed on `message_id`, it can also **overwrite a genuine message**. The other nine handlers call the same verifier first.

Telegram's `secret_token` is an *optional* `setWebhook` parameter, so an unset secret is the default rather than an exotic misconfiguration.

## Tests

`packages/telegram/webhooks/webhooks.test.ts`, 8 tests, all passing.

**Verifier** — missing secret → `Missing webhook secret`; missing header; mismatched token; matching token; array-valued header.

**Handler** — and this is the part that matters:

- no secret configured → 401 **and** `ctx.db.messages.upsertByEntityId` never called
- forged token → 401 **and** no upsert
- correct token → success, message persisted with the expected id and chat_id

## Checklist

- [x] I have run `pnpm lint` and all checks pass — lint-staged (`biome check --write`) ran clean on both commits
- [x] I have run `pnpm typecheck` and there are no TypeScript errors — `tsc --build packages/telegram` clean
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass — green in CI; **see note** for local runs
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation — none required, no public API or plugin option changed

**On the test box.** My suite passes 8/8. The package's two pre-existing suites fail identically on clean `main` (`api.test.ts` needs live credentials, `integration.test.ts` needs a workspace build), unchanged here:

```
clean main:   Test Suites: 2 failed, 2 total            Tests: 12 failed, 1 passed, 13 total
this branch:  Test Suites: 2 failed, 1 passed, 3 total  Tests: 12 failed, 9 passed, 21 total
                                     ^ +1 (mine)               ^ identical  ^ +8 (mine)
```

### One extra line: the jest config

`packages/telegram/jest.config.cjs` mapped `corsair/http` but not `corsair/core`. The handler imports `logEventFromContext` from `corsair/core`, so without that mapping the suite can't import a handler at all — it dies with `Cannot find module 'corsair/core'` before a single assertion. Added the one mapping, copied from `packages/cloudinary/jest.config.cjs`, which already does handler-level webhook tests. Still inside `packages/telegram/**`, so R1 holds.

## Screenshots / Demos (if applicable)

Per R4's rationale ("neither CI nor review bots can call the real third-party API") — this is a local string comparison, calls no Telegram endpoint, and needs no credentials. The tests are the verification and they run in CI:

```
$ pnpm --filter @corsair-dev/telegram test

 PASS  webhooks/webhooks.test.ts
  verifyTelegramWebhookSignature
    √ should fail closed when no secret token is configured
    √ should reject a request with no secret-token header
    √ should reject a mismatched secret token
    √ should accept a matching secret token
    √ should accept the header when provided as an array
  message handler
    √ rejects with 401 and persists nothing when no secret is configured
    √ rejects a forged secret token with 401 and persists nothing
    √ accepts a correctly signed update and persists the message
```

**Working proof:** the CI run for this branch executes that suite on your infrastructure rather than my machine — repo CI: https://github.com/corsairdev/corsair/actions

To be straight about it: that is CI, not a screen recording. I can't record one, and there's nothing to film here — no UI, no CLI output, no third-party call. If a recording is required regardless, say so and I'll arrange it.

## Additional Notes

- Scope is `packages/telegram/**` only (R1).
- **Behaviour-changing for live traffic**, and worth a release note: any deployment currently running Telegram webhooks *without* a `secret_token` will start getting 401s until one is set via `setWebhook`. That is the intent, but unlike the other fixes in this family it will bite working (if insecure) installs.
- Out of scope but noted while in the file: the check is `providedToken === secretToken`, a plain comparison of a shared secret rather than a timing-safe one — same observation as on #609 for GitLab. Happy to send that separately.
- This was the last instance of the fail-open family I could find; #626/#627 cover a different root cause (empty `value[]`) in the Graph plugins.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Telegram webhook requests are now rejected when no webhook secret is configured.
  * Invalid, missing, or unauthorized signature headers now consistently return an unauthorized response.
  * Unauthorized webhook requests no longer create or persist messages.
  * Valid requests continue to be accepted, including supported string and array header formats.

* **Tests**
  * Added comprehensive coverage for webhook authentication and message handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->