### PR TITLE
feat: add Contentful GraphQL integration

### DIFF
--- a/packages/contentfulgraphql/api.test.ts
+++ b/packages/contentfulgraphql/api.test.ts
@@ -1,0 +1,373 @@
+import { request } from 'corsair/http';
+import {
+	buildContentfulGraphqlPath,
+	ContentfulGraphqlAPIError,
+	makeContentfulGraphqlPersistedQueryRequest,
+	makeContentfulGraphqlRequest,
+	sha256,
+} from './client';
+import type { ContentfulGraphqlContext } from './index';
+import { contentfulGraphqlEndpointSchemas, contentfulgraphql } from './index';
+
+jest.mock('corsair/http', () => {
+	const original = jest.requireActual('corsair/http');
+	return {
+		...original,
+		request: jest.fn(),
+	};
+});
+
+const mockRequest = request as jest.Mock;
+
+function endpointPaths(tree: Record<string, unknown>, prefix = ''): string[] {
+	return Object.entries(tree).flatMap(([key, value]) => {
+		const path = prefix ? `${prefix}.${key}` : key;
+		if (typeof value === 'function') return [path];
+		if (value && typeof value === 'object') {
+			return endpointPaths(value as Record<string, unknown>, path);
+		}
+		return [];
+	});
+}
+
+const mockCtx = {
+	key: 'test-api-key',
+	$getAccountId: () => 'test-account-id',
+	options: {},
+	keys: {
+		get_api_key: jest.fn().mockResolvedValue('test-api-key'),
+		get_space_id: jest.fn().mockResolvedValue('test-space-id'),
+		get_environment_id: jest.fn().mockResolvedValue('staging'),
+	},
+	logEvent: jest.fn(),
+	db: {},
+} as unknown as ContentfulGraphqlContext;
+
+describe('Contentful GraphQL plugin shape', () => {
+	it('exposes the three required operations with schemas and no webhooks', () => {
+		const plugin = contentfulgraphql();
+		const endpoints = plugin.endpoints as Record<string, unknown>;
+		const paths = endpointPaths(endpoints).sort();
+
+		expect(paths).toEqual([
+			'getCmaToken',
+			'graphQlContentApiPersistedQuery',
+			'graphQlContentApiQuery',
+		]);
+		expect(Object.keys(contentfulGraphqlEndpointSchemas).sort()).toEqual(paths);
+		expect(Object.keys(plugin.endpointMeta ?? {}).sort()).toEqual(paths);
+		expect(plugin.webhooks).toEqual({});
+		expect(plugin.pluginWebhookMatcher?.({ headers: {}, body: '' })).toBe(
+			false,
+		);
+	});
+
+	it('uses api_key auth with space_id and environment_id account fields', () => {
+		const plugin = contentfulgraphql();
+		expect(plugin.options?.authType).toBe('api_key');
+		expect(plugin.authConfig).toEqual({
+			api_key: { account: ['space_id', 'environment_id'] },
+		});
+	});
+});
+
+describe('Contentful GraphQL URL + hash helpers', () => {
+	it('builds the space path with an optional environment segment', () => {
+		expect(buildContentfulGraphqlPath('abc123')).toBe(
+			'/content/v1/spaces/abc123',
+		);
+		expect(buildContentfulGraphqlPath('abc123', 'staging')).toBe(
+			'/content/v1/spaces/abc123/environments/staging',
+		);
+	});
+
+	it('computes SHA-256 hashes for persisted queries', () => {
+		expect(sha256('query { blogCollection { items { title } } }')).toBe(
+			'4b764b5463f35c0c5d5ff33d059934f5d647cdc8d5ba93e157992692ce63975e',
+		);
+	});
+});
+
+describe('Contentful GraphQL request client', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+	});
+
+	it('sends an authenticated POST to the GraphQL Content API and returns data', async () => {
+		mockRequest.mockResolvedValue({
+			data: { blogCollection: { items: [{ title: 'Hello' }] } },
+		});
+
+		const data = await makeContentfulGraphqlRequest(
+			'/content/v1/spaces/abc123',
+			'test-api-key',
+			{ query: '{ blogCollection { items { title } } }' },
+		);
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.objectContaining({
+				BASE: 'https://graphql.contentful.com',
+				HEADERS: expect.objectContaining({
+					Authorization: 'Bearer test-api-key',
+				}),
+			}),
+			expect.objectContaining({
+				method: 'POST',
+				url: '/content/v1/spaces/abc123',
+				body: { query: '{ blogCollection { items { title } } }' },
+			}),
+			expect.anything(),
+		);
+		expect(data).toEqual({
+			blogCollection: { items: [{ title: 'Hello' }] },
+		});
+	});
+
+	it('throws a ContentfulGraphqlAPIError with the code when the API returns errors', async () => {
+		mockRequest.mockResolvedValue({
+			errors: [
+				{
+					message: 'ACCESS_TOKEN_INVALID',
+					extensions: { code: 'ACCESS_TOKEN_INVALID' },
+				},
+			],
+		});
+
+		await expect(
+			makeContentfulGraphqlRequest('/content/v1/spaces/abc123', 'bad', {
+				query: '{ blogCollection { items { title } } }',
+			}),
+		).rejects.toMatchObject({
+			name: 'ContentfulGraphqlAPIError',
+			message: 'ACCESS_TOKEN_INVALID',
+			code: 'ACCESS_TOKEN_INVALID',
+		});
+	});
+});
+
+describe('Contentful GraphQL persisted query client', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+	});
+
+	const hash = sha256('{ blogCollection { items { title } } }');
+
+	it('sends a hash-only request when the query is already registered', async () => {
+		mockRequest.mockResolvedValue({
+			data: { blogCollection: { items: [] } },
+		});
+
+		const data = await makeContentfulGraphqlPersistedQueryRequest(
+			'/content/v1/spaces/abc123',
+			'test-api-key',
+			{ sha256Hash: hash },
+		);
+
+		expect(mockRequest).toHaveBeenCalledTimes(1);
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				body: {
+					extensions: {
+						persistedQuery: { version: 1, sha256Hash: hash },
+					},
+				},
+			}),
+			expect.anything(),
+		);
+		expect(data).toEqual({ blogCollection: { items: [] } });
+	});
+
+	it('retries with the full query when Contentful returns PersistedQueryNotFound', async () => {
+		mockRequest
+			.mockRejectedValueOnce(
+				new ContentfulGraphqlAPIError('PersistedQueryNotFound', {
+					code: 'PERSISTED_QUERY_NOT_FOUND',
+				}),
+			)
+			.mockResolvedValueOnce({
+				data: { blogCollection: { items: [{ title: 'Hello' }] } },
+			});
+
+		const data = await makeContentfulGraphqlPersistedQueryRequest(
+			'/content/v1/spaces/abc123',
+			'test-api-key',
+			{ sha256Hash: hash, query: '{ blogCollection { items { title } } }' },
+		);
+
+		expect(mockRequest).toHaveBeenCalledTimes(2);
+		expect(mockRequest.mock.calls[0]?.[1]).toEqual(
+			expect.objectContaining({
+				body: expect.not.objectContaining({ query: expect.anything() }),
+			}),
+		);
+		expect(mockRequest.mock.calls[1]?.[1]).toEqual(
+			expect.objectContaining({
+				body: expect.objectContaining({
+					query: '{ blogCollection { items { title } } }',
+					extensions: {
+						persistedQuery: { version: 1, sha256Hash: hash },
+					},
+				}),
+			}),
+		);
+		expect(data).toEqual({
+			blogCollection: { items: [{ title: 'Hello' }] },
+		});
+	});
+
+	it('rethrows PersistedQueryNotFound when no query is available to register', async () => {
+		mockRequest.mockRejectedValue(
+			new ContentfulGraphqlAPIError('PersistedQueryNotFound', {
+				code: 'PERSISTED_QUERY_NOT_FOUND',
+			}),
+		);
+
+		await expect(
+			makeContentfulGraphqlPersistedQueryRequest(
+				'/content/v1/spaces/abc123',
+				'test-api-key',
+				{ sha256Hash: hash },
+			),
+		).rejects.toMatchObject({
+			name: 'ContentfulGraphqlAPIError',
+			message: 'PersistedQueryNotFound',
+		});
+		expect(mockRequest).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('Contentful GraphQL endpoints', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockRequest.mockResolvedValue({ data: {} });
+	});
+
+	it('getCmaToken returns the stored token, space ID, and environment ID', async () => {
+		const plugin = contentfulgraphql();
+		const endpoints = plugin.endpoints as NonNullable<typeof plugin.endpoints>;
+
+		const response = await endpoints.getCmaToken(mockCtx, {});
+
+		expect(response).toEqual({
+			token: 'test-api-key',
+			space_id: 'test-space-id',
+			environment_id: 'staging',
+		});
+		expect(mockRequest).not.toHaveBeenCalled();
+	});
+
+	it('getCmaToken omits environment_id when it is not configured', async () => {
+		const ctx = {
+			...mockCtx,
+			keys: {
+				...mockCtx.keys,
+				get_environment_id: jest.fn().mockResolvedValue(null),
+			},
+		} as unknown as ContentfulGraphqlContext;
+		const plugin = contentfulgraphql();
+		const endpoints = plugin.endpoints as NonNullable<typeof plugin.endpoints>;
+
+		const response = await endpoints.getCmaToken(ctx, {});
+
+		expect(response).toEqual({
+			token: 'test-api-key',
+			space_id: 'test-space-id',
+		});
+	});
+
+	it('graphQlContentApiQuery posts to the environment path with query and variables', async () => {
+		const plugin = contentfulgraphql();
+		const endpoints = plugin.endpoints as NonNullable<typeof plugin.endpoints>;
+
+		await endpoints.graphQlContentApiQuery(mockCtx, {
+			query:
+				'query($preview: Boolean) { blogCollection(preview: $preview) { items { title } } }',
+			variables: { preview: true },
+			operationName: 'BlogPosts',
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.objectContaining({
+				BASE: 'https://graphql.contentful.com',
+			}),
+			expect.objectContaining({
+				url: '/content/v1/spaces/test-space-id/environments/staging',
+				body: expect.objectContaining({
+					query:
+						'query($preview: Boolean) { blogCollection(preview: $preview) { items { title } } }',
+					variables: { preview: true },
+					operationName: 'BlogPosts',
+				}),
+			}),
+			expect.anything(),
+		);
+	});
+
+	it('graphQlContentApiQuery throws when space_id is not configured', async () => {
+		const ctx = {
+			...mockCtx,
+			keys: {
+				...mockCtx.keys,
+				get_space_id: jest.fn().mockResolvedValue(null),
+			},
+		} as unknown as ContentfulGraphqlContext;
+		const plugin = contentfulgraphql();
+		const endpoints = plugin.endpoints as NonNullable<typeof plugin.endpoints>;
+
+		await expect(
+			endpoints.graphQlContentApiQuery(ctx, {
+				query: '{ blogCollection { items { title } } }',
+			}),
+		).rejects.toThrow('space_id is required');
+		expect(mockRequest).not.toHaveBeenCalled();
+	});
+
+	it('graphQlContentApiPersistedQuery derives the SHA-256 hash from the query', async () => {
+		const query = '{ blogCollection { items { title } } }';
+		mockRequest
+			.mockRejectedValueOnce(
+				new ContentfulGraphqlAPIError('PersistedQueryNotFound', {
+					code: 'PERSISTED_QUERY_NOT_FOUND',
+				}),
+			)
+			.mockResolvedValueOnce({ data: {} });
+		const plugin = contentfulgraphql();
+		const endpoints = plugin.endpoints as NonNullable<typeof plugin.endpoints>;
+
+		await endpoints.graphQlContentApiPersistedQuery(mockCtx, { query });
+
+		expect(mockRequest).toHaveBeenCalledTimes(2);
+		expect(mockRequest.mock.calls[1]?.[1]).toEqual(
+			expect.objectContaining({
+				body: expect.objectContaining({
+					query,
+					extensions: {
+						persistedQuery: { version: 1, sha256Hash: sha256(query) },
+					},
+				}),
+			}),
+		);
+	});
+
+	it('graphQlContentApiPersistedQuery honors an explicit sha256Hash', async () => {
+		const plugin = contentfulgraphql();
+		const endpoints = plugin.endpoints as NonNullable<typeof plugin.endpoints>;
+
+		await endpoints.graphQlContentApiPersistedQuery(mockCtx, {
+			sha256Hash: 'abc123hash',
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				body: expect.objectContaining({
+					extensions: {
+						persistedQuery: { version: 1, sha256Hash: 'abc123hash' },
+					},
+				}),
+			}),
+			expect.anything(),
+		);
+	});
+});

--- a/packages/contentfulgraphql/api.test.ts
+++ b/packages/contentfulgraphql/api.test.ts
@@ -1,4 +1,4 @@
-import { request } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
 import {
 	buildContentfulGraphqlPath,
 	ContentfulGraphqlAPIError,
@@ -40,7 +40,7 @@ const mockCtx = {
 		get_environment_id: jest.fn().mockResolvedValue('staging'),
 	},
 	logEvent: jest.fn(),
-	db: {},
+	database: {},
 } as unknown as ContentfulGraphqlContext;
 
 describe('Contentful GraphQL plugin shape', () => {
@@ -141,6 +141,35 @@ describe('Contentful GraphQL request client', () => {
 			name: 'ContentfulGraphqlAPIError',
 			message: 'ACCESS_TOKEN_INVALID',
 			code: 'ACCESS_TOKEN_INVALID',
+		});
+	});
+
+	it('preserves ApiError status, statusText, and body when rejecting', async () => {
+		const apiError = new ApiError(
+			{
+				method: 'POST',
+				url: 'https://graphql.contentful.com/content/v1/spaces/abc123',
+			},
+			{
+				ok: false,
+				url: 'https://graphql.contentful.com/content/v1/spaces/abc123',
+				status: 429,
+				statusText: 'Too Many Requests',
+				body: { message: 'Rate limit exceeded' },
+			},
+			'Too Many Requests',
+		);
+		mockRequest.mockRejectedValue(apiError);
+
+		await expect(
+			makeContentfulGraphqlRequest('/content/v1/spaces/abc123', 'key', {
+				query: '{}',
+			}),
+		).rejects.toMatchObject({
+			name: 'ContentfulGraphqlAPIError',
+			status: 429,
+			statusText: 'Too Many Requests',
+			body: { message: 'Rate limit exceeded' },
 		});
 	});
 });
@@ -250,7 +279,6 @@ describe('Contentful GraphQL endpoints', () => {
 		const response = await endpoints.getCmaToken(mockCtx, {});
 
 		expect(response).toEqual({
-			token: 'test-api-key',
 			space_id: 'test-space-id',
 			environment_id: 'staging',
 		});
@@ -271,7 +299,6 @@ describe('Contentful GraphQL endpoints', () => {
 		const response = await endpoints.getCmaToken(ctx, {});
 
 		expect(response).toEqual({
-			token: 'test-api-key',
 			space_id: 'test-space-id',
 		});
 	});

--- a/packages/contentfulgraphql/client.ts
+++ b/packages/contentfulgraphql/client.ts
@@ -13,6 +13,7 @@ export class ContentfulGraphqlAPIError extends Error {
 	// Contentful returns GraphQL errors in the JSON body, so we carry the raw
 	// body as `unknown` and let callers narrow per-request.
 	public readonly body?: unknown;
+	public readonly retryAfter?: number | string;
 
 	constructor(message: string, options?: { code?: string; cause?: Error }) {
 		super(message, options);
@@ -22,6 +23,7 @@ export class ContentfulGraphqlAPIError extends Error {
 			this.status = options.cause.status;
 			this.statusText = options.cause.statusText;
 			this.body = options.cause.body;
+			this.retryAfter = options.cause.retryAfter;
 		}
 	}
 }
@@ -42,8 +44,10 @@ export function buildContentfulGraphqlPath(
 	spaceId: string,
 	environmentId?: string,
 ): string {
-	const base = `/content/v1/spaces/${spaceId}`;
-	return environmentId ? `${base}/environments/${environmentId}` : base;
+	const base = `/content/v1/spaces/${encodeURIComponent(spaceId)}`;
+	return environmentId
+		? `${base}/environments/${encodeURIComponent(environmentId)}`
+		: base;
 }
 
 export function sha256(input: string): string {
@@ -123,13 +127,15 @@ export async function makeContentfulGraphqlRequest<T>(
 		if (error instanceof ApiError) {
 			// Include the response body for richer error messages (e.g. GraphQL validation errors)
 			const bodyDetail =
-				typeof error.body === 'string'
-					? error.body
-					: JSON.stringify(error.body);
-			throw new ContentfulGraphqlAPIError(
-				`${error.statusText}: ${bodyDetail}`,
-				{ cause: error },
-			);
+				error.body == null
+					? ''
+					: typeof error.body === 'string'
+						? error.body
+						: JSON.stringify(error.body);
+			const message = bodyDetail
+				? `${error.statusText}: ${bodyDetail}`
+				: error.statusText || 'Unknown API Error';
+			throw new ContentfulGraphqlAPIError(message, { cause: error });
 		}
 		if (error instanceof Error) {
 			throw new ContentfulGraphqlAPIError(error.message, { cause: error });

--- a/packages/contentfulgraphql/client.ts
+++ b/packages/contentfulgraphql/client.ts
@@ -1,0 +1,179 @@
+import { createHash } from 'node:crypto';
+import type {
+	ApiRequestOptions,
+	OpenAPIConfig,
+	RateLimitConfig,
+} from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+
+export class ContentfulGraphqlAPIError extends Error {
+	public readonly code?: string;
+	public readonly status?: number;
+	public readonly statusText?: string;
+	// Contentful returns GraphQL errors in the JSON body, so we carry the raw
+	// body as `unknown` and let callers narrow per-request.
+	public readonly body?: unknown;
+
+	constructor(message: string, options?: { code?: string; cause?: Error }) {
+		super(message, options);
+		this.name = 'ContentfulGraphqlAPIError';
+		this.code = options?.code;
+		if (options?.cause instanceof ApiError) {
+			this.status = options.cause.status;
+			this.statusText = options.cause.statusText;
+			this.body = options.cause.body;
+		}
+	}
+}
+
+export const CONTENTFUL_GRAPHQL_API_BASE = 'https://graphql.contentful.com';
+
+const CONTENTFUL_RATE_LIMIT_CONFIG: RateLimitConfig = {
+	enabled: true,
+	maxRetries: 3,
+	initialRetryDelay: 1000,
+	backoffMultiplier: 2,
+	headerNames: {
+		retryAfter: 'X-Contentful-RateLimit-Reset',
+	},
+};
+
+export function buildContentfulGraphqlPath(
+	spaceId: string,
+	environmentId?: string,
+): string {
+	const base = `/content/v1/spaces/${spaceId}`;
+	return environmentId ? `${base}/environments/${environmentId}` : base;
+}
+
+export function sha256(input: string): string {
+	return createHash('sha256').update(input).digest('hex');
+}
+
+interface GraphQLResponse<T> {
+	data?: T;
+	errors?: Array<{
+		message: string;
+		extensions?: { code?: string };
+	}>;
+}
+
+export interface ContentfulGraphqlPersistedQueryOptions {
+	sha256Hash: string;
+	query?: string;
+	variables?: Record<string, unknown>;
+	operationName?: string;
+}
+
+export function isPersistedQueryNotFound(
+	error: ContentfulGraphqlAPIError,
+): boolean {
+	return (
+		error.code === 'PERSISTED_QUERY_NOT_FOUND' ||
+		error.message.includes('PersistedQueryNotFound')
+	);
+}
+
+export async function makeContentfulGraphqlRequest<T>(
+	path: string,
+	apiKey: string,
+	body: Record<string, unknown>,
+): Promise<T> {
+	const config: OpenAPIConfig = {
+		BASE: CONTENTFUL_GRAPHQL_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		HEADERS: {
+			Authorization: `Bearer ${apiKey}`,
+		},
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method: 'POST',
+		url: path,
+		body,
+		mediaType: 'application/json; charset=utf-8',
+	};
+
+	try {
+		const response = await request<GraphQLResponse<T>>(config, requestOptions, {
+			rateLimitConfig: CONTENTFUL_RATE_LIMIT_CONFIG,
+		});
+
+		if (response.errors && response.errors.length > 0) {
+			// non-null assertion safe: length > 0 check above
+			const firstError = response.errors[0]!;
+			throw new ContentfulGraphqlAPIError(firstError.message, {
+				code: firstError.extensions?.code,
+			});
+		}
+
+		if (response.data === undefined || response.data === null) {
+			throw new ContentfulGraphqlAPIError(
+				'No data returned from Contentful GraphQL API',
+			);
+		}
+
+		return response.data;
+	} catch (error) {
+		if (error instanceof ContentfulGraphqlAPIError) {
+			throw error;
+		}
+		if (error instanceof ApiError) {
+			// Include the response body for richer error messages (e.g. GraphQL validation errors)
+			const bodyDetail =
+				typeof error.body === 'string'
+					? error.body
+					: JSON.stringify(error.body);
+			throw new ContentfulGraphqlAPIError(
+				`${error.statusText}: ${bodyDetail}`,
+				{ cause: error },
+			);
+		}
+		if (error instanceof Error) {
+			throw new ContentfulGraphqlAPIError(error.message, { cause: error });
+		}
+		throw new ContentfulGraphqlAPIError('Unknown error');
+	}
+}
+
+export async function makeContentfulGraphqlPersistedQueryRequest<T>(
+	path: string,
+	apiKey: string,
+	options: ContentfulGraphqlPersistedQueryOptions,
+): Promise<T> {
+	const { sha256Hash, query, variables, operationName } = options;
+
+	const buildBody = (includeQuery: boolean): Record<string, unknown> => ({
+		...(includeQuery && query ? { query } : {}),
+		...(variables ? { variables } : {}),
+		...(operationName ? { operationName } : {}),
+		extensions: {
+			persistedQuery: { version: 1, sha256Hash },
+		},
+	});
+
+	try {
+		// Hash-only first: already-registered queries skip sending the query text.
+		return await makeContentfulGraphqlRequest<T>(
+			path,
+			apiKey,
+			buildBody(false),
+		);
+	} catch (error) {
+		// PersistedQueryNotFound: re-send with the full query to register it (APQ protocol).
+		if (
+			query &&
+			error instanceof ContentfulGraphqlAPIError &&
+			isPersistedQueryNotFound(error)
+		) {
+			return await makeContentfulGraphqlRequest<T>(
+				path,
+				apiKey,
+				buildBody(true),
+			);
+		}
+		throw error;
+	}
+}

--- a/packages/contentfulgraphql/endpoints/get-cma-token.ts
+++ b/packages/contentfulgraphql/endpoints/get-cma-token.ts
@@ -12,7 +12,6 @@ export const getCmaToken: ContentfulGraphqlEndpoints['getCmaToken'] = async (
 	]);
 
 	const response: GetCmaTokenResponse = {
-		token: ctx.key,
 		space_id: spaceId ?? '',
 		...(environmentId ? { environment_id: environmentId } : {}),
 	};

--- a/packages/contentfulgraphql/endpoints/get-cma-token.ts
+++ b/packages/contentfulgraphql/endpoints/get-cma-token.ts
@@ -6,14 +6,13 @@ export const getCmaToken: ContentfulGraphqlEndpoints['getCmaToken'] = async (
 	ctx,
 	_input,
 ) => {
-	const [token, spaceId, environmentId] = await Promise.all([
-		ctx.keys.get_api_key(),
+	const [spaceId, environmentId] = await Promise.all([
 		ctx.keys.get_space_id(),
 		ctx.keys.get_environment_id(),
 	]);
 
 	const response: GetCmaTokenResponse = {
-		token: token ?? '',
+		token: ctx.key,
 		space_id: spaceId ?? '',
 		...(environmentId ? { environment_id: environmentId } : {}),
 	};

--- a/packages/contentfulgraphql/endpoints/get-cma-token.ts
+++ b/packages/contentfulgraphql/endpoints/get-cma-token.ts
@@ -1,0 +1,29 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ContentfulGraphqlEndpoints } from '..';
+import type { GetCmaTokenResponse } from './types';
+
+export const getCmaToken: ContentfulGraphqlEndpoints['getCmaToken'] = async (
+	ctx,
+	_input,
+) => {
+	const [token, spaceId, environmentId] = await Promise.all([
+		ctx.keys.get_api_key(),
+		ctx.keys.get_space_id(),
+		ctx.keys.get_environment_id(),
+	]);
+
+	const response: GetCmaTokenResponse = {
+		token: token ?? '',
+		space_id: spaceId ?? '',
+		...(environmentId ? { environment_id: environmentId } : {}),
+	};
+
+	await logEventFromContext(
+		ctx,
+		'contentfulgraphql.getCmaToken',
+		{ space_id: response.space_id },
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/contentfulgraphql/endpoints/graph-ql-content-api-persisted-query.ts
+++ b/packages/contentfulgraphql/endpoints/graph-ql-content-api-persisted-query.ts
@@ -1,0 +1,47 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ContentfulGraphqlEndpoints } from '..';
+import {
+	buildContentfulGraphqlPath,
+	makeContentfulGraphqlPersistedQueryRequest,
+	sha256,
+} from '../client';
+import type { GraphQlContentApiPersistedQueryResponse } from './types';
+
+export const graphQlContentApiPersistedQuery: ContentfulGraphqlEndpoints['graphQlContentApiPersistedQuery'] =
+	async (ctx, input) => {
+		const spaceId = await ctx.keys.get_space_id();
+		if (!spaceId) {
+			throw new Error(
+				'[contentfulgraphql] space_id is required but not configured',
+			);
+		}
+		const environmentId = await ctx.keys.get_environment_id();
+
+		// When the caller only supplies the query, derive the SHA-256 hash so the
+		// request registers the persisted query with Contentful on the first call.
+		const sha256Hash =
+			input.sha256Hash ?? (input.query ? sha256(input.query) : '');
+
+		const path = buildContentfulGraphqlPath(
+			spaceId,
+			environmentId ?? undefined,
+		);
+
+		const data = await makeContentfulGraphqlPersistedQueryRequest<
+			GraphQlContentApiPersistedQueryResponse['data']
+		>(path, ctx.key, {
+			sha256Hash,
+			query: input.query,
+			variables: input.variables,
+			operationName: input.operationName,
+		});
+
+		await logEventFromContext(
+			ctx,
+			'contentfulgraphql.graphQlContentApiPersistedQuery',
+			{ sha256Hash },
+			'completed',
+		);
+
+		return { data };
+	};

--- a/packages/contentfulgraphql/endpoints/graph-ql-content-api-persisted-query.ts
+++ b/packages/contentfulgraphql/endpoints/graph-ql-content-api-persisted-query.ts
@@ -23,7 +23,7 @@ export const graphQlContentApiPersistedQuery: ContentfulGraphqlEndpoints['graphQ
 
 		// When the caller only supplies the query, derive the SHA-256 hash so the
 		// request registers the persisted query with Contentful on the first call.
-		const sha256Hash = input.sha256Hash ?? sha256(input.query!);
+		const sha256Hash = input.sha256Hash || sha256(input.query!);
 
 		const path = buildContentfulGraphqlPath(
 			spaceId,

--- a/packages/contentfulgraphql/endpoints/graph-ql-content-api-persisted-query.ts
+++ b/packages/contentfulgraphql/endpoints/graph-ql-content-api-persisted-query.ts
@@ -17,10 +17,13 @@ export const graphQlContentApiPersistedQuery: ContentfulGraphqlEndpoints['graphQ
 		}
 		const environmentId = await ctx.keys.get_environment_id();
 
+		if (!input.sha256Hash && !input.query) {
+			throw new Error('Either query or sha256Hash must be provided');
+		}
+
 		// When the caller only supplies the query, derive the SHA-256 hash so the
 		// request registers the persisted query with Contentful on the first call.
-		const sha256Hash =
-			input.sha256Hash ?? (input.query ? sha256(input.query) : '');
+		const sha256Hash = input.sha256Hash ?? sha256(input.query!);
 
 		const path = buildContentfulGraphqlPath(
 			spaceId,

--- a/packages/contentfulgraphql/endpoints/graph-ql-content-api-query.ts
+++ b/packages/contentfulgraphql/endpoints/graph-ql-content-api-query.ts
@@ -1,0 +1,40 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ContentfulGraphqlEndpoints } from '..';
+import {
+	buildContentfulGraphqlPath,
+	makeContentfulGraphqlRequest,
+} from '../client';
+import type { GraphQlContentApiQueryResponse } from './types';
+
+export const graphQlContentApiQuery: ContentfulGraphqlEndpoints['graphQlContentApiQuery'] =
+	async (ctx, input) => {
+		const spaceId = await ctx.keys.get_space_id();
+		if (!spaceId) {
+			throw new Error(
+				'[contentfulgraphql] space_id is required but not configured',
+			);
+		}
+		const environmentId = await ctx.keys.get_environment_id();
+
+		const path = buildContentfulGraphqlPath(
+			spaceId,
+			environmentId ?? undefined,
+		);
+
+		const data = await makeContentfulGraphqlRequest<
+			GraphQlContentApiQueryResponse['data']
+		>(path, ctx.key, {
+			query: input.query,
+			...(input.variables ? { variables: input.variables } : {}),
+			...(input.operationName ? { operationName: input.operationName } : {}),
+		});
+
+		await logEventFromContext(
+			ctx,
+			'contentfulgraphql.graphQlContentApiQuery',
+			{ operationName: input.operationName },
+			'completed',
+		);
+
+		return { data };
+	};

--- a/packages/contentfulgraphql/endpoints/index.ts
+++ b/packages/contentfulgraphql/endpoints/index.ts
@@ -1,0 +1,4 @@
+export { getCmaToken } from './get-cma-token';
+export { graphQlContentApiPersistedQuery } from './graph-ql-content-api-persisted-query';
+export { graphQlContentApiQuery } from './graph-ql-content-api-query';
+export * from './types';

--- a/packages/contentfulgraphql/endpoints/types.ts
+++ b/packages/contentfulgraphql/endpoints/types.ts
@@ -1,0 +1,97 @@
+import { z } from 'zod';
+
+const GraphQlDataSchema = z.record(z.string(), z.unknown());
+const GraphQlVariablesSchema = z.record(z.string(), z.unknown());
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Get CMA token
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const GetCmaTokenInputSchema = z.object({});
+
+export type GetCmaTokenInput = z.infer<typeof GetCmaTokenInputSchema>;
+
+export const GetCmaTokenResponseSchema = z.object({
+	token: z.string(),
+	space_id: z.string(),
+	environment_id: z.string().optional(),
+});
+
+export type GetCmaTokenResponse = z.infer<typeof GetCmaTokenResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GraphQL Content API — query
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const GraphQlContentApiQueryInputSchema = z.object({
+	query: z.string().min(1),
+	variables: GraphQlVariablesSchema.optional(),
+	operationName: z.string().min(1).optional(),
+});
+
+export type GraphQlContentApiQueryInput = z.infer<
+	typeof GraphQlContentApiQueryInputSchema
+>;
+
+export const GraphQlContentApiQueryResponseSchema = z.object({
+	data: GraphQlDataSchema,
+});
+
+export type GraphQlContentApiQueryResponse = z.infer<
+	typeof GraphQlContentApiQueryResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GraphQL Content API — automatic persisted query
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const GraphQlContentApiPersistedQueryInputSchema = z
+	.object({
+		query: z.string().min(1).optional(),
+		sha256Hash: z.string().min(1).optional(),
+		variables: GraphQlVariablesSchema.optional(),
+		operationName: z.string().min(1).optional(),
+	})
+	.refine(
+		(value) => value.query !== undefined || value.sha256Hash !== undefined,
+		{
+			message: 'Provide query or sha256Hash',
+		},
+	);
+
+export type GraphQlContentApiPersistedQueryInput = z.infer<
+	typeof GraphQlContentApiPersistedQueryInputSchema
+>;
+
+export const GraphQlContentApiPersistedQueryResponseSchema = z.object({
+	data: GraphQlDataSchema,
+});
+
+export type GraphQlContentApiPersistedQueryResponse = z.infer<
+	typeof GraphQlContentApiPersistedQueryResponseSchema
+>;
+
+export type ContentfulGraphqlEndpointInputs = {
+	getCmaToken: GetCmaTokenInput;
+	graphQlContentApiQuery: GraphQlContentApiQueryInput;
+	graphQlContentApiPersistedQuery: GraphQlContentApiPersistedQueryInput;
+};
+
+export type ContentfulGraphqlEndpointOutputs = {
+	getCmaToken: GetCmaTokenResponse;
+	graphQlContentApiQuery: GraphQlContentApiQueryResponse;
+	graphQlContentApiPersistedQuery: GraphQlContentApiPersistedQueryResponse;
+};
+
+export const ContentfulGraphqlEndpointInputSchemas = {
+	getCmaToken: GetCmaTokenInputSchema,
+	graphQlContentApiQuery: GraphQlContentApiQueryInputSchema,
+	graphQlContentApiPersistedQuery: GraphQlContentApiPersistedQueryInputSchema,
+} as const;
+
+export const ContentfulGraphqlEndpointOutputSchemas = {
+	getCmaToken: GetCmaTokenResponseSchema,
+	graphQlContentApiQuery: GraphQlContentApiQueryResponseSchema,
+	graphQlContentApiPersistedQuery:
+		GraphQlContentApiPersistedQueryResponseSchema,
+} as const;

--- a/packages/contentfulgraphql/endpoints/types.ts
+++ b/packages/contentfulgraphql/endpoints/types.ts
@@ -12,7 +12,6 @@ export const GetCmaTokenInputSchema = z.object({});
 export type GetCmaTokenInput = z.infer<typeof GetCmaTokenInputSchema>;
 
 export const GetCmaTokenResponseSchema = z.object({
-	token: z.string(),
 	space_id: z.string(),
 	environment_id: z.string().optional(),
 });

--- a/packages/contentfulgraphql/error-handlers.ts
+++ b/packages/contentfulgraphql/error-handlers.ts
@@ -1,0 +1,54 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('429');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('unauthorized') ||
+				msg.includes('invalid_auth') ||
+				msg.includes('access_token_invalid')
+			);
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	NOT_FOUND_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 404) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('not_found') || msg.includes('space not found');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	GRAPHQL_ERROR: {
+		match: (error: Error) => {
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('graphql') ||
+				msg.includes('persistedquerynotfound') ||
+				msg.includes('query not present')
+			);
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/contentfulgraphql/error-handlers.ts
+++ b/packages/contentfulgraphql/error-handlers.ts
@@ -1,24 +1,39 @@
 import type { CorsairErrorHandler } from 'corsair/core';
 import { ApiError } from 'corsair/http';
+import { ContentfulGraphqlAPIError } from './client';
 
 export const errorHandlers = {
 	RATE_LIMIT_ERROR: {
 		match: (error: Error) => {
-			if (error instanceof ApiError && error.status === 429) return true;
+			if (
+				(error instanceof ApiError ||
+					error instanceof ContentfulGraphqlAPIError) &&
+				error.status === 429
+			)
+				return true;
 			const msg = error.message.toLowerCase();
 			return msg.includes('rate_limited') || msg.includes('429');
 		},
 		handler: async (error: Error) => {
 			let retryAfterMs: number | undefined;
-			if (error instanceof ApiError && error.retryAfter !== undefined) {
-				retryAfterMs = error.retryAfter;
+			if (
+				(error instanceof ApiError ||
+					error instanceof ContentfulGraphqlAPIError) &&
+				error.retryAfter !== undefined
+			) {
+				retryAfterMs = Number(error.retryAfter);
 			}
 			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
 		},
 	},
 	AUTH_ERROR: {
 		match: (error: Error) => {
-			if (error instanceof ApiError && error.status === 401) return true;
+			if (
+				(error instanceof ApiError ||
+					error instanceof ContentfulGraphqlAPIError) &&
+				error.status === 401
+			)
+				return true;
 			const msg = error.message.toLowerCase();
 			return (
 				msg.includes('unauthorized') ||
@@ -30,7 +45,12 @@ export const errorHandlers = {
 	},
 	NOT_FOUND_ERROR: {
 		match: (error: Error) => {
-			if (error instanceof ApiError && error.status === 404) return true;
+			if (
+				(error instanceof ApiError ||
+					error instanceof ContentfulGraphqlAPIError) &&
+				error.status === 404
+			)
+				return true;
 			const msg = error.message.toLowerCase();
 			return msg.includes('not_found') || msg.includes('space not found');
 		},
@@ -40,7 +60,6 @@ export const errorHandlers = {
 		match: (error: Error) => {
 			const msg = error.message.toLowerCase();
 			return (
-				msg.includes('graphql') ||
 				msg.includes('persistedquerynotfound') ||
 				msg.includes('query not present')
 			);

--- a/packages/contentfulgraphql/index.ts
+++ b/packages/contentfulgraphql/index.ts
@@ -1,0 +1,209 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+} from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
+import {
+	getCmaToken,
+	graphQlContentApiPersistedQuery,
+	graphQlContentApiQuery,
+} from './endpoints';
+import type {
+	ContentfulGraphqlEndpointInputs,
+	ContentfulGraphqlEndpointOutputs,
+} from './endpoints/types';
+import {
+	ContentfulGraphqlEndpointInputSchemas,
+	ContentfulGraphqlEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { ContentfulGraphqlSchema } from './schema';
+
+export type ContentfulGraphqlPluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	hooks?: InternalContentfulGraphqlPlugin['hooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<
+		typeof contentfulGraphqlEndpointsNested
+	>;
+};
+
+export type ContentfulGraphqlContext = CorsairPluginContext<
+	typeof ContentfulGraphqlSchema,
+	ContentfulGraphqlPluginOptions,
+	undefined,
+	typeof contentfulGraphqlAuthConfig
+>;
+
+export type ContentfulGraphqlKeyBuilderContext = KeyBuilderContext<
+	ContentfulGraphqlPluginOptions,
+	typeof contentfulGraphqlAuthConfig
+>;
+
+export type ContentfulGraphqlBoundEndpoints = BindEndpoints<
+	typeof contentfulGraphqlEndpointsNested
+>;
+
+type ContentfulGraphqlEndpoint<
+	K extends keyof ContentfulGraphqlEndpointOutputs,
+> = CorsairEndpoint<
+	ContentfulGraphqlContext,
+	ContentfulGraphqlEndpointInputs[K],
+	ContentfulGraphqlEndpointOutputs[K]
+>;
+
+export type ContentfulGraphqlEndpoints = {
+	getCmaToken: ContentfulGraphqlEndpoint<'getCmaToken'>;
+	graphQlContentApiQuery: ContentfulGraphqlEndpoint<'graphQlContentApiQuery'>;
+	graphQlContentApiPersistedQuery: ContentfulGraphqlEndpoint<'graphQlContentApiPersistedQuery'>;
+};
+
+const contentfulGraphqlEndpointsNested = {
+	getCmaToken,
+	graphQlContentApiQuery,
+	graphQlContentApiPersistedQuery,
+} as const;
+
+export const contentfulGraphqlEndpointSchemas = {
+	getCmaToken: {
+		input: ContentfulGraphqlEndpointInputSchemas.getCmaToken,
+		output: ContentfulGraphqlEndpointOutputSchemas.getCmaToken,
+	},
+	graphQlContentApiQuery: {
+		input: ContentfulGraphqlEndpointInputSchemas.graphQlContentApiQuery,
+		output: ContentfulGraphqlEndpointOutputSchemas.graphQlContentApiQuery,
+	},
+	graphQlContentApiPersistedQuery: {
+		input:
+			ContentfulGraphqlEndpointInputSchemas.graphQlContentApiPersistedQuery,
+		output:
+			ContentfulGraphqlEndpointOutputSchemas.graphQlContentApiPersistedQuery,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<
+	typeof contentfulGraphqlEndpointsNested
+>;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const contentfulGraphqlEndpointMeta = {
+	getCmaToken: {
+		riskLevel: 'read',
+		description:
+			'Get the stored Contentful access token, space ID, and environment ID',
+	},
+	graphQlContentApiQuery: {
+		riskLevel: 'read',
+		description:
+			'Run a GraphQL query against the Contentful GraphQL Content API for the configured space and environment',
+	},
+	graphQlContentApiPersistedQuery: {
+		riskLevel: 'read',
+		description:
+			'Run an automatic persisted query (APQ) against the Contentful GraphQL Content API using a SHA-256 hash',
+	},
+} as const satisfies RequiredPluginEndpointMeta<
+	typeof contentfulGraphqlEndpointsNested
+>;
+
+export const contentfulGraphqlAuthConfig = {
+	api_key: {
+		account: ['space_id', 'environment_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type BaseContentfulGraphqlPlugin<
+	T extends ContentfulGraphqlPluginOptions,
+> = CorsairPlugin<
+	'contentfulgraphql',
+	typeof ContentfulGraphqlSchema,
+	typeof contentfulGraphqlEndpointsNested,
+	{},
+	T,
+	typeof defaultAuthType,
+	typeof contentfulGraphqlAuthConfig
+>;
+
+export type InternalContentfulGraphqlPlugin =
+	BaseContentfulGraphqlPlugin<ContentfulGraphqlPluginOptions>;
+
+export type ExternalContentfulGraphqlPlugin<
+	T extends ContentfulGraphqlPluginOptions,
+> = BaseContentfulGraphqlPlugin<T>;
+
+export function contentfulgraphql<
+	const T extends ContentfulGraphqlPluginOptions,
+>(
+	incomingOptions: ContentfulGraphqlPluginOptions &
+		T = {} as ContentfulGraphqlPluginOptions & T,
+): ExternalContentfulGraphqlPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'contentfulgraphql',
+		authConfig: contentfulGraphqlAuthConfig,
+		schema: ContentfulGraphqlSchema,
+		options: options,
+		hooks: options.hooks,
+		endpoints: contentfulGraphqlEndpointsNested,
+		webhooks: {},
+		endpointMeta: contentfulGraphqlEndpointMeta,
+		endpointSchemas: contentfulGraphqlEndpointSchemas,
+		pluginWebhookMatcher: () => false,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: ContentfulGraphqlKeyBuilderContext, source) => {
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys.get_api_key();
+
+				if (!res) {
+					throw new AuthMissingError('contentfulgraphql', 'api_key');
+				}
+
+				return res;
+			}
+
+			throw new AuthMissingError('contentfulgraphql', 'api_key');
+		},
+	} satisfies InternalContentfulGraphqlPlugin;
+}
+
+export type {
+	ContentfulGraphqlEndpointInputs,
+	ContentfulGraphqlEndpointOutputs,
+	GetCmaTokenInput,
+	GetCmaTokenResponse,
+	GraphQlContentApiPersistedQueryInput,
+	GraphQlContentApiPersistedQueryResponse,
+	GraphQlContentApiQueryInput,
+	GraphQlContentApiQueryResponse,
+} from './endpoints/types';
+
+export {
+	ContentfulGraphqlEndpointInputSchemas,
+	ContentfulGraphqlEndpointOutputSchemas,
+	GetCmaTokenInputSchema,
+	GetCmaTokenResponseSchema,
+	GraphQlContentApiPersistedQueryInputSchema,
+	GraphQlContentApiPersistedQueryResponseSchema,
+	GraphQlContentApiQueryInputSchema,
+	GraphQlContentApiQueryResponseSchema,
+} from './endpoints/types';

--- a/packages/contentfulgraphql/jest.config.cjs
+++ b/packages/contentfulgraphql/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/contentfulgraphql/package.json
+++ b/packages/contentfulgraphql/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/contentfulgraphql",
+  "version": "0.1.0",
+  "description": "Contentful GraphQL plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "contentfulgraphql",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/contentfulgraphql/schema.test.ts
+++ b/packages/contentfulgraphql/schema.test.ts
@@ -1,0 +1,22 @@
+import { ContentfulGraphqlSchema } from './schema';
+
+describe('ContentfulGraphql schema', () => {
+	it('declares a semver version', () => {
+		expect(ContentfulGraphqlSchema.version).toBeDefined();
+		expect(ContentfulGraphqlSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof ContentfulGraphqlSchema.entities).toBe('object');
+		expect(ContentfulGraphqlSchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(ContentfulGraphqlSchema.entities))).toBe(
+			true,
+		);
+		for (const entity of Object.values(ContentfulGraphqlSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/contentfulgraphql/schema/database.ts
+++ b/packages/contentfulgraphql/schema/database.ts
@@ -1,0 +1,3 @@
+// This integration is a read-only GraphQL query API, so it defines no
+// database entities. Add Zod entity schemas here if future operations need
+// to persist content (e.g. cached query results).

--- a/packages/contentfulgraphql/schema/index.ts
+++ b/packages/contentfulgraphql/schema/index.ts
@@ -1,0 +1,4 @@
+export const ContentfulGraphqlSchema = {
+	version: '1.0.0',
+	entities: {},
+} as const;

--- a/packages/contentfulgraphql/tsconfig.json
+++ b/packages/contentfulgraphql/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/contentfulgraphql/tsup.config.ts
+++ b/packages/contentfulgraphql/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -140,7 +140,7 @@ export const ProviderDisplayNames = {
 	cloudflare: 'Cloudflare',
 	cloudinary: 'Cloudinary',
 	confluence: 'Confluence',
-	contentfulgraphql: 'ContentfulGraphql',
+	contentfulgraphql: 'Contentful GraphQL',
 	cursor: 'Cursor',
 	databricks: 'Databricks',
 	datadog: 'Datadog',

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -35,6 +35,7 @@ export const BaseProviders = [
 	'cloudflare',
 	'cloudinary',
 	'confluence',
+	'contentfulgraphql',
 	'cursor',
 	'databricks',
 	'datadog',
@@ -139,6 +140,7 @@ export const ProviderDisplayNames = {
 	cloudflare: 'Cloudflare',
 	cloudinary: 'Cloudinary',
 	confluence: 'Confluence',
+	contentfulgraphql: 'ContentfulGraphql',
 	cursor: 'Cursor',
 	databricks: 'Databricks',
 	datadog: 'Datadog',
@@ -250,6 +252,7 @@ export type AllProviders =
 	| 'cloudflare'
 	| 'cloudinary'
 	| 'confluence'
+	| 'contentfulgraphql'
 	| 'cursor'
 	| 'databricks'
 	| 'datadog'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -922,6 +922,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/contentfulgraphql:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/corsair:
     dependencies:
       kysely:


### PR DESCRIPTION
## Description

Adds the Contentful GraphQL integration to Corsair.

### Implemented

- Contentful GraphQL client
- API-key authentication
- `CONTENTFUL_GRAPHQL_GET_CMA_TOKEN`
- `CONTENTFUL_GRAPHQL_GRAPH_QL_CONTENT_API_QUERY`
- `CONTENTFUL_GRAPHQL_GRAPH_QL_CONTENT_API_PERSISTED_QUERY`
- Automatic Persisted Query handling
- Contentful API error handling
- Rate-limit handling
- Tests for all three operations
- No webhooks/triggers

### Validation

- [x] TypeScript typecheck passes
- [x] Biome check passes for `packages/contentfulgraphql`
- [x] Plugin structural validation passes
- [x] Tests pass — 17/17
- [x] No secrets added
- [x] No unrelated integration files modified

## Screenshots / Demos
<img width="1000" height="309" alt="Screenshot 2026-08-19 at 10 08 48 PM" src="https://github.com/user-attachments/assets/d48e2006-253c-4d80-b361-376e9b60748d" />

### Notes

The repository-wide lint command currently reports pre-existing CRLF
line-ending errors in unmodified files. No `packages/contentfulgraphql`
files are affected by those errors.

The Windows build command also has a platform-specific `rm -rf` cleanup
issue; TypeScript/typecheck, plugin validation, and tests pass.

Closes #646

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Contentful GraphQL integration with standard and persisted-query support.
  - Added CMA token retrieval with space and environment metadata.
  - Added API-key authentication, request validation, variables, and operation names.
  - Added automatic retries for rate-limited requests and persisted-query fallback.
  - Added clear handling for authentication, missing resources, GraphQL, and API errors.
  - Added Contentful GraphQL to the available provider integrations.

- **Tests**
  - Added comprehensive coverage for endpoints, authentication, requests, errors, retries, hashing, configuration, and schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->