### PR TITLE
fix(telegram): fail closed when no webhook secret token is configured

### DIFF
--- a/packages/telegram/jest.config.cjs
+++ b/packages/telegram/jest.config.cjs
@@ -44,6 +44,7 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',
 	},

--- a/packages/telegram/webhooks/types.ts
+++ b/packages/telegram/webhooks/types.ts
@@ -265,8 +265,7 @@ export function verifyTelegramWebhookSignature(
 	secretToken: string,
 ): { valid: boolean; error?: string } {
 	if (!secretToken) {
-		// No secret configured — skip verification (valid deployment scenario)
-		return { valid: true };
+		return { valid: false, error: 'Missing webhook secret' };
 	}
 
 	const headers = request.headers;

--- a/packages/telegram/webhooks/webhooks.test.ts
+++ b/packages/telegram/webhooks/webhooks.test.ts
@@ -1,0 +1,154 @@
+import type { WebhookRequest } from 'corsair/core';
+import type { TelegramContext } from '../index';
+import { message } from './message';
+import type { TelegramUpdate } from './types';
+import { verifyTelegramWebhookSignature } from './types';
+
+const WEBHOOK_SECRET = 'telegram-webhook-secret';
+
+function makeUpdate(): TelegramUpdate {
+	return {
+		update_id: 100,
+		message: {
+			message_id: 42,
+			date: 1700000000,
+			text: 'hello',
+			from: { id: 7, is_bot: false, first_name: 'Ada' },
+			chat: { id: 99, type: 'private' },
+		},
+	} as TelegramUpdate;
+}
+
+function makeWebhookRequest(
+	payload: TelegramUpdate,
+	options?: { secretToken?: string | string[] | null },
+): WebhookRequest<TelegramUpdate> {
+	const headers: Record<string, string | string[]> = {};
+	const token =
+		options && 'secretToken' in options ? options.secretToken : WEBHOOK_SECRET;
+
+	if (token !== null && token !== undefined) {
+		headers['x-telegram-bot-api-secret-token'] = token;
+	}
+
+	return {
+		payload,
+		rawBody: JSON.stringify(payload),
+		headers,
+	} as WebhookRequest<TelegramUpdate>;
+}
+
+function makeCtx(key: string = WEBHOOK_SECRET): TelegramContext {
+	return {
+		key,
+		db: {
+			messages: {
+				upsertByEntityId: jest.fn().mockResolvedValue({ id: 'entity-1' }),
+			},
+		},
+		$getAccountId: jest.fn().mockResolvedValue('account-1'),
+	} as unknown as TelegramContext;
+}
+
+describe('verifyTelegramWebhookSignature', () => {
+	it('fails closed when no secret token is configured', () => {
+		const result = verifyTelegramWebhookSignature(
+			makeWebhookRequest(makeUpdate()),
+			'',
+		);
+
+		expect(result.valid).toBe(false);
+		expect(result.error).toBe('Missing webhook secret');
+	});
+
+	it('rejects a request with no secret-token header', () => {
+		const result = verifyTelegramWebhookSignature(
+			makeWebhookRequest(makeUpdate(), { secretToken: null }),
+			WEBHOOK_SECRET,
+		);
+
+		expect(result.valid).toBe(false);
+		expect(result.error).toMatch(/missing x-telegram-bot-api-secret-token/i);
+	});
+
+	it('rejects a mismatched secret token', () => {
+		const result = verifyTelegramWebhookSignature(
+			makeWebhookRequest(makeUpdate(), { secretToken: 'not-the-secret' }),
+			WEBHOOK_SECRET,
+		);
+
+		expect(result.valid).toBe(false);
+		expect(result.error).toBe('Invalid secret token');
+	});
+
+	it('accepts a matching secret token', () => {
+		const result = verifyTelegramWebhookSignature(
+			makeWebhookRequest(makeUpdate()),
+			WEBHOOK_SECRET,
+		);
+
+		expect(result.valid).toBe(true);
+		expect(result.error).toBeUndefined();
+	});
+
+	it('accepts the header when provided as an array', () => {
+		const result = verifyTelegramWebhookSignature(
+			makeWebhookRequest(makeUpdate(), { secretToken: [WEBHOOK_SECRET] }),
+			WEBHOOK_SECRET,
+		);
+
+		expect(result.valid).toBe(true);
+	});
+});
+
+describe('message webhook handler', () => {
+	it('rejects with 401 and persists nothing when no secret is configured', async () => {
+		const ctx = makeCtx('');
+
+		const result = await message.handler(
+			ctx,
+			makeWebhookRequest(makeUpdate()) as never,
+		);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.statusCode).toBe(401);
+			expect(result.error).toBe('Missing webhook secret');
+		}
+		expect(ctx.db.messages?.upsertByEntityId).not.toHaveBeenCalled();
+	});
+
+	it('rejects a forged secret token with 401 and persists nothing', async () => {
+		const ctx = makeCtx();
+
+		const result = await message.handler(
+			ctx,
+			makeWebhookRequest(makeUpdate(), { secretToken: 'forged' }) as never,
+		);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.statusCode).toBe(401);
+		}
+		expect(ctx.db.messages?.upsertByEntityId).not.toHaveBeenCalled();
+	});
+
+	it('accepts a correctly signed update and persists the message', async () => {
+		const ctx = makeCtx();
+
+		const result = await message.handler(
+			ctx,
+			makeWebhookRequest(makeUpdate()) as never,
+		);
+
+		expect(result.success).toBe(true);
+		expect(ctx.db.messages?.upsertByEntityId).toHaveBeenCalledWith(
+			'42',
+			expect.objectContaining({
+				id: '42',
+				chat_id: '99',
+				authorId: '7',
+			}),
+		);
+	});
+});


### PR DESCRIPTION
> **Duplicate disclosure, up front:** @sushantlokhande14 reported #628 and already has an open, green PR for it in #629. I did not see it until after I had claimed the issue. **If #629 is the one you want, close this — it has priority and I have no objection.** I'm opening this only because the claim was already linked against #628; I'm not trying to race the reporter.

## Description

Fixes #628.

`verifyTelegramWebhookSignature` returned `{ valid: true }` whenever no secret token was configured, so any caller who knew the webhook URL was treated as Telegram.

```ts
// before
if (!secretToken) {
	// No secret configured — skip verification (valid deployment scenario)
	return { valid: true };
}
```
```ts
// after
if (!secretToken) {
	return { valid: false, error: 'Missing webhook secret' };
}
```

One line, matching the shape and `'Missing webhook secret'` string adopted across this family (#594, #595, #581, #585).

### Why it matters

All ten Telegram webhook handlers call this verifier first, and `packages/telegram/webhooks/message.ts` does not stop at verification — it proceeds into a database write:

```ts
const entity = await ctx.db.messages.upsertByEntityId(
	event.message.message_id.toString(),
	{
		...event.message,
		id: event.message.message_id.toString(),
		chat_id: event.message.chat.id.toString(),
		authorId: event.message.from?.id.toString(),
		createdAt: new Date(event.message.date * 1000),
	},
);
```

Every value there comes from the request body. Against a deployment with no secret token, an unauthenticated caller can insert rows with an arbitrary `message_id`, `chat_id`, `authorId`, text and timestamp — forging messages attributed to a chosen user in a chosen chat. Because it is an upsert keyed on `message_id`, it can also **overwrite a genuine message**.

Telegram's `secret_token` is an *optional* `setWebhook` parameter, so an unset secret is the default rather than an exotic misconfiguration.

## Tests

`packages/telegram/webhooks/webhooks.test.ts` — 8 tests, all passing.

**Verifier (5):** missing secret → `Missing webhook secret`; missing header; mismatched token; matching token; array-valued header.

**Handler (3)** — the ones that encode the actual security property:

- no secret configured → 401 **and** `ctx.db.messages.upsertByEntityId` never called
- forged token → 401 **and** no upsert
- correct token → success, message persisted with the expected `id` and `chat_id`

I verified the tests actually catch the bug rather than passing vacuously — reverting the one-line fix and re-running turns exactly the two fail-closed tests red:

```
× fails closed when no secret token is configured
√ rejects a request with no secret-token header
√ rejects a mismatched secret token
√ accepts a matching secret token
√ accepts the header when provided as an array
× rejects with 401 and persists nothing when no secret is configured
√ rejects a forged secret token with 401 and persists nothing
√ accepts a correctly signed update and persists the message

Tests: 2 failed, 6 passed, 8 total
```

### One extra line: the jest config

`packages/telegram/jest.config.cjs` mapped `corsair/http` but not `corsair/core`. The handler imports `logEventFromContext` from `corsair/core`, so without that mapping the suite cannot import a handler at all — it dies with `Cannot find module 'corsair/core'` before a single assertion. Added the one mapping, copied from `packages/cloudinary/jest.config.cjs`, which already does handler-level webhook tests. Still inside `packages/telegram/**`, so R1 holds.

## Checklist

- [x] I have run `pnpm lint` and all checks pass — `biome check --write` clean on all three files
- [x] I have run `pnpm typecheck` and there are no TypeScript errors — `tsc --noEmit` clean for `@corsair-dev/telegram`
- [x] I have run `pnpm build` and all packages build successfully — **see note**, I built this package, not the full workspace
- [x] I have run `pnpm test` and all tests pass — my 8 pass; **see note** on two pre-existing failures
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation — none required, no public API or plugin option changed

**Note on `pnpm build`.** I built `@corsair-dev/telegram` (`tsc --build` + `tsup`, clean). I could not run a full-workspace build on my machine: `better-sqlite3` needs a native compile and this box has no MSVC toolchain, so the install only completes with `--ignore-scripts`. That is my environment, not this branch — nothing here touches native deps. CI covers the full build.

**Note on `pnpm test`.** My suite passes 8/8. The package's two pre-existing suites fail identically on clean `main`, unchanged by this branch (`api.test.ts` needs live credentials; `integration.test.ts` needs `corsair/orm`, which the workspace build supplies):

```
clean main:   Test Suites: 2 failed, 2 total            Tests: 12 failed,  1 passed, 13 total
this branch:  Test Suites: 2 failed, 1 passed, 3 total  Tests: 12 failed,  9 passed, 21 total
                                     ^ +1 (mine)               ^ identical  ^ +8 (mine)
```

## Screenshots / Demos (if applicable)

Nothing to record, and I want to be straight about that rather than tick R4 falsely. This change is a local string comparison — it calls no Telegram endpoint, has no UI and no CLI output, and needs no credentials. The tests are the verification, and they run in CI on your infrastructure rather than on my machine. If you require a recording regardless, say so and I'll arrange one.

## Additional Notes

- Scope is `packages/telegram/**` only (R1) — three files, no `constants.ts` edit needed.
- **Behaviour-changing for live traffic**, and worth a release note: any deployment currently running Telegram webhooks *without* a `secret_token` will start getting 401s until one is set via `setWebhook`. That is the intent, but unlike the other fixes in this family it will bite working (if insecure) installs.
- Out of scope but noted while in the file: the check is `providedToken === secretToken`, a plain comparison of a shared secret rather than a timing-safe one — same observation as on #609 for GitLab. Happy to send that separately if wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Telegram webhook requests are now rejected when no secret token is configured, improving request validation.
  * Unauthorized webhook requests no longer persist incoming data.
  * Valid webhook updates continue to be accepted and saved correctly.

* **Tests**
  * Added coverage for missing, mismatched, matching, and array-form secret tokens, plus request authorization and persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->