### PR TITLE
fix(hub): surface OAuth callback URL on connect session results

### DIFF
--- a/packages/corsair/core/management/operations.ts
+++ b/packages/corsair/core/management/operations.ts
@@ -436,6 +436,7 @@ async function createHubModeConnectLink(
 	return {
 		connectUrl: session.connectUrl,
 		expiresAt: session.expiresAt,
+		oauthCallbackUrl: session.oauthCallbackUrl,
 	};
 }
 

--- a/packages/corsair/core/management/types.ts
+++ b/packages/corsair/core/management/types.ts
@@ -61,6 +61,14 @@ export type CreateConnectLinkInput = {
 export type ConnectLink = {
 	connectUrl: string;
 	expiresAt?: string;
+	/**
+	 * Hub mode only. OAuth callback URL the Hub uses to finish the provider
+	 * flow. With BYO, the app must register this exact URL on its own OAuth
+	 * app; with managed auth, the Hub's registered app is used. Exposed so
+	 * consumers can verify registration instead of chasing a generic provider
+	 * error.
+	 */
+	oauthCallbackUrl?: string;
 };
 
 export type ResolvedConnectLink = {

--- a/packages/corsair/hub/connect.ts
+++ b/packages/corsair/hub/connect.ts
@@ -2,7 +2,11 @@ import type { CorsairPlugin } from '../core/plugins';
 import { getCorsairInternal } from '../core/utils/corsair-instance';
 import type { CorsairDatabase } from '../db/kysely/database';
 import { hubApiPost } from './client/http';
-import { getHubConfig, inferHubEnvironmentSlug } from './config';
+import {
+	getHubConfig,
+	inferHubEnvironmentSlug,
+	resolveHubOAuthCallbackUrl,
+} from './config';
 import type { ConnectPluginManifestEntry } from './contracts/connect-api';
 import { parseConnectSessionResponse } from './contracts/connect-api';
 import { resolveHubDeliveryUrl } from './resolve-delivery-url';
@@ -53,7 +57,7 @@ export async function postHubConnectSession(
 		});
 	}
 
-	return hubApiPost({
+	const result = await hubApiPost({
 		hub,
 		path: '/connect/sessions',
 		notFoundMessage:
@@ -61,6 +65,15 @@ export async function postHubConnectSession(
 		body,
 		parseResponse: parseConnectSessionResponse,
 	});
+
+	// Managed OAuth (e.g. GitHub) is hosted by the Hub, which uses this exact
+	// callback URL when generating the provider authorize link. If the
+	// provider's OAuth app does not have it registered, the user gets an opaque
+	// provider error (GitHub's "Error code 404") after login. Surface it so the
+	// app can verify registration instead of guessing.
+	result.oauthCallbackUrl = resolveHubOAuthCallbackUrl(hub);
+
+	return result;
 }
 
 /**

--- a/packages/corsair/hub/types.ts
+++ b/packages/corsair/hub/types.ts
@@ -44,6 +44,15 @@ export type HubConnectSessionResult = {
 	projectId: string;
 	environmentId: string;
 	expiresAt?: string;
+	/**
+	 * OAuth redirect URL the Hub will use when finishing the provider flow.
+	 * For managed OAuth (e.g. GitHub) the provider's OAuth app must have this
+	 * exact URL registered; otherwise the provider rejects the callback with a
+	 * generic error (GitHub's "Error code 404") right after the user logs in.
+	 * Exposed so apps can verify registration instead of chasing an opaque
+	 * provider error.
+	 */
+	oauthCallbackUrl?: string;
 };
 
 export type HubListProjectConnectionsInput = {

--- a/packages/corsair/tests/management-connect.test.ts
+++ b/packages/corsair/tests/management-connect.test.ts
@@ -418,6 +418,7 @@ describe('corsair.manage.connect — hub mode', () => {
 			expect(link).toEqual({
 				connectUrl: 'https://auth.corsair.dev/connect/signed-token',
 				expiresAt: '2026-06-24T12:00:00.000Z',
+				oauthCallbackUrl: 'https://auth.corsair.dev/oauth/callback',
 			});
 			expect(global.fetch).toHaveBeenCalledWith(
 				expect.stringContaining('/connect/sessions'),

--- a/packages/corsair/tests/post-hub-connect-session.test.ts
+++ b/packages/corsair/tests/post-hub-connect-session.test.ts
@@ -134,4 +134,40 @@ describe('postHubConnectSession', () => {
 
 		expect(getRequestBody()).not.toHaveProperty('redirectUri');
 	});
+
+	it('surfaces the managed OAuth callback URL on the session result', async () => {
+		const { fetchMock } = mockHubConnectFetch();
+		global.fetch = fetchMock;
+
+		const result = await postHubConnectSession(devHub, {
+			tenantId: 'default',
+			plugins: [
+				{
+					plugin: 'github',
+					providerName: 'GitHub',
+					authKind: 'oauth',
+					oauthMode: 'managed',
+				},
+			],
+		});
+
+		expect(result.oauthCallbackUrl).toBe('https://hub.example/oauth/callback');
+	});
+
+	it('uses an explicit oauthCallbackUrl when hub config sets it', async () => {
+		const { fetchMock } = mockHubConnectFetch();
+		global.fetch = fetchMock;
+
+		const result = await postHubConnectSession(
+			{
+				...prodHub,
+				oauthCallbackUrl: 'https://auth.corsair.dev/oauth/callback',
+			},
+			{ tenantId: 'default', plugins },
+		);
+
+		expect(result.oauthCallbackUrl).toBe(
+			'https://auth.corsair.dev/oauth/callback',
+		);
+	});
 });


### PR DESCRIPTION
## Summary

issue #483 — Hub managed GitHub login returns "Error code 404" right after the user logs in because the provider's OAuth app does not have the Hub's callback URL registered.

## Change

Surface the resolved Hub OAuth callback URL (`resolveHubOAuthCallbackUrl`) on connect session results so apps can verify their provider OAuth registration instead of guessing.

- `HubConnectSessionResult` and `ConnectLink` gain an optional `oauthCallbackUrl` field
- `postHubConnectSession` now populates it from hub config
- `manage.connect.createLink` (hub mode) passes it through

## Testing

- Two new tests in `post-hub-connect-session.test.ts`
- Existing fixture in `management-connect.test.ts` updated
- 53/53 relevant tests pass; biome clean; tsc clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Hub-mode connection links now include the OAuth callback URL used for authentication.
  - OAuth callback details are available for both managed authentication and bring-your-own authentication setups.
  - Explicitly configured callback URLs are preserved and returned with the connection session.

- **Bug Fixes**
  - Improved consistency between Hub connection sessions and the callback URL provided in returned connection links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->