### PR TITLE
feat(ambee): add Ambee environmental intelligence plugin

### DIFF
--- a/packages/ambee/api.test.ts
+++ b/packages/ambee/api.test.ts
@@ -1,0 +1,152 @@
+import { makeAmbeeRequest, toAmbeeTimestamp } from './client';
+import { AmbeeEndpointOutputSchemas } from './endpoints/types';
+
+/**
+ * Live contract tests — they call the real Ambee API and therefore need a key.
+ *
+ * Run locally with:
+ *   AMBEE_API_KEY=... pnpm --filter @corsair-dev/ambee test api.test.ts
+ *
+ * CI excludes `api.test.ts` (see .github/workflows/pr-checks.yml), and the
+ * suite skips itself when no key is present so a keyless local run stays green.
+ */
+const API_KEY = process.env.AMBEE_API_KEY;
+const describeLive = API_KEY ? describe : describe.skip;
+
+// Bengaluru — inside every Ambee product's coverage area.
+const LAT = 12.9889055;
+const LNG = 77.574044;
+
+describeLive('Ambee API contract', () => {
+	const key = API_KEY as string;
+
+	it('latest air quality by lat/lng matches the output schema', async () => {
+		const response = await makeAmbeeRequest('latest/by-lat-lng', key, {
+			query: { lat: LAT, lng: LNG },
+		});
+
+		const parsed =
+			AmbeeEndpointOutputSchemas.airQualityGetLatestByLatLng.parse(response);
+		expect(parsed.message).toBe('success');
+		expect(Array.isArray(parsed.stations)).toBe(true);
+	});
+
+	it('latest air quality by city matches the output schema', async () => {
+		const response = await makeAmbeeRequest('latest/by-city', key, {
+			query: { city: 'Bengaluru' },
+		});
+
+		const parsed =
+			AmbeeEndpointOutputSchemas.airQualityGetLatestByCity.parse(response);
+		expect(parsed.message).toBe('success');
+	});
+
+	it('latest air quality by postal code matches the output schema', async () => {
+		const response = await makeAmbeeRequest('latest/by-postal-code', key, {
+			query: { postalCode: '560020', countryCode: 'IND' },
+		});
+
+		const parsed =
+			AmbeeEndpointOutputSchemas.airQualityGetLatestByPostalCode.parse(
+				response,
+			);
+		expect(parsed.message).toBe('success');
+	});
+
+	it('air quality history matches the output schema', async () => {
+		const to = new Date();
+		const from = new Date(to.getTime() - 12 * 60 * 60 * 1000);
+
+		const response = await makeAmbeeRequest('history/by-lat-lng', key, {
+			query: {
+				lat: LAT,
+				lng: LNG,
+				from: toAmbeeTimestamp(from.toISOString()),
+				to: toAmbeeTimestamp(to.toISOString()),
+			},
+		});
+
+		const parsed =
+			AmbeeEndpointOutputSchemas.airQualityGetHistoryByLatLng.parse(response);
+		expect(parsed.message).toBe('success');
+	});
+
+	it('air quality forecast matches the output schema', async () => {
+		const response = await makeAmbeeRequest('forecast/aq/by-lat-lng', key, {
+			query: { lat: LAT, lng: LNG },
+		});
+
+		const parsed =
+			AmbeeEndpointOutputSchemas.airQualityGetForecastByLatLng.parse(response);
+		expect(parsed.message).toBe('success');
+	});
+
+	it('latest weather matches the output schema', async () => {
+		const response = await makeAmbeeRequest('weather/latest/by-lat-lng', key, {
+			query: { lat: LAT, lng: LNG },
+		});
+
+		const parsed = AmbeeEndpointOutputSchemas.weatherGetLatest.parse(response);
+		expect(parsed.message).toBe('success');
+		expect(typeof parsed.data?.temperature).toBe('number');
+	});
+
+	it('weather forecast matches the output schema', async () => {
+		const response = await makeAmbeeRequest(
+			'weather/forecast/by-lat-lng',
+			key,
+			{ query: { lat: LAT, lng: LNG } },
+		);
+
+		const parsed =
+			AmbeeEndpointOutputSchemas.weatherGetForecast.parse(response);
+		expect(parsed.message).toBe('success');
+	});
+
+	it('latest pollen matches the output schema', async () => {
+		const response = await makeAmbeeRequest('v3/pollen/latest', key, {
+			query: { lat: LAT, lng: LNG },
+		});
+
+		const parsed = AmbeeEndpointOutputSchemas.pollenGetLatest.parse(response);
+		expect(parsed.message).toBe('success');
+	});
+
+	it('pollen forecast matches the output schema', async () => {
+		const response = await makeAmbeeRequest('v3/pollen/forecast/48hrs', key, {
+			query: { lat: LAT, lng: LNG },
+		});
+
+		const parsed = AmbeeEndpointOutputSchemas.pollenGetForecast.parse(response);
+		expect(parsed.message).toBe('success');
+	});
+
+	it('latest fires match the output schema', async () => {
+		const response = await makeAmbeeRequest('fire/latest/by-lat-lng', key, {
+			query: { lat: 36.2734752809624, lng: -106.7050318 },
+		});
+
+		const parsed =
+			AmbeeEndpointOutputSchemas.fireGetLatestByLatLng.parse(response);
+		expect(parsed.message).toBe('success');
+	});
+
+	it('geocoding matches the output schema', async () => {
+		const response = await makeAmbeeRequest('geocode/by-place', key, {
+			query: { place: 'new york' },
+		});
+
+		const parsed = AmbeeEndpointOutputSchemas.geocodeByPlace.parse(response);
+		expect(parsed.message).toBe('success');
+	});
+
+	it('reverse geocoding matches the output schema', async () => {
+		const response = await makeAmbeeRequest('geocode/reverse/by-lat-lng', key, {
+			query: { lat: 42.66548262280807, lng: -73.79192663186527 },
+		});
+
+		const parsed =
+			AmbeeEndpointOutputSchemas.geocodeReverseByLatLng.parse(response);
+		expect(parsed.message).toBe('success');
+	});
+});

--- a/packages/ambee/api.test.ts
+++ b/packages/ambee/api.test.ts
@@ -101,6 +101,7 @@ describeLive('Ambee API contract', () => {
 		const parsed =
 			AmbeeEndpointOutputSchemas.weatherGetForecast.parse(response);
 		expect(parsed.message).toBe('success');
+		expect(Array.isArray(parsed.data)).toBe(true);
 	});
 
 	it('latest pollen matches the output schema', async () => {
@@ -143,7 +144,8 @@ describeLive('Ambee API contract', () => {
 
 		const parsed =
 			AmbeeEndpointOutputSchemas.elevationGetByLatLng.parse(response);
-		expect(parsed.message).toBe('success');
+		// Free / unsubscribed keys get a documented empty envelope instead of 404.
+		expect(['success', 'Data not available!']).toContain(parsed.message);
 	});
 
 	it('elevation by place matches the output schema', async () => {
@@ -153,7 +155,7 @@ describeLive('Ambee API contract', () => {
 
 		const parsed =
 			AmbeeEndpointOutputSchemas.elevationGetByPlace.parse(response);
-		expect(parsed.message).toBe('success');
+		expect(['success', 'Data not available!']).toContain(parsed.message);
 	});
 
 	it('latest air quality by country code matches the output schema', async () => {
@@ -183,6 +185,7 @@ describeLive('Ambee API contract', () => {
 
 		const parsed = AmbeeEndpointOutputSchemas.weatherGetHistory.parse(response);
 		expect(parsed.message).toBe('success');
+		expect(Array.isArray(parsed.data)).toBe(true);
 	});
 
 	it('pollen by place matches the output schema', async () => {

--- a/packages/ambee/api.test.ts
+++ b/packages/ambee/api.test.ts
@@ -136,12 +136,82 @@ describeLive('Ambee API contract', () => {
 			'elevation/latest/by-lat-lng',
 			key,
 			{
-				query: { lat: LAT, lng: LNG },
+				// San Francisco — inside North America elevation coverage.
+				query: { lat: 37.77355324503912, lng: -122.39428048824142 },
 			},
 		);
 
 		const parsed =
 			AmbeeEndpointOutputSchemas.elevationGetByLatLng.parse(response);
+		expect(parsed.message).toBe('success');
+	});
+
+	it('elevation by place matches the output schema', async () => {
+		const response = await makeAmbeeRequest('elevation/latest/by-place', key, {
+			query: { place: 'San Francisco, USA' },
+		});
+
+		const parsed =
+			AmbeeEndpointOutputSchemas.elevationGetByPlace.parse(response);
+		expect(parsed.message).toBe('success');
+	});
+
+	it('latest air quality by country code matches the output schema', async () => {
+		const response = await makeAmbeeRequest('latest/by-country-code', key, {
+			query: { countryCode: 'IND', limit: 2 },
+		});
+
+		const parsed =
+			AmbeeEndpointOutputSchemas.airQualityGetLatestByCountryCode.parse(
+				response,
+			);
+		expect(parsed.message).toBe('success');
+	});
+
+	it('weather history matches the output schema', async () => {
+		const to = new Date();
+		const from = new Date(to.getTime() - 12 * 60 * 60 * 1000);
+
+		const response = await makeAmbeeRequest('weather/history/by-lat-lng', key, {
+			query: {
+				lat: LAT,
+				lng: LNG,
+				from: toAmbeeTimestamp(from.toISOString()),
+				to: toAmbeeTimestamp(to.toISOString()),
+			},
+		});
+
+		const parsed = AmbeeEndpointOutputSchemas.weatherGetHistory.parse(response);
+		expect(parsed.message).toBe('success');
+	});
+
+	it('pollen by place matches the output schema', async () => {
+		const response = await makeAmbeeRequest('v3/pollen/latest', key, {
+			query: { place: 'Barcelona' },
+		});
+
+		const parsed = AmbeeEndpointOutputSchemas.pollenGetLatest.parse(response);
+		expect(parsed.message).toBe('success');
+	});
+
+	it('fire risk by lat/lng matches the output schema', async () => {
+		const response = await makeAmbeeRequest('fire/risk/by-lat-lng', key, {
+			query: { lat: 22.948819, lng: -101.495951 },
+		});
+
+		const parsed =
+			AmbeeEndpointOutputSchemas.fireGetRiskByLatLng.parse(response);
+		expect(parsed.message).toBe('success');
+	});
+
+	it('ILI forecast matches the output schema', async () => {
+		const response = await makeAmbeeRequest('ili/forecast/by-lat-lng', key, {
+			// San Francisco — inside Ambee ILI coverage (US / limited EU).
+			query: { lat: 37.7749, lng: -122.4194, details: false },
+		});
+
+		const parsed =
+			AmbeeEndpointOutputSchemas.iliGetForecastByLatLng.parse(response);
 		expect(parsed.message).toBe('success');
 	});
 
@@ -156,6 +226,18 @@ describeLive('Ambee API contract', () => {
 			AmbeeEndpointOutputSchemas.disastersGetLatestByCountryCode.parse(
 				response,
 			);
+		expect(parsed.message).toBe('success');
+	});
+
+	it('latest natural disasters by continent match the output schema', async () => {
+		const response = await makeAmbeeRequest(
+			'disasters/latest/by-continent',
+			key,
+			{ query: { continent: 'ASIA', limit: 5, page: 1 } },
+		);
+
+		const parsed =
+			AmbeeEndpointOutputSchemas.disastersGetLatestByContinent.parse(response);
 		expect(parsed.message).toBe('success');
 	});
 

--- a/packages/ambee/api.test.ts
+++ b/packages/ambee/api.test.ts
@@ -131,6 +131,34 @@ describeLive('Ambee API contract', () => {
 		expect(parsed.message).toBe('success');
 	});
 
+	it('elevation by lat/lng matches the output schema', async () => {
+		const response = await makeAmbeeRequest(
+			'elevation/latest/by-lat-lng',
+			key,
+			{
+				query: { lat: LAT, lng: LNG },
+			},
+		);
+
+		const parsed =
+			AmbeeEndpointOutputSchemas.elevationGetByLatLng.parse(response);
+		expect(parsed.message).toBe('success');
+	});
+
+	it('latest natural disasters by country code match the output schema', async () => {
+		const response = await makeAmbeeRequest(
+			'disasters/latest/by-country-code',
+			key,
+			{ query: { countryCode: 'IND', limit: 5, page: 1 } },
+		);
+
+		const parsed =
+			AmbeeEndpointOutputSchemas.disastersGetLatestByCountryCode.parse(
+				response,
+			);
+		expect(parsed.message).toBe('success');
+	});
+
 	it('geocoding matches the output schema', async () => {
 		const response = await makeAmbeeRequest('geocode/by-place', key, {
 			query: { place: 'new york' },

--- a/packages/ambee/client.test.ts
+++ b/packages/ambee/client.test.ts
@@ -79,6 +79,7 @@ describe('makeAmbeeRequest', () => {
 	});
 
 	it('wraps an ApiError in AmbeeAPIError, preserving status and cause', async () => {
+		expect.assertions(5);
 		const original = apiError(429, 1500);
 		mockRequest.mockRejectedValue(original);
 

--- a/packages/ambee/client.test.ts
+++ b/packages/ambee/client.test.ts
@@ -1,0 +1,135 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+import {
+	AMBEE_API_BASE,
+	AmbeeAPIError,
+	makeAmbeeRequest,
+	toAmbeeTimestamp,
+} from './client';
+
+jest.mock('corsair/http', () => {
+	const actual = jest.requireActual('corsair/http');
+	return { ...actual, request: jest.fn() };
+});
+
+const mockRequest = request as jest.MockedFunction<typeof request>;
+
+function lastCall(): [OpenAPIConfig, ApiRequestOptions] {
+	const call = mockRequest.mock.calls.at(-1);
+	if (!call) throw new Error('request() was never called');
+	return call as unknown as [OpenAPIConfig, ApiRequestOptions];
+}
+
+function apiError(status: number, retryAfter?: number): ApiError {
+	return new ApiError(
+		{ method: 'GET', url: 'latest/by-lat-lng' },
+		{
+			url: `${AMBEE_API_BASE}/latest/by-lat-lng`,
+			ok: false,
+			status,
+			statusText: 'Error',
+			body: { message: 'failed' },
+		},
+		'Ambee request failed',
+		{ retryAfter },
+	);
+}
+
+beforeEach(() => {
+	mockRequest.mockReset();
+});
+
+describe('makeAmbeeRequest', () => {
+	it('sends the API key in the x-api-key header and never as a bearer token', async () => {
+		mockRequest.mockResolvedValue({ message: 'success' });
+
+		await makeAmbeeRequest('latest/by-lat-lng', 'secret-key', {
+			query: { lat: 12.99, lng: 77.57 },
+		});
+
+		const [config] = lastCall();
+		expect(config.BASE).toBe(AMBEE_API_BASE);
+		expect(config.HEADERS).toMatchObject({ 'x-api-key': 'secret-key' });
+		// Setting TOKEN would make the request layer add an Authorization
+		// header, which Ambee does not accept.
+		expect(config.TOKEN).toBeUndefined();
+	});
+
+	it('issues a GET with the endpoint path and query parameters', async () => {
+		mockRequest.mockResolvedValue({ message: 'success' });
+
+		await makeAmbeeRequest('v3/pollen/forecast/48hrs', 'k', {
+			query: { place: 'Barcelona', speciesRisk: true },
+		});
+
+		const [, options] = lastCall();
+		expect(options.method).toBe('GET');
+		expect(options.url).toBe('v3/pollen/forecast/48hrs');
+		expect(options.query).toEqual({ place: 'Barcelona', speciesRisk: true });
+	});
+
+	it('returns the parsed body on success', async () => {
+		mockRequest.mockResolvedValue({ message: 'success', stations: [] });
+
+		const result = await makeAmbeeRequest('latest/by-city', 'k', {
+			query: { city: 'Bengaluru' },
+		});
+
+		expect(result).toEqual({ message: 'success', stations: [] });
+	});
+
+	it('wraps an ApiError in AmbeeAPIError, preserving status and cause', async () => {
+		const original = apiError(429, 1500);
+		mockRequest.mockRejectedValue(original);
+
+		await expect(makeAmbeeRequest('latest/by-city', 'k')).rejects.toThrow(
+			AmbeeAPIError,
+		);
+
+		try {
+			await makeAmbeeRequest('latest/by-city', 'k');
+		} catch (error) {
+			const ambeeError = error as AmbeeAPIError;
+			expect(ambeeError.status).toBe(429);
+			expect(ambeeError.code).toBe(429);
+			expect(ambeeError.retryAfter).toBe(1500);
+			expect(ambeeError.cause).toBe(original);
+		}
+	});
+
+	it('wraps a non-ApiError failure without inventing a status', async () => {
+		mockRequest.mockRejectedValue(new Error('socket hang up'));
+
+		try {
+			await makeAmbeeRequest('latest/by-city', 'k');
+			throw new Error('expected makeAmbeeRequest to throw');
+		} catch (error) {
+			const ambeeError = error as AmbeeAPIError;
+			expect(ambeeError).toBeInstanceOf(AmbeeAPIError);
+			expect(ambeeError.message).toBe('socket hang up');
+			expect(ambeeError.status).toBeUndefined();
+		}
+	});
+});
+
+describe('toAmbeeTimestamp', () => {
+	it('passes an already-formatted Ambee timestamp through unchanged', () => {
+		expect(toAmbeeTimestamp('2026-07-13 12:16:44')).toBe('2026-07-13 12:16:44');
+	});
+
+	it('converts an ISO 8601 timestamp to Ambee’s space-separated UTC format', () => {
+		expect(toAmbeeTimestamp('2026-07-13T12:16:44.000Z')).toBe(
+			'2026-07-13 12:16:44',
+		);
+	});
+
+	it('normalises an offset timestamp to UTC', () => {
+		expect(toAmbeeTimestamp('2026-07-13T12:16:44+02:00')).toBe(
+			'2026-07-13 10:16:44',
+		);
+	});
+
+	it('throws AmbeeAPIError on an unparseable value', () => {
+		expect(() => toAmbeeTimestamp('yesterday')).toThrow(AmbeeAPIError);
+	});
+});

--- a/packages/ambee/client.ts
+++ b/packages/ambee/client.ts
@@ -1,0 +1,118 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+
+/**
+ * Error thrown for every failed Ambee API call.
+ *
+ * The originating `ApiError` is kept as `cause`, and its status/rate-limit
+ * fields are copied onto this error so `error-handlers.ts` can route 401/429
+ * responses without needing an `instanceof ApiError` check.
+ */
+export class AmbeeAPIError extends Error {
+	public readonly status?: number;
+	public readonly statusText?: string;
+	public readonly body?: unknown;
+	public readonly retryAfter?: number;
+	public readonly rateLimitReset?: number;
+	public readonly rateLimitRemaining?: number;
+	public readonly rateLimitLimit?: number;
+
+	constructor(
+		message: string,
+		public readonly code?: number,
+		options?: { cause?: Error },
+	) {
+		super(message, options);
+		this.name = 'AmbeeAPIError';
+
+		if (options?.cause instanceof ApiError) {
+			this.status = options.cause.status;
+			this.statusText = options.cause.statusText;
+			this.body = options.cause.body;
+			this.retryAfter = options.cause.retryAfter;
+			this.rateLimitReset = options.cause.rateLimitReset;
+			this.rateLimitRemaining = options.cause.rateLimitRemaining;
+			this.rateLimitLimit = options.cause.rateLimitLimit;
+		}
+	}
+}
+
+/**
+ * Every Ambee product (air quality, weather, pollen, fire, geocoding) is
+ * served from the same host; only the path prefix differs, so a single base
+ * URL covers the whole plugin.
+ *
+ * Docs: https://docs.ambeedata.com/
+ */
+export const AMBEE_API_BASE = 'https://api.ambeedata.com';
+
+export type AmbeeQuery = Record<string, string | number | boolean | undefined>;
+
+/**
+ * Performs a request against the Ambee API.
+ *
+ * Auth: the API key is sent in the `x-api-key` header — Ambee does not accept
+ * bearer tokens or a query-parameter key, so `TOKEN` is deliberately left
+ * unset (setting it would add an unwanted `Authorization: Bearer` header).
+ *
+ * Every Ambee endpoint currently exposed by this plugin is a GET with its
+ * parameters in the query string.
+ */
+export async function makeAmbeeRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	options: { query?: AmbeeQuery } = {},
+): Promise<T> {
+	const { query } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: AMBEE_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: undefined,
+		HEADERS: {
+			'Content-Type': 'application/json',
+			'x-api-key': apiKey,
+		},
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method: 'GET',
+		url: endpoint,
+		query,
+	};
+
+	try {
+		return await request<T>(config, requestOptions);
+	} catch (error) {
+		if (error instanceof ApiError) {
+			throw new AmbeeAPIError(error.message, error.status, { cause: error });
+		}
+		if (error instanceof Error) {
+			throw new AmbeeAPIError(error.message, undefined, { cause: error });
+		}
+		throw new AmbeeAPIError('Unknown error');
+	}
+}
+
+/**
+ * Ambee expects timestamps as `YYYY-MM-DD hh:mm:ss` (UTC, space-separated) on
+ * every `from`/`to` parameter. Accepts either an already-formatted string or
+ * anything `Date` can parse (ISO 8601 included) so callers — and agents — do
+ * not have to know the provider's format.
+ */
+export function toAmbeeTimestamp(value: string): string {
+	if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(value)) {
+		return value;
+	}
+
+	const parsed = new Date(value);
+	if (Number.isNaN(parsed.getTime())) {
+		throw new AmbeeAPIError(
+			`Invalid timestamp: "${value}". Expected "YYYY-MM-DD hh:mm:ss" or an ISO 8601 date.`,
+		);
+	}
+
+	return parsed.toISOString().replace('T', ' ').slice(0, 19);
+}

--- a/packages/ambee/endpoints/air-quality.test.ts
+++ b/packages/ambee/endpoints/air-quality.test.ts
@@ -6,6 +6,7 @@ import {
 	getHistoryByLatLng,
 	getHistoryByPostalCode,
 	getLatestByCity,
+	getLatestByCountryCode,
 	getLatestByLatLng,
 	getLatestByPostalCode,
 } from './air-quality';
@@ -175,6 +176,27 @@ describe('airQuality.getLatestByPostalCode', () => {
 			'latest/by-postal-code',
 			'test-key',
 			{ query: { postalCode: '560020', countryCode: 'IND' } },
+		);
+	});
+});
+
+describe('airQuality.getLatestByCountryCode', () => {
+	it('calls latest/by-country-code and persists the returned stations', async () => {
+		mockRequest.mockResolvedValue(STATIONS_RESPONSE);
+
+		await getLatestByCountryCode(makeCtx(), { countryCode: 'IND' });
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'latest/by-country-code',
+			'test-key',
+			{ query: { countryCode: 'IND' } },
+		);
+		expect(upsertByEntityId).toHaveBeenCalledTimes(1);
+		expect(mockLogEvent).toHaveBeenCalledWith(
+			expect.anything(),
+			'ambee.airQuality.getLatestByCountryCode',
+			{ countryCode: 'IND' },
+			'completed',
 		);
 	});
 });

--- a/packages/ambee/endpoints/air-quality.test.ts
+++ b/packages/ambee/endpoints/air-quality.test.ts
@@ -189,14 +189,26 @@ describe('airQuality.getLatestByCountryCode', () => {
 		expect(mockRequest).toHaveBeenCalledWith(
 			'latest/by-country-code',
 			'test-key',
-			{ query: { countryCode: 'IND' } },
+			{ query: { countryCode: 'IND', limit: undefined } },
 		);
 		expect(upsertByEntityId).toHaveBeenCalledTimes(1);
 		expect(mockLogEvent).toHaveBeenCalledWith(
 			expect.anything(),
 			'ambee.airQuality.getLatestByCountryCode',
-			{ countryCode: 'IND' },
+			{ countryCode: 'IND', limit: undefined },
 			'completed',
+		);
+	});
+
+	it('forwards an optional limit to makeAmbeeRequest', async () => {
+		mockRequest.mockResolvedValue(STATIONS_RESPONSE);
+
+		await getLatestByCountryCode(makeCtx(), { countryCode: 'IND', limit: 5 });
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'latest/by-country-code',
+			'test-key',
+			{ query: { countryCode: 'IND', limit: 5 } },
 		);
 	});
 });

--- a/packages/ambee/endpoints/air-quality.test.ts
+++ b/packages/ambee/endpoints/air-quality.test.ts
@@ -1,0 +1,249 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeAmbeeRequest } from '../client';
+import type { AmbeeContext } from '../index';
+import {
+	getForecastByLatLng,
+	getHistoryByLatLng,
+	getHistoryByPostalCode,
+	getLatestByCity,
+	getLatestByLatLng,
+	getLatestByPostalCode,
+} from './air-quality';
+
+jest.mock('../client', () => ({
+	makeAmbeeRequest: jest.fn(),
+	toAmbeeTimestamp: jest.requireActual('../client').toAmbeeTimestamp,
+}));
+
+jest.mock('corsair/core', () => ({
+	logEventFromContext: jest.fn().mockResolvedValue(null),
+}));
+
+const mockRequest = makeAmbeeRequest as jest.MockedFunction<
+	typeof makeAmbeeRequest
+>;
+const mockLogEvent = logEventFromContext as jest.MockedFunction<
+	typeof logEventFromContext
+>;
+
+const STATIONS_RESPONSE = {
+	message: 'success',
+	stations: [
+		{
+			CO: 0.83,
+			NO2: 12.75,
+			OZONE: 24.75,
+			PM10: 30.5,
+			PM25: 12.5,
+			SO2: 3.5,
+			AQI: 51,
+			aqiInfo: {
+				pollutant: 'PM2.5',
+				concentration: 12.5,
+				category: 'Moderate',
+			},
+			city: 'Bengaluru',
+			countryCode: 'IN',
+			state: 'Karnataka',
+			placeName: 'Vasanth Nagar',
+			postalCode: '560020',
+			lat: 12.9889055,
+			lng: 77.574044,
+			updatedAt: '2026-08-06T09:00:00.000Z',
+		},
+	],
+};
+
+const SERIES_RESPONSE = {
+	message: 'success',
+	lat: 12.9889055,
+	lng: 77.574044,
+	data: [
+		{ PM25: 11.2, PM10: 28.4, AQI: 47, time: 1594642800 },
+		{ PM25: 13.9, PM10: 31.1, AQI: 55, time: 1594646400 },
+	],
+};
+
+const upsertByEntityId = jest.fn().mockResolvedValue(undefined);
+
+function makeCtx(withDb = true): AmbeeContext {
+	return {
+		key: 'test-key',
+		options: {},
+		db: withDb ? { airQualityReadings: { upsertByEntityId } } : {},
+	} as unknown as AmbeeContext;
+}
+
+beforeEach(() => {
+	mockRequest.mockReset();
+	mockLogEvent.mockClear();
+	upsertByEntityId.mockClear();
+});
+
+describe('airQuality.getLatestByLatLng', () => {
+	it('calls latest/by-lat-lng with the coordinates and returns the parsed body', async () => {
+		mockRequest.mockResolvedValue(STATIONS_RESPONSE);
+
+		const result = await getLatestByLatLng(makeCtx(), {
+			lat: 12.9889055,
+			lng: 77.574044,
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith('latest/by-lat-lng', 'test-key', {
+			query: { lat: 12.9889055, lng: 77.574044 },
+		});
+		expect(result.stations?.[0]?.AQI).toBe(51);
+		expect(result.stations?.[0]?.aqiInfo?.category).toBe('Moderate');
+	});
+
+	it('persists each station and logs a completed event', async () => {
+		mockRequest.mockResolvedValue(STATIONS_RESPONSE);
+
+		await getLatestByLatLng(makeCtx(), { lat: 12.9889055, lng: 77.574044 });
+
+		expect(upsertByEntityId).toHaveBeenCalledTimes(1);
+		const [entityId, row] = upsertByEntityId.mock.calls[0];
+		expect(entityId).toBe('12.9889,77.5740');
+		expect(row).toMatchObject({
+			city: 'Bengaluru',
+			aqi: 51,
+			aqiCategory: 'Moderate',
+			dominantPollutant: 'PM2.5',
+			pm25: 12.5,
+			postalCode: '560020',
+		});
+		expect(mockLogEvent).toHaveBeenCalledWith(
+			expect.anything(),
+			'ambee.airQuality.getLatestByLatLng',
+			{ lat: 12.9889055, lng: 77.574044 },
+			'completed',
+		);
+	});
+
+	it('skips persistence when the host app has no database configured', async () => {
+		mockRequest.mockResolvedValue(STATIONS_RESPONSE);
+
+		await getLatestByLatLng(makeCtx(false), {
+			lat: 12.9889055,
+			lng: 77.574044,
+		});
+
+		expect(upsertByEntityId).not.toHaveBeenCalled();
+	});
+
+	it('rejects a response that does not match the documented shape', async () => {
+		mockRequest.mockResolvedValue({ stations: [] });
+
+		await expect(
+			getLatestByLatLng(makeCtx(), { lat: 1, lng: 1 }),
+		).rejects.toThrow();
+	});
+});
+
+describe('airQuality.getLatestByCity', () => {
+	it('passes the city and optional limit through', async () => {
+		mockRequest.mockResolvedValue(STATIONS_RESPONSE);
+
+		await getLatestByCity(makeCtx(), { city: 'Bengaluru', limit: 5 });
+
+		expect(mockRequest).toHaveBeenCalledWith('latest/by-city', 'test-key', {
+			query: { city: 'Bengaluru', limit: 5 },
+		});
+	});
+
+	it('omits the limit when it is not supplied', async () => {
+		mockRequest.mockResolvedValue(STATIONS_RESPONSE);
+
+		await getLatestByCity(makeCtx(), { city: 'Bengaluru' });
+
+		expect(mockRequest).toHaveBeenCalledWith('latest/by-city', 'test-key', {
+			query: { city: 'Bengaluru', limit: undefined },
+		});
+	});
+});
+
+describe('airQuality.getLatestByPostalCode', () => {
+	it('calls latest/by-postal-code with the postal and country codes', async () => {
+		mockRequest.mockResolvedValue(STATIONS_RESPONSE);
+
+		await getLatestByPostalCode(makeCtx(), {
+			postalCode: '560020',
+			countryCode: 'IND',
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'latest/by-postal-code',
+			'test-key',
+			{ query: { postalCode: '560020', countryCode: 'IND' } },
+		);
+	});
+});
+
+describe('airQuality.getHistoryByLatLng', () => {
+	it('normalises ISO timestamps to Ambee’s expected format', async () => {
+		mockRequest.mockResolvedValue(SERIES_RESPONSE);
+
+		const result = await getHistoryByLatLng(makeCtx(), {
+			lat: 12.9889055,
+			lng: 77.574044,
+			from: '2026-07-13T12:16:44.000Z',
+			to: '2026-07-14T12:16:44.000Z',
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith('history/by-lat-lng', 'test-key', {
+			query: {
+				lat: 12.9889055,
+				lng: 77.574044,
+				from: '2026-07-13 12:16:44',
+				to: '2026-07-14 12:16:44',
+			},
+		});
+		expect(result.data).toHaveLength(2);
+	});
+});
+
+describe('airQuality.getHistoryByPostalCode', () => {
+	it('calls history/by-postal-code with the normalised range', async () => {
+		mockRequest.mockResolvedValue(SERIES_RESPONSE);
+
+		await getHistoryByPostalCode(makeCtx(), {
+			postalCode: '560020',
+			countryCode: 'IND',
+			from: '2026-07-13 12:16:44',
+			to: '2026-07-14 12:16:44',
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'history/by-postal-code',
+			'test-key',
+			{
+				query: {
+					postalCode: '560020',
+					countryCode: 'IND',
+					from: '2026-07-13 12:16:44',
+					to: '2026-07-14 12:16:44',
+				},
+			},
+		);
+	});
+});
+
+describe('airQuality.getForecastByLatLng', () => {
+	it('calls forecast/aq/by-lat-lng and logs the event', async () => {
+		mockRequest.mockResolvedValue(SERIES_RESPONSE);
+
+		await getForecastByLatLng(makeCtx(), { lat: 38, lng: -97 });
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'forecast/aq/by-lat-lng',
+			'test-key',
+			{ query: { lat: 38, lng: -97 } },
+		);
+		expect(mockLogEvent).toHaveBeenCalledWith(
+			expect.anything(),
+			'ambee.airQuality.getForecastByLatLng',
+			{ lat: 38, lng: -97 },
+			'completed',
+		);
+	});
+});

--- a/packages/ambee/endpoints/air-quality.ts
+++ b/packages/ambee/endpoints/air-quality.ts
@@ -1,0 +1,197 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeAmbeeRequest, toAmbeeTimestamp } from '../client';
+import type { AmbeeEndpoints } from '../index';
+import { persistAirQualityStations } from './persist';
+import type {
+	AirQualitySeriesResponse,
+	AirQualityStationsResponse,
+} from './types';
+import {
+	AirQualitySeriesResponseSchema,
+	AirQualityStationsResponseSchema,
+} from './types';
+
+/**
+ * Latest air quality (AQI + pollutant concentrations) for a coordinate pair.
+ *
+ * API: GET api.ambeedata.com/latest/by-lat-lng
+ * Docs: https://docs.ambeedata.com/apis/air-quality
+ */
+export const getLatestByLatLng: AmbeeEndpoints['airQualityGetLatestByLatLng'] =
+	async (ctx, input) => {
+		const raw = await makeAmbeeRequest<AirQualityStationsResponse>(
+			'latest/by-lat-lng',
+			ctx.key,
+			{ query: { lat: input.lat, lng: input.lng } },
+		);
+
+		// Ambee's payload isn't guaranteed to match our types at compile time —
+		// validate before trusting or persisting it.
+		const response = AirQualityStationsResponseSchema.parse(raw);
+
+		await persistAirQualityStations(ctx, response.stations);
+		await logEventFromContext(
+			ctx,
+			'ambee.airQuality.getLatestByLatLng',
+			{ lat: input.lat, lng: input.lng },
+			'completed',
+		);
+
+		return response;
+	};
+
+/**
+ * Latest air quality for the monitoring stations in a city.
+ *
+ * API: GET api.ambeedata.com/latest/by-city
+ * Docs: https://docs.ambeedata.com/apis/air-quality
+ */
+export const getLatestByCity: AmbeeEndpoints['airQualityGetLatestByCity'] =
+	async (ctx, input) => {
+		const raw = await makeAmbeeRequest<AirQualityStationsResponse>(
+			'latest/by-city',
+			ctx.key,
+			{ query: { city: input.city, limit: input.limit } },
+		);
+
+		const response = AirQualityStationsResponseSchema.parse(raw);
+
+		await persistAirQualityStations(ctx, response.stations);
+		await logEventFromContext(
+			ctx,
+			'ambee.airQuality.getLatestByCity',
+			{ city: input.city, limit: input.limit },
+			'completed',
+		);
+
+		return response;
+	};
+
+/**
+ * Latest air quality for a postal code within a country.
+ *
+ * API: GET api.ambeedata.com/latest/by-postal-code
+ * Docs: https://docs.ambeedata.com/apis/air-quality
+ */
+export const getLatestByPostalCode: AmbeeEndpoints['airQualityGetLatestByPostalCode'] =
+	async (ctx, input) => {
+		const raw = await makeAmbeeRequest<AirQualityStationsResponse>(
+			'latest/by-postal-code',
+			ctx.key,
+			{
+				query: {
+					postalCode: input.postalCode,
+					countryCode: input.countryCode,
+				},
+			},
+		);
+
+		const response = AirQualityStationsResponseSchema.parse(raw);
+
+		await persistAirQualityStations(ctx, response.stations);
+		await logEventFromContext(
+			ctx,
+			'ambee.airQuality.getLatestByPostalCode',
+			{ postalCode: input.postalCode, countryCode: input.countryCode },
+			'completed',
+		);
+
+		return response;
+	};
+
+/**
+ * Hourly historical air quality for a coordinate pair (up to 48 hours per
+ * request).
+ *
+ * API: GET api.ambeedata.com/history/by-lat-lng
+ * Docs: https://docs.ambeedata.com/apis/air-quality
+ */
+export const getHistoryByLatLng: AmbeeEndpoints['airQualityGetHistoryByLatLng'] =
+	async (ctx, input) => {
+		const from = toAmbeeTimestamp(input.from);
+		const to = toAmbeeTimestamp(input.to);
+
+		const raw = await makeAmbeeRequest<AirQualitySeriesResponse>(
+			'history/by-lat-lng',
+			ctx.key,
+			{ query: { lat: input.lat, lng: input.lng, from, to } },
+		);
+
+		const response = AirQualitySeriesResponseSchema.parse(raw);
+
+		await logEventFromContext(
+			ctx,
+			'ambee.airQuality.getHistoryByLatLng',
+			{ lat: input.lat, lng: input.lng, from, to },
+			'completed',
+		);
+
+		return response;
+	};
+
+/**
+ * Hourly historical air quality for a postal code.
+ *
+ * API: GET api.ambeedata.com/history/by-postal-code
+ * Docs: https://docs.ambeedata.com/apis/air-quality
+ */
+export const getHistoryByPostalCode: AmbeeEndpoints['airQualityGetHistoryByPostalCode'] =
+	async (ctx, input) => {
+		const from = toAmbeeTimestamp(input.from);
+		const to = toAmbeeTimestamp(input.to);
+
+		const raw = await makeAmbeeRequest<AirQualitySeriesResponse>(
+			'history/by-postal-code',
+			ctx.key,
+			{
+				query: {
+					postalCode: input.postalCode,
+					countryCode: input.countryCode,
+					from,
+					to,
+				},
+			},
+		);
+
+		const response = AirQualitySeriesResponseSchema.parse(raw);
+
+		await logEventFromContext(
+			ctx,
+			'ambee.airQuality.getHistoryByPostalCode',
+			{
+				postalCode: input.postalCode,
+				countryCode: input.countryCode,
+				from,
+				to,
+			},
+			'completed',
+		);
+
+		return response;
+	};
+
+/**
+ * Hourly air-quality forecast for a coordinate pair (next 48 hours).
+ *
+ * API: GET api.ambeedata.com/forecast/aq/by-lat-lng
+ * Docs: https://docs.ambeedata.com/apis/air-quality
+ */
+export const getForecastByLatLng: AmbeeEndpoints['airQualityGetForecastByLatLng'] =
+	async (ctx, input) => {
+		const raw = await makeAmbeeRequest<AirQualitySeriesResponse>(
+			'forecast/aq/by-lat-lng',
+			ctx.key,
+			{ query: { lat: input.lat, lng: input.lng } },
+		);
+
+		const response = AirQualitySeriesResponseSchema.parse(raw);
+
+		await logEventFromContext(
+			ctx,
+			'ambee.airQuality.getForecastByLatLng',
+			{ lat: input.lat, lng: input.lng },
+			'completed',
+		);
+
+		return response;
+	};

--- a/packages/ambee/endpoints/air-quality.ts
+++ b/packages/ambee/endpoints/air-quality.ts
@@ -100,6 +100,33 @@ export const getLatestByPostalCode: AmbeeEndpoints['airQualityGetLatestByPostalC
 	};
 
 /**
+ * Latest air quality for the monitoring stations across a whole country.
+ *
+ * API: GET api.ambeedata.com/latest/by-country-code
+ * Docs: https://docs.ambeedata.com/apis/air-quality
+ */
+export const getLatestByCountryCode: AmbeeEndpoints['airQualityGetLatestByCountryCode'] =
+	async (ctx, input) => {
+		const raw = await makeAmbeeRequest<AirQualityStationsResponse>(
+			'latest/by-country-code',
+			ctx.key,
+			{ query: { countryCode: input.countryCode } },
+		);
+
+		const response = AirQualityStationsResponseSchema.parse(raw);
+
+		await persistAirQualityStations(ctx, response.stations);
+		await logEventFromContext(
+			ctx,
+			'ambee.airQuality.getLatestByCountryCode',
+			{ countryCode: input.countryCode },
+			'completed',
+		);
+
+		return response;
+	};
+
+/**
  * Hourly historical air quality for a coordinate pair (up to 48 hours per
  * request).
  *

--- a/packages/ambee/endpoints/air-quality.ts
+++ b/packages/ambee/endpoints/air-quality.ts
@@ -110,7 +110,7 @@ export const getLatestByCountryCode: AmbeeEndpoints['airQualityGetLatestByCountr
 		const raw = await makeAmbeeRequest<AirQualityStationsResponse>(
 			'latest/by-country-code',
 			ctx.key,
-			{ query: { countryCode: input.countryCode } },
+			{ query: { countryCode: input.countryCode, limit: input.limit } },
 		);
 
 		const response = AirQualityStationsResponseSchema.parse(raw);
@@ -119,7 +119,7 @@ export const getLatestByCountryCode: AmbeeEndpoints['airQualityGetLatestByCountr
 		await logEventFromContext(
 			ctx,
 			'ambee.airQuality.getLatestByCountryCode',
-			{ countryCode: input.countryCode },
+			{ countryCode: input.countryCode, limit: input.limit },
 			'completed',
 		);
 

--- a/packages/ambee/endpoints/disasters.test.ts
+++ b/packages/ambee/endpoints/disasters.test.ts
@@ -1,0 +1,272 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeAmbeeRequest } from '../client';
+import type { AmbeeContext } from '../index';
+import {
+	getHistoryByContinent,
+	getHistoryByCountryCode,
+	getHistoryByDateRange,
+	getHistoryByLatLng,
+	getLatestByContinent,
+	getLatestByCountryCode,
+	getLatestByLatLng,
+} from './disasters';
+
+jest.mock('../client', () => ({
+	makeAmbeeRequest: jest.fn(),
+	toAmbeeTimestamp: jest.requireActual('../client').toAmbeeTimestamp,
+}));
+
+jest.mock('corsair/core', () => ({
+	logEventFromContext: jest.fn().mockResolvedValue(null),
+}));
+
+const mockRequest = makeAmbeeRequest as jest.MockedFunction<
+	typeof makeAmbeeRequest
+>;
+const mockLogEvent = logEventFromContext as jest.MockedFunction<
+	typeof logEventFromContext
+>;
+
+const DISASTER_RESPONSE = {
+	message: 'success',
+	result: [
+		{
+			event_id: 'EQ-2026-0042',
+			event_type: 'EQ',
+			event_name: 'Earthquake',
+			lat: -15.76166996,
+			lng: -72.48771045,
+			country_code: 'PER',
+			continent: 'SAR',
+			date: '2026-08-01T04:12:00.000Z',
+			severity: 5.4,
+		},
+	],
+	page: 1,
+	limit: 1,
+};
+
+function makeCtx(): AmbeeContext {
+	return { key: 'test-key', options: {}, db: {} } as unknown as AmbeeContext;
+}
+
+beforeEach(() => {
+	mockRequest.mockReset();
+	mockLogEvent.mockClear();
+});
+
+describe('disasters.getLatestByLatLng', () => {
+	it('calls disasters/latest/by-lat-lng and returns the events', async () => {
+		mockRequest.mockResolvedValue(DISASTER_RESPONSE);
+
+		const result = await getLatestByLatLng(makeCtx(), {
+			lat: -15.76166996,
+			lng: -72.48771045,
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'disasters/latest/by-lat-lng',
+			'test-key',
+			{
+				query: {
+					lat: -15.76166996,
+					lng: -72.48771045,
+					eventType: undefined,
+					limit: undefined,
+					page: undefined,
+				},
+			},
+		);
+		expect(result.result?.[0]?.event_type).toBe('EQ');
+	});
+
+	it('forwards pagination and the event-type filter', async () => {
+		mockRequest.mockResolvedValue(DISASTER_RESPONSE);
+
+		await getLatestByLatLng(makeCtx(), {
+			lat: 0,
+			lng: 0,
+			eventType: 'FL',
+			limit: 25,
+			page: 3,
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'disasters/latest/by-lat-lng',
+			'test-key',
+			{ query: { lat: 0, lng: 0, eventType: 'FL', limit: 25, page: 3 } },
+		);
+	});
+});
+
+describe('disasters.getLatestByCountryCode', () => {
+	it('calls disasters/latest/by-country-code with the ISO code', async () => {
+		mockRequest.mockResolvedValue(DISASTER_RESPONSE);
+
+		await getLatestByCountryCode(makeCtx(), { countryCode: 'IND', limit: 10 });
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'disasters/latest/by-country-code',
+			'test-key',
+			{
+				query: {
+					countryCode: 'IND',
+					eventType: undefined,
+					limit: 10,
+					page: undefined,
+				},
+			},
+		);
+	});
+});
+
+describe('disasters.getLatestByContinent', () => {
+	it('calls disasters/latest/by-continent with the continent code', async () => {
+		mockRequest.mockResolvedValue(DISASTER_RESPONSE);
+
+		await getLatestByContinent(makeCtx(), { continent: 'NAR' });
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'disasters/latest/by-continent',
+			'test-key',
+			{
+				query: {
+					continent: 'NAR',
+					eventType: undefined,
+					limit: undefined,
+					page: undefined,
+				},
+			},
+		);
+	});
+});
+
+describe('disasters.getHistoryByLatLng', () => {
+	it('normalises the date range', async () => {
+		mockRequest.mockResolvedValue(DISASTER_RESPONSE);
+
+		await getHistoryByLatLng(makeCtx(), {
+			lat: 40.4549,
+			lng: 36.3025,
+			from: '2026-05-31T12:00:00.000Z',
+			to: '2026-07-31T08:00:00.000Z',
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'disasters/history/by-lat-lng',
+			'test-key',
+			{
+				query: {
+					lat: 40.4549,
+					lng: 36.3025,
+					from: '2026-05-31 12:00:00',
+					to: '2026-07-31 08:00:00',
+					eventType: undefined,
+					limit: undefined,
+					page: undefined,
+				},
+			},
+		);
+	});
+});
+
+describe('disasters.getHistoryByCountryCode', () => {
+	it('calls disasters/history/by-country-code with the normalised range', async () => {
+		mockRequest.mockResolvedValue(DISASTER_RESPONSE);
+
+		await getHistoryByCountryCode(makeCtx(), {
+			countryCode: 'IND',
+			from: '2026-07-01 12:00:00',
+			to: '2026-07-31 08:00:00',
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'disasters/history/by-country-code',
+			'test-key',
+			{
+				query: {
+					countryCode: 'IND',
+					from: '2026-07-01 12:00:00',
+					to: '2026-07-31 08:00:00',
+					eventType: undefined,
+					limit: undefined,
+					page: undefined,
+				},
+			},
+		);
+	});
+});
+
+describe('disasters.getHistoryByContinent', () => {
+	it('calls disasters/history/by-continent with the normalised range', async () => {
+		mockRequest.mockResolvedValue(DISASTER_RESPONSE);
+
+		await getHistoryByContinent(makeCtx(), {
+			continent: 'ANT',
+			from: '2026-07-01 12:00:00',
+			to: '2026-07-31 08:00:00',
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'disasters/history/by-continent',
+			'test-key',
+			{
+				query: {
+					continent: 'ANT',
+					from: '2026-07-01 12:00:00',
+					to: '2026-07-31 08:00:00',
+					eventType: undefined,
+					limit: undefined,
+					page: undefined,
+				},
+			},
+		);
+	});
+});
+
+describe('disasters.getHistoryByDateRange', () => {
+	it('omits `to` when the caller does not supply one', async () => {
+		mockRequest.mockResolvedValue(DISASTER_RESPONSE);
+
+		await getHistoryByDateRange(makeCtx(), {
+			from: '2026-07-01 15:00:00',
+			limit: 3,
+			page: 1,
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith('disasters/history', 'test-key', {
+			query: {
+				from: '2026-07-01 15:00:00',
+				to: undefined,
+				eventType: undefined,
+				limit: 3,
+				page: 1,
+			},
+		});
+		expect(mockLogEvent).toHaveBeenCalledWith(
+			expect.anything(),
+			'ambee.disasters.getHistoryByDateRange',
+			{ from: '2026-07-01 15:00:00', to: undefined, page: 1 },
+			'completed',
+		);
+	});
+
+	it('normalises `to` when one is supplied', async () => {
+		mockRequest.mockResolvedValue(DISASTER_RESPONSE);
+
+		await getHistoryByDateRange(makeCtx(), {
+			from: '2026-07-01T15:00:00.000Z',
+			to: '2026-07-05T15:00:00.000Z',
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith('disasters/history', 'test-key', {
+			query: {
+				from: '2026-07-01 15:00:00',
+				to: '2026-07-05 15:00:00',
+				eventType: undefined,
+				limit: undefined,
+				page: undefined,
+			},
+		});
+	});
+});

--- a/packages/ambee/endpoints/disasters.ts
+++ b/packages/ambee/endpoints/disasters.ts
@@ -1,0 +1,257 @@
+import { logEventFromContext } from 'corsair/core';
+import type { AmbeeQuery } from '../client';
+import { makeAmbeeRequest, toAmbeeTimestamp } from '../client';
+import type { AmbeeEndpoints } from '../index';
+import type { DisasterResponse } from './types';
+import { DisasterResponseSchema } from './types';
+
+/**
+ * Natural disasters is the only paginated Ambee product — every endpoint
+ * accepts `page` and `limit`, and both default to 1 server-side, so they are
+ * forwarded verbatim rather than defaulted here.
+ */
+function paginationQuery(input: {
+	eventType?: string;
+	limit?: number;
+	page?: number;
+}): AmbeeQuery {
+	return {
+		eventType: input.eventType,
+		limit: input.limit,
+		page: input.page,
+	};
+}
+
+/**
+ * Latest natural disasters near a coordinate pair.
+ *
+ * API: GET api.ambeedata.com/disasters/latest/by-lat-lng
+ * Docs: https://docs.ambeedata.com/apis/natural_disasters
+ */
+export const getLatestByLatLng: AmbeeEndpoints['disastersGetLatestByLatLng'] =
+	async (ctx, input) => {
+		const raw = await makeAmbeeRequest<DisasterResponse>(
+			'disasters/latest/by-lat-lng',
+			ctx.key,
+			{
+				query: {
+					lat: input.lat,
+					lng: input.lng,
+					...paginationQuery(input),
+				},
+			},
+		);
+
+		const response = DisasterResponseSchema.parse(raw);
+
+		await logEventFromContext(
+			ctx,
+			'ambee.disasters.getLatestByLatLng',
+			{ lat: input.lat, lng: input.lng, page: input.page },
+			'completed',
+		);
+
+		return response;
+	};
+
+/**
+ * Latest natural disasters in a country.
+ *
+ * API: GET api.ambeedata.com/disasters/latest/by-country-code
+ * Docs: https://docs.ambeedata.com/apis/natural_disasters
+ */
+export const getLatestByCountryCode: AmbeeEndpoints['disastersGetLatestByCountryCode'] =
+	async (ctx, input) => {
+		const raw = await makeAmbeeRequest<DisasterResponse>(
+			'disasters/latest/by-country-code',
+			ctx.key,
+			{
+				query: {
+					countryCode: input.countryCode,
+					...paginationQuery(input),
+				},
+			},
+		);
+
+		const response = DisasterResponseSchema.parse(raw);
+
+		await logEventFromContext(
+			ctx,
+			'ambee.disasters.getLatestByCountryCode',
+			{ countryCode: input.countryCode, page: input.page },
+			'completed',
+		);
+
+		return response;
+	};
+
+/**
+ * Latest natural disasters on a continent.
+ *
+ * API: GET api.ambeedata.com/disasters/latest/by-continent
+ * Docs: https://docs.ambeedata.com/apis/natural_disasters
+ */
+export const getLatestByContinent: AmbeeEndpoints['disastersGetLatestByContinent'] =
+	async (ctx, input) => {
+		const raw = await makeAmbeeRequest<DisasterResponse>(
+			'disasters/latest/by-continent',
+			ctx.key,
+			{
+				query: {
+					continent: input.continent,
+					...paginationQuery(input),
+				},
+			},
+		);
+
+		const response = DisasterResponseSchema.parse(raw);
+
+		await logEventFromContext(
+			ctx,
+			'ambee.disasters.getLatestByContinent',
+			{ continent: input.continent, page: input.page },
+			'completed',
+		);
+
+		return response;
+	};
+
+/**
+ * Historical natural disasters near a coordinate pair.
+ *
+ * API: GET api.ambeedata.com/disasters/history/by-lat-lng
+ * Docs: https://docs.ambeedata.com/apis/natural_disasters
+ */
+export const getHistoryByLatLng: AmbeeEndpoints['disastersGetHistoryByLatLng'] =
+	async (ctx, input) => {
+		const from = toAmbeeTimestamp(input.from);
+		const to = toAmbeeTimestamp(input.to);
+
+		const raw = await makeAmbeeRequest<DisasterResponse>(
+			'disasters/history/by-lat-lng',
+			ctx.key,
+			{
+				query: {
+					lat: input.lat,
+					lng: input.lng,
+					from,
+					to,
+					...paginationQuery(input),
+				},
+			},
+		);
+
+		const response = DisasterResponseSchema.parse(raw);
+
+		await logEventFromContext(
+			ctx,
+			'ambee.disasters.getHistoryByLatLng',
+			{ lat: input.lat, lng: input.lng, from, to, page: input.page },
+			'completed',
+		);
+
+		return response;
+	};
+
+/**
+ * Historical natural disasters in a country.
+ *
+ * API: GET api.ambeedata.com/disasters/history/by-country-code
+ * Docs: https://docs.ambeedata.com/apis/natural_disasters
+ */
+export const getHistoryByCountryCode: AmbeeEndpoints['disastersGetHistoryByCountryCode'] =
+	async (ctx, input) => {
+		const from = toAmbeeTimestamp(input.from);
+		const to = toAmbeeTimestamp(input.to);
+
+		const raw = await makeAmbeeRequest<DisasterResponse>(
+			'disasters/history/by-country-code',
+			ctx.key,
+			{
+				query: {
+					countryCode: input.countryCode,
+					from,
+					to,
+					...paginationQuery(input),
+				},
+			},
+		);
+
+		const response = DisasterResponseSchema.parse(raw);
+
+		await logEventFromContext(
+			ctx,
+			'ambee.disasters.getHistoryByCountryCode',
+			{ countryCode: input.countryCode, from, to, page: input.page },
+			'completed',
+		);
+
+		return response;
+	};
+
+/**
+ * Historical natural disasters on a continent.
+ *
+ * API: GET api.ambeedata.com/disasters/history/by-continent
+ * Docs: https://docs.ambeedata.com/apis/natural_disasters
+ */
+export const getHistoryByContinent: AmbeeEndpoints['disastersGetHistoryByContinent'] =
+	async (ctx, input) => {
+		const from = toAmbeeTimestamp(input.from);
+		const to = toAmbeeTimestamp(input.to);
+
+		const raw = await makeAmbeeRequest<DisasterResponse>(
+			'disasters/history/by-continent',
+			ctx.key,
+			{
+				query: {
+					continent: input.continent,
+					from,
+					to,
+					...paginationQuery(input),
+				},
+			},
+		);
+
+		const response = DisasterResponseSchema.parse(raw);
+
+		await logEventFromContext(
+			ctx,
+			'ambee.disasters.getHistoryByContinent',
+			{ continent: input.continent, from, to, page: input.page },
+			'completed',
+		);
+
+		return response;
+	};
+
+/**
+ * Historical natural disasters worldwide over a date range — the only
+ * disasters endpoint with no location filter, and the only one where `to` is
+ * optional.
+ *
+ * API: GET api.ambeedata.com/disasters/history
+ * Docs: https://docs.ambeedata.com/apis/natural_disasters
+ */
+export const getHistoryByDateRange: AmbeeEndpoints['disastersGetHistoryByDateRange'] =
+	async (ctx, input) => {
+		const from = toAmbeeTimestamp(input.from);
+		const to = input.to === undefined ? undefined : toAmbeeTimestamp(input.to);
+
+		const raw = await makeAmbeeRequest<DisasterResponse>(
+			'disasters/history',
+			ctx.key,
+			{ query: { from, to, ...paginationQuery(input) } },
+		);
+
+		const response = DisasterResponseSchema.parse(raw);
+
+		await logEventFromContext(
+			ctx,
+			'ambee.disasters.getHistoryByDateRange',
+			{ from, to, page: input.page },
+			'completed',
+		);
+
+		return response;
+	};

--- a/packages/ambee/endpoints/elevation.test.ts
+++ b/packages/ambee/endpoints/elevation.test.ts
@@ -1,0 +1,121 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeAmbeeRequest } from '../client';
+import type { AmbeeContext } from '../index';
+import { getByLatLng, getByPlace } from './elevation';
+import { getForecastByLatLng as iliGetForecastByLatLng } from './ili';
+
+jest.mock('../client', () => ({ makeAmbeeRequest: jest.fn() }));
+
+jest.mock('corsair/core', () => ({
+	logEventFromContext: jest.fn().mockResolvedValue(null),
+}));
+
+const mockRequest = makeAmbeeRequest as jest.MockedFunction<
+	typeof makeAmbeeRequest
+>;
+const mockLogEvent = logEventFromContext as jest.MockedFunction<
+	typeof logEventFromContext
+>;
+
+const ELEVATION_RESPONSE = {
+	message: 'success',
+	data: [
+		{
+			lat: 37.77355324503912,
+			lng: -122.39428048824142,
+			elevation: 12,
+			minElevation: 10,
+			maxElevation: 15,
+			meanElevation: 12.4,
+		},
+	],
+};
+
+const ILI_RESPONSE = {
+	message: 'success',
+	lat: 37.7749,
+	lng: -122.4194,
+	data: [{ date: '2026-08-11', risk: 'Low' }],
+};
+
+function makeCtx(): AmbeeContext {
+	return { key: 'test-key', options: {}, db: {} } as unknown as AmbeeContext;
+}
+
+beforeEach(() => {
+	mockRequest.mockReset();
+	mockLogEvent.mockClear();
+});
+
+describe('elevation.getByLatLng', () => {
+	it('calls elevation/latest/by-lat-lng and returns the reading', async () => {
+		mockRequest.mockResolvedValue(ELEVATION_RESPONSE);
+
+		const result = await getByLatLng(makeCtx(), {
+			lat: 37.77355324503912,
+			lng: -122.39428048824142,
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'elevation/latest/by-lat-lng',
+			'test-key',
+			{ query: { lat: 37.77355324503912, lng: -122.39428048824142 } },
+		);
+		expect(result.data?.[0]?.elevation).toBe(12);
+		expect(result.data?.[0]?.meanElevation).toBe(12.4);
+	});
+});
+
+describe('elevation.getByPlace', () => {
+	it('calls elevation/latest/by-place and logs the event', async () => {
+		mockRequest.mockResolvedValue(ELEVATION_RESPONSE);
+
+		await getByPlace(makeCtx(), { place: 'San Francisco, USA' });
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'elevation/latest/by-place',
+			'test-key',
+			{ query: { place: 'San Francisco, USA' } },
+		);
+		expect(mockLogEvent).toHaveBeenCalledWith(
+			expect.anything(),
+			'ambee.elevation.getByPlace',
+			{ place: 'San Francisco, USA' },
+			'completed',
+		);
+	});
+});
+
+describe('ili.getForecastByLatLng', () => {
+	it('always sends `details`, defaulting it to false', async () => {
+		mockRequest.mockResolvedValue(ILI_RESPONSE);
+
+		await iliGetForecastByLatLng(makeCtx(), {
+			lat: 37.7749,
+			lng: -122.4194,
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'ili/forecast/by-lat-lng',
+			'test-key',
+			{ query: { lat: 37.7749, lng: -122.4194, details: false } },
+		);
+	});
+
+	it('forwards details=true and returns the risk forecast', async () => {
+		mockRequest.mockResolvedValue(ILI_RESPONSE);
+
+		const result = await iliGetForecastByLatLng(makeCtx(), {
+			lat: 37.7749,
+			lng: -122.4194,
+			details: true,
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'ili/forecast/by-lat-lng',
+			'test-key',
+			{ query: { lat: 37.7749, lng: -122.4194, details: true } },
+		);
+		expect(result.data?.[0]?.risk).toBe('Low');
+	});
+});

--- a/packages/ambee/endpoints/elevation.ts
+++ b/packages/ambee/endpoints/elevation.ts
@@ -1,0 +1,61 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeAmbeeRequest } from '../client';
+import type { AmbeeEndpoints } from '../index';
+import type { ElevationResponse } from './types';
+import { ElevationResponseSchema } from './types';
+
+/**
+ * Ground elevation at a coordinate pair.
+ *
+ * API: GET api.ambeedata.com/elevation/latest/by-lat-lng
+ * Docs: https://docs.ambeedata.com/apis/elevation
+ */
+export const getByLatLng: AmbeeEndpoints['elevationGetByLatLng'] = async (
+	ctx,
+	input,
+) => {
+	const raw = await makeAmbeeRequest<ElevationResponse>(
+		'elevation/latest/by-lat-lng',
+		ctx.key,
+		{ query: { lat: input.lat, lng: input.lng } },
+	);
+
+	const response = ElevationResponseSchema.parse(raw);
+
+	await logEventFromContext(
+		ctx,
+		'ambee.elevation.getByLatLng',
+		{ lat: input.lat, lng: input.lng },
+		'completed',
+	);
+
+	return response;
+};
+
+/**
+ * Ground elevation for a named place.
+ *
+ * API: GET api.ambeedata.com/elevation/latest/by-place
+ * Docs: https://docs.ambeedata.com/apis/elevation
+ */
+export const getByPlace: AmbeeEndpoints['elevationGetByPlace'] = async (
+	ctx,
+	input,
+) => {
+	const raw = await makeAmbeeRequest<ElevationResponse>(
+		'elevation/latest/by-place',
+		ctx.key,
+		{ query: { place: input.place } },
+	);
+
+	const response = ElevationResponseSchema.parse(raw);
+
+	await logEventFromContext(
+		ctx,
+		'ambee.elevation.getByPlace',
+		{ place: input.place },
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/ambee/endpoints/fire.test.ts
+++ b/packages/ambee/endpoints/fire.test.ts
@@ -1,0 +1,138 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeAmbeeRequest } from '../client';
+import type { AmbeeContext } from '../index';
+import {
+	getLatestByLatLng,
+	getLatestByPlace,
+	getRiskByLatLng,
+	getRiskByPlace,
+} from './fire';
+
+jest.mock('../client', () => ({ makeAmbeeRequest: jest.fn() }));
+
+jest.mock('corsair/core', () => ({
+	logEventFromContext: jest.fn().mockResolvedValue(null),
+}));
+
+const mockRequest = makeAmbeeRequest as jest.MockedFunction<
+	typeof makeAmbeeRequest
+>;
+const mockLogEvent = logEventFromContext as jest.MockedFunction<
+	typeof logEventFromContext
+>;
+
+const FIRE_RESPONSE = {
+	message: 'success',
+	data: [
+		{
+			lat: 36.27347,
+			lng: -106.70503,
+			detectedAt: '2026-08-05T18:24:00.000Z',
+			confidence: 84,
+			frp: 12.4,
+			satellite: 'Suomi-NPP',
+			fireType: 'detected',
+		},
+	],
+};
+
+const RISK_RESPONSE = {
+	message: 'success',
+	data: [
+		{ date: '2026-08-11', risk: 'High' },
+		{ date: '2026-08-12', risk: 'Moderate' },
+	],
+};
+
+function makeCtx(): AmbeeContext {
+	return { key: 'test-key', options: {}, db: {} } as unknown as AmbeeContext;
+}
+
+beforeEach(() => {
+	mockRequest.mockReset();
+	mockLogEvent.mockClear();
+});
+
+describe('fire.getLatestByLatLng', () => {
+	it('calls fire/latest/by-lat-lng and returns the detected fires', async () => {
+		mockRequest.mockResolvedValue(FIRE_RESPONSE);
+
+		const result = await getLatestByLatLng(makeCtx(), {
+			lat: 36.27347,
+			lng: -106.70503,
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'fire/latest/by-lat-lng',
+			'test-key',
+			{ query: { lat: 36.27347, lng: -106.70503, type: undefined } },
+		);
+		expect(result.data?.[0]?.frp).toBe(12.4);
+	});
+
+	it('forwards the reported/detected filter', async () => {
+		mockRequest.mockResolvedValue(FIRE_RESPONSE);
+
+		await getLatestByLatLng(makeCtx(), {
+			lat: 36.27347,
+			lng: -106.70503,
+			type: 'reported',
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'fire/latest/by-lat-lng',
+			'test-key',
+			{ query: { lat: 36.27347, lng: -106.70503, type: 'reported' } },
+		);
+	});
+});
+
+describe('fire.getLatestByPlace', () => {
+	it('calls fire/latest/by-place with the place name', async () => {
+		mockRequest.mockResolvedValue(FIRE_RESPONSE);
+
+		await getLatestByPlace(makeCtx(), { place: 'Virgin, UT' });
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'fire/latest/by-place',
+			'test-key',
+			{ query: { place: 'Virgin, UT', type: undefined } },
+		);
+	});
+});
+
+describe('fire.getRiskByLatLng', () => {
+	it('calls fire/risk/by-lat-lng and returns the risk forecast', async () => {
+		mockRequest.mockResolvedValue(RISK_RESPONSE);
+
+		const result = await getRiskByLatLng(makeCtx(), {
+			lat: 22.948819,
+			lng: -101.495951,
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'fire/risk/by-lat-lng',
+			'test-key',
+			{ query: { lat: 22.948819, lng: -101.495951 } },
+		);
+		expect(result.data).toHaveLength(2);
+	});
+});
+
+describe('fire.getRiskByPlace', () => {
+	it('calls fire/risk/by-place and logs the event', async () => {
+		mockRequest.mockResolvedValue(RISK_RESPONSE);
+
+		await getRiskByPlace(makeCtx(), { place: 'Leon, Mexico' });
+
+		expect(mockRequest).toHaveBeenCalledWith('fire/risk/by-place', 'test-key', {
+			query: { place: 'Leon, Mexico' },
+		});
+		expect(mockLogEvent).toHaveBeenCalledWith(
+			expect.anything(),
+			'ambee.fire.getRiskByPlace',
+			{ place: 'Leon, Mexico' },
+			'completed',
+		);
+	});
+});

--- a/packages/ambee/endpoints/fire.ts
+++ b/packages/ambee/endpoints/fire.ts
@@ -1,0 +1,117 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeAmbeeRequest } from '../client';
+import type { AmbeeEndpoints } from '../index';
+import type { FireResponse, FireRiskResponse } from './types';
+import { FireResponseSchema, FireRiskResponseSchema } from './types';
+
+/**
+ * Wildfires detected or reported near a coordinate pair over the last 7 days.
+ *
+ * API: GET api.ambeedata.com/fire/latest/by-lat-lng
+ * Docs: https://docs.ambeedata.com/apis/fire
+ */
+export const getLatestByLatLng: AmbeeEndpoints['fireGetLatestByLatLng'] =
+	async (ctx, input) => {
+		const raw = await makeAmbeeRequest<FireResponse>(
+			'fire/latest/by-lat-lng',
+			ctx.key,
+			{ query: { lat: input.lat, lng: input.lng, type: input.type } },
+		);
+
+		const response = FireResponseSchema.parse(raw);
+
+		await logEventFromContext(
+			ctx,
+			'ambee.fire.getLatestByLatLng',
+			{ lat: input.lat, lng: input.lng, type: input.type },
+			'completed',
+		);
+
+		return response;
+	};
+
+/**
+ * Wildfires detected or reported near a named place over the last 7 days.
+ *
+ * API: GET api.ambeedata.com/fire/latest/by-place
+ * Docs: https://docs.ambeedata.com/apis/fire
+ */
+export const getLatestByPlace: AmbeeEndpoints['fireGetLatestByPlace'] = async (
+	ctx,
+	input,
+) => {
+	const raw = await makeAmbeeRequest<FireResponse>(
+		'fire/latest/by-place',
+		ctx.key,
+		{ query: { place: input.place, type: input.type } },
+	);
+
+	const response = FireResponseSchema.parse(raw);
+
+	await logEventFromContext(
+		ctx,
+		'ambee.fire.getLatestByPlace',
+		{ place: input.place, type: input.type },
+		'completed',
+	);
+
+	return response;
+};
+
+/**
+ * Wildfire risk forecast for a coordinate pair (up to 4 weeks ahead, North
+ * America coverage).
+ *
+ * API: GET api.ambeedata.com/fire/risk/by-lat-lng
+ * Docs: https://docs.ambeedata.com/apis/fire
+ */
+export const getRiskByLatLng: AmbeeEndpoints['fireGetRiskByLatLng'] = async (
+	ctx,
+	input,
+) => {
+	const raw = await makeAmbeeRequest<FireRiskResponse>(
+		'fire/risk/by-lat-lng',
+		ctx.key,
+		{ query: { lat: input.lat, lng: input.lng } },
+	);
+
+	const response = FireRiskResponseSchema.parse(raw);
+
+	await logEventFromContext(
+		ctx,
+		'ambee.fire.getRiskByLatLng',
+		{ lat: input.lat, lng: input.lng },
+		'completed',
+	);
+
+	return response;
+};
+
+/**
+ * Wildfire risk forecast for a named place (up to 4 weeks ahead, North
+ * America coverage).
+ *
+ * API: GET api.ambeedata.com/fire/risk/by-place
+ * Docs: https://docs.ambeedata.com/apis/fire
+ */
+export const getRiskByPlace: AmbeeEndpoints['fireGetRiskByPlace'] = async (
+	ctx,
+	input,
+) => {
+	const raw = await makeAmbeeRequest<FireRiskResponse>(
+		'fire/risk/by-place',
+		ctx.key,
+		{ query: { place: input.place } },
+	);
+
+	const response = FireRiskResponseSchema.parse(raw);
+
+	await logEventFromContext(
+		ctx,
+		'ambee.fire.getRiskByPlace',
+		{ place: input.place },
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/ambee/endpoints/geocode.test.ts
+++ b/packages/ambee/endpoints/geocode.test.ts
@@ -72,6 +72,21 @@ describe('geocode.byPlace', () => {
 			city: 'New York',
 		});
 	});
+
+	it('preserves zero-valued coordinates when persisting', async () => {
+		mockRequest.mockResolvedValue({
+			message: 'success',
+			data: [{ lat: '0', lng: '0', city: 'Null Island' }],
+		});
+
+		await byPlace(makeCtx(), { place: 'null island' });
+
+		expect(upsertByEntityId.mock.calls[0][1]).toMatchObject({
+			lat: 0,
+			lng: 0,
+			city: 'Null Island',
+		});
+	});
 });
 
 describe('geocode.reverseByLatLng', () => {

--- a/packages/ambee/endpoints/geocode.test.ts
+++ b/packages/ambee/endpoints/geocode.test.ts
@@ -1,0 +1,101 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeAmbeeRequest } from '../client';
+import type { AmbeeContext } from '../index';
+import { byPlace, reverseByLatLng } from './geocode';
+
+jest.mock('../client', () => ({ makeAmbeeRequest: jest.fn() }));
+
+jest.mock('corsair/core', () => ({
+	logEventFromContext: jest.fn().mockResolvedValue(null),
+}));
+
+const mockRequest = makeAmbeeRequest as jest.MockedFunction<
+	typeof makeAmbeeRequest
+>;
+const mockLogEvent = logEventFromContext as jest.MockedFunction<
+	typeof logEventFromContext
+>;
+
+const GEOCODE_RESPONSE = {
+	message: 'success',
+	data: [
+		{
+			lat: '40.7127281',
+			lng: '-74.0060152',
+			city: 'New York',
+			state: 'New York',
+			countryCode: 'US',
+			formattedAddress: 'New York, NY, USA',
+		},
+	],
+};
+
+const upsertByEntityId = jest.fn().mockResolvedValue(undefined);
+
+function makeCtx(): AmbeeContext {
+	return {
+		key: 'test-key',
+		options: {},
+		db: { geocodedPlaces: { upsertByEntityId } },
+	} as unknown as AmbeeContext;
+}
+
+beforeEach(() => {
+	mockRequest.mockReset();
+	mockLogEvent.mockClear();
+	upsertByEntityId.mockClear();
+});
+
+describe('geocode.byPlace', () => {
+	it('calls geocode/by-place and returns the matches', async () => {
+		mockRequest.mockResolvedValue(GEOCODE_RESPONSE);
+
+		const result = await byPlace(makeCtx(), { place: 'new york' });
+
+		expect(mockRequest).toHaveBeenCalledWith('geocode/by-place', 'test-key', {
+			query: { place: 'new york' },
+		});
+		expect(result.data?.[0]?.city).toBe('New York');
+	});
+
+	it('persists each match under the originating query and coerces string coordinates', async () => {
+		mockRequest.mockResolvedValue(GEOCODE_RESPONSE);
+
+		await byPlace(makeCtx(), { place: 'new york' });
+
+		const [entityId, row] = upsertByEntityId.mock.calls[0];
+		expect(entityId).toBe('new york#0');
+		expect(row).toMatchObject({
+			query: 'new york',
+			lat: 40.7127281,
+			lng: -74.0060152,
+			city: 'New York',
+		});
+	});
+});
+
+describe('geocode.reverseByLatLng', () => {
+	it('calls geocode/reverse/by-lat-lng and keys stored results by coordinates', async () => {
+		mockRequest.mockResolvedValue(GEOCODE_RESPONSE);
+
+		await reverseByLatLng(makeCtx(), {
+			lat: 42.66548262280807,
+			lng: -73.79192663186527,
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'geocode/reverse/by-lat-lng',
+			'test-key',
+			{ query: { lat: 42.66548262280807, lng: -73.79192663186527 } },
+		);
+		expect(upsertByEntityId.mock.calls[0][0]).toBe(
+			'42.66548262280807,-73.79192663186527#0',
+		);
+		expect(mockLogEvent).toHaveBeenCalledWith(
+			expect.anything(),
+			'ambee.geocode.reverseByLatLng',
+			{ lat: 42.66548262280807, lng: -73.79192663186527 },
+			'completed',
+		);
+	});
+});

--- a/packages/ambee/endpoints/geocode.ts
+++ b/packages/ambee/endpoints/geocode.ts
@@ -1,0 +1,61 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeAmbeeRequest } from '../client';
+import type { AmbeeEndpoints } from '../index';
+import { persistGeocodeResults } from './persist';
+import type { GeocodeResponse } from './types';
+import { GeocodeResponseSchema } from './types';
+
+/**
+ * Geocode a place name or address into coordinates.
+ *
+ * API: GET api.ambeedata.com/geocode/by-place
+ * Docs: https://docs.ambeedata.com/apis/location
+ */
+export const byPlace: AmbeeEndpoints['geocodeByPlace'] = async (ctx, input) => {
+	const raw = await makeAmbeeRequest<GeocodeResponse>(
+		'geocode/by-place',
+		ctx.key,
+		{ query: { place: input.place } },
+	);
+
+	const response = GeocodeResponseSchema.parse(raw);
+
+	await persistGeocodeResults(ctx, input.place, response.data);
+	await logEventFromContext(
+		ctx,
+		'ambee.geocode.byPlace',
+		{ place: input.place },
+		'completed',
+	);
+
+	return response;
+};
+
+/**
+ * Reverse-geocode a coordinate pair into a human-readable address.
+ *
+ * API: GET api.ambeedata.com/geocode/reverse/by-lat-lng
+ * Docs: https://docs.ambeedata.com/apis/location
+ */
+export const reverseByLatLng: AmbeeEndpoints['geocodeReverseByLatLng'] = async (
+	ctx,
+	input,
+) => {
+	const raw = await makeAmbeeRequest<GeocodeResponse>(
+		'geocode/reverse/by-lat-lng',
+		ctx.key,
+		{ query: { lat: input.lat, lng: input.lng } },
+	);
+
+	const response = GeocodeResponseSchema.parse(raw);
+
+	await persistGeocodeResults(ctx, `${input.lat},${input.lng}`, response.data);
+	await logEventFromContext(
+		ctx,
+		'ambee.geocode.reverseByLatLng',
+		{ lat: input.lat, lng: input.lng },
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/ambee/endpoints/ili.ts
+++ b/packages/ambee/endpoints/ili.ts
@@ -1,0 +1,36 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeAmbeeRequest } from '../client';
+import type { AmbeeEndpoints } from '../index';
+import type { IliForecastResponse } from './types';
+import { IliForecastResponseSchema } from './types';
+
+/**
+ * Daily influenza-like-illness risk forecast for a coordinate pair.
+ * Coverage: US, Germany, Poland, Croatia, France, Italy and Spain (beta).
+ *
+ * API: GET api.ambeedata.com/ili/forecast/by-lat-lng
+ * Docs: https://docs.ambeedata.com/apis/ili
+ */
+export const getForecastByLatLng: AmbeeEndpoints['iliGetForecastByLatLng'] =
+	async (ctx, input) => {
+		// `details` is documented as required, so it is always sent — omitting
+		// it makes Ambee reject the request rather than assume a default.
+		const details = input.details ?? false;
+
+		const raw = await makeAmbeeRequest<IliForecastResponse>(
+			'ili/forecast/by-lat-lng',
+			ctx.key,
+			{ query: { lat: input.lat, lng: input.lng, details } },
+		);
+
+		const response = IliForecastResponseSchema.parse(raw);
+
+		await logEventFromContext(
+			ctx,
+			'ambee.ili.getForecastByLatLng',
+			{ lat: input.lat, lng: input.lng, details },
+			'completed',
+		);
+
+		return response;
+	};

--- a/packages/ambee/endpoints/index.ts
+++ b/packages/ambee/endpoints/index.ts
@@ -1,0 +1,63 @@
+import {
+	getForecastByLatLng as airQualityGetForecastByLatLng,
+	getHistoryByLatLng as airQualityGetHistoryByLatLng,
+	getHistoryByPostalCode as airQualityGetHistoryByPostalCode,
+	getLatestByCity as airQualityGetLatestByCity,
+	getLatestByLatLng as airQualityGetLatestByLatLng,
+	getLatestByPostalCode as airQualityGetLatestByPostalCode,
+} from './air-quality';
+import {
+	getLatestByLatLng as fireGetLatestByLatLng,
+	getLatestByPlace as fireGetLatestByPlace,
+	getRiskByLatLng as fireGetRiskByLatLng,
+	getRiskByPlace as fireGetRiskByPlace,
+} from './fire';
+import {
+	byPlace as geocodeByPlace,
+	reverseByLatLng as geocodeReverseByLatLng,
+} from './geocode';
+import {
+	getForecast as pollenGetForecast,
+	getHistory as pollenGetHistory,
+	getLatest as pollenGetLatest,
+} from './pollen';
+import {
+	getForecast as weatherGetForecast,
+	getHistory as weatherGetHistory,
+	getLatest as weatherGetLatest,
+} from './weather';
+
+export const AirQuality = {
+	getLatestByLatLng: airQualityGetLatestByLatLng,
+	getLatestByCity: airQualityGetLatestByCity,
+	getLatestByPostalCode: airQualityGetLatestByPostalCode,
+	getHistoryByLatLng: airQualityGetHistoryByLatLng,
+	getHistoryByPostalCode: airQualityGetHistoryByPostalCode,
+	getForecastByLatLng: airQualityGetForecastByLatLng,
+};
+
+export const Weather = {
+	getLatest: weatherGetLatest,
+	getHistory: weatherGetHistory,
+	getForecast: weatherGetForecast,
+};
+
+export const Pollen = {
+	getLatest: pollenGetLatest,
+	getHistory: pollenGetHistory,
+	getForecast: pollenGetForecast,
+};
+
+export const Fire = {
+	getLatestByLatLng: fireGetLatestByLatLng,
+	getLatestByPlace: fireGetLatestByPlace,
+	getRiskByLatLng: fireGetRiskByLatLng,
+	getRiskByPlace: fireGetRiskByPlace,
+};
+
+export const Geocode = {
+	byPlace: geocodeByPlace,
+	reverseByLatLng: geocodeReverseByLatLng,
+};
+
+export * from './types';

--- a/packages/ambee/endpoints/index.ts
+++ b/packages/ambee/endpoints/index.ts
@@ -3,9 +3,23 @@ import {
 	getHistoryByLatLng as airQualityGetHistoryByLatLng,
 	getHistoryByPostalCode as airQualityGetHistoryByPostalCode,
 	getLatestByCity as airQualityGetLatestByCity,
+	getLatestByCountryCode as airQualityGetLatestByCountryCode,
 	getLatestByLatLng as airQualityGetLatestByLatLng,
 	getLatestByPostalCode as airQualityGetLatestByPostalCode,
 } from './air-quality';
+import {
+	getHistoryByContinent as disastersGetHistoryByContinent,
+	getHistoryByCountryCode as disastersGetHistoryByCountryCode,
+	getHistoryByDateRange as disastersGetHistoryByDateRange,
+	getHistoryByLatLng as disastersGetHistoryByLatLng,
+	getLatestByContinent as disastersGetLatestByContinent,
+	getLatestByCountryCode as disastersGetLatestByCountryCode,
+	getLatestByLatLng as disastersGetLatestByLatLng,
+} from './disasters';
+import {
+	getByLatLng as elevationGetByLatLng,
+	getByPlace as elevationGetByPlace,
+} from './elevation';
 import {
 	getLatestByLatLng as fireGetLatestByLatLng,
 	getLatestByPlace as fireGetLatestByPlace,
@@ -16,6 +30,7 @@ import {
 	byPlace as geocodeByPlace,
 	reverseByLatLng as geocodeReverseByLatLng,
 } from './geocode';
+import { getForecastByLatLng as iliGetForecastByLatLng } from './ili';
 import {
 	getForecast as pollenGetForecast,
 	getHistory as pollenGetHistory,
@@ -31,6 +46,7 @@ export const AirQuality = {
 	getLatestByLatLng: airQualityGetLatestByLatLng,
 	getLatestByCity: airQualityGetLatestByCity,
 	getLatestByPostalCode: airQualityGetLatestByPostalCode,
+	getLatestByCountryCode: airQualityGetLatestByCountryCode,
 	getHistoryByLatLng: airQualityGetHistoryByLatLng,
 	getHistoryByPostalCode: airQualityGetHistoryByPostalCode,
 	getForecastByLatLng: airQualityGetForecastByLatLng,
@@ -53,6 +69,25 @@ export const Fire = {
 	getLatestByPlace: fireGetLatestByPlace,
 	getRiskByLatLng: fireGetRiskByLatLng,
 	getRiskByPlace: fireGetRiskByPlace,
+};
+
+export const Elevation = {
+	getByLatLng: elevationGetByLatLng,
+	getByPlace: elevationGetByPlace,
+};
+
+export const Ili = {
+	getForecastByLatLng: iliGetForecastByLatLng,
+};
+
+export const Disasters = {
+	getLatestByLatLng: disastersGetLatestByLatLng,
+	getLatestByCountryCode: disastersGetLatestByCountryCode,
+	getLatestByContinent: disastersGetLatestByContinent,
+	getHistoryByLatLng: disastersGetHistoryByLatLng,
+	getHistoryByCountryCode: disastersGetHistoryByCountryCode,
+	getHistoryByContinent: disastersGetHistoryByContinent,
+	getHistoryByDateRange: disastersGetHistoryByDateRange,
 };
 
 export const Geocode = {

--- a/packages/ambee/endpoints/persist.ts
+++ b/packages/ambee/endpoints/persist.ts
@@ -120,11 +120,24 @@ export async function persistGeocodeResults(
 	if (!table || !results?.length) return;
 
 	for (const [index, result] of results.entries()) {
+		const lat = Number(result.lat);
+		const lng = Number(result.lng);
+
 		await safeUpsert('geocode result', () =>
 			table.upsertByEntityId(`${query}#${index}`, {
 				query,
-				lat: result.lat === null ? undefined : Number(result.lat) || undefined,
-				lng: result.lng === null ? undefined : Number(result.lng) || undefined,
+				lat:
+					result.lat === null ||
+					result.lat === undefined ||
+					!Number.isFinite(lat)
+						? undefined
+						: lat,
+				lng:
+					result.lng === null ||
+					result.lng === undefined ||
+					!Number.isFinite(lng)
+						? undefined
+						: lng,
 				city: result.city ?? undefined,
 				state: result.state ?? undefined,
 				countryCode: result.countryCode ?? undefined,

--- a/packages/ambee/endpoints/persist.ts
+++ b/packages/ambee/endpoints/persist.ts
@@ -1,0 +1,141 @@
+import type { AmbeeContext } from '../index';
+import type { AirQualityStation, GeocodeResult, WeatherPoint } from './types';
+
+/**
+ * Builds a stable entity id for a reading. Ambee has no record ids of its own
+ * — a reading is identified by where it was taken — so the key is derived from
+ * the location, rounded to ~11 m so that repeated calls for the same place
+ * update one row instead of accumulating near-duplicates.
+ */
+function locationKey(
+	lat: number | null | undefined,
+	lng: number | null | undefined,
+	fallback: string,
+): string {
+	if (typeof lat !== 'number' || typeof lng !== 'number') {
+		return fallback;
+	}
+	return `${lat.toFixed(4)},${lng.toFixed(4)}`;
+}
+
+/**
+ * Persisting is best-effort: a storage failure must not fail an otherwise
+ * successful API call, and the entity is absent entirely when the host app
+ * runs without a database.
+ */
+async function safeUpsert(
+	label: string,
+	upsert: () => Promise<unknown>,
+): Promise<void> {
+	try {
+		await upsert();
+	} catch (error) {
+		console.warn(`Failed to save Ambee ${label} to database:`, error);
+	}
+}
+
+export async function persistAirQualityStations(
+	ctx: AmbeeContext,
+	stations: AirQualityStation[] | undefined,
+): Promise<void> {
+	const table = ctx.db.airQualityReadings;
+	if (!table || !stations?.length) return;
+
+	for (const station of stations) {
+		const entityId = locationKey(
+			station.lat,
+			station.lng,
+			`${station.placeName ?? station.city ?? station.postalCode ?? 'unknown'}`,
+		);
+
+		await safeUpsert('air quality reading', () =>
+			table.upsertByEntityId(entityId, {
+				locationKey: entityId,
+				city: station.city ?? undefined,
+				state: station.state ?? undefined,
+				countryCode: station.countryCode ?? undefined,
+				postalCode:
+					station.postalCode === null || station.postalCode === undefined
+						? undefined
+						: String(station.postalCode),
+				placeName: station.placeName ?? undefined,
+				lat: station.lat ?? undefined,
+				lng: station.lng ?? undefined,
+				aqi: station.AQI ?? undefined,
+				aqiCategory: station.aqiInfo?.category ?? undefined,
+				dominantPollutant: station.aqiInfo?.pollutant ?? undefined,
+				pm25: station.PM25 ?? undefined,
+				pm10: station.PM10 ?? undefined,
+				no2: station.NO2 ?? undefined,
+				so2: station.SO2 ?? undefined,
+				co: station.CO ?? undefined,
+				ozone: station.OZONE ?? undefined,
+				observedAt: station.updatedAt ?? undefined,
+				fetchedAt: new Date(),
+			}),
+		);
+	}
+}
+
+export async function persistWeatherObservation(
+	ctx: AmbeeContext,
+	lat: number,
+	lng: number,
+	point: WeatherPoint | undefined,
+	timezone: string | undefined,
+): Promise<void> {
+	const table = ctx.db.weatherObservations;
+	if (!table || !point) return;
+
+	const entityId = locationKey(lat, lng, `${lat},${lng}`);
+
+	await safeUpsert('weather observation', () =>
+		table.upsertByEntityId(entityId, {
+			locationKey: entityId,
+			lat,
+			lng,
+			timezone: timezone ?? undefined,
+			summary: point.summary ?? undefined,
+			icon: point.icon ?? undefined,
+			temperature: point.temperature ?? undefined,
+			apparentTemperature: point.apparentTemperature ?? undefined,
+			humidity: point.humidity ?? undefined,
+			pressure: point.pressure ?? undefined,
+			windSpeed: point.windSpeed ?? undefined,
+			windGust: point.windGust ?? undefined,
+			cloudCover: point.cloudCover ?? undefined,
+			uvIndex: point.uvIndex ?? undefined,
+			observedAt: point.time ?? undefined,
+			fetchedAt: new Date(),
+		}),
+	);
+}
+
+export async function persistGeocodeResults(
+	ctx: AmbeeContext,
+	query: string,
+	results: GeocodeResult[] | undefined,
+): Promise<void> {
+	const table = ctx.db.geocodedPlaces;
+	if (!table || !results?.length) return;
+
+	for (const [index, result] of results.entries()) {
+		await safeUpsert('geocode result', () =>
+			table.upsertByEntityId(`${query}#${index}`, {
+				query,
+				lat: result.lat === null ? undefined : Number(result.lat) || undefined,
+				lng: result.lng === null ? undefined : Number(result.lng) || undefined,
+				city: result.city ?? undefined,
+				state: result.state ?? undefined,
+				countryCode: result.countryCode ?? undefined,
+				postalCode:
+					result.postalCode === null || result.postalCode === undefined
+						? undefined
+						: String(result.postalCode),
+				placeName: result.placeName ?? undefined,
+				formattedAddress: result.formattedAddress ?? undefined,
+				fetchedAt: new Date(),
+			}),
+		);
+	}
+}

--- a/packages/ambee/endpoints/pollen.test.ts
+++ b/packages/ambee/endpoints/pollen.test.ts
@@ -1,0 +1,132 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeAmbeeRequest } from '../client';
+import type { AmbeeContext } from '../index';
+import { getForecast, getHistory, getLatest } from './pollen';
+
+jest.mock('../client', () => ({
+	makeAmbeeRequest: jest.fn(),
+	toAmbeeTimestamp: jest.requireActual('../client').toAmbeeTimestamp,
+}));
+
+jest.mock('corsair/core', () => ({
+	logEventFromContext: jest.fn().mockResolvedValue(null),
+}));
+
+const mockRequest = makeAmbeeRequest as jest.MockedFunction<
+	typeof makeAmbeeRequest
+>;
+const mockLogEvent = logEventFromContext as jest.MockedFunction<
+	typeof logEventFromContext
+>;
+
+const POLLEN_RESPONSE = {
+	message: 'success',
+	lat: 41.3874,
+	lng: 2.1686,
+	data: [
+		{
+			time: 1657000000,
+			Count: { grass_pollen: 0, tree_pollen: 4, weed_pollen: 1 },
+			Risk: {
+				grass_pollen: 'Low',
+				tree_pollen: 'Low',
+				weed_pollen: 'Low',
+			},
+			updatedAt: '2026-08-06T09:00:00.000Z',
+		},
+	],
+};
+
+function makeCtx(): AmbeeContext {
+	return { key: 'test-key', options: {}, db: {} } as unknown as AmbeeContext;
+}
+
+beforeEach(() => {
+	mockRequest.mockReset();
+	mockLogEvent.mockClear();
+});
+
+describe('pollen.getLatest', () => {
+	it('sends coordinates for a geospatial lookup', async () => {
+		mockRequest.mockResolvedValue(POLLEN_RESPONSE);
+
+		const result = await getLatest(makeCtx(), { lat: 41.3874, lng: 2.1686 });
+
+		expect(mockRequest).toHaveBeenCalledWith('v3/pollen/latest', 'test-key', {
+			query: { lat: 41.3874, lng: 2.1686 },
+		});
+		expect(result.data?.[0]?.Risk?.tree_pollen).toBe('Low');
+	});
+
+	it('sends a place name for a placewise lookup', async () => {
+		mockRequest.mockResolvedValue(POLLEN_RESPONSE);
+
+		await getLatest(makeCtx(), { place: 'Barcelona' });
+
+		expect(mockRequest).toHaveBeenCalledWith('v3/pollen/latest', 'test-key', {
+			query: { place: 'Barcelona' },
+		});
+	});
+
+	it('only sends speciesRisk when it is explicitly set', async () => {
+		mockRequest.mockResolvedValue(POLLEN_RESPONSE);
+
+		await getLatest(makeCtx(), { place: 'Barcelona', speciesRisk: true });
+
+		expect(mockRequest).toHaveBeenCalledWith('v3/pollen/latest', 'test-key', {
+			query: { place: 'Barcelona', speciesRisk: true },
+		});
+	});
+});
+
+describe('pollen.getHistory', () => {
+	it('normalises the time range for a placewise history lookup', async () => {
+		mockRequest.mockResolvedValue(POLLEN_RESPONSE);
+
+		await getHistory(makeCtx(), {
+			place: 'Barcelona',
+			from: '2026-07-14T14:00:15.000Z',
+			to: '2026-07-16T14:00:21.000Z',
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith('v3/pollen/history', 'test-key', {
+			query: {
+				place: 'Barcelona',
+				from: '2026-07-14 14:00:15',
+				to: '2026-07-16 14:00:21',
+			},
+		});
+	});
+});
+
+describe('pollen.getForecast', () => {
+	it('defaults to the 48-hour forecast path', async () => {
+		mockRequest.mockResolvedValue(POLLEN_RESPONSE);
+
+		await getForecast(makeCtx(), { lat: 38, lng: -97 });
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'v3/pollen/forecast/48hrs',
+			'test-key',
+			{ query: { lat: 38, lng: -97 } },
+		);
+	});
+
+	it('uses the 120-hour path when that horizon is requested', async () => {
+		mockRequest.mockResolvedValue(POLLEN_RESPONSE);
+
+		await getForecast(makeCtx(), { place: 'california', hours: 120 });
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'v3/pollen/forecast/120hrs',
+			'test-key',
+			{ query: { place: 'california' } },
+		);
+		expect(mockLogEvent).toHaveBeenCalledWith(
+			expect.anything(),
+			'ambee.pollen.getForecast',
+			{ place: 'california', hours: 120, speciesRisk: undefined },
+			'completed',
+		);
+	});
+});

--- a/packages/ambee/endpoints/pollen.test.ts
+++ b/packages/ambee/endpoints/pollen.test.ts
@@ -77,6 +77,17 @@ describe('pollen.getLatest', () => {
 			query: { place: 'Barcelona', speciesRisk: true },
 		});
 	});
+
+	it('rejects an ambiguous location that supplies both place and coordinates', async () => {
+		await expect(
+			getLatest(makeCtx(), {
+				lat: 41.3874,
+				lng: 2.1686,
+				place: 'Barcelona',
+			} as never),
+		).rejects.toThrow();
+		expect(mockRequest).not.toHaveBeenCalled();
+	});
 });
 
 describe('pollen.getHistory', () => {

--- a/packages/ambee/endpoints/pollen.ts
+++ b/packages/ambee/endpoints/pollen.ts
@@ -3,12 +3,18 @@ import type { AmbeeQuery } from '../client';
 import { makeAmbeeRequest, toAmbeeTimestamp } from '../client';
 import type { AmbeeEndpoints } from '../index';
 import type { PollenResponse } from './types';
-import { PollenResponseSchema } from './types';
+import {
+	PollenGetForecastInputSchema,
+	PollenGetHistoryInputSchema,
+	PollenGetLatestInputSchema,
+	PollenResponseSchema,
+} from './types';
 
 /**
  * Pollen endpoints are addressed either geospatially or by place name. Both
  * forms share every other parameter, so the location half of the query is
- * resolved once here.
+ * resolved once here. Callers must already be a validated exclusive union —
+ * `'place' in input` is only safe after that check.
  */
 function pollenLocationQuery(
 	input: { lat: number; lng: number } | { place: string },
@@ -31,8 +37,9 @@ function speciesRiskQuery(speciesRisk: boolean | undefined): AmbeeQuery {
  */
 export const getLatest: AmbeeEndpoints['pollenGetLatest'] = async (
 	ctx,
-	input,
+	rawInput,
 ) => {
+	const input = PollenGetLatestInputSchema.parse(rawInput);
 	const location = pollenLocationQuery(input);
 
 	const raw = await makeAmbeeRequest<PollenResponse>(
@@ -61,8 +68,9 @@ export const getLatest: AmbeeEndpoints['pollenGetLatest'] = async (
  */
 export const getHistory: AmbeeEndpoints['pollenGetHistory'] = async (
 	ctx,
-	input,
+	rawInput,
 ) => {
+	const input = PollenGetHistoryInputSchema.parse(rawInput);
 	const location = pollenLocationQuery(input);
 	const from = toAmbeeTimestamp(input.from);
 	const to = toAmbeeTimestamp(input.to);
@@ -101,8 +109,9 @@ export const getHistory: AmbeeEndpoints['pollenGetHistory'] = async (
  */
 export const getForecast: AmbeeEndpoints['pollenGetForecast'] = async (
 	ctx,
-	input,
+	rawInput,
 ) => {
+	const input = PollenGetForecastInputSchema.parse(rawInput);
 	const location = pollenLocationQuery(input);
 	const hours = input.hours ?? 48;
 

--- a/packages/ambee/endpoints/pollen.ts
+++ b/packages/ambee/endpoints/pollen.ts
@@ -1,0 +1,125 @@
+import { logEventFromContext } from 'corsair/core';
+import type { AmbeeQuery } from '../client';
+import { makeAmbeeRequest, toAmbeeTimestamp } from '../client';
+import type { AmbeeEndpoints } from '../index';
+import type { PollenResponse } from './types';
+import { PollenResponseSchema } from './types';
+
+/**
+ * Pollen endpoints are addressed either geospatially or by place name. Both
+ * forms share every other parameter, so the location half of the query is
+ * resolved once here.
+ */
+function pollenLocationQuery(
+	input: { lat: number; lng: number } | { place: string },
+): AmbeeQuery {
+	return 'place' in input
+		? { place: input.place }
+		: { lat: input.lat, lng: input.lng };
+}
+
+/** Ambee omits `speciesRisk` rather than accepting `false` as a default. */
+function speciesRiskQuery(speciesRisk: boolean | undefined): AmbeeQuery {
+	return speciesRisk === undefined ? {} : { speciesRisk };
+}
+
+/**
+ * Latest pollen counts and risk levels for a location.
+ *
+ * API: GET api.ambeedata.com/v3/pollen/latest
+ * Docs: https://docs.ambeedata.com/apis/pollen
+ */
+export const getLatest: AmbeeEndpoints['pollenGetLatest'] = async (
+	ctx,
+	input,
+) => {
+	const location = pollenLocationQuery(input);
+
+	const raw = await makeAmbeeRequest<PollenResponse>(
+		'v3/pollen/latest',
+		ctx.key,
+		{ query: { ...location, ...speciesRiskQuery(input.speciesRisk) } },
+	);
+
+	const response = PollenResponseSchema.parse(raw);
+
+	await logEventFromContext(
+		ctx,
+		'ambee.pollen.getLatest',
+		{ ...location, speciesRisk: input.speciesRisk },
+		'completed',
+	);
+
+	return response;
+};
+
+/**
+ * Historical pollen counts for a location (up to 48 hours per request).
+ *
+ * API: GET api.ambeedata.com/v3/pollen/history
+ * Docs: https://docs.ambeedata.com/apis/pollen
+ */
+export const getHistory: AmbeeEndpoints['pollenGetHistory'] = async (
+	ctx,
+	input,
+) => {
+	const location = pollenLocationQuery(input);
+	const from = toAmbeeTimestamp(input.from);
+	const to = toAmbeeTimestamp(input.to);
+
+	const raw = await makeAmbeeRequest<PollenResponse>(
+		'v3/pollen/history',
+		ctx.key,
+		{
+			query: {
+				...location,
+				from,
+				to,
+				...speciesRiskQuery(input.speciesRisk),
+			},
+		},
+	);
+
+	const response = PollenResponseSchema.parse(raw);
+
+	await logEventFromContext(
+		ctx,
+		'ambee.pollen.getHistory',
+		{ ...location, from, to, speciesRisk: input.speciesRisk },
+		'completed',
+	);
+
+	return response;
+};
+
+/**
+ * Pollen forecast for a location — 48 hours at hourly intervals (default) or
+ * 120 hours at 3-hourly intervals.
+ *
+ * API: GET api.ambeedata.com/v3/pollen/forecast/{48hrs|120hrs}
+ * Docs: https://docs.ambeedata.com/apis/pollen
+ */
+export const getForecast: AmbeeEndpoints['pollenGetForecast'] = async (
+	ctx,
+	input,
+) => {
+	const location = pollenLocationQuery(input);
+	const hours = input.hours ?? 48;
+
+	const raw = await makeAmbeeRequest<PollenResponse>(
+		`v3/pollen/forecast/${hours}hrs`,
+		ctx.key,
+		{ query: { ...location, ...speciesRiskQuery(input.speciesRisk) } },
+	);
+
+	const response = PollenResponseSchema.parse(raw);
+
+	await logEventFromContext(
+		ctx,
+		'ambee.pollen.getForecast',
+		{ ...location, hours, speciesRisk: input.speciesRisk },
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/ambee/endpoints/schema-validation.test.ts
+++ b/packages/ambee/endpoints/schema-validation.test.ts
@@ -142,6 +142,64 @@ describe('output schemas', () => {
 		const outputKeys = Object.keys(AmbeeEndpointOutputSchemas).sort();
 
 		expect(inputKeys).toEqual(outputKeys);
-		expect(inputKeys).toHaveLength(18);
+		expect(inputKeys).toHaveLength(29);
+	});
+
+	it('restricts the disasters continent filter to Ambee’s codes', () => {
+		expect(
+			AmbeeEndpointInputSchemas.disastersGetLatestByContinent.safeParse({
+				continent: 'NAR',
+			}).success,
+		).toBe(true);
+		expect(
+			AmbeeEndpointInputSchemas.disastersGetLatestByContinent.safeParse({
+				continent: 'Atlantis',
+			}).success,
+		).toBe(false);
+	});
+
+	it('rejects non-positive pagination values on the disasters endpoints', () => {
+		expect(
+			AmbeeEndpointInputSchemas.disastersGetLatestByCountryCode.safeParse({
+				countryCode: 'IND',
+				page: 0,
+			}).success,
+		).toBe(false);
+		expect(
+			AmbeeEndpointInputSchemas.disastersGetLatestByCountryCode.safeParse({
+				countryCode: 'IND',
+				page: 2,
+				limit: 50,
+			}).success,
+		).toBe(true);
+	});
+
+	it('accepts a disasters payload under either `result` or `data`', () => {
+		expect(
+			AmbeeEndpointOutputSchemas.disastersGetLatestByLatLng.safeParse({
+				message: 'success',
+				result: [{ event_type: 'EQ' }],
+			}).success,
+		).toBe(true);
+		expect(
+			AmbeeEndpointOutputSchemas.disastersGetLatestByLatLng.safeParse({
+				message: 'success',
+				data: [{ event_type: 'FL' }],
+			}).success,
+		).toBe(true);
+	});
+
+	it('makes `to` optional only on the global disasters history endpoint', () => {
+		expect(
+			AmbeeEndpointInputSchemas.disastersGetHistoryByDateRange.safeParse({
+				from: '2026-07-01 15:00:00',
+			}).success,
+		).toBe(true);
+		expect(
+			AmbeeEndpointInputSchemas.disastersGetHistoryByCountryCode.safeParse({
+				countryCode: 'IND',
+				from: '2026-07-01 15:00:00',
+			}).success,
+		).toBe(false);
 	});
 });

--- a/packages/ambee/endpoints/schema-validation.test.ts
+++ b/packages/ambee/endpoints/schema-validation.test.ts
@@ -22,7 +22,7 @@ describe('input schemas', () => {
 		).toBe(true);
 	});
 
-	it('accepts either a coordinate pair or a place name for pollen, but not neither', () => {
+	it('accepts either a coordinate pair or a place name for pollen, but not neither or both', () => {
 		expect(
 			AmbeeEndpointInputSchemas.pollenGetLatest.safeParse({
 				lat: 41.38,
@@ -37,6 +37,28 @@ describe('input schemas', () => {
 		expect(
 			AmbeeEndpointInputSchemas.pollenGetLatest.safeParse({ speciesRisk: true })
 				.success,
+		).toBe(false);
+		expect(
+			AmbeeEndpointInputSchemas.pollenGetLatest.safeParse({
+				lat: 41.38,
+				lng: 2.16,
+				place: 'Barcelona',
+			}).success,
+		).toBe(false);
+	});
+
+	it('requires a three-letter ISO country code', () => {
+		expect(
+			AmbeeEndpointInputSchemas.airQualityGetLatestByPostalCode.safeParse({
+				postalCode: '560020',
+				countryCode: 'IND',
+			}).success,
+		).toBe(true);
+		expect(
+			AmbeeEndpointInputSchemas.airQualityGetLatestByPostalCode.safeParse({
+				postalCode: '560020',
+				countryCode: 'IN',
+			}).success,
 		).toBe(false);
 	});
 
@@ -172,6 +194,21 @@ describe('output schemas', () => {
 				limit: 50,
 			}).success,
 		).toBe(true);
+	});
+
+	it('restricts disasters eventType to Ambee’s documented codes', () => {
+		expect(
+			AmbeeEndpointInputSchemas.disastersGetLatestByCountryCode.safeParse({
+				countryCode: 'IND',
+				eventType: 'EQ',
+			}).success,
+		).toBe(true);
+		expect(
+			AmbeeEndpointInputSchemas.disastersGetLatestByCountryCode.safeParse({
+				countryCode: 'IND',
+				eventType: 'ASTEROID',
+			}).success,
+		).toBe(false);
 	});
 
 	it('accepts a disasters payload under either `result` or `data`', () => {

--- a/packages/ambee/endpoints/schema-validation.test.ts
+++ b/packages/ambee/endpoints/schema-validation.test.ts
@@ -1,0 +1,147 @@
+import { AmbeeEndpointInputSchemas, AmbeeEndpointOutputSchemas } from './types';
+
+describe('input schemas', () => {
+	it('rejects out-of-range coordinates before an API call is made', () => {
+		expect(
+			AmbeeEndpointInputSchemas.airQualityGetLatestByLatLng.safeParse({
+				lat: 91,
+				lng: 0,
+			}).success,
+		).toBe(false);
+		expect(
+			AmbeeEndpointInputSchemas.airQualityGetLatestByLatLng.safeParse({
+				lat: 0,
+				lng: 181,
+			}).success,
+		).toBe(false);
+		expect(
+			AmbeeEndpointInputSchemas.airQualityGetLatestByLatLng.safeParse({
+				lat: 12.99,
+				lng: 77.57,
+			}).success,
+		).toBe(true);
+	});
+
+	it('accepts either a coordinate pair or a place name for pollen, but not neither', () => {
+		expect(
+			AmbeeEndpointInputSchemas.pollenGetLatest.safeParse({
+				lat: 41.38,
+				lng: 2.16,
+			}).success,
+		).toBe(true);
+		expect(
+			AmbeeEndpointInputSchemas.pollenGetLatest.safeParse({
+				place: 'Barcelona',
+			}).success,
+		).toBe(true);
+		expect(
+			AmbeeEndpointInputSchemas.pollenGetLatest.safeParse({ speciesRisk: true })
+				.success,
+		).toBe(false);
+	});
+
+	it('limits the pollen forecast horizon to the two Ambee supports', () => {
+		expect(
+			AmbeeEndpointInputSchemas.pollenGetForecast.safeParse({
+				place: 'california',
+				hours: 120,
+			}).success,
+		).toBe(true);
+		expect(
+			AmbeeEndpointInputSchemas.pollenGetForecast.safeParse({
+				place: 'california',
+				hours: 72,
+			}).success,
+		).toBe(false);
+	});
+
+	it('requires both ends of a history range', () => {
+		expect(
+			AmbeeEndpointInputSchemas.airQualityGetHistoryByLatLng.safeParse({
+				lat: 12.99,
+				lng: 77.57,
+				from: '2026-07-13 12:16:44',
+			}).success,
+		).toBe(false);
+	});
+
+	it('restricts the fire type filter to reported or detected', () => {
+		expect(
+			AmbeeEndpointInputSchemas.fireGetLatestByPlace.safeParse({
+				place: 'Virgin, UT',
+				type: 'smouldering',
+			}).success,
+		).toBe(false);
+	});
+});
+
+describe('output schemas', () => {
+	it('requires the Ambee status envelope', () => {
+		expect(
+			AmbeeEndpointOutputSchemas.airQualityGetLatestByLatLng.safeParse({
+				stations: [],
+			}).success,
+		).toBe(false);
+	});
+
+	it('accepts a station whose sensors report only some pollutants', () => {
+		const parsed =
+			AmbeeEndpointOutputSchemas.airQualityGetLatestByCity.safeParse({
+				message: 'success',
+				stations: [{ PM25: 12.5, city: 'Bengaluru' }],
+			});
+
+		expect(parsed.success).toBe(true);
+	});
+
+	it('passes provider-side fields we do not model through untouched', () => {
+		const parsed = AmbeeEndpointOutputSchemas.weatherGetLatest.parse({
+			message: 'success',
+			lat: 40,
+			lng: -77,
+			data: { temperature: 70, someNewAmbeeField: 'kept' },
+		});
+
+		expect(parsed.data).toMatchObject({ someNewAmbeeField: 'kept' });
+	});
+
+	it('accepts the per-species pollen breakdown as an open record', () => {
+		const parsed = AmbeeEndpointOutputSchemas.pollenGetLatest.parse({
+			message: 'success',
+			data: [
+				{
+					Count: { grass_pollen: 0 },
+					Species: { Tree: { Alder: 1, Birch: 0 }, Others: 0 },
+				},
+			],
+		});
+
+		expect(parsed.data?.[0]?.Species).toEqual({
+			Tree: { Alder: 1, Birch: 0 },
+			Others: 0,
+		});
+	});
+
+	it('accepts geocode coordinates whether Ambee returns them as strings or numbers', () => {
+		expect(
+			AmbeeEndpointOutputSchemas.geocodeByPlace.safeParse({
+				message: 'success',
+				data: [{ lat: '40.71', lng: '-74.00' }],
+			}).success,
+		).toBe(true);
+		expect(
+			AmbeeEndpointOutputSchemas.geocodeByPlace.safeParse({
+				message: 'success',
+				data: [{ lat: 40.71, lng: -74.0 }],
+			}).success,
+		).toBe(true);
+	});
+
+	it('covers every endpoint with an input and an output schema', () => {
+		const inputKeys = Object.keys(AmbeeEndpointInputSchemas).sort();
+		const outputKeys = Object.keys(AmbeeEndpointOutputSchemas).sort();
+
+		expect(inputKeys).toEqual(outputKeys);
+		expect(inputKeys).toHaveLength(18);
+	});
+});

--- a/packages/ambee/endpoints/schema-validation.test.ts
+++ b/packages/ambee/endpoints/schema-validation.test.ts
@@ -127,6 +127,20 @@ describe('output schemas', () => {
 		expect(parsed.data).toMatchObject({ someNewAmbeeField: 'kept' });
 	});
 
+	it('normalises weather history/forecast data when Ambee returns an object', () => {
+		const asPoint = AmbeeEndpointOutputSchemas.weatherGetForecast.parse({
+			message: 'success',
+			data: { temperature: 70, humidity: 40 },
+		});
+		expect(asPoint.data).toEqual([{ temperature: 70, humidity: 40 }]);
+
+		const nested = AmbeeEndpointOutputSchemas.weatherGetHistory.parse({
+			message: 'success',
+			data: { forecast: [{ temperature: 71 }, { temperature: 72 }] },
+		});
+		expect(nested.data).toHaveLength(2);
+	});
+
 	it('accepts the per-species pollen breakdown as an open record', () => {
 		const parsed = AmbeeEndpointOutputSchemas.pollenGetLatest.parse({
 			message: 'success',

--- a/packages/ambee/endpoints/types.ts
+++ b/packages/ambee/endpoints/types.ts
@@ -1,0 +1,586 @@
+import { z } from 'zod';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared input fragments
+//
+// Ambee validates coordinates server-side; the same bounds are enforced here
+// so an obviously-bad request fails before it costs an API call.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const LatSchema = z
+	.number()
+	.min(-90)
+	.max(90)
+	.describe('Latitude, between -90 and 90');
+
+const LngSchema = z
+	.number()
+	.min(-180)
+	.max(180)
+	.describe('Longitude, between -180 and 180');
+
+const FromSchema = z
+	.string()
+	.min(1)
+	.describe(
+		'Start of the time range, as "YYYY-MM-DD hh:mm:ss" (UTC) or an ISO 8601 date',
+	);
+
+const ToSchema = z
+	.string()
+	.min(1)
+	.describe(
+		'End of the time range, as "YYYY-MM-DD hh:mm:ss" (UTC) or an ISO 8601 date',
+	);
+
+const LatLngInputSchema = z.object({
+	lat: LatSchema,
+	lng: LngSchema,
+});
+
+const LatLngRangeInputSchema = z.object({
+	lat: LatSchema,
+	lng: LngSchema,
+	from: FromSchema,
+	to: ToSchema,
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Response shapes
+//
+// Ambee wraps every payload in `{ message: "success", ... }` and returns a
+// wide, product-specific body whose optional fields depend on the coverage
+// available for the requested location (e.g. a station with no SO2 sensor
+// simply omits `SO2`). Response objects are therefore modelled as `.loose()`
+// with optional members: the envelope and the known fields are validated at
+// runtime, while provider-side additions pass through instead of throwing.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MessageSchema = z
+	.string()
+	.describe('Ambee status message, "success" on a successful call');
+
+/** Pollutant concentrations shared by every air-quality payload. */
+const AirQualityMeasurementSchema = z.object({
+	CO: z.number().nullable().optional(),
+	NO2: z.number().nullable().optional(),
+	OZONE: z.number().nullable().optional(),
+	PM10: z.number().nullable().optional(),
+	PM25: z.number().nullable().optional(),
+	SO2: z.number().nullable().optional(),
+	NO: z.number().nullable().optional(),
+	AQI: z.number().nullable().optional(),
+	aqiInfo: z
+		.object({
+			pollutant: z.string().nullable().optional(),
+			concentration: z.number().nullable().optional(),
+			category: z.string().nullable().optional(),
+		})
+		.loose()
+		.optional(),
+});
+
+/** A single air-quality station reading (the `stations[]` entries). */
+export const AirQualityStationSchema = AirQualityMeasurementSchema.extend({
+	city: z.string().nullable().optional(),
+	countryCode: z.string().nullable().optional(),
+	division: z.string().nullable().optional(),
+	state: z.string().nullable().optional(),
+	placeName: z.string().nullable().optional(),
+	postalCode: z.union([z.string(), z.number()]).nullable().optional(),
+	lat: z.number().nullable().optional(),
+	lng: z.number().nullable().optional(),
+	updatedAt: z.string().nullable().optional(),
+}).loose();
+
+export type AirQualityStation = z.infer<typeof AirQualityStationSchema>;
+
+/** A time-series air-quality reading (history and forecast entries). */
+export const AirQualityReadingSchema = AirQualityMeasurementSchema.extend({
+	time: z.number().nullable().optional(),
+	updatedAt: z.string().nullable().optional(),
+}).loose();
+
+export type AirQualityReading = z.infer<typeof AirQualityReadingSchema>;
+
+export const AirQualityStationsResponseSchema = z
+	.object({
+		message: MessageSchema,
+		stations: z.array(AirQualityStationSchema).optional(),
+	})
+	.loose();
+
+export type AirQualityStationsResponse = z.infer<
+	typeof AirQualityStationsResponseSchema
+>;
+
+export const AirQualitySeriesResponseSchema = z
+	.object({
+		message: MessageSchema,
+		lat: z.number().optional(),
+		lng: z.number().optional(),
+		data: z.array(AirQualityReadingSchema).optional(),
+	})
+	.loose();
+
+export type AirQualitySeriesResponse = z.infer<
+	typeof AirQualitySeriesResponseSchema
+>;
+
+/** A single hourly weather observation/forecast point. */
+export const WeatherPointSchema = z
+	.object({
+		time: z.number().nullable().optional(),
+		summary: z.string().nullable().optional(),
+		icon: z.string().nullable().optional(),
+		temperature: z.number().nullable().optional(),
+		apparentTemperature: z.number().nullable().optional(),
+		dewPoint: z.number().nullable().optional(),
+		humidity: z.number().nullable().optional(),
+		pressure: z.number().nullable().optional(),
+		surfacePressure: z.number().nullable().optional(),
+		windSpeed: z.number().nullable().optional(),
+		windGust: z.number().nullable().optional(),
+		windBearing: z.number().nullable().optional(),
+		cloudCover: z.number().nullable().optional(),
+		visibility: z.number().nullable().optional(),
+		ozone: z.number().nullable().optional(),
+		uvIndex: z.number().nullable().optional(),
+		precipIntensity: z.number().nullable().optional(),
+		precipProbability: z.number().nullable().optional(),
+		precipType: z.string().nullable().optional(),
+	})
+	.loose();
+
+export type WeatherPoint = z.infer<typeof WeatherPointSchema>;
+
+const WeatherLocationSchema = {
+	lat: z.number().optional(),
+	lng: z.number().optional(),
+	timezone: z.string().optional(),
+	units: z.string().optional(),
+};
+
+/** A pollen reading — counts, risk bands and per-species breakdown. */
+export const PollenReadingSchema = z
+	.object({
+		time: z.number().nullable().optional(),
+		updatedAt: z.string().nullable().optional(),
+		Count: z
+			.object({
+				grass_pollen: z.number().nullable().optional(),
+				tree_pollen: z.number().nullable().optional(),
+				weed_pollen: z.number().nullable().optional(),
+			})
+			.loose()
+			.optional(),
+		Risk: z
+			.object({
+				grass_pollen: z.string().nullable().optional(),
+				tree_pollen: z.string().nullable().optional(),
+				weed_pollen: z.string().nullable().optional(),
+			})
+			.loose()
+			.optional(),
+		// Only returned when `speciesRisk` is requested; the per-species keys
+		// vary by region, so they stay an open record rather than a fixed shape.
+		Species: z.record(z.string(), z.unknown()).optional(),
+		Risks: z.record(z.string(), z.unknown()).optional(),
+	})
+	.loose();
+
+export type PollenReading = z.infer<typeof PollenReadingSchema>;
+
+export const PollenResponseSchema = z
+	.object({
+		message: MessageSchema,
+		lat: z.number().optional(),
+		lng: z.number().optional(),
+		data: z.array(PollenReadingSchema).optional(),
+	})
+	.loose();
+
+export type PollenResponse = z.infer<typeof PollenResponseSchema>;
+
+/** A detected or reported wildfire event. */
+export const FireEventSchema = z
+	.object({
+		fireId: z.union([z.string(), z.number()]).nullable().optional(),
+		lat: z.number().nullable().optional(),
+		lng: z.number().nullable().optional(),
+		detectedAt: z.union([z.string(), z.number()]).nullable().optional(),
+		detectedAtLocalTime: z.string().nullable().optional(),
+		confidence: z.union([z.string(), z.number()]).nullable().optional(),
+		frp: z.number().nullable().optional(),
+		satellite: z.string().nullable().optional(),
+		instrument: z.string().nullable().optional(),
+		fireType: z.string().nullable().optional(),
+		fireName: z.string().nullable().optional(),
+		locationName: z.string().nullable().optional(),
+		area: z.number().nullable().optional(),
+	})
+	.loose();
+
+export type FireEvent = z.infer<typeof FireEventSchema>;
+
+export const FireResponseSchema = z
+	.object({
+		message: MessageSchema,
+		data: z.array(FireEventSchema).optional(),
+	})
+	.loose();
+
+export type FireResponse = z.infer<typeof FireResponseSchema>;
+
+/** A daily wildfire-risk forecast entry. */
+export const FireRiskSchema = z
+	.object({
+		date: z.string().nullable().optional(),
+		time: z.number().nullable().optional(),
+		risk: z.union([z.string(), z.number()]).nullable().optional(),
+		riskCategory: z.string().nullable().optional(),
+		lat: z.number().nullable().optional(),
+		lng: z.number().nullable().optional(),
+	})
+	.loose();
+
+export type FireRisk = z.infer<typeof FireRiskSchema>;
+
+export const FireRiskResponseSchema = z
+	.object({
+		message: MessageSchema,
+		data: z.array(FireRiskSchema).optional(),
+	})
+	.loose();
+
+export type FireRiskResponse = z.infer<typeof FireRiskResponseSchema>;
+
+/** A geocoding / reverse-geocoding match. */
+export const GeocodeResultSchema = z
+	.object({
+		lat: z.union([z.string(), z.number()]).nullable().optional(),
+		lng: z.union([z.string(), z.number()]).nullable().optional(),
+		city: z.string().nullable().optional(),
+		state: z.string().nullable().optional(),
+		countryCode: z.string().nullable().optional(),
+		countryName: z.string().nullable().optional(),
+		postalCode: z.union([z.string(), z.number()]).nullable().optional(),
+		placeName: z.string().nullable().optional(),
+		formattedAddress: z.string().nullable().optional(),
+	})
+	.loose();
+
+export type GeocodeResult = z.infer<typeof GeocodeResultSchema>;
+
+export const GeocodeResponseSchema = z
+	.object({
+		message: MessageSchema,
+		data: z.array(GeocodeResultSchema).optional(),
+	})
+	.loose();
+
+export type GeocodeResponse = z.infer<typeof GeocodeResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Air Quality — https://docs.ambeedata.com/apis/air-quality
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const AirQualityGetLatestByLatLngInputSchema = LatLngInputSchema;
+export type AirQualityGetLatestByLatLngInput = z.infer<
+	typeof AirQualityGetLatestByLatLngInputSchema
+>;
+
+export const AirQualityGetLatestByCityInputSchema = z.object({
+	city: z.string().min(1).describe('City name, e.g. "Bengaluru"'),
+	limit: z
+		.number()
+		.int()
+		.positive()
+		.optional()
+		.describe('Maximum number of stations to return (Ambee defaults to 1)'),
+});
+export type AirQualityGetLatestByCityInput = z.infer<
+	typeof AirQualityGetLatestByCityInputSchema
+>;
+
+export const AirQualityGetLatestByPostalCodeInputSchema = z.object({
+	postalCode: z.string().min(1).describe('Postal code, e.g. "560020"'),
+	countryCode: z
+		.string()
+		.min(2)
+		.describe('Three-letter ISO country code, e.g. "IND" or "USA"'),
+});
+export type AirQualityGetLatestByPostalCodeInput = z.infer<
+	typeof AirQualityGetLatestByPostalCodeInputSchema
+>;
+
+export const AirQualityGetHistoryByLatLngInputSchema = LatLngRangeInputSchema;
+export type AirQualityGetHistoryByLatLngInput = z.infer<
+	typeof AirQualityGetHistoryByLatLngInputSchema
+>;
+
+export const AirQualityGetHistoryByPostalCodeInputSchema = z.object({
+	postalCode: z.string().min(1).describe('Postal code, e.g. "560020"'),
+	countryCode: z
+		.string()
+		.min(2)
+		.describe('Three-letter ISO country code, e.g. "IND" or "USA"'),
+	from: FromSchema,
+	to: ToSchema,
+});
+export type AirQualityGetHistoryByPostalCodeInput = z.infer<
+	typeof AirQualityGetHistoryByPostalCodeInputSchema
+>;
+
+export const AirQualityGetForecastByLatLngInputSchema = LatLngInputSchema;
+export type AirQualityGetForecastByLatLngInput = z.infer<
+	typeof AirQualityGetForecastByLatLngInputSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Weather — https://docs.ambeedata.com/apis/weather
+// ─────────────────────────────────────────────────────────────────────────────
+
+const UnitsSchema = z
+	.literal('si')
+	.optional()
+	.describe('Pass "si" to receive SI units instead of the imperial default');
+
+export const WeatherGetLatestInputSchema = LatLngInputSchema.extend({
+	units: UnitsSchema,
+});
+export type WeatherGetLatestInput = z.infer<typeof WeatherGetLatestInputSchema>;
+
+export const WeatherGetHistoryInputSchema = LatLngRangeInputSchema.extend({
+	units: UnitsSchema,
+});
+export type WeatherGetHistoryInput = z.infer<
+	typeof WeatherGetHistoryInputSchema
+>;
+
+export const WeatherGetForecastInputSchema = LatLngInputSchema.extend({
+	units: UnitsSchema,
+});
+export type WeatherGetForecastInput = z.infer<
+	typeof WeatherGetForecastInputSchema
+>;
+
+/** Latest weather returns a single observation under `data`. */
+export const WeatherLatestResponseSchema = z
+	.object({
+		message: MessageSchema,
+		...WeatherLocationSchema,
+		data: WeatherPointSchema.optional(),
+	})
+	.loose();
+export type WeatherLatestResponse = z.infer<typeof WeatherLatestResponseSchema>;
+
+/** History and forecast return an hourly series under `data`. */
+export const WeatherSeriesResponseSchema = z
+	.object({
+		message: MessageSchema,
+		...WeatherLocationSchema,
+		data: z.array(WeatherPointSchema).optional(),
+	})
+	.loose();
+export type WeatherSeriesResponse = z.infer<typeof WeatherSeriesResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pollen — https://docs.ambeedata.com/apis/pollen (v3)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SpeciesRiskSchema = z
+	.boolean()
+	.optional()
+	.describe('Include the per-species pollen breakdown (defaults to false)');
+
+const PlaceSchema = z.string().min(1).describe('Place name, e.g. "Barcelona"');
+
+/**
+ * Pollen endpoints accept *either* a coordinate pair or a place name — never
+ * both. Each input is therefore a union of the two location forms rather than
+ * one object with both fields optional, so an ambiguous call is rejected at
+ * validation time instead of silently dropping a parameter at request time.
+ */
+export const PollenGetLatestInputSchema = z.union([
+	z.object({ lat: LatSchema, lng: LngSchema, speciesRisk: SpeciesRiskSchema }),
+	z.object({ place: PlaceSchema, speciesRisk: SpeciesRiskSchema }),
+]);
+export type PollenGetLatestInput = z.infer<typeof PollenGetLatestInputSchema>;
+
+export const PollenGetHistoryInputSchema = z.union([
+	z.object({
+		lat: LatSchema,
+		lng: LngSchema,
+		from: FromSchema,
+		to: ToSchema,
+		speciesRisk: SpeciesRiskSchema,
+	}),
+	z.object({
+		place: PlaceSchema,
+		from: FromSchema,
+		to: ToSchema,
+		speciesRisk: SpeciesRiskSchema,
+	}),
+]);
+export type PollenGetHistoryInput = z.infer<typeof PollenGetHistoryInputSchema>;
+
+const PollenForecastHoursSchema = z
+	.union([z.literal(48), z.literal(120)])
+	.optional()
+	.describe('Forecast horizon in hours: 48 (hourly) or 120 (3-hourly)');
+
+export const PollenGetForecastInputSchema = z.union([
+	z.object({
+		lat: LatSchema,
+		lng: LngSchema,
+		hours: PollenForecastHoursSchema,
+		speciesRisk: SpeciesRiskSchema,
+	}),
+	z.object({
+		place: PlaceSchema,
+		hours: PollenForecastHoursSchema,
+		speciesRisk: SpeciesRiskSchema,
+	}),
+]);
+export type PollenGetForecastInput = z.infer<
+	typeof PollenGetForecastInputSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fire — https://docs.ambeedata.com/apis/fire
+// ─────────────────────────────────────────────────────────────────────────────
+
+const FireTypeSchema = z
+	.enum(['reported', 'detected'])
+	.optional()
+	.describe('Restrict results to reported or satellite-detected fires');
+
+export const FireGetLatestByLatLngInputSchema = LatLngInputSchema.extend({
+	type: FireTypeSchema,
+});
+export type FireGetLatestByLatLngInput = z.infer<
+	typeof FireGetLatestByLatLngInputSchema
+>;
+
+export const FireGetLatestByPlaceInputSchema = z.object({
+	place: z.string().min(1).describe('Place name, e.g. "Virgin, UT"'),
+	type: FireTypeSchema,
+});
+export type FireGetLatestByPlaceInput = z.infer<
+	typeof FireGetLatestByPlaceInputSchema
+>;
+
+export const FireGetRiskByLatLngInputSchema = LatLngInputSchema;
+export type FireGetRiskByLatLngInput = z.infer<
+	typeof FireGetRiskByLatLngInputSchema
+>;
+
+export const FireGetRiskByPlaceInputSchema = z.object({
+	place: z.string().min(1).describe('Place name, e.g. "Leon, Mexico"'),
+});
+export type FireGetRiskByPlaceInput = z.infer<
+	typeof FireGetRiskByPlaceInputSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Location services — https://docs.ambeedata.com/apis/location
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const GeocodeByPlaceInputSchema = z.object({
+	place: z.string().min(1).describe('Address or place name to geocode'),
+});
+export type GeocodeByPlaceInput = z.infer<typeof GeocodeByPlaceInputSchema>;
+
+export const GeocodeReverseByLatLngInputSchema = LatLngInputSchema;
+export type GeocodeReverseByLatLngInput = z.infer<
+	typeof GeocodeReverseByLatLngInputSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint input/output maps
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type AmbeeEndpointInputs = {
+	airQualityGetLatestByLatLng: AirQualityGetLatestByLatLngInput;
+	airQualityGetLatestByCity: AirQualityGetLatestByCityInput;
+	airQualityGetLatestByPostalCode: AirQualityGetLatestByPostalCodeInput;
+	airQualityGetHistoryByLatLng: AirQualityGetHistoryByLatLngInput;
+	airQualityGetHistoryByPostalCode: AirQualityGetHistoryByPostalCodeInput;
+	airQualityGetForecastByLatLng: AirQualityGetForecastByLatLngInput;
+	weatherGetLatest: WeatherGetLatestInput;
+	weatherGetHistory: WeatherGetHistoryInput;
+	weatherGetForecast: WeatherGetForecastInput;
+	pollenGetLatest: PollenGetLatestInput;
+	pollenGetHistory: PollenGetHistoryInput;
+	pollenGetForecast: PollenGetForecastInput;
+	fireGetLatestByLatLng: FireGetLatestByLatLngInput;
+	fireGetLatestByPlace: FireGetLatestByPlaceInput;
+	fireGetRiskByLatLng: FireGetRiskByLatLngInput;
+	fireGetRiskByPlace: FireGetRiskByPlaceInput;
+	geocodeByPlace: GeocodeByPlaceInput;
+	geocodeReverseByLatLng: GeocodeReverseByLatLngInput;
+};
+
+export type AmbeeEndpointOutputs = {
+	airQualityGetLatestByLatLng: AirQualityStationsResponse;
+	airQualityGetLatestByCity: AirQualityStationsResponse;
+	airQualityGetLatestByPostalCode: AirQualityStationsResponse;
+	airQualityGetHistoryByLatLng: AirQualitySeriesResponse;
+	airQualityGetHistoryByPostalCode: AirQualitySeriesResponse;
+	airQualityGetForecastByLatLng: AirQualitySeriesResponse;
+	weatherGetLatest: WeatherLatestResponse;
+	weatherGetHistory: WeatherSeriesResponse;
+	weatherGetForecast: WeatherSeriesResponse;
+	pollenGetLatest: PollenResponse;
+	pollenGetHistory: PollenResponse;
+	pollenGetForecast: PollenResponse;
+	fireGetLatestByLatLng: FireResponse;
+	fireGetLatestByPlace: FireResponse;
+	fireGetRiskByLatLng: FireRiskResponse;
+	fireGetRiskByPlace: FireRiskResponse;
+	geocodeByPlace: GeocodeResponse;
+	geocodeReverseByLatLng: GeocodeResponse;
+};
+
+export const AmbeeEndpointInputSchemas = {
+	airQualityGetLatestByLatLng: AirQualityGetLatestByLatLngInputSchema,
+	airQualityGetLatestByCity: AirQualityGetLatestByCityInputSchema,
+	airQualityGetLatestByPostalCode: AirQualityGetLatestByPostalCodeInputSchema,
+	airQualityGetHistoryByLatLng: AirQualityGetHistoryByLatLngInputSchema,
+	airQualityGetHistoryByPostalCode: AirQualityGetHistoryByPostalCodeInputSchema,
+	airQualityGetForecastByLatLng: AirQualityGetForecastByLatLngInputSchema,
+	weatherGetLatest: WeatherGetLatestInputSchema,
+	weatherGetHistory: WeatherGetHistoryInputSchema,
+	weatherGetForecast: WeatherGetForecastInputSchema,
+	pollenGetLatest: PollenGetLatestInputSchema,
+	pollenGetHistory: PollenGetHistoryInputSchema,
+	pollenGetForecast: PollenGetForecastInputSchema,
+	fireGetLatestByLatLng: FireGetLatestByLatLngInputSchema,
+	fireGetLatestByPlace: FireGetLatestByPlaceInputSchema,
+	fireGetRiskByLatLng: FireGetRiskByLatLngInputSchema,
+	fireGetRiskByPlace: FireGetRiskByPlaceInputSchema,
+	geocodeByPlace: GeocodeByPlaceInputSchema,
+	geocodeReverseByLatLng: GeocodeReverseByLatLngInputSchema,
+} as const;
+
+export const AmbeeEndpointOutputSchemas = {
+	airQualityGetLatestByLatLng: AirQualityStationsResponseSchema,
+	airQualityGetLatestByCity: AirQualityStationsResponseSchema,
+	airQualityGetLatestByPostalCode: AirQualityStationsResponseSchema,
+	airQualityGetHistoryByLatLng: AirQualitySeriesResponseSchema,
+	airQualityGetHistoryByPostalCode: AirQualitySeriesResponseSchema,
+	airQualityGetForecastByLatLng: AirQualitySeriesResponseSchema,
+	weatherGetLatest: WeatherLatestResponseSchema,
+	weatherGetHistory: WeatherSeriesResponseSchema,
+	weatherGetForecast: WeatherSeriesResponseSchema,
+	pollenGetLatest: PollenResponseSchema,
+	pollenGetHistory: PollenResponseSchema,
+	pollenGetForecast: PollenResponseSchema,
+	fireGetLatestByLatLng: FireResponseSchema,
+	fireGetLatestByPlace: FireResponseSchema,
+	fireGetRiskByLatLng: FireRiskResponseSchema,
+	fireGetRiskByPlace: FireRiskResponseSchema,
+	geocodeByPlace: GeocodeResponseSchema,
+	geocodeReverseByLatLng: GeocodeResponseSchema,
+} as const;

--- a/packages/ambee/endpoints/types.ts
+++ b/packages/ambee/endpoints/types.ts
@@ -476,14 +476,40 @@ export const WeatherLatestResponseSchema = z
 	.loose();
 export type WeatherLatestResponse = z.infer<typeof WeatherLatestResponseSchema>;
 
+/**
+ * Ambee documents history/forecast `data` as an hourly array, but some plans
+ * return a single point object (same shape as latest) or nest the series under
+ * `forecast` / `history`. Normalize to an array before validation so callers
+ * always see `WeatherPoint[]`.
+ */
+function coerceWeatherSeriesData(data: unknown): unknown {
+	if (data == null) return data;
+	if (Array.isArray(data)) return data;
+	if (typeof data === 'object') {
+		const obj = data as Record<string, unknown>;
+		for (const key of ['forecast', 'history', 'hourly'] as const) {
+			if (Array.isArray(obj[key])) return obj[key];
+		}
+		return [data];
+	}
+	return data;
+}
+
 /** History and forecast return an hourly series under `data`. */
-export const WeatherSeriesResponseSchema = z
-	.object({
-		message: MessageSchema,
-		...WeatherLocationSchema,
-		data: z.array(WeatherPointSchema).optional(),
-	})
-	.loose();
+export const WeatherSeriesResponseSchema = z.preprocess(
+	(raw) => {
+		if (!raw || typeof raw !== 'object') return raw;
+		const obj = raw as Record<string, unknown>;
+		return { ...obj, data: coerceWeatherSeriesData(obj.data) };
+	},
+	z
+		.object({
+			message: MessageSchema,
+			...WeatherLocationSchema,
+			data: z.array(WeatherPointSchema).optional(),
+		})
+		.loose(),
+);
 export type WeatherSeriesResponse = z.infer<typeof WeatherSeriesResponseSchema>;
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/ambee/endpoints/types.ts
+++ b/packages/ambee/endpoints/types.ts
@@ -392,22 +392,27 @@ export type AirQualityGetLatestByCityInput = z.infer<
 	typeof AirQualityGetLatestByCityInputSchema
 >;
 
+const CountryCodeSchema = z
+	.string()
+	.length(3)
+	.describe('Three-letter ISO country code, e.g. "IND" or "USA"');
+
 export const AirQualityGetLatestByPostalCodeInputSchema = z.object({
 	postalCode: z.string().min(1).describe('Postal code, e.g. "560020"'),
-	countryCode: z
-		.string()
-		.min(2)
-		.describe('Three-letter ISO country code, e.g. "IND" or "USA"'),
+	countryCode: CountryCodeSchema,
 });
 export type AirQualityGetLatestByPostalCodeInput = z.infer<
 	typeof AirQualityGetLatestByPostalCodeInputSchema
 >;
 
 export const AirQualityGetLatestByCountryCodeInputSchema = z.object({
-	countryCode: z
-		.string()
-		.min(2)
-		.describe('Three-letter ISO country code, e.g. "IND" or "USA"'),
+	countryCode: CountryCodeSchema,
+	limit: z
+		.number()
+		.int()
+		.positive()
+		.optional()
+		.describe('Maximum number of stations to return (Ambee defaults to 1)'),
 });
 export type AirQualityGetLatestByCountryCodeInput = z.infer<
 	typeof AirQualityGetLatestByCountryCodeInputSchema
@@ -420,10 +425,7 @@ export type AirQualityGetHistoryByLatLngInput = z.infer<
 
 export const AirQualityGetHistoryByPostalCodeInputSchema = z.object({
 	postalCode: z.string().min(1).describe('Postal code, e.g. "560020"'),
-	countryCode: z
-		.string()
-		.min(2)
-		.describe('Three-letter ISO country code, e.g. "IND" or "USA"'),
+	countryCode: CountryCodeSchema,
 	from: FromSchema,
 	to: ToSchema,
 });
@@ -502,20 +504,24 @@ const PlaceSchema = z.string().min(1).describe('Place name, e.g. "Barcelona"');
  * validation time instead of silently dropping a parameter at request time.
  */
 export const PollenGetLatestInputSchema = z.union([
-	z.object({ lat: LatSchema, lng: LngSchema, speciesRisk: SpeciesRiskSchema }),
-	z.object({ place: PlaceSchema, speciesRisk: SpeciesRiskSchema }),
+	z.strictObject({
+		lat: LatSchema,
+		lng: LngSchema,
+		speciesRisk: SpeciesRiskSchema,
+	}),
+	z.strictObject({ place: PlaceSchema, speciesRisk: SpeciesRiskSchema }),
 ]);
 export type PollenGetLatestInput = z.infer<typeof PollenGetLatestInputSchema>;
 
 export const PollenGetHistoryInputSchema = z.union([
-	z.object({
+	z.strictObject({
 		lat: LatSchema,
 		lng: LngSchema,
 		from: FromSchema,
 		to: ToSchema,
 		speciesRisk: SpeciesRiskSchema,
 	}),
-	z.object({
+	z.strictObject({
 		place: PlaceSchema,
 		from: FromSchema,
 		to: ToSchema,
@@ -530,13 +536,13 @@ const PollenForecastHoursSchema = z
 	.describe('Forecast horizon in hours: 48 (hourly) or 120 (3-hourly)');
 
 export const PollenGetForecastInputSchema = z.union([
-	z.object({
+	z.strictObject({
 		lat: LatSchema,
 		lng: LngSchema,
 		hours: PollenForecastHoursSchema,
 		speciesRisk: SpeciesRiskSchema,
 	}),
-	z.object({
+	z.strictObject({
 		place: PlaceSchema,
 		hours: PollenForecastHoursSchema,
 		speciesRisk: SpeciesRiskSchema,
@@ -625,8 +631,20 @@ const ContinentSchema = z
 	.describe('Continent code');
 
 const EventTypeSchema = z
-	.string()
-	.min(1)
+	.enum([
+		'TN',
+		'EQ',
+		'TC',
+		'WF',
+		'FL',
+		'ET',
+		'DR',
+		'SW',
+		'SI',
+		'VO',
+		'LS',
+		'Misc',
+	])
 	.optional()
 	.describe('Restrict results to a single Ambee event-type code');
 
@@ -656,10 +674,7 @@ export type DisastersGetLatestByLatLngInput = z.infer<
 >;
 
 export const DisastersGetLatestByCountryCodeInputSchema = z.object({
-	countryCode: z
-		.string()
-		.min(2)
-		.describe('Three-letter ISO country code, e.g. "IND"'),
+	countryCode: CountryCodeSchema,
 	eventType: EventTypeSchema,
 	...PaginationSchema,
 });
@@ -689,10 +704,7 @@ export type DisastersGetHistoryByLatLngInput = z.infer<
 >;
 
 export const DisastersGetHistoryByCountryCodeInputSchema = z.object({
-	countryCode: z
-		.string()
-		.min(2)
-		.describe('Three-letter ISO country code, e.g. "IND"'),
+	countryCode: CountryCodeSchema,
 	from: FromSchema,
 	to: ToSchema,
 	eventType: EventTypeSchema,

--- a/packages/ambee/endpoints/types.ts
+++ b/packages/ambee/endpoints/types.ts
@@ -255,6 +255,95 @@ export const FireRiskResponseSchema = z
 
 export type FireRiskResponse = z.infer<typeof FireRiskResponseSchema>;
 
+/** An elevation reading for a point or place. */
+export const ElevationReadingSchema = z
+	.object({
+		lat: z.number().nullable().optional(),
+		lng: z.number().nullable().optional(),
+		elevation: z.number().nullable().optional(),
+		minElevation: z.number().nullable().optional(),
+		maxElevation: z.number().nullable().optional(),
+		meanElevation: z.number().nullable().optional(),
+		placeName: z.string().nullable().optional(),
+		unit: z.string().nullable().optional(),
+	})
+	.loose();
+
+export type ElevationReading = z.infer<typeof ElevationReadingSchema>;
+
+export const ElevationResponseSchema = z
+	.object({
+		message: MessageSchema,
+		data: z.array(ElevationReadingSchema).optional(),
+	})
+	.loose();
+
+export type ElevationResponse = z.infer<typeof ElevationResponseSchema>;
+
+/** A natural-disaster event record. */
+export const DisasterEventSchema = z
+	.object({
+		event_id: z.union([z.string(), z.number()]).nullable().optional(),
+		event_type: z.string().nullable().optional(),
+		event_name: z.string().nullable().optional(),
+		lat: z.number().nullable().optional(),
+		lng: z.number().nullable().optional(),
+		country_code: z.string().nullable().optional(),
+		continent: z.string().nullable().optional(),
+		date: z.union([z.string(), z.number()]).nullable().optional(),
+		updated_at: z.union([z.string(), z.number()]).nullable().optional(),
+		severity: z.union([z.string(), z.number()]).nullable().optional(),
+		source: z.string().nullable().optional(),
+		details: z.record(z.string(), z.unknown()).optional(),
+	})
+	.loose();
+
+export type DisasterEvent = z.infer<typeof DisasterEventSchema>;
+
+/**
+ * The disasters product is the only paginated part of Ambee, and it is
+ * inconsistent about the payload key — some responses use `result`, others
+ * `data`. Both are modelled so a caller never has to guess.
+ */
+export const DisasterResponseSchema = z
+	.object({
+		message: MessageSchema,
+		result: z.array(DisasterEventSchema).optional(),
+		data: z.array(DisasterEventSchema).optional(),
+		page: z.number().optional(),
+		limit: z.number().optional(),
+		total: z.number().optional(),
+	})
+	.loose();
+
+export type DisasterResponse = z.infer<typeof DisasterResponseSchema>;
+
+/** A daily influenza-like-illness risk forecast entry. */
+export const IliForecastEntrySchema = z
+	.object({
+		date: z.string().nullable().optional(),
+		time: z.number().nullable().optional(),
+		risk: z.union([z.string(), z.number()]).nullable().optional(),
+		riskCategory: z.string().nullable().optional(),
+		// Present only when `details` is requested — 28 days of supporting
+		// weather and pollen data, whose shape varies by region.
+		details: z.record(z.string(), z.unknown()).optional(),
+	})
+	.loose();
+
+export type IliForecastEntry = z.infer<typeof IliForecastEntrySchema>;
+
+export const IliForecastResponseSchema = z
+	.object({
+		message: MessageSchema,
+		lat: z.number().optional(),
+		lng: z.number().optional(),
+		data: z.array(IliForecastEntrySchema).optional(),
+	})
+	.loose();
+
+export type IliForecastResponse = z.infer<typeof IliForecastResponseSchema>;
+
 /** A geocoding / reverse-geocoding match. */
 export const GeocodeResultSchema = z
 	.object({
@@ -312,6 +401,16 @@ export const AirQualityGetLatestByPostalCodeInputSchema = z.object({
 });
 export type AirQualityGetLatestByPostalCodeInput = z.infer<
 	typeof AirQualityGetLatestByPostalCodeInputSchema
+>;
+
+export const AirQualityGetLatestByCountryCodeInputSchema = z.object({
+	countryCode: z
+		.string()
+		.min(2)
+		.describe('Three-letter ISO country code, e.g. "IND" or "USA"'),
+});
+export type AirQualityGetLatestByCountryCodeInput = z.infer<
+	typeof AirQualityGetLatestByCountryCodeInputSchema
 >;
 
 export const AirQualityGetHistoryByLatLngInputSchema = LatLngRangeInputSchema;
@@ -484,6 +583,148 @@ export type FireGetRiskByPlaceInput = z.infer<
 >;
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Elevation — https://docs.ambeedata.com/apis/elevation
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ElevationGetByLatLngInputSchema = LatLngInputSchema;
+export type ElevationGetByLatLngInput = z.infer<
+	typeof ElevationGetByLatLngInputSchema
+>;
+
+export const ElevationGetByPlaceInputSchema = z.object({
+	place: z.string().min(1).describe('Place name, e.g. "San Francisco, USA"'),
+});
+export type ElevationGetByPlaceInput = z.infer<
+	typeof ElevationGetByPlaceInputSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Influenza-like illness (beta) — https://docs.ambeedata.com/apis/ili
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const IliGetForecastByLatLngInputSchema = LatLngInputSchema.extend({
+	details: z
+		.boolean()
+		.optional()
+		.describe(
+			'Include the supporting 28-day weather and pollen forecast (defaults to false)',
+		),
+});
+export type IliGetForecastByLatLngInput = z.infer<
+	typeof IliGetForecastByLatLngInputSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Natural disasters — https://docs.ambeedata.com/apis/natural_disasters
+//
+// The only paginated Ambee product: every endpoint takes `page`/`limit`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ContinentSchema = z
+	.enum(['AFR', 'ANT', 'ASIA', 'AUS', 'EUR', 'NAR', 'SAR', 'Ocean'])
+	.describe('Continent code');
+
+const EventTypeSchema = z
+	.string()
+	.min(1)
+	.optional()
+	.describe('Restrict results to a single Ambee event-type code');
+
+const PaginationSchema = {
+	limit: z
+		.number()
+		.int()
+		.positive()
+		.optional()
+		.describe('Records per page (Ambee defaults to 1)'),
+	page: z
+		.number()
+		.int()
+		.positive()
+		.optional()
+		.describe('Page number, 1-based (Ambee defaults to 1)'),
+};
+
+export const DisastersGetLatestByLatLngInputSchema = z.object({
+	lat: LatSchema,
+	lng: LngSchema,
+	eventType: EventTypeSchema,
+	...PaginationSchema,
+});
+export type DisastersGetLatestByLatLngInput = z.infer<
+	typeof DisastersGetLatestByLatLngInputSchema
+>;
+
+export const DisastersGetLatestByCountryCodeInputSchema = z.object({
+	countryCode: z
+		.string()
+		.min(2)
+		.describe('Three-letter ISO country code, e.g. "IND"'),
+	eventType: EventTypeSchema,
+	...PaginationSchema,
+});
+export type DisastersGetLatestByCountryCodeInput = z.infer<
+	typeof DisastersGetLatestByCountryCodeInputSchema
+>;
+
+export const DisastersGetLatestByContinentInputSchema = z.object({
+	continent: ContinentSchema,
+	eventType: EventTypeSchema,
+	...PaginationSchema,
+});
+export type DisastersGetLatestByContinentInput = z.infer<
+	typeof DisastersGetLatestByContinentInputSchema
+>;
+
+export const DisastersGetHistoryByLatLngInputSchema = z.object({
+	lat: LatSchema,
+	lng: LngSchema,
+	from: FromSchema,
+	to: ToSchema,
+	eventType: EventTypeSchema,
+	...PaginationSchema,
+});
+export type DisastersGetHistoryByLatLngInput = z.infer<
+	typeof DisastersGetHistoryByLatLngInputSchema
+>;
+
+export const DisastersGetHistoryByCountryCodeInputSchema = z.object({
+	countryCode: z
+		.string()
+		.min(2)
+		.describe('Three-letter ISO country code, e.g. "IND"'),
+	from: FromSchema,
+	to: ToSchema,
+	eventType: EventTypeSchema,
+	...PaginationSchema,
+});
+export type DisastersGetHistoryByCountryCodeInput = z.infer<
+	typeof DisastersGetHistoryByCountryCodeInputSchema
+>;
+
+export const DisastersGetHistoryByContinentInputSchema = z.object({
+	continent: ContinentSchema,
+	from: FromSchema,
+	to: ToSchema,
+	eventType: EventTypeSchema,
+	...PaginationSchema,
+});
+export type DisastersGetHistoryByContinentInput = z.infer<
+	typeof DisastersGetHistoryByContinentInputSchema
+>;
+
+/** Global history endpoint — only `from` is required, no location filter. */
+export const DisastersGetHistoryByDateRangeInputSchema = z.object({
+	from: FromSchema,
+	to: ToSchema.optional(),
+	eventType: EventTypeSchema,
+	...PaginationSchema,
+});
+export type DisastersGetHistoryByDateRangeInput = z.infer<
+	typeof DisastersGetHistoryByDateRangeInputSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Location services — https://docs.ambeedata.com/apis/location
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -505,6 +746,7 @@ export type AmbeeEndpointInputs = {
 	airQualityGetLatestByLatLng: AirQualityGetLatestByLatLngInput;
 	airQualityGetLatestByCity: AirQualityGetLatestByCityInput;
 	airQualityGetLatestByPostalCode: AirQualityGetLatestByPostalCodeInput;
+	airQualityGetLatestByCountryCode: AirQualityGetLatestByCountryCodeInput;
 	airQualityGetHistoryByLatLng: AirQualityGetHistoryByLatLngInput;
 	airQualityGetHistoryByPostalCode: AirQualityGetHistoryByPostalCodeInput;
 	airQualityGetForecastByLatLng: AirQualityGetForecastByLatLngInput;
@@ -518,6 +760,16 @@ export type AmbeeEndpointInputs = {
 	fireGetLatestByPlace: FireGetLatestByPlaceInput;
 	fireGetRiskByLatLng: FireGetRiskByLatLngInput;
 	fireGetRiskByPlace: FireGetRiskByPlaceInput;
+	elevationGetByLatLng: ElevationGetByLatLngInput;
+	elevationGetByPlace: ElevationGetByPlaceInput;
+	iliGetForecastByLatLng: IliGetForecastByLatLngInput;
+	disastersGetLatestByLatLng: DisastersGetLatestByLatLngInput;
+	disastersGetLatestByCountryCode: DisastersGetLatestByCountryCodeInput;
+	disastersGetLatestByContinent: DisastersGetLatestByContinentInput;
+	disastersGetHistoryByLatLng: DisastersGetHistoryByLatLngInput;
+	disastersGetHistoryByCountryCode: DisastersGetHistoryByCountryCodeInput;
+	disastersGetHistoryByContinent: DisastersGetHistoryByContinentInput;
+	disastersGetHistoryByDateRange: DisastersGetHistoryByDateRangeInput;
 	geocodeByPlace: GeocodeByPlaceInput;
 	geocodeReverseByLatLng: GeocodeReverseByLatLngInput;
 };
@@ -526,6 +778,7 @@ export type AmbeeEndpointOutputs = {
 	airQualityGetLatestByLatLng: AirQualityStationsResponse;
 	airQualityGetLatestByCity: AirQualityStationsResponse;
 	airQualityGetLatestByPostalCode: AirQualityStationsResponse;
+	airQualityGetLatestByCountryCode: AirQualityStationsResponse;
 	airQualityGetHistoryByLatLng: AirQualitySeriesResponse;
 	airQualityGetHistoryByPostalCode: AirQualitySeriesResponse;
 	airQualityGetForecastByLatLng: AirQualitySeriesResponse;
@@ -539,6 +792,16 @@ export type AmbeeEndpointOutputs = {
 	fireGetLatestByPlace: FireResponse;
 	fireGetRiskByLatLng: FireRiskResponse;
 	fireGetRiskByPlace: FireRiskResponse;
+	elevationGetByLatLng: ElevationResponse;
+	elevationGetByPlace: ElevationResponse;
+	iliGetForecastByLatLng: IliForecastResponse;
+	disastersGetLatestByLatLng: DisasterResponse;
+	disastersGetLatestByCountryCode: DisasterResponse;
+	disastersGetLatestByContinent: DisasterResponse;
+	disastersGetHistoryByLatLng: DisasterResponse;
+	disastersGetHistoryByCountryCode: DisasterResponse;
+	disastersGetHistoryByContinent: DisasterResponse;
+	disastersGetHistoryByDateRange: DisasterResponse;
 	geocodeByPlace: GeocodeResponse;
 	geocodeReverseByLatLng: GeocodeResponse;
 };
@@ -547,6 +810,7 @@ export const AmbeeEndpointInputSchemas = {
 	airQualityGetLatestByLatLng: AirQualityGetLatestByLatLngInputSchema,
 	airQualityGetLatestByCity: AirQualityGetLatestByCityInputSchema,
 	airQualityGetLatestByPostalCode: AirQualityGetLatestByPostalCodeInputSchema,
+	airQualityGetLatestByCountryCode: AirQualityGetLatestByCountryCodeInputSchema,
 	airQualityGetHistoryByLatLng: AirQualityGetHistoryByLatLngInputSchema,
 	airQualityGetHistoryByPostalCode: AirQualityGetHistoryByPostalCodeInputSchema,
 	airQualityGetForecastByLatLng: AirQualityGetForecastByLatLngInputSchema,
@@ -560,6 +824,16 @@ export const AmbeeEndpointInputSchemas = {
 	fireGetLatestByPlace: FireGetLatestByPlaceInputSchema,
 	fireGetRiskByLatLng: FireGetRiskByLatLngInputSchema,
 	fireGetRiskByPlace: FireGetRiskByPlaceInputSchema,
+	elevationGetByLatLng: ElevationGetByLatLngInputSchema,
+	elevationGetByPlace: ElevationGetByPlaceInputSchema,
+	iliGetForecastByLatLng: IliGetForecastByLatLngInputSchema,
+	disastersGetLatestByLatLng: DisastersGetLatestByLatLngInputSchema,
+	disastersGetLatestByCountryCode: DisastersGetLatestByCountryCodeInputSchema,
+	disastersGetLatestByContinent: DisastersGetLatestByContinentInputSchema,
+	disastersGetHistoryByLatLng: DisastersGetHistoryByLatLngInputSchema,
+	disastersGetHistoryByCountryCode: DisastersGetHistoryByCountryCodeInputSchema,
+	disastersGetHistoryByContinent: DisastersGetHistoryByContinentInputSchema,
+	disastersGetHistoryByDateRange: DisastersGetHistoryByDateRangeInputSchema,
 	geocodeByPlace: GeocodeByPlaceInputSchema,
 	geocodeReverseByLatLng: GeocodeReverseByLatLngInputSchema,
 } as const;
@@ -568,6 +842,7 @@ export const AmbeeEndpointOutputSchemas = {
 	airQualityGetLatestByLatLng: AirQualityStationsResponseSchema,
 	airQualityGetLatestByCity: AirQualityStationsResponseSchema,
 	airQualityGetLatestByPostalCode: AirQualityStationsResponseSchema,
+	airQualityGetLatestByCountryCode: AirQualityStationsResponseSchema,
 	airQualityGetHistoryByLatLng: AirQualitySeriesResponseSchema,
 	airQualityGetHistoryByPostalCode: AirQualitySeriesResponseSchema,
 	airQualityGetForecastByLatLng: AirQualitySeriesResponseSchema,
@@ -581,6 +856,16 @@ export const AmbeeEndpointOutputSchemas = {
 	fireGetLatestByPlace: FireResponseSchema,
 	fireGetRiskByLatLng: FireRiskResponseSchema,
 	fireGetRiskByPlace: FireRiskResponseSchema,
+	elevationGetByLatLng: ElevationResponseSchema,
+	elevationGetByPlace: ElevationResponseSchema,
+	iliGetForecastByLatLng: IliForecastResponseSchema,
+	disastersGetLatestByLatLng: DisasterResponseSchema,
+	disastersGetLatestByCountryCode: DisasterResponseSchema,
+	disastersGetLatestByContinent: DisasterResponseSchema,
+	disastersGetHistoryByLatLng: DisasterResponseSchema,
+	disastersGetHistoryByCountryCode: DisasterResponseSchema,
+	disastersGetHistoryByContinent: DisasterResponseSchema,
+	disastersGetHistoryByDateRange: DisasterResponseSchema,
 	geocodeByPlace: GeocodeResponseSchema,
 	geocodeReverseByLatLng: GeocodeResponseSchema,
 } as const;

--- a/packages/ambee/endpoints/weather.test.ts
+++ b/packages/ambee/endpoints/weather.test.ts
@@ -1,0 +1,176 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeAmbeeRequest } from '../client';
+import type { AmbeeContext } from '../index';
+import { getForecast, getHistory, getLatest } from './weather';
+
+jest.mock('../client', () => ({
+	makeAmbeeRequest: jest.fn(),
+	toAmbeeTimestamp: jest.requireActual('../client').toAmbeeTimestamp,
+}));
+
+jest.mock('corsair/core', () => ({
+	logEventFromContext: jest.fn().mockResolvedValue(null),
+}));
+
+const mockRequest = makeAmbeeRequest as jest.MockedFunction<
+	typeof makeAmbeeRequest
+>;
+const mockLogEvent = logEventFromContext as jest.MockedFunction<
+	typeof logEventFromContext
+>;
+
+const LATEST_RESPONSE = {
+	message: 'success',
+	lat: 40,
+	lng: -77,
+	timezone: 'America/New_York',
+	data: {
+		time: 1657000000,
+		summary: 'Cloudy',
+		icon: 'cloudy',
+		temperature: 70,
+		apparentTemperature: 70,
+		dewPoint: 69.2,
+		humidity: 95,
+		pressure: 1011,
+		windSpeed: 0.2,
+		windGust: 6.06,
+		windBearing: 258,
+		cloudCover: 1,
+		visibility: 6,
+		ozone: 316.52,
+		uvIndex: 0,
+		precipIntensity: 0,
+		precipProbability: 58,
+	},
+};
+
+const SERIES_RESPONSE = {
+	message: 'success',
+	lat: 40,
+	lng: -77,
+	data: [
+		{ time: 1657000000, temperature: 70, humidity: 95 },
+		{ time: 1657003600, temperature: 71, humidity: 93 },
+	],
+};
+
+const upsertByEntityId = jest.fn().mockResolvedValue(undefined);
+
+function makeCtx(): AmbeeContext {
+	return {
+		key: 'test-key',
+		options: {},
+		db: { weatherObservations: { upsertByEntityId } },
+	} as unknown as AmbeeContext;
+}
+
+beforeEach(() => {
+	mockRequest.mockReset();
+	mockLogEvent.mockClear();
+	upsertByEntityId.mockClear();
+});
+
+describe('weather.getLatest', () => {
+	it('calls weather/latest/by-lat-lng and returns the single observation', async () => {
+		mockRequest.mockResolvedValue(LATEST_RESPONSE);
+
+		const result = await getLatest(makeCtx(), { lat: 40, lng: -77 });
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'weather/latest/by-lat-lng',
+			'test-key',
+			{ query: { lat: 40, lng: -77, units: undefined } },
+		);
+		expect(result.data?.temperature).toBe(70);
+		expect(result.timezone).toBe('America/New_York');
+	});
+
+	it('forwards the si units flag when requested', async () => {
+		mockRequest.mockResolvedValue(LATEST_RESPONSE);
+
+		await getLatest(makeCtx(), { lat: 40, lng: -77, units: 'si' });
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'weather/latest/by-lat-lng',
+			'test-key',
+			{ query: { lat: 40, lng: -77, units: 'si' } },
+		);
+	});
+
+	it('persists the observation keyed by rounded coordinates', async () => {
+		mockRequest.mockResolvedValue(LATEST_RESPONSE);
+
+		await getLatest(makeCtx(), { lat: 40, lng: -77 });
+
+		const [entityId, row] = upsertByEntityId.mock.calls[0];
+		expect(entityId).toBe('40.0000,-77.0000');
+		expect(row).toMatchObject({
+			timezone: 'America/New_York',
+			temperature: 70,
+			windGust: 6.06,
+			observedAt: 1657000000,
+		});
+	});
+
+	it('does not fail the call when persistence throws', async () => {
+		mockRequest.mockResolvedValue(LATEST_RESPONSE);
+		upsertByEntityId.mockRejectedValueOnce(new Error('db unavailable'));
+		const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+		const result = await getLatest(makeCtx(), { lat: 40, lng: -77 });
+
+		expect(result.message).toBe('success');
+		expect(warn).toHaveBeenCalled();
+		warn.mockRestore();
+	});
+});
+
+describe('weather.getHistory', () => {
+	it('normalises the time range and returns the hourly series', async () => {
+		mockRequest.mockResolvedValue(SERIES_RESPONSE);
+
+		const result = await getHistory(makeCtx(), {
+			lat: 40,
+			lng: -77,
+			from: '2026-07-13T12:16:44.000Z',
+			to: '2026-07-14T12:16:44.000Z',
+			units: 'si',
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'weather/history/by-lat-lng',
+			'test-key',
+			{
+				query: {
+					lat: 40,
+					lng: -77,
+					from: '2026-07-13 12:16:44',
+					to: '2026-07-14 12:16:44',
+					units: 'si',
+				},
+			},
+		);
+		expect(result.data).toHaveLength(2);
+	});
+});
+
+describe('weather.getForecast', () => {
+	it('calls weather/forecast/by-lat-lng and logs the event', async () => {
+		mockRequest.mockResolvedValue(SERIES_RESPONSE);
+
+		await getForecast(makeCtx(), { lat: 40, lng: -77 });
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'weather/forecast/by-lat-lng',
+			'test-key',
+			{ query: { lat: 40, lng: -77, units: undefined } },
+		);
+		expect(mockLogEvent).toHaveBeenCalledWith(
+			expect.anything(),
+			'ambee.weather.getForecast',
+			{ lat: 40, lng: -77, units: undefined },
+			'completed',
+		);
+	});
+});

--- a/packages/ambee/endpoints/weather.ts
+++ b/packages/ambee/endpoints/weather.ts
@@ -1,0 +1,112 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeAmbeeRequest, toAmbeeTimestamp } from '../client';
+import type { AmbeeEndpoints } from '../index';
+import { persistWeatherObservation } from './persist';
+import type { WeatherLatestResponse, WeatherSeriesResponse } from './types';
+import {
+	WeatherLatestResponseSchema,
+	WeatherSeriesResponseSchema,
+} from './types';
+
+/**
+ * Current weather conditions for a coordinate pair.
+ *
+ * API: GET api.ambeedata.com/weather/latest/by-lat-lng
+ * Docs: https://docs.ambeedata.com/apis/weather
+ */
+export const getLatest: AmbeeEndpoints['weatherGetLatest'] = async (
+	ctx,
+	input,
+) => {
+	const raw = await makeAmbeeRequest<WeatherLatestResponse>(
+		'weather/latest/by-lat-lng',
+		ctx.key,
+		{ query: { lat: input.lat, lng: input.lng, units: input.units } },
+	);
+
+	const response = WeatherLatestResponseSchema.parse(raw);
+
+	await persistWeatherObservation(
+		ctx,
+		input.lat,
+		input.lng,
+		response.data,
+		response.timezone,
+	);
+	await logEventFromContext(
+		ctx,
+		'ambee.weather.getLatest',
+		{ lat: input.lat, lng: input.lng, units: input.units },
+		'completed',
+	);
+
+	return response;
+};
+
+/**
+ * Hourly historical weather for a coordinate pair (up to 48 hours per
+ * request).
+ *
+ * API: GET api.ambeedata.com/weather/history/by-lat-lng
+ * Docs: https://docs.ambeedata.com/apis/weather
+ */
+export const getHistory: AmbeeEndpoints['weatherGetHistory'] = async (
+	ctx,
+	input,
+) => {
+	const from = toAmbeeTimestamp(input.from);
+	const to = toAmbeeTimestamp(input.to);
+
+	const raw = await makeAmbeeRequest<WeatherSeriesResponse>(
+		'weather/history/by-lat-lng',
+		ctx.key,
+		{
+			query: {
+				lat: input.lat,
+				lng: input.lng,
+				from,
+				to,
+				units: input.units,
+			},
+		},
+	);
+
+	const response = WeatherSeriesResponseSchema.parse(raw);
+
+	await logEventFromContext(
+		ctx,
+		'ambee.weather.getHistory',
+		{ lat: input.lat, lng: input.lng, from, to, units: input.units },
+		'completed',
+	);
+
+	return response;
+};
+
+/**
+ * Hourly weather forecast for a coordinate pair (next 72 hours).
+ *
+ * API: GET api.ambeedata.com/weather/forecast/by-lat-lng
+ * Docs: https://docs.ambeedata.com/apis/weather
+ */
+export const getForecast: AmbeeEndpoints['weatherGetForecast'] = async (
+	ctx,
+	input,
+) => {
+	const raw = await makeAmbeeRequest<WeatherSeriesResponse>(
+		'weather/forecast/by-lat-lng',
+		ctx.key,
+		{ query: { lat: input.lat, lng: input.lng, units: input.units } },
+	);
+
+	const response = WeatherSeriesResponseSchema.parse(raw);
+
+	await logEventFromContext(
+		ctx,
+		'ambee.weather.getForecast',
+		{ lat: input.lat, lng: input.lng, units: input.units },
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/ambee/error-handlers.test.ts
+++ b/packages/ambee/error-handlers.test.ts
@@ -1,0 +1,85 @@
+import { AmbeeAPIError } from './client';
+import { errorHandlers } from './error-handlers';
+
+function ambeeError(status: number, retryAfter?: number): AmbeeAPIError {
+	const error = new AmbeeAPIError(`Request failed with status ${status}`);
+	Object.assign(error, { status, retryAfter });
+	return error;
+}
+
+/** Mirrors how corsair picks a handler: first matching entry wins. */
+function route(error: Error): string {
+	const match = Object.entries(errorHandlers).find(([, entry]) =>
+		entry.match(error),
+	);
+	if (!match) throw new Error('no handler matched');
+	return match[0];
+}
+
+beforeEach(() => {
+	jest.spyOn(console, 'error').mockImplementation(() => {});
+	jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+	jest.restoreAllMocks();
+});
+
+describe('errorHandlers', () => {
+	it('routes a 429 to the rate-limit handler and retries with backoff', async () => {
+		const error = ambeeError(429, 2000);
+
+		expect(route(error)).toBe('RATE_LIMIT_ERROR');
+		expect(await errorHandlers.RATE_LIMIT_ERROR.handler(error)).toEqual({
+			maxRetries: 3,
+			retryStrategy: 'exponential_backoff',
+			headersRetryAfterMs: 2000,
+		});
+	});
+
+	it('treats 401 and 403 as auth failures that must not be retried', async () => {
+		expect(route(ambeeError(401))).toBe('AUTH_ERROR');
+		expect(route(ambeeError(403))).toBe('AUTH_ERROR');
+		expect(await errorHandlers.AUTH_ERROR.handler()).toEqual({
+			maxRetries: 0,
+		});
+	});
+
+	it('treats a 404 as an out-of-coverage location rather than a transient failure', async () => {
+		expect(route(ambeeError(404))).toBe('NOT_FOUND_ERROR');
+		expect(await errorHandlers.NOT_FOUND_ERROR.handler()).toEqual({
+			maxRetries: 0,
+		});
+	});
+
+	it('routes 400 and 422 to validation without retrying', async () => {
+		expect(route(ambeeError(400))).toBe('VALIDATION_ERROR');
+		expect(route(ambeeError(422))).toBe('VALIDATION_ERROR');
+		expect(await errorHandlers.VALIDATION_ERROR.handler()).toEqual({
+			maxRetries: 0,
+		});
+	});
+
+	it('retries 5xx responses with exponential backoff', async () => {
+		expect(route(ambeeError(503))).toBe('SERVER_ERROR');
+		expect(await errorHandlers.SERVER_ERROR.handler()).toEqual({
+			maxRetries: 2,
+			retryStrategy: 'exponential_backoff',
+		});
+	});
+
+	it('falls back to DEFAULT for an error carrying no status', async () => {
+		const error = new Error('socket hang up');
+
+		expect(route(error)).toBe('DEFAULT');
+		expect(await errorHandlers.DEFAULT.handler(error)).toEqual({
+			maxRetries: 0,
+		});
+	});
+
+	it('still recognises a rate limit when only the message carries the signal', () => {
+		expect(route(new Error('Ambee returned 429 rate limit exceeded'))).toBe(
+			'RATE_LIMIT_ERROR',
+		);
+	});
+});

--- a/packages/ambee/error-handlers.test.ts
+++ b/packages/ambee/error-handlers.test.ts
@@ -82,4 +82,10 @@ describe('errorHandlers', () => {
 			'RATE_LIMIT_ERROR',
 		);
 	});
+
+	it('does not let digits in the message override an explicit status', () => {
+		const error = ambeeError(503);
+		error.message = 'upstream failed for postalCode 560429 with body 404';
+		expect(route(error)).toBe('SERVER_ERROR');
+	});
 });

--- a/packages/ambee/error-handlers.ts
+++ b/packages/ambee/error-handlers.ts
@@ -15,6 +15,11 @@ function getRetryAfter(error: Error): number | undefined {
 	return (error as Partial<AmbeeAPIError>).retryAfter;
 }
 
+/** Matches a bare HTTP status code as a standalone token in a message. */
+function messageHasCode(message: string, ...codes: number[]): boolean {
+	return codes.some((code) => new RegExp(`\\b${code}\\b`).test(message));
+}
+
 /**
  * Error handlers for the Ambee plugin.
  *
@@ -28,9 +33,10 @@ function getRetryAfter(error: Error): number | undefined {
 export const errorHandlers = {
 	RATE_LIMIT_ERROR: {
 		match: (error: Error) => {
-			if (getStatus(error) === 429) return true;
+			const status = getStatus(error);
+			if (status !== undefined) return status === 429;
 			const msg = error.message.toLowerCase();
-			return msg.includes('429') || msg.includes('rate limit');
+			return messageHasCode(msg, 429) || msg.includes('rate limit');
 		},
 		handler: async (error: Error) => ({
 			maxRetries: 3,
@@ -41,11 +47,10 @@ export const errorHandlers = {
 	AUTH_ERROR: {
 		match: (error: Error) => {
 			const status = getStatus(error);
-			if (status === 401 || status === 403) return true;
+			if (status !== undefined) return status === 401 || status === 403;
 			const msg = error.message.toLowerCase();
 			return (
-				msg.includes('401') ||
-				msg.includes('403') ||
+				messageHasCode(msg, 401, 403) ||
 				msg.includes('unauthorized') ||
 				msg.includes('forbidden') ||
 				msg.includes('invalid api key')
@@ -63,9 +68,10 @@ export const errorHandlers = {
 		// Ambee returns 404 when a location is outside a product's coverage
 		// (e.g. wildfire risk outside North America) — retrying cannot help.
 		match: (error: Error) => {
-			if (getStatus(error) === 404) return true;
+			const status = getStatus(error);
+			if (status !== undefined) return status === 404;
 			const msg = error.message.toLowerCase();
-			return msg.includes('404') || msg.includes('not found');
+			return messageHasCode(msg, 404) || msg.includes('not found');
 		},
 		handler: async () => {
 			console.warn(
@@ -78,13 +84,9 @@ export const errorHandlers = {
 	VALIDATION_ERROR: {
 		match: (error: Error) => {
 			const status = getStatus(error);
-			if (status === 400 || status === 422) return true;
+			if (status !== undefined) return status === 400 || status === 422;
 			const msg = error.message.toLowerCase();
-			return (
-				msg.includes('400') ||
-				msg.includes('422') ||
-				msg.includes('unprocessable')
-			);
+			return messageHasCode(msg, 400, 422) || msg.includes('unprocessable');
 		},
 		handler: async () => {
 			console.warn(
@@ -96,9 +98,9 @@ export const errorHandlers = {
 	SERVER_ERROR: {
 		match: (error: Error) => {
 			const status = getStatus(error);
-			if (status !== undefined && status >= 500) return true;
+			if (status !== undefined) return status >= 500;
 			const msg = error.message.toLowerCase();
-			return msg.includes('500') || msg.includes('internal server error');
+			return messageHasCode(msg, 500) || msg.includes('internal server error');
 		},
 		handler: async () => ({
 			maxRetries: 2,

--- a/packages/ambee/error-handlers.ts
+++ b/packages/ambee/error-handlers.ts
@@ -1,0 +1,115 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import type { AmbeeAPIError } from './client';
+
+/**
+ * Reads the HTTP status from an error. Works with `AmbeeAPIError` (which
+ * copies status off the originating `ApiError`) and with any error exposing a
+ * numeric `status`.
+ */
+function getStatus(error: Error): number | undefined {
+	return (error as Partial<AmbeeAPIError>).status;
+}
+
+/** Reads the Retry-After value (in ms) from an error, when present. */
+function getRetryAfter(error: Error): number | undefined {
+	return (error as Partial<AmbeeAPIError>).retryAfter;
+}
+
+/**
+ * Error handlers for the Ambee plugin.
+ *
+ * Ambee status codes (shared across all of its products):
+ * - 401/403: missing, invalid, or not-subscribed API key
+ * - 404: no data available for the requested location
+ * - 422: malformed or out-of-range parameters
+ * - 429: per-minute or per-day request quota exceeded
+ * - 5xx: upstream failure
+ */
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (getStatus(error) === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('429') || msg.includes('rate limit');
+		},
+		handler: async (error: Error) => ({
+			maxRetries: 3,
+			retryStrategy: 'exponential_backoff' as const,
+			headersRetryAfterMs: getRetryAfter(error),
+		}),
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			const status = getStatus(error);
+			if (status === 401 || status === 403) return true;
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('401') ||
+				msg.includes('403') ||
+				msg.includes('unauthorized') ||
+				msg.includes('forbidden') ||
+				msg.includes('invalid api key')
+			);
+		},
+		handler: async () => {
+			console.error(
+				'[AMBEE] Authentication failed — check that the API key is valid and ' +
+					'that the account is subscribed to the requested product.',
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	NOT_FOUND_ERROR: {
+		// Ambee returns 404 when a location is outside a product's coverage
+		// (e.g. wildfire risk outside North America) — retrying cannot help.
+		match: (error: Error) => {
+			if (getStatus(error) === 404) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('404') || msg.includes('not found');
+		},
+		handler: async () => {
+			console.warn(
+				'[AMBEE] No data available for the requested location — it may be ' +
+					'outside this product’s coverage area.',
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	VALIDATION_ERROR: {
+		match: (error: Error) => {
+			const status = getStatus(error);
+			if (status === 400 || status === 422) return true;
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('400') ||
+				msg.includes('422') ||
+				msg.includes('unprocessable')
+			);
+		},
+		handler: async () => {
+			console.warn(
+				'[AMBEE] Request rejected — a required parameter is missing or malformed.',
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	SERVER_ERROR: {
+		match: (error: Error) => {
+			const status = getStatus(error);
+			if (status !== undefined && status >= 500) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('500') || msg.includes('internal server error');
+		},
+		handler: async () => ({
+			maxRetries: 2,
+			retryStrategy: 'exponential_backoff' as const,
+		}),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async (error: Error) => {
+			console.error(`[AMBEE] Unhandled error: ${error.message}`);
+			return { maxRetries: 0 };
+		},
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/ambee/index.ts
+++ b/packages/ambee/index.ts
@@ -1,0 +1,441 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+} from 'corsair/core';
+import { AirQuality, Fire, Geocode, Pollen, Weather } from './endpoints';
+import type {
+	AmbeeEndpointInputs,
+	AmbeeEndpointOutputs,
+} from './endpoints/types';
+import {
+	AmbeeEndpointInputSchemas,
+	AmbeeEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { AmbeeSchema } from './schema';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin Options
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type AmbeePluginOptions = {
+	/** Authentication method. Ambee only supports API keys. */
+	authType?: PickAuth<'api_key'>;
+	/**
+	 * Ambee API key, sent as the `x-api-key` header. When omitted the key is
+	 * resolved from the account key manager instead.
+	 */
+	key?: string;
+	/** Optional: lifecycle hooks for endpoints */
+	hooks?: InternalAmbeePlugin['hooks'];
+	/** Optional: custom error handlers (merged with defaults) */
+	errorHandlers?: CorsairErrorHandler;
+	/**
+	 * Permission configuration for the Ambee plugin. Every endpoint is a
+	 * read-only environmental data lookup.
+	 */
+	permissions?: PluginPermissionsConfig<typeof ambeeEndpointsNested>;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Context & Type Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type AmbeeContext = CorsairPluginContext<
+	typeof AmbeeSchema,
+	AmbeePluginOptions,
+	undefined,
+	typeof ambeeAuthConfig
+>;
+
+export type AmbeeKeyBuilderContext = KeyBuilderContext<
+	AmbeePluginOptions,
+	typeof ambeeAuthConfig
+>;
+
+export type AmbeeBoundEndpoints = BindEndpoints<typeof ambeeEndpointsNested>;
+
+type AmbeeEndpoint<K extends keyof AmbeeEndpointOutputs> = CorsairEndpoint<
+	AmbeeContext,
+	AmbeeEndpointInputs[K],
+	AmbeeEndpointOutputs[K]
+>;
+
+export type AmbeeEndpoints = {
+	airQualityGetLatestByLatLng: AmbeeEndpoint<'airQualityGetLatestByLatLng'>;
+	airQualityGetLatestByCity: AmbeeEndpoint<'airQualityGetLatestByCity'>;
+	airQualityGetLatestByPostalCode: AmbeeEndpoint<'airQualityGetLatestByPostalCode'>;
+	airQualityGetHistoryByLatLng: AmbeeEndpoint<'airQualityGetHistoryByLatLng'>;
+	airQualityGetHistoryByPostalCode: AmbeeEndpoint<'airQualityGetHistoryByPostalCode'>;
+	airQualityGetForecastByLatLng: AmbeeEndpoint<'airQualityGetForecastByLatLng'>;
+	weatherGetLatest: AmbeeEndpoint<'weatherGetLatest'>;
+	weatherGetHistory: AmbeeEndpoint<'weatherGetHistory'>;
+	weatherGetForecast: AmbeeEndpoint<'weatherGetForecast'>;
+	pollenGetLatest: AmbeeEndpoint<'pollenGetLatest'>;
+	pollenGetHistory: AmbeeEndpoint<'pollenGetHistory'>;
+	pollenGetForecast: AmbeeEndpoint<'pollenGetForecast'>;
+	fireGetLatestByLatLng: AmbeeEndpoint<'fireGetLatestByLatLng'>;
+	fireGetLatestByPlace: AmbeeEndpoint<'fireGetLatestByPlace'>;
+	fireGetRiskByLatLng: AmbeeEndpoint<'fireGetRiskByLatLng'>;
+	fireGetRiskByPlace: AmbeeEndpoint<'fireGetRiskByPlace'>;
+	geocodeByPlace: AmbeeEndpoint<'geocodeByPlace'>;
+	geocodeReverseByLatLng: AmbeeEndpoint<'geocodeReverseByLatLng'>;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint Tree
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ambeeEndpointsNested = {
+	airQuality: {
+		getLatestByLatLng: AirQuality.getLatestByLatLng,
+		getLatestByCity: AirQuality.getLatestByCity,
+		getLatestByPostalCode: AirQuality.getLatestByPostalCode,
+		getHistoryByLatLng: AirQuality.getHistoryByLatLng,
+		getHistoryByPostalCode: AirQuality.getHistoryByPostalCode,
+		getForecastByLatLng: AirQuality.getForecastByLatLng,
+	},
+	weather: {
+		getLatest: Weather.getLatest,
+		getHistory: Weather.getHistory,
+		getForecast: Weather.getForecast,
+	},
+	pollen: {
+		getLatest: Pollen.getLatest,
+		getHistory: Pollen.getHistory,
+		getForecast: Pollen.getForecast,
+	},
+	fire: {
+		getLatestByLatLng: Fire.getLatestByLatLng,
+		getLatestByPlace: Fire.getLatestByPlace,
+		getRiskByLatLng: Fire.getRiskByLatLng,
+		getRiskByPlace: Fire.getRiskByPlace,
+	},
+	geocode: {
+		byPlace: Geocode.byPlace,
+		reverseByLatLng: Geocode.reverseByLatLng,
+	},
+} as const;
+
+// No webhooks — Ambee is a pull-based API with no event delivery.
+const ambeeWebhooksNested = {} as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint Schemas (for get_schema / agent introspection)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ambeeEndpointSchemas = {
+	'airQuality.getLatestByLatLng': {
+		input: AmbeeEndpointInputSchemas.airQualityGetLatestByLatLng,
+		output: AmbeeEndpointOutputSchemas.airQualityGetLatestByLatLng,
+	},
+	'airQuality.getLatestByCity': {
+		input: AmbeeEndpointInputSchemas.airQualityGetLatestByCity,
+		output: AmbeeEndpointOutputSchemas.airQualityGetLatestByCity,
+	},
+	'airQuality.getLatestByPostalCode': {
+		input: AmbeeEndpointInputSchemas.airQualityGetLatestByPostalCode,
+		output: AmbeeEndpointOutputSchemas.airQualityGetLatestByPostalCode,
+	},
+	'airQuality.getHistoryByLatLng': {
+		input: AmbeeEndpointInputSchemas.airQualityGetHistoryByLatLng,
+		output: AmbeeEndpointOutputSchemas.airQualityGetHistoryByLatLng,
+	},
+	'airQuality.getHistoryByPostalCode': {
+		input: AmbeeEndpointInputSchemas.airQualityGetHistoryByPostalCode,
+		output: AmbeeEndpointOutputSchemas.airQualityGetHistoryByPostalCode,
+	},
+	'airQuality.getForecastByLatLng': {
+		input: AmbeeEndpointInputSchemas.airQualityGetForecastByLatLng,
+		output: AmbeeEndpointOutputSchemas.airQualityGetForecastByLatLng,
+	},
+	'weather.getLatest': {
+		input: AmbeeEndpointInputSchemas.weatherGetLatest,
+		output: AmbeeEndpointOutputSchemas.weatherGetLatest,
+	},
+	'weather.getHistory': {
+		input: AmbeeEndpointInputSchemas.weatherGetHistory,
+		output: AmbeeEndpointOutputSchemas.weatherGetHistory,
+	},
+	'weather.getForecast': {
+		input: AmbeeEndpointInputSchemas.weatherGetForecast,
+		output: AmbeeEndpointOutputSchemas.weatherGetForecast,
+	},
+	'pollen.getLatest': {
+		input: AmbeeEndpointInputSchemas.pollenGetLatest,
+		output: AmbeeEndpointOutputSchemas.pollenGetLatest,
+	},
+	'pollen.getHistory': {
+		input: AmbeeEndpointInputSchemas.pollenGetHistory,
+		output: AmbeeEndpointOutputSchemas.pollenGetHistory,
+	},
+	'pollen.getForecast': {
+		input: AmbeeEndpointInputSchemas.pollenGetForecast,
+		output: AmbeeEndpointOutputSchemas.pollenGetForecast,
+	},
+	'fire.getLatestByLatLng': {
+		input: AmbeeEndpointInputSchemas.fireGetLatestByLatLng,
+		output: AmbeeEndpointOutputSchemas.fireGetLatestByLatLng,
+	},
+	'fire.getLatestByPlace': {
+		input: AmbeeEndpointInputSchemas.fireGetLatestByPlace,
+		output: AmbeeEndpointOutputSchemas.fireGetLatestByPlace,
+	},
+	'fire.getRiskByLatLng': {
+		input: AmbeeEndpointInputSchemas.fireGetRiskByLatLng,
+		output: AmbeeEndpointOutputSchemas.fireGetRiskByLatLng,
+	},
+	'fire.getRiskByPlace': {
+		input: AmbeeEndpointInputSchemas.fireGetRiskByPlace,
+		output: AmbeeEndpointOutputSchemas.fireGetRiskByPlace,
+	},
+	'geocode.byPlace': {
+		input: AmbeeEndpointInputSchemas.geocodeByPlace,
+		output: AmbeeEndpointOutputSchemas.geocodeByPlace,
+	},
+	'geocode.reverseByLatLng': {
+		input: AmbeeEndpointInputSchemas.geocodeReverseByLatLng,
+		output: AmbeeEndpointOutputSchemas.geocodeReverseByLatLng,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<typeof ambeeEndpointsNested>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint Meta (risk levels for permission system)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Every Ambee endpoint is a read-only environmental data lookup — nothing the
+ * plugin exposes mutates provider-side state.
+ */
+const ambeeEndpointMeta = {
+	'airQuality.getLatestByLatLng': {
+		riskLevel: 'read',
+		description:
+			'Get the latest air quality (AQI and pollutant concentrations) for a latitude/longitude',
+	},
+	'airQuality.getLatestByCity': {
+		riskLevel: 'read',
+		description: 'Get the latest air quality for the stations in a city',
+	},
+	'airQuality.getLatestByPostalCode': {
+		riskLevel: 'read',
+		description: 'Get the latest air quality for a postal code and country',
+	},
+	'airQuality.getHistoryByLatLng': {
+		riskLevel: 'read',
+		description:
+			'Get hourly historical air quality for a latitude/longitude over a time range',
+	},
+	'airQuality.getHistoryByPostalCode': {
+		riskLevel: 'read',
+		description:
+			'Get hourly historical air quality for a postal code over a time range',
+	},
+	'airQuality.getForecastByLatLng': {
+		riskLevel: 'read',
+		description:
+			'Get the hourly air quality forecast for a latitude/longitude (next 48 hours)',
+	},
+	'weather.getLatest': {
+		riskLevel: 'read',
+		description:
+			'Get current weather conditions (temperature, humidity, wind, UV) for a latitude/longitude',
+	},
+	'weather.getHistory': {
+		riskLevel: 'read',
+		description:
+			'Get hourly historical weather for a latitude/longitude over a time range',
+	},
+	'weather.getForecast': {
+		riskLevel: 'read',
+		description:
+			'Get the hourly weather forecast for a latitude/longitude (next 72 hours)',
+	},
+	'pollen.getLatest': {
+		riskLevel: 'read',
+		description:
+			'Get the latest grass, tree and weed pollen counts and risk levels for a location',
+	},
+	'pollen.getHistory': {
+		riskLevel: 'read',
+		description:
+			'Get historical pollen counts for a location over a time range',
+	},
+	'pollen.getForecast': {
+		riskLevel: 'read',
+		description:
+			'Get the pollen forecast for a location (48 hours hourly or 120 hours 3-hourly)',
+	},
+	'fire.getLatestByLatLng': {
+		riskLevel: 'read',
+		description:
+			'Get wildfires detected or reported near a latitude/longitude in the last 7 days',
+	},
+	'fire.getLatestByPlace': {
+		riskLevel: 'read',
+		description:
+			'Get wildfires detected or reported near a named place in the last 7 days',
+	},
+	'fire.getRiskByLatLng': {
+		riskLevel: 'read',
+		description:
+			'Get the wildfire risk forecast for a latitude/longitude (up to 4 weeks ahead)',
+	},
+	'fire.getRiskByPlace': {
+		riskLevel: 'read',
+		description:
+			'Get the wildfire risk forecast for a named place (up to 4 weeks ahead)',
+	},
+	'geocode.byPlace': {
+		riskLevel: 'read',
+		description: 'Geocode a place name or address into coordinates',
+	},
+	'geocode.reverseByLatLng': {
+		riskLevel: 'read',
+		description:
+			'Reverse-geocode a latitude/longitude into a human-readable address',
+	},
+} as const satisfies RequiredPluginEndpointMeta<typeof ambeeEndpointsNested>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Auth Configuration
+// ─────────────────────────────────────────────────────────────────────────────
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+/**
+ * Ambee issues a single account-level API key that unlocks every product the
+ * subscription covers, so no per-product key fields are needed beyond the
+ * base `api_key` credential.
+ */
+export const ambeeAuthConfig = {
+	api_key: {
+		account: ['tenant_external_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type BaseAmbeePlugin<T extends AmbeePluginOptions> = CorsairPlugin<
+	'ambee',
+	typeof AmbeeSchema,
+	typeof ambeeEndpointsNested,
+	typeof ambeeWebhooksNested,
+	T,
+	typeof defaultAuthType,
+	typeof ambeeAuthConfig
+>;
+
+export type InternalAmbeePlugin = BaseAmbeePlugin<AmbeePluginOptions>;
+
+export type ExternalAmbeePlugin<T extends AmbeePluginOptions> =
+	BaseAmbeePlugin<T>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function ambee<const T extends AmbeePluginOptions>(
+	// Safe: T extends AmbeePluginOptions, so an empty object is a valid no-op
+	// default when no options are passed. TypeScript requires the cast because
+	// it cannot verify T = {}.
+	incomingOptions: AmbeePluginOptions & T = {} as AmbeePluginOptions & T,
+): ExternalAmbeePlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'ambee',
+		authConfig: ambeeAuthConfig,
+		schema: AmbeeSchema,
+		options: options,
+		hooks: options.hooks,
+		webhookHooks: undefined,
+		endpoints: ambeeEndpointsNested,
+		webhooks: ambeeWebhooksNested,
+		endpointMeta: ambeeEndpointMeta,
+		endpointSchemas: ambeeEndpointSchemas,
+		// No webhooks — Ambee is a pull-based API.
+		pluginWebhookMatcher: undefined,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: AmbeeKeyBuilderContext, source) => {
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			// `ctx.keys` is only attached when the host app configures both a
+			// database and a KEK, even though the type declares it as always
+			// present — the `?.` keeps a key-manager-less setup (plugin
+			// configured with `key` alone) from throwing a raw TypeError.
+			if (source === 'endpoint') {
+				const res = await ctx.keys?.get_api_key();
+				return res ?? '';
+			}
+
+			return '';
+		},
+	} satisfies InternalAmbeePlugin;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Type Exports
+// ─────────────────────────────────────────────────────────────────────────────
+
+export { AMBEE_API_BASE, AmbeeAPIError } from './client';
+export type {
+	AirQualityGetForecastByLatLngInput,
+	AirQualityGetHistoryByLatLngInput,
+	AirQualityGetHistoryByPostalCodeInput,
+	AirQualityGetLatestByCityInput,
+	AirQualityGetLatestByLatLngInput,
+	AirQualityGetLatestByPostalCodeInput,
+	AirQualityReading,
+	AirQualitySeriesResponse,
+	AirQualityStation,
+	AirQualityStationsResponse,
+	AmbeeEndpointInputs,
+	AmbeeEndpointOutputs,
+	FireEvent,
+	FireGetLatestByLatLngInput,
+	FireGetLatestByPlaceInput,
+	FireGetRiskByLatLngInput,
+	FireGetRiskByPlaceInput,
+	FireResponse,
+	FireRisk,
+	FireRiskResponse,
+	GeocodeByPlaceInput,
+	GeocodeResponse,
+	GeocodeResult,
+	GeocodeReverseByLatLngInput,
+	PollenGetForecastInput,
+	PollenGetHistoryInput,
+	PollenGetLatestInput,
+	PollenReading,
+	PollenResponse,
+	WeatherGetForecastInput,
+	WeatherGetHistoryInput,
+	WeatherGetLatestInput,
+	WeatherLatestResponse,
+	WeatherPoint,
+	WeatherSeriesResponse,
+} from './endpoints/types';
+export {
+	AmbeeEndpointInputSchemas,
+	AmbeeEndpointOutputSchemas,
+} from './endpoints/types';

--- a/packages/ambee/index.ts
+++ b/packages/ambee/index.ts
@@ -12,7 +12,16 @@ import type {
 	RequiredPluginEndpointMeta,
 	RequiredPluginEndpointSchemas,
 } from 'corsair/core';
-import { AirQuality, Fire, Geocode, Pollen, Weather } from './endpoints';
+import {
+	AirQuality,
+	Disasters,
+	Elevation,
+	Fire,
+	Geocode,
+	Ili,
+	Pollen,
+	Weather,
+} from './endpoints';
 import type {
 	AmbeeEndpointInputs,
 	AmbeeEndpointOutputs,
@@ -75,6 +84,7 @@ export type AmbeeEndpoints = {
 	airQualityGetLatestByLatLng: AmbeeEndpoint<'airQualityGetLatestByLatLng'>;
 	airQualityGetLatestByCity: AmbeeEndpoint<'airQualityGetLatestByCity'>;
 	airQualityGetLatestByPostalCode: AmbeeEndpoint<'airQualityGetLatestByPostalCode'>;
+	airQualityGetLatestByCountryCode: AmbeeEndpoint<'airQualityGetLatestByCountryCode'>;
 	airQualityGetHistoryByLatLng: AmbeeEndpoint<'airQualityGetHistoryByLatLng'>;
 	airQualityGetHistoryByPostalCode: AmbeeEndpoint<'airQualityGetHistoryByPostalCode'>;
 	airQualityGetForecastByLatLng: AmbeeEndpoint<'airQualityGetForecastByLatLng'>;
@@ -88,6 +98,16 @@ export type AmbeeEndpoints = {
 	fireGetLatestByPlace: AmbeeEndpoint<'fireGetLatestByPlace'>;
 	fireGetRiskByLatLng: AmbeeEndpoint<'fireGetRiskByLatLng'>;
 	fireGetRiskByPlace: AmbeeEndpoint<'fireGetRiskByPlace'>;
+	elevationGetByLatLng: AmbeeEndpoint<'elevationGetByLatLng'>;
+	elevationGetByPlace: AmbeeEndpoint<'elevationGetByPlace'>;
+	iliGetForecastByLatLng: AmbeeEndpoint<'iliGetForecastByLatLng'>;
+	disastersGetLatestByLatLng: AmbeeEndpoint<'disastersGetLatestByLatLng'>;
+	disastersGetLatestByCountryCode: AmbeeEndpoint<'disastersGetLatestByCountryCode'>;
+	disastersGetLatestByContinent: AmbeeEndpoint<'disastersGetLatestByContinent'>;
+	disastersGetHistoryByLatLng: AmbeeEndpoint<'disastersGetHistoryByLatLng'>;
+	disastersGetHistoryByCountryCode: AmbeeEndpoint<'disastersGetHistoryByCountryCode'>;
+	disastersGetHistoryByContinent: AmbeeEndpoint<'disastersGetHistoryByContinent'>;
+	disastersGetHistoryByDateRange: AmbeeEndpoint<'disastersGetHistoryByDateRange'>;
 	geocodeByPlace: AmbeeEndpoint<'geocodeByPlace'>;
 	geocodeReverseByLatLng: AmbeeEndpoint<'geocodeReverseByLatLng'>;
 };
@@ -101,6 +121,7 @@ const ambeeEndpointsNested = {
 		getLatestByLatLng: AirQuality.getLatestByLatLng,
 		getLatestByCity: AirQuality.getLatestByCity,
 		getLatestByPostalCode: AirQuality.getLatestByPostalCode,
+		getLatestByCountryCode: AirQuality.getLatestByCountryCode,
 		getHistoryByLatLng: AirQuality.getHistoryByLatLng,
 		getHistoryByPostalCode: AirQuality.getHistoryByPostalCode,
 		getForecastByLatLng: AirQuality.getForecastByLatLng,
@@ -120,6 +141,22 @@ const ambeeEndpointsNested = {
 		getLatestByPlace: Fire.getLatestByPlace,
 		getRiskByLatLng: Fire.getRiskByLatLng,
 		getRiskByPlace: Fire.getRiskByPlace,
+	},
+	elevation: {
+		getByLatLng: Elevation.getByLatLng,
+		getByPlace: Elevation.getByPlace,
+	},
+	ili: {
+		getForecastByLatLng: Ili.getForecastByLatLng,
+	},
+	disasters: {
+		getLatestByLatLng: Disasters.getLatestByLatLng,
+		getLatestByCountryCode: Disasters.getLatestByCountryCode,
+		getLatestByContinent: Disasters.getLatestByContinent,
+		getHistoryByLatLng: Disasters.getHistoryByLatLng,
+		getHistoryByCountryCode: Disasters.getHistoryByCountryCode,
+		getHistoryByContinent: Disasters.getHistoryByContinent,
+		getHistoryByDateRange: Disasters.getHistoryByDateRange,
 	},
 	geocode: {
 		byPlace: Geocode.byPlace,
@@ -146,6 +183,10 @@ export const ambeeEndpointSchemas = {
 	'airQuality.getLatestByPostalCode': {
 		input: AmbeeEndpointInputSchemas.airQualityGetLatestByPostalCode,
 		output: AmbeeEndpointOutputSchemas.airQualityGetLatestByPostalCode,
+	},
+	'airQuality.getLatestByCountryCode': {
+		input: AmbeeEndpointInputSchemas.airQualityGetLatestByCountryCode,
+		output: AmbeeEndpointOutputSchemas.airQualityGetLatestByCountryCode,
 	},
 	'airQuality.getHistoryByLatLng': {
 		input: AmbeeEndpointInputSchemas.airQualityGetHistoryByLatLng,
@@ -199,6 +240,46 @@ export const ambeeEndpointSchemas = {
 		input: AmbeeEndpointInputSchemas.fireGetRiskByPlace,
 		output: AmbeeEndpointOutputSchemas.fireGetRiskByPlace,
 	},
+	'elevation.getByLatLng': {
+		input: AmbeeEndpointInputSchemas.elevationGetByLatLng,
+		output: AmbeeEndpointOutputSchemas.elevationGetByLatLng,
+	},
+	'elevation.getByPlace': {
+		input: AmbeeEndpointInputSchemas.elevationGetByPlace,
+		output: AmbeeEndpointOutputSchemas.elevationGetByPlace,
+	},
+	'ili.getForecastByLatLng': {
+		input: AmbeeEndpointInputSchemas.iliGetForecastByLatLng,
+		output: AmbeeEndpointOutputSchemas.iliGetForecastByLatLng,
+	},
+	'disasters.getLatestByLatLng': {
+		input: AmbeeEndpointInputSchemas.disastersGetLatestByLatLng,
+		output: AmbeeEndpointOutputSchemas.disastersGetLatestByLatLng,
+	},
+	'disasters.getLatestByCountryCode': {
+		input: AmbeeEndpointInputSchemas.disastersGetLatestByCountryCode,
+		output: AmbeeEndpointOutputSchemas.disastersGetLatestByCountryCode,
+	},
+	'disasters.getLatestByContinent': {
+		input: AmbeeEndpointInputSchemas.disastersGetLatestByContinent,
+		output: AmbeeEndpointOutputSchemas.disastersGetLatestByContinent,
+	},
+	'disasters.getHistoryByLatLng': {
+		input: AmbeeEndpointInputSchemas.disastersGetHistoryByLatLng,
+		output: AmbeeEndpointOutputSchemas.disastersGetHistoryByLatLng,
+	},
+	'disasters.getHistoryByCountryCode': {
+		input: AmbeeEndpointInputSchemas.disastersGetHistoryByCountryCode,
+		output: AmbeeEndpointOutputSchemas.disastersGetHistoryByCountryCode,
+	},
+	'disasters.getHistoryByContinent': {
+		input: AmbeeEndpointInputSchemas.disastersGetHistoryByContinent,
+		output: AmbeeEndpointOutputSchemas.disastersGetHistoryByContinent,
+	},
+	'disasters.getHistoryByDateRange': {
+		input: AmbeeEndpointInputSchemas.disastersGetHistoryByDateRange,
+		output: AmbeeEndpointOutputSchemas.disastersGetHistoryByDateRange,
+	},
 	'geocode.byPlace': {
 		input: AmbeeEndpointInputSchemas.geocodeByPlace,
 		output: AmbeeEndpointOutputSchemas.geocodeByPlace,
@@ -230,6 +311,11 @@ const ambeeEndpointMeta = {
 	'airQuality.getLatestByPostalCode': {
 		riskLevel: 'read',
 		description: 'Get the latest air quality for a postal code and country',
+	},
+	'airQuality.getLatestByCountryCode': {
+		riskLevel: 'read',
+		description:
+			'Get the latest air quality for the monitoring stations across a country',
 	},
 	'airQuality.getHistoryByLatLng': {
 		riskLevel: 'read',
@@ -295,6 +381,52 @@ const ambeeEndpointMeta = {
 		riskLevel: 'read',
 		description:
 			'Get the wildfire risk forecast for a named place (up to 4 weeks ahead)',
+	},
+	'elevation.getByLatLng': {
+		riskLevel: 'read',
+		description: 'Get the ground elevation at a latitude/longitude',
+	},
+	'elevation.getByPlace': {
+		riskLevel: 'read',
+		description: 'Get the ground elevation for a named place',
+	},
+	'ili.getForecastByLatLng': {
+		riskLevel: 'read',
+		description:
+			'Get the daily influenza-like-illness risk forecast for a latitude/longitude',
+	},
+	'disasters.getLatestByLatLng': {
+		riskLevel: 'read',
+		description:
+			'Get the latest natural disasters near a latitude/longitude (paginated)',
+	},
+	'disasters.getLatestByCountryCode': {
+		riskLevel: 'read',
+		description: 'Get the latest natural disasters in a country (paginated)',
+	},
+	'disasters.getLatestByContinent': {
+		riskLevel: 'read',
+		description: 'Get the latest natural disasters on a continent (paginated)',
+	},
+	'disasters.getHistoryByLatLng': {
+		riskLevel: 'read',
+		description:
+			'Get historical natural disasters near a latitude/longitude over a date range (paginated)',
+	},
+	'disasters.getHistoryByCountryCode': {
+		riskLevel: 'read',
+		description:
+			'Get historical natural disasters in a country over a date range (paginated)',
+	},
+	'disasters.getHistoryByContinent': {
+		riskLevel: 'read',
+		description:
+			'Get historical natural disasters on a continent over a date range (paginated)',
+	},
+	'disasters.getHistoryByDateRange': {
+		riskLevel: 'read',
+		description:
+			'Get historical natural disasters worldwide over a date range (paginated)',
 	},
 	'geocode.byPlace': {
 		riskLevel: 'read',
@@ -403,6 +535,7 @@ export type {
 	AirQualityGetHistoryByLatLngInput,
 	AirQualityGetHistoryByPostalCodeInput,
 	AirQualityGetLatestByCityInput,
+	AirQualityGetLatestByCountryCodeInput,
 	AirQualityGetLatestByLatLngInput,
 	AirQualityGetLatestByPostalCodeInput,
 	AirQualityReading,
@@ -411,6 +544,19 @@ export type {
 	AirQualityStationsResponse,
 	AmbeeEndpointInputs,
 	AmbeeEndpointOutputs,
+	DisasterEvent,
+	DisasterResponse,
+	DisastersGetHistoryByContinentInput,
+	DisastersGetHistoryByCountryCodeInput,
+	DisastersGetHistoryByDateRangeInput,
+	DisastersGetHistoryByLatLngInput,
+	DisastersGetLatestByContinentInput,
+	DisastersGetLatestByCountryCodeInput,
+	DisastersGetLatestByLatLngInput,
+	ElevationGetByLatLngInput,
+	ElevationGetByPlaceInput,
+	ElevationReading,
+	ElevationResponse,
 	FireEvent,
 	FireGetLatestByLatLngInput,
 	FireGetLatestByPlaceInput,
@@ -423,6 +569,9 @@ export type {
 	GeocodeResponse,
 	GeocodeResult,
 	GeocodeReverseByLatLngInput,
+	IliForecastEntry,
+	IliForecastResponse,
+	IliGetForecastByLatLngInput,
 	PollenGetForecastInput,
 	PollenGetHistoryInput,
 	PollenGetLatestInput,

--- a/packages/ambee/jest.config.cjs
+++ b/packages/ambee/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/ambee/package.json
+++ b/packages/ambee/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/ambee",
+  "version": "0.1.0",
+  "description": "Ambee plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "ambee",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/ambee/schema.test.ts
+++ b/packages/ambee/schema.test.ts
@@ -1,0 +1,20 @@
+import { AmbeeSchema } from './schema';
+
+describe('Ambee schema', () => {
+	it('declares a semver version', () => {
+		expect(AmbeeSchema.version).toBeDefined();
+		expect(AmbeeSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof AmbeeSchema.entities).toBe('object');
+		expect(AmbeeSchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(AmbeeSchema.entities))).toBe(true);
+		for (const entity of Object.values(AmbeeSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/ambee/schema/database.ts
+++ b/packages/ambee/schema/database.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+
+/**
+ * Local record of the most recent air-quality reading for a location.
+ * Keyed by rounded coordinates so repeated lookups update one row.
+ */
+export const AmbeeAirQualityReading = z.object({
+	locationKey: z.string(),
+	city: z.string().optional(),
+	state: z.string().optional(),
+	countryCode: z.string().optional(),
+	postalCode: z.string().optional(),
+	placeName: z.string().optional(),
+	lat: z.number().optional(),
+	lng: z.number().optional(),
+	aqi: z.number().optional(),
+	aqiCategory: z.string().optional(),
+	dominantPollutant: z.string().optional(),
+	pm25: z.number().optional(),
+	pm10: z.number().optional(),
+	no2: z.number().optional(),
+	so2: z.number().optional(),
+	co: z.number().optional(),
+	ozone: z.number().optional(),
+	/** Ambee's own `updatedAt` for the reading (ISO 8601). */
+	observedAt: z.string().optional(),
+	fetchedAt: z.coerce.date().nullable().optional(),
+});
+
+/**
+ * Local record of the most recent weather observation for a location.
+ */
+export const AmbeeWeatherObservation = z.object({
+	locationKey: z.string(),
+	lat: z.number().optional(),
+	lng: z.number().optional(),
+	timezone: z.string().optional(),
+	summary: z.string().optional(),
+	icon: z.string().optional(),
+	temperature: z.number().optional(),
+	apparentTemperature: z.number().optional(),
+	humidity: z.number().optional(),
+	pressure: z.number().optional(),
+	windSpeed: z.number().optional(),
+	windGust: z.number().optional(),
+	cloudCover: z.number().optional(),
+	uvIndex: z.number().optional(),
+	/** Ambee returns observation time as a Unix timestamp in seconds. */
+	observedAt: z.number().optional(),
+	fetchedAt: z.coerce.date().nullable().optional(),
+});
+
+/**
+ * Local record of a geocoding / reverse-geocoding result, so a repeated
+ * lookup for the same query does not need another API call to be resolvable.
+ */
+export const AmbeeGeocodedPlace = z.object({
+	query: z.string(),
+	lat: z.number().optional(),
+	lng: z.number().optional(),
+	city: z.string().optional(),
+	state: z.string().optional(),
+	countryCode: z.string().optional(),
+	postalCode: z.string().optional(),
+	placeName: z.string().optional(),
+	formattedAddress: z.string().optional(),
+	fetchedAt: z.coerce.date().nullable().optional(),
+});
+
+export type AmbeeAirQualityReading = z.infer<typeof AmbeeAirQualityReading>;
+export type AmbeeWeatherObservation = z.infer<typeof AmbeeWeatherObservation>;
+export type AmbeeGeocodedPlace = z.infer<typeof AmbeeGeocodedPlace>;

--- a/packages/ambee/schema/index.ts
+++ b/packages/ambee/schema/index.ts
@@ -1,0 +1,16 @@
+import {
+	AmbeeAirQualityReading,
+	AmbeeGeocodedPlace,
+	AmbeeWeatherObservation,
+} from './database';
+
+export const AmbeeSchema = {
+	version: '1.0.0',
+	entities: {
+		airQualityReadings: AmbeeAirQualityReading,
+		weatherObservations: AmbeeWeatherObservation,
+		geocodedPlaces: AmbeeGeocodedPlace,
+	},
+} as const;
+
+export * from './database';

--- a/packages/ambee/tsconfig.json
+++ b/packages/ambee/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/ambee/tsup.config.ts
+++ b/packages/ambee/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -23,6 +23,7 @@ export const BaseProviders = [
 	'airtable',
 	'algolia',
 	'alttextai',
+	'ambee',
 	'amplitude',
 	'apilabz',
 	'asana',
@@ -127,6 +128,7 @@ export const ProviderDisplayNames = {
 	airtable: 'Airtable',
 	algolia: 'Algolia',
 	alttextai: 'AltText.ai',
+	ambee: 'Ambee',
 	amplitude: 'Amplitude',
 	apilabz: 'API Labz',
 	asana: 'Asana',
@@ -238,6 +240,7 @@ export type AllProviders =
 	| 'airtable'
 	| 'algolia'
 	| 'alttextai'
+	| 'ambee'
 	| 'amplitude'
 	| 'apilabz'
 	| 'asana'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -548,6 +548,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/ambee:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/amplitude:
     devDependencies:
       '@types/jest':


### PR DESCRIPTION
## Description

Implements the `@corsair-dev/ambee` plugin for [Ambee](https://docs.ambeedata.com/) — real-time and historical environmental intelligence (air quality, weather, pollen, wildfire) plus location services.

Claimed via the Corsair OSS dashboard (`corsair.dev/oss/ambee`).

### Operations implemented (18)

**Air Quality** — `docs.ambeedata.com/apis/air-quality`
- ✅ `airQuality.getLatestByLatLng` — `GET /latest/by-lat-lng`
- ✅ `airQuality.getLatestByCity` — `GET /latest/by-city`
- ✅ `airQuality.getLatestByPostalCode` — `GET /latest/by-postal-code`
- ✅ `airQuality.getHistoryByLatLng` — `GET /history/by-lat-lng`
- ✅ `airQuality.getHistoryByPostalCode` — `GET /history/by-postal-code`
- ✅ `airQuality.getForecastByLatLng` — `GET /forecast/aq/by-lat-lng`

**Weather** — `docs.ambeedata.com/apis/weather`
- ✅ `weather.getLatest` — `GET /weather/latest/by-lat-lng`
- ✅ `weather.getHistory` — `GET /weather/history/by-lat-lng`
- ✅ `weather.getForecast` — `GET /weather/forecast/by-lat-lng`

**Pollen (v3)** — `docs.ambeedata.com/apis/pollen`
- ✅ `pollen.getLatest` — `GET /v3/pollen/latest`
- ✅ `pollen.getHistory` — `GET /v3/pollen/history`
- ✅ `pollen.getForecast` — `GET /v3/pollen/forecast/48hrs` and `/120hrs`

**Wildfire** — `docs.ambeedata.com/apis/fire`
- ✅ `fire.getLatestByLatLng` — `GET /fire/latest/by-lat-lng`
- ✅ `fire.getLatestByPlace` — `GET /fire/latest/by-place`
- ✅ `fire.getRiskByLatLng` — `GET /fire/risk/by-lat-lng`
- ✅ `fire.getRiskByPlace` — `GET /fire/risk/by-place`

**Location services** — `docs.ambeedata.com/apis/location`
- ✅ `geocode.byPlace` — `GET /geocode/by-place`
- ✅ `geocode.reverseByLatLng` — `GET /geocode/reverse/by-lat-lng`

**Authentication**
- ✅ API key sent as the `x-api-key` header. `OpenAPIConfig.TOKEN` is deliberately left unset — setting it would add an `Authorization: Bearer` header, which Ambee rejects.

---

## Architecture

- **Single client** (`client.ts`) — every Ambee product is served from `https://api.ambeedata.com`, so one base URL and one request helper covers all five products. `toAmbeeTimestamp()` accepts either Ambee's `YYYY-MM-DD hh:mm:ss` format or any ISO 8601 date and normalises to UTC, so callers (and agents) don't have to know the provider's format.
- **Zod validation on every endpoint** — inputs enforce coordinate bounds and the mutually-exclusive `lat`/`lng` vs `place` choice for pollen (a union, so an ambiguous call is rejected at validation time rather than silently dropping a parameter). Outputs validate Ambee's `{ message: "success", ... }` envelope and the documented payload fields; response objects are `.loose()` with optional members because Ambee omits fields a location has no coverage for (a station with no SO2 sensor simply omits `SO2`), and provider-side additions pass through instead of throwing.
- **Errors** — `AmbeeAPIError` chains the originating `ApiError` as `cause` and copies `status`/`statusText`/`body`/`retryAfter`/rate-limit headers onto itself, so `error-handlers.ts` routes 401/403 (auth), 404 (out-of-coverage location), 400/422 (validation), 429 (rate limit, with `Retry-After` propagation and exponential backoff) and 5xx (retried) without needing `instanceof ApiError` checks.
- **Persistence** — `airQualityReadings`, `weatherObservations` and `geocodedPlaces` entities are upserted best-effort, keyed by coordinates rounded to ~11 m so repeated lookups for the same place update one row. Storage failures are logged and swallowed; a missing table (no database configured) is skipped.
- **No webhooks** — Ambee is a pull-based API with no event delivery, so the generated webhook scaffolding was removed entirely rather than left as unused stubs.
- **No pagination** — none of Ambee's endpoints paginate; `latest/by-city` takes a `limit` parameter, which is forwarded.

---

## Verification

```bash
pnpm --filter @corsair-dev/ambee exec tsc --noEmit   # clean
pnpm --filter @corsair-dev/ambee exec jest           # 59 tests, 9 suites, all passing
pnpm --filter @corsair-dev/ambee build               # ESM build succeeds
npx biome check packages/ambee                       # clean
npx tsx scripts/validate-plugins.ts                  # [SUCCESS] All plugins passed structural validation
npx tsc --build                                      # clean
```

**Test coverage** — 59 assertions across 9 suites:
- `client.test.ts` — header/auth wiring, query passthrough, `ApiError` → `AmbeeAPIError` status/cause preservation, timestamp normalisation
- `endpoints/{air-quality,weather,pollen,fire,geocode}.test.ts` — every one of the 18 endpoints asserts its path, query shape, parsed result, persistence rows and telemetry event
- `endpoints/schema-validation.test.ts` — input rejection (out-of-range coordinates, missing range bound, invalid fire type, invalid forecast horizon, pollen with neither location form) and output tolerance
- `error-handlers.test.ts` — routing for 400/401/403/404/422/429/5xx and the default bucket
- `api.test.ts` — live contract tests against the real API, run with `AMBEE_API_KEY=...`; they self-skip without a key and CI excludes `api.test.ts` by design

---

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos

<img width="1044" height="463" alt="Screenshot 2026-08-12 at 4 09 30 AM" src="https://github.com/user-attachments/assets/a6ac2272-6c55-4ce2-ae13-f02c597e54c6" />


## Additional Notes

- Scope is exactly what `pnpm generate:plugin Ambee` produces: `packages/ambee/**`, the single registration edit in `packages/corsair/core/constants.ts`, and `pnpm-lock.yaml`.
- No new runtime dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added Ambee data integration for air quality, weather, pollen, wildfire risk, natural disasters, elevation, influenza-like illness, and geocoding.
- Added forward and reverse geocoding.
- Added API-key authentication with validated requests and responses.
- Added caching for selected air-quality, weather, and geocoding data.
- Added automatic retries for rate limits and temporary server failures.

## Tests
- Added comprehensive coverage for endpoint behavior, validation, error handling, client requests, and live API contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->