### PR TITLE
fix: register youcom plugin in core provider registration

### DIFF
--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -110,6 +110,7 @@ export const BaseProviders = [
 	'whatsapp',
 	'wiza',
 	'xquik',
+	'youcom',
 	'youtube',
 	'zendesk',
 	'zohomail',
@@ -214,6 +215,7 @@ export const ProviderDisplayNames = {
 	whatsapp: 'WhatsApp',
 	wiza: 'Wiza',
 	xquik: 'XQuik',
+	youcom: 'You.com',
 	youtube: 'YouTube',
 	zendesk: 'Zendesk',
 	zohomail: 'Zoho Mail',
@@ -325,6 +327,7 @@ export type AllProviders =
 	| 'whatsapp'
 	| 'wiza'
 	| 'xquik'
+	| 'youcom'
 	| 'youtube'
 	| 'zendesk'
 	| 'zohomail'


### PR DESCRIPTION
The `youcom` plugin (You.com Web Search) was fully implemented at 
     `packages/youcom/` but was missing from the core provider registry, 
     so it wasn't recognized by the type system, display-name lookup, 
     or provider list.

     This adds `youcom` to `BaseProviders`, `ProviderDisplayNames`, and 
     `AllProviders` in `packages/corsair/core/constants.ts`, in 
     alphabetical order, matching the existing pattern.

     Fixes #622

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added You.com as a supported provider.
  - You.com is now available in provider selections and displays with its proper name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->