### PR TITLE
fix(telegram): webhook verification fails open when no secret token i…

### DIFF
--- a/packages/telegram/webhooks/types.test.ts
+++ b/packages/telegram/webhooks/types.test.ts
@@ -1,0 +1,58 @@
+import { verifyTelegramWebhookSignature } from './types';
+
+describe('verifyTelegramWebhookSignature', () => {
+    const request = {
+        headers: {
+            'x-telegram-bot-api-secret-token': 'test-secret',
+        },
+    };
+
+    it('rejects when webhook secret is missing', () => {
+        const result = verifyTelegramWebhookSignature(
+            request as any,
+            '',
+        );
+
+        expect(result).toEqual({
+            valid: false,
+            error: 'Missing webhook secret',
+        });
+    });
+
+    it('rejects when the secret header is missing', () => {
+        const requestWithoutHeader = {
+            headers: {},
+        };
+
+        const result = verifyTelegramWebhookSignature(
+            requestWithoutHeader as any,
+            'test-secret',
+        );
+
+        expect(result).toEqual({
+            valid: false,
+            error: 'Missing x-telegram-bot-api-secret-token header',
+        });
+    });
+
+    it('accepts a correct secret', () => {
+        const result = verifyTelegramWebhookSignature(
+            request as any,
+            'test-secret',
+        );
+
+        expect(result.valid).toBe(true);
+    });
+
+    it('rejects an incorrect secret', () => {
+        const result = verifyTelegramWebhookSignature(
+            request as any,
+            'wrong-secret',
+        );
+
+        expect(result).toEqual({
+            valid: false,
+            error: 'Invalid secret token',
+        });
+    });
+});

--- a/packages/telegram/webhooks/types.ts
+++ b/packages/telegram/webhooks/types.ts
@@ -265,9 +265,8 @@ export function verifyTelegramWebhookSignature(
 	secretToken: string,
 ): { valid: boolean; error?: string } {
 	if (!secretToken) {
-		// No secret configured — skip verification (valid deployment scenario)
-		return { valid: true };
-	}
+    return { valid: false, error: 'Missing webhook secret' };
+}
 
 	const headers = request.headers;
 	const providedToken = Array.isArray(


### PR DESCRIPTION
…s configured, allowing forged messages to be persisted

Fixes #628

<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

<!-- Briefly describe the changes you've made and why they're necessary. -->
<!-- Link to any related issues (e.g. "Fixes #123"). -->

## Checklist

Before submitting your PR, please verify the following:

- [ ] I have run `pnpm lint` and all checks pass
- [ ] I have run `pnpm typecheck` and there are no TypeScript errors
- [ ] I have run `pnpm build` and all packages build successfully
- [ ] I have run `pnpm test` and all tests pass
- [ ] I have added or updated tests where applicable
- [ ] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

<!-- If your changes affect the UI or CLI output, please include screenshots or terminal recordings. -->

## Additional Notes

<!-- Any other information that reviewers should know? (e.g. breaking changes, new dependencies) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook requests are now rejected when no verification secret is configured.
  * Improved validation responses for missing secrets, missing headers, valid secrets, and invalid tokens.

* **Tests**
  * Added coverage for webhook signature verification scenarios and expected error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->