### PR TITLE
fix(corsair): register youcom plugin in provider constants

### DIFF
--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -110,6 +110,7 @@ export const BaseProviders = [
 	'whatsapp',
 	'wiza',
 	'xquik',
+	'youcom',
 	'youtube',
 	'zendesk',
 	'zohomail',
@@ -214,6 +215,7 @@ export const ProviderDisplayNames = {
 	whatsapp: 'WhatsApp',
 	wiza: 'Wiza',
 	xquik: 'XQuik',
+	youcom: 'You.com',
 	youtube: 'YouTube',
 	zendesk: 'Zendesk',
 	zohomail: 'Zoho Mail',
@@ -325,6 +327,7 @@ export type AllProviders =
 	| 'whatsapp'
 	| 'wiza'
 	| 'xquik'
+	| 'youcom'
 	| 'youtube'
 	| 'zendesk'
 	| 'zohomail'


### PR DESCRIPTION
The youcom package is a fully implemented You.com Web Search plugin (client, endpoints, error handlers, schema, tests), but it was never added to the central provider registry, so the core system had no way to know it exists.

Register it in all three places in core/constants.ts:

- BaseProviders, alphabetically between xquik and youtube
- ProviderDisplayNames, with the display name You.com
- the AllProviders union type

Closes #622

<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

<!-- Briefly describe the changes you've made and why they're necessary. -->
<!-- Link to any related issues (e.g. "Fixes #123"). -->

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

<!-- If your changes affect the UI or CLI output, please include screenshots or terminal recordings. -->

## Additional Notes

<!-- Any other information that reviewers should know? (e.g. breaking changes, new dependencies) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added You.com as a supported provider.
  * You.com now appears with its display name wherever provider options are shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->