### PR TITLE
refactor(connect): dedup redelivered webhooks + tighten connect loop

### DIFF
--- a/packages/corsair/hub/connect/loop.ts
+++ b/packages/corsair/hub/connect/loop.ts
@@ -147,19 +147,16 @@ export function startConnectLoop(
 	} catch {
 		return { stop: () => {} };
 	}
-	// A prod key means connect is out of scope — stay silent. But a dev key with
-	// execution gated off is almost always a mistake (it used to fail silently:
-	// the app just never polls). Say why, and where the flag actually goes.
+	// A prod key means connect is out of scope — prod apps receive server push.
 	if (!hub.projectApiKey.startsWith('ck_dev_')) {
 		return { stop: () => {} };
 	}
-	if (!hub.allowWorkflowExecution) {
-		console.warn(
-			'[corsair] workflow executions not enabled. ' +
-				'Please set hub: { ..., allowWorkflowExecution: true }',
-		);
-		return { stop: () => {} };
-	}
+	// The loop is the dev app's single inbound channel for ALL hub-delivered work.
+	// Webhooks must drain regardless of allowWorkflowExecution; run/probe execution
+	// is gated per-envelope inside processCorsair, so starting the loop here is safe
+	// even when execution is disabled (a delivered run just acks back "not enabled").
+	// ponytail: every dev key long-polls (~once/25s). Fine at current scale; gate on
+	// registered-webhook-or-execution intent if idle polling ever becomes a cost.
 	const key = hub.projectApiKey;
 	if (activeLoops.has(key)) {
 		return { stop: () => {} };

--- a/packages/corsair/hub/connect/loop.ts
+++ b/packages/corsair/hub/connect/loop.ts
@@ -155,8 +155,6 @@ export function startConnectLoop(
 	// Webhooks must drain regardless of allowWorkflowExecution; run/probe execution
 	// is gated per-envelope inside processCorsair, so starting the loop here is safe
 	// even when execution is disabled (a delivered run just acks back "not enabled").
-	// ponytail: every dev key long-polls (~once/25s). Fine at current scale; gate on
-	// registered-webhook-or-execution intent if idle polling ever becomes a cost.
 	const key = hub.projectApiKey;
 	if (activeLoops.has(key)) {
 		return { stop: () => {} };

--- a/packages/corsair/tests/connect-loop.test.ts
+++ b/packages/corsair/tests/connect-loop.test.ts
@@ -175,18 +175,19 @@ describe('startConnectLoop', () => {
 		fetchSpy.mockRestore();
 	});
 
-	it('warns and does not poll for a dev key with execution disabled', async () => {
-		const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(res(204));
+	it('polls for a dev key even when execution is disabled (webhooks still drain)', async () => {
 		const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-		const handle = startConnectLoop(mockCorsair('ck_dev_noexec', false));
-		await Promise.resolve();
-		expect(fetchSpy).not.toHaveBeenCalled();
-		expect(warnSpy).toHaveBeenCalledWith(
+		const { state, deps } = countingIdleDeps();
+		const handle = startConnectLoop(mockCorsair('ck_dev_noexec', false), deps);
+		await sleep(40);
+		// The loop is the app's only inbound channel for webhooks, so it must poll
+		// regardless of allowWorkflowExecution — and no longer warns about it.
+		expect(state.calls).toBeGreaterThan(0);
+		expect(warnSpy).not.toHaveBeenCalledWith(
 			expect.stringContaining('workflow executions not enabled'),
 		);
 		handle.stop();
 		warnSpy.mockRestore();
-		fetchSpy.mockRestore();
 	});
 
 	function countingIdleDeps() {

--- a/packages/corsair/tests/tunnel.test.ts
+++ b/packages/corsair/tests/tunnel.test.ts
@@ -133,6 +133,34 @@ describe('processCorsair', () => {
 		expect(ack.error).not.toBe('Invalid or missing tunnel timestamp');
 	});
 
+	it('does not dedupe a FAILED webhook — a redelivery is re-attempted, not dropped', async () => {
+		const secret = 'tunnel-signing-secret';
+		const body = JSON.stringify({
+			type: 'webhook',
+			// No handler is registered (plugins: []), so this delivery fails. The key
+			// must NOT be marked seen on failure, or the durable-queue redelivery
+			// would be silently acked as a duplicate and the event lost.
+			payload: {
+				headers: {},
+				body: '{}',
+				plugin: 'github',
+				tenantId: 't1',
+				dedupeKey: 'evt-1',
+			},
+		});
+		const call = () =>
+			processCorsair(
+				createMockCorsair(),
+				{ headers: signedTunnelHeaders(body, secret), body },
+				{ signingSecret: secret },
+			);
+
+		const first = await call();
+		expect(first.status).toBe('failed');
+		const second = await call();
+		expect(second.status).toBe('failed'); // re-attempted, not a duplicate 'ok'
+	});
+
 	it('rejects replayed tunnel nonces', async () => {
 		const secret = 'tunnel-signing-secret';
 		const nonce = randomUUID();

--- a/packages/corsair/tunnel/index.ts
+++ b/packages/corsair/tunnel/index.ts
@@ -251,22 +251,29 @@ async function resolveWebhookTenantId(
 	return resolved ?? undefined;
 }
 
-// Bounded set of webhook delivery ids already handled this session, so a
-// redelivery (provider retry, or a durable-queue lease reclaim) doesn't re-fire
-// handlers — the SDK's own dedup, since webhook handlers carry none. In-memory
-// and bounded: a process restart forgets, so a redelivery after restart can
-// still double-fire. Acceptable at dev scale; a durable seen-store is the upgrade.
+// Bounded set of webhook deliveries already handled this session, so a redelivery
+// (provider retry, or a durable-queue lease reclaim) doesn't re-fire handlers —
+// the SDK's own dedup, since webhook handlers carry none. In-memory and bounded:
+// a process restart forgets, so a redelivery after restart can still double-fire.
+// Acceptable at dev scale; a durable seen-store is the upgrade.
+//
+// A key is recorded only AFTER a successful handle (see handleWebhookTunnel), so a
+// failed/thrown delivery stays retryable — recording before running would burn the
+// key and turn every retry into a silent duplicate-ack that drops the event.
 const WEBHOOK_SEEN_MAX = 1000;
 const seenWebhookDeliveries = new Map<string, true>();
 
-function markWebhookSeen(key: string): boolean {
-	if (seenWebhookDeliveries.has(key)) return false;
+function hasWebhookSeen(key: string): boolean {
+	return seenWebhookDeliveries.has(key);
+}
+
+function recordWebhookSeen(key: string): void {
+	if (seenWebhookDeliveries.has(key)) return;
 	seenWebhookDeliveries.set(key, true);
 	if (seenWebhookDeliveries.size > WEBHOOK_SEEN_MAX) {
 		const oldest = seenWebhookDeliveries.keys().next().value;
 		if (oldest !== undefined) seenWebhookDeliveries.delete(oldest);
 	}
-	return true;
 }
 
 async function handleWebhookTunnel(
@@ -274,8 +281,14 @@ async function handleWebhookTunnel(
 	internal: CorsairInternalConfig,
 	payload: WebhookTunnelPayload,
 ): Promise<TunnelAck> {
+	// Tenant-scope the dedup key to match Hub's (tenant, environment, dedupeKey)
+	// uniqueness, so two tenants under one dev env that share an identical-body
+	// event (a plugin with no provider delivery id) don't collapse onto each other.
+	const seenKey = payload.dedupeKey
+		? `${payload.tenantId ?? ''}:${payload.dedupeKey}`
+		: undefined;
 	// Already handled this delivery — ack ok without re-running the handler.
-	if (payload.dedupeKey && !markWebhookSeen(payload.dedupeKey)) {
+	if (seenKey && hasWebhookSeen(seenKey)) {
 		return { status: 'ok' };
 	}
 	const tenantId = await resolveWebhookTenantId(corsair, internal, payload);
@@ -323,6 +336,11 @@ async function handleWebhookTunnel(
 			: returnToSender
 				? returnToSender
 				: (result.response?.data ?? result.response);
+
+	// Handler ran cleanly — only now record the delivery as seen, so any failure
+	// above (thrown, no handler, or success:false) stays retryable via redelivery
+	// or a Hub lease reclaim.
+	if (seenKey) recordWebhookSeen(seenKey);
 
 	return {
 		status: 'ok',

--- a/packages/corsair/tunnel/index.ts
+++ b/packages/corsair/tunnel/index.ts
@@ -281,17 +281,18 @@ async function handleWebhookTunnel(
 	internal: CorsairInternalConfig,
 	payload: WebhookTunnelPayload,
 ): Promise<TunnelAck> {
-	// Tenant-scope the dedup key to match Hub's (tenant, environment, dedupeKey)
-	// uniqueness, so two tenants under one dev env that share an identical-body
-	// event (a plugin with no provider delivery id) don't collapse onto each other.
+	// Resolve the tenant first, then tenant-scope the dedup key on the RESOLVED id.
+	// Keying on payload.tenantId alone would collapse two tenants whose identity
+	// comes from query.tenantId or a webhook-link lookup (both would share the empty
+	// prefix). Scoping matches Hub's (tenant, environment, dedupeKey) uniqueness.
+	const tenantId = await resolveWebhookTenantId(corsair, internal, payload);
 	const seenKey = payload.dedupeKey
-		? `${payload.tenantId ?? ''}:${payload.dedupeKey}`
+		? `${tenantId ?? ''}:${payload.dedupeKey}`
 		: undefined;
 	// Already handled this delivery — ack ok without re-running the handler.
 	if (seenKey && hasWebhookSeen(seenKey)) {
 		return { status: 'ok' };
 	}
-	const tenantId = await resolveWebhookTenantId(corsair, internal, payload);
 	const query = {
 		...(payload.query ?? {}),
 		...(tenantId ? { tenantId } : {}),

--- a/packages/corsair/tunnel/index.ts
+++ b/packages/corsair/tunnel/index.ts
@@ -100,6 +100,12 @@ export type WebhookTunnelPayload = {
 	linkType?: string;
 	externalId?: string;
 	tenantId?: string;
+	/**
+	 * Stable per-event id (provider delivery id, else a body hash) set by Hub. Used
+	 * to skip a handler re-fire when the same event is redelivered — a provider
+	 * retry, or a durable-queue lease reclaim.
+	 */
+	dedupeKey?: string;
 };
 
 export type OAuthCallbackTunnelPayload = {
@@ -245,11 +251,33 @@ async function resolveWebhookTenantId(
 	return resolved ?? undefined;
 }
 
+// Bounded set of webhook delivery ids already handled this session, so a
+// redelivery (provider retry, or a durable-queue lease reclaim) doesn't re-fire
+// handlers — the SDK's own dedup, since webhook handlers carry none. In-memory
+// and bounded: a process restart forgets, so a redelivery after restart can
+// still double-fire. Acceptable at dev scale; a durable seen-store is the upgrade.
+const WEBHOOK_SEEN_MAX = 1000;
+const seenWebhookDeliveries = new Map<string, true>();
+
+function markWebhookSeen(key: string): boolean {
+	if (seenWebhookDeliveries.has(key)) return false;
+	seenWebhookDeliveries.set(key, true);
+	if (seenWebhookDeliveries.size > WEBHOOK_SEEN_MAX) {
+		const oldest = seenWebhookDeliveries.keys().next().value;
+		if (oldest !== undefined) seenWebhookDeliveries.delete(oldest);
+	}
+	return true;
+}
+
 async function handleWebhookTunnel(
 	corsair: unknown,
 	internal: CorsairInternalConfig,
 	payload: WebhookTunnelPayload,
 ): Promise<TunnelAck> {
+	// Already handled this delivery — ack ok without re-running the handler.
+	if (payload.dedupeKey && !markWebhookSeen(payload.dedupeKey)) {
+		return { status: 'ok' };
+	}
 	const tenantId = await resolveWebhookTenantId(corsair, internal, payload);
 	const query = {
 		...(payload.query ?? {}),


### PR DESCRIPTION
SDK side of durable webhook delivery: dedup a redelivered webhook (idempotent on the Hub delivery id) so a re-queued delivery after a lost ack is a no-op, and tighten connect-loop handling.

Pairs with corsairdev/hub#62 (Hub delivery queue). Merge Hub first (+ migration 0027); this guard is additive and safe if Hub hasn't deployed yet.

Verified locally: 0 type errors in the changed files (connect/loop.ts, tunnel/index.ts); tunnel tests pass. (Repo-wide typecheck has pre-existing, unrelated test-dep errors.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional deduplication keys for webhook deliveries.
  * Duplicate deliveries are acknowledged without rerunning handlers.
  * Deduplication tracks up to 1,000 recent keys per tenant.

* **Bug Fixes**
  * Failed webhook deliveries remain retryable when deduplication is enabled.
  * Development connections now start even when workflow execution is disabled.
  * Webhooks continue polling while workflow execution remains restricted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->