### PR TITLE
fix(core): register youcom provider

### DIFF
--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -110,6 +110,7 @@ export const BaseProviders = [
 	'whatsapp',
 	'wiza',
 	'xquik',
+	'youcom',
 	'youtube',
 	'zendesk',
 	'zohomail',
@@ -214,6 +215,7 @@ export const ProviderDisplayNames = {
 	whatsapp: 'WhatsApp',
 	wiza: 'Wiza',
 	xquik: 'XQuik',
+	youcom: 'You.com',
 	youtube: 'YouTube',
 	zendesk: 'Zendesk',
 	zohomail: 'Zoho Mail',
@@ -325,6 +327,7 @@ export type AllProviders =
 	| 'whatsapp'
 	| 'wiza'
 	| 'xquik'
+	| 'youcom'
 	| 'youtube'
 	| 'zendesk'
 	| 'zohomail'


### PR DESCRIPTION
## Summary

Registers the existing You.com plugin in Corsair's central provider registry.

## Changes

- Added `youcom` to `BaseProviders`
- Added `youcom` to `ProviderDisplayNames`
- Added `youcom` to `AllProviders`

## Issue

Fixes #622

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added You.com as an available provider.
  * You.com now appears with its proper display name wherever providers are listed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->