### PR TITLE
feat(workflows): event bus — step.waitForEvent + step.sendEvent

### DIFF
--- a/packages/corsair/hub/contracts/tunnel.ts
+++ b/packages/corsair/hub/contracts/tunnel.ts
@@ -51,7 +51,12 @@ export const INBOUND_TUNNEL_TYPES = new Set<TunnelType>([
 // only runs the failed step + everything after it.
 // ─────────────────────────────────────────────────────────────────────────────
 
-export type RunTriggerType = 'cron' | 'cadence' | 'webhook' | 'manual';
+export type RunTriggerType =
+	| 'cron'
+	| 'cadence'
+	| 'webhook'
+	| 'manual'
+	| 'event';
 
 /** Hub → app: a single workflow execution attempt. */
 export type RunTunnelPayload = {
@@ -91,6 +96,19 @@ export type RunStepResult = {
 	error?: string;
 };
 
+/** What a `waiting` run is blocked on — Hub persists this as an open waiter. */
+export type WaiterDescriptor = {
+	stepId: string;
+	name: string;
+	seq: number;
+	/** Event name to match (e.g. `'<plugin>.<event>'` or a custom name). */
+	event: string;
+	/** Dot-path → value equalities, all ANDed. Null when unfiltered. */
+	match: Record<string, unknown> | null;
+	/** ISO time the wait resolves to `null`; null = wait forever. */
+	timeoutAt: string | null;
+};
+
 /**
  * App → Hub: outcome of one execution attempt (returned in the tunnel ack body).
  *
@@ -99,13 +117,18 @@ export type RunStepResult = {
  * `sleepUntil`; on the next attempt the sleep step is memoized (satisfied) and
  * execution continues past it. This is what makes long, multi-day workflows
  * survive process restarts.
+ *
+ * `waiting` is a durable event wait: the workflow called `step.waitForEvent(...)`.
+ * Hub parks the run until a matching event arrives (or `timeoutAt` elapses).
  */
 export type RunResultPayload = {
-	status: 'completed' | 'failed' | 'sleeping';
+	status: 'completed' | 'failed' | 'sleeping' | 'waiting';
 	steps: RunStepResult[];
 	error?: { message: string; failedStep?: string };
 	/** ISO timestamp when a `sleeping` run should be re-invoked. */
 	sleepUntil?: string;
+	/** Present only when `status === 'waiting'`. */
+	waiter?: WaiterDescriptor;
 };
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/corsair/tests/event-bus-e2e.test.ts
+++ b/packages/corsair/tests/event-bus-e2e.test.ts
@@ -1,0 +1,75 @@
+import { computeStepId, executeWorkflowRun } from '../workflows/execute';
+
+const code = `
+	module.exports.main = async (corsair, payload, step) => {
+		await step('ask', async () => corsair.slack.api.messages.post({ text: 'approve?' }));
+		const d = await step.waitForEvent('decision', {
+			event: 'slack.block_actions',
+			match: { 'data.callback_id': payload.id },
+			timeout: '1d',
+		});
+		if (!d || d.data.action !== 'approve') return 'stopped';
+		return step('refund', async () => corsair.stripe.api.refunds.create({ id: payload.id }));
+	};
+`;
+
+it('suspends at the wait, then replays to completion with the injected event', async () => {
+	const corsair = {
+		slack: { api: { messages: { post: async () => ({ ok: true }) } } },
+		stripe: {
+			api: { refunds: { create: async (i: unknown) => ({ refunded: i }) } },
+		},
+	};
+	// Phase 1: run until the wait.
+	const first = await executeWorkflowRun({
+		corsair,
+		code,
+		payload: { id: 'r1' },
+	});
+	expect(first.status).toBe('waiting');
+	expect(first.waiter?.event).toBe('slack.block_actions');
+	expect(first.steps.map((s) => s.name)).toEqual(['ask']);
+
+	// Simulate Hub resolving the waiter: persist the event under the wait stepId.
+	const stepId = computeStepId('decision', 1); // seq 1 (after 'ask' at seq 0)
+	const memo = {
+		[computeStepId('ask', 0)]: { output: { ok: true } },
+		[stepId]: {
+			output: {
+				name: 'slack.block_actions',
+				data: { action: 'approve', callback_id: 'r1' },
+			},
+		},
+	};
+	// Phase 2: replay past the wait.
+	const second = await executeWorkflowRun({
+		corsair,
+		code,
+		payload: { id: 'r1' },
+		memoizedSteps: memo,
+	});
+	expect(second.status).toBe('completed');
+	expect(second.steps.find((s) => s.name === 'refund')?.output).toEqual({
+		refunded: { id: 'r1' },
+	});
+});
+
+it('branches on timeout (null injection)', async () => {
+	const corsair = {
+		slack: { api: { messages: { post: async () => ({ ok: true }) } } },
+		stripe: { api: { refunds: { create: async () => ({}) } } },
+	};
+	const memo = {
+		[computeStepId('ask', 0)]: { output: { ok: true } },
+		[computeStepId('decision', 1)]: { output: null },
+	};
+	const result = await executeWorkflowRun({
+		corsair,
+		code,
+		payload: { id: 'r1' },
+		memoizedSteps: memo,
+	});
+	expect(result.status).toBe('completed');
+	// 'refund' never ran; main returned 'stopped'.
+	expect(result.steps.map((s) => s.name)).not.toContain('refund');
+});

--- a/packages/corsair/tests/events.test.ts
+++ b/packages/corsair/tests/events.test.ts
@@ -1,0 +1,49 @@
+import type { HubConfig } from '../hub/types';
+import { createSendEventCallback } from '../workflows/events';
+
+function fakeHub(): HubConfig {
+	return {
+		apiUrl: 'https://hub.test',
+		projectApiKey: 'ck_dev_k',
+		signingSecret: 's',
+	};
+}
+
+it('POSTs the event to /events with the run + tenant context', async () => {
+	const calls: Array<{ path: string; body: unknown }> = [];
+	const fetchSpy = jest
+		.spyOn(global, 'fetch')
+		.mockImplementation(async (input, init) => {
+			const url = typeof input === 'string' ? input : (input as Request).url;
+			calls.push({
+				path: url,
+				body: JSON.parse((init?.body as string) ?? 'null'),
+			});
+			return new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				headers: { 'content-type': 'application/json' },
+			});
+		});
+
+	try {
+		const cb = createSendEventCallback({
+			hub: fakeHub(),
+			runId: 'r1',
+			workflowId: 'w1',
+			tenantId: 't1',
+		});
+		await cb('order.paid', JSON.stringify({ id: 'o1' }));
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]!.path).toContain('tenantId=t1');
+		expect(calls[0]!.path).toContain('/events');
+		expect(calls[0]!.body).toEqual({
+			runId: 'r1',
+			workflowId: 'w1',
+			name: 'order.paid',
+			data: { id: 'o1' },
+		});
+	} finally {
+		fetchSpy.mockRestore();
+	}
+});

--- a/packages/corsair/tests/step-suite.test.ts
+++ b/packages/corsair/tests/step-suite.test.ts
@@ -178,6 +178,61 @@ describe('step.waitForEvent — durable coordinate', () => {
 	});
 });
 
+describe('step.sendEvent — emit into the stream', () => {
+	it('calls the host send capability once and memoizes it', async () => {
+		const sent: Array<{ name: string; data: unknown }> = [];
+		const { promise } = run(
+			`
+			module.exports.main = async (corsair, payload, step) => {
+				await step.sendEvent('order.paid', { id: 'o1' });
+			};
+		`,
+			{
+				sendEvent: (name: string, dataJson: string) => {
+					sent.push({ name, data: JSON.parse(dataJson) });
+					return Promise.resolve();
+				},
+			},
+		);
+		const result = await promise;
+		expect(result.status).toBe('completed');
+		expect(sent).toEqual([{ name: 'order.paid', data: { id: 'o1' } }]);
+	});
+
+	it('replays a memoized send without re-emitting', async () => {
+		const stepId = computeStepId('order.paid', 0);
+		const sent: unknown[] = [];
+		const { promise } = run(
+			`
+			module.exports.main = async (corsair, payload, step) => {
+				await step.sendEvent('order.paid', { id: 'o1' });
+			};
+		`,
+			{
+				memoizedSteps: { [stepId]: { output: null } },
+				sendEvent: (name: string, dataJson: string) => {
+					sent.push(dataJson);
+					return Promise.resolve();
+				},
+			},
+		);
+		const result = await promise;
+		expect(result.status).toBe('completed');
+		expect(sent).toEqual([]);
+	});
+
+	it('fails the step clearly when sendEvent is unavailable', async () => {
+		const { promise } = run(`
+			module.exports.main = async (corsair, payload, step) => {
+				await step.sendEvent('order.paid', { id: 'o1' });
+			};
+		`);
+		const result = await promise;
+		expect(result.status).toBe('failed');
+		expect(result.error?.message).toContain('sendEvent is unavailable');
+	});
+});
+
 describe('step.sleepUntil — absolute-time pause', () => {
 	it('suspends until a future time', async () => {
 		const when = new Date(Date.now() + 60_000).toISOString();

--- a/packages/corsair/tests/step-suite.test.ts
+++ b/packages/corsair/tests/step-suite.test.ts
@@ -104,6 +104,80 @@ describe('step.corsair — typed op call', () => {
 	});
 });
 
+describe('step.waitForEvent — durable coordinate', () => {
+	it('suspends with a waiter descriptor on first encounter', async () => {
+		const { promise } = run(`
+			module.exports.main = async (corsair, payload, step) => {
+				const d = await step.waitForEvent('decision', {
+					event: 'slack.block_actions',
+					match: { 'data.callback_id': 'refund_1' },
+					timeout: '1d',
+				});
+				await step('after', async () => d);
+			};
+		`);
+		const result = await promise;
+		expect(result.status).toBe('waiting');
+		expect(result.waiter?.name).toBe('decision');
+		expect(result.waiter?.event).toBe('slack.block_actions');
+		expect(result.waiter?.match).toEqual({ 'data.callback_id': 'refund_1' });
+		expect(result.waiter?.stepId).toBe(computeStepId('decision', 0));
+		// timeoutAt is ~1 day out.
+		const dtMs = new Date(result.waiter!.timeoutAt!).getTime() - Date.now();
+		expect(Math.abs(dtMs - 86_400_000)).toBeLessThan(5_000);
+		// The step after the wait did not run this attempt.
+		expect(result.steps.map((s) => s.name)).toEqual([]);
+	});
+
+	it('replays past the wait with the injected event on resume', async () => {
+		const stepId = computeStepId('decision', 0);
+		const event = { name: 'slack.block_actions', data: { action: 'approve' } };
+		const { promise } = run(
+			`
+			module.exports.main = async (corsair, payload, step) => {
+				const d = await step.waitForEvent('decision', { event: 'slack.block_actions' });
+				return step('after', async () => d.data.action);
+			};
+		`,
+			{ memoizedSteps: { [stepId]: { output: event } } },
+		);
+		const result = await promise;
+		expect(result.status).toBe('completed');
+		expect(result.steps.find((s) => s.name === 'after')?.output).toBe(
+			'approve',
+		);
+	});
+
+	it('resumes with null when the memoized output is null (timeout)', async () => {
+		const stepId = computeStepId('decision', 0);
+		const { promise } = run(
+			`
+			module.exports.main = async (corsair, payload, step) => {
+				const d = await step.waitForEvent('decision', { event: 'x' });
+				return step('after', async () => (d === null ? 'timed-out' : 'got-it'));
+			};
+		`,
+			{ memoizedSteps: { [stepId]: { output: null } } },
+		);
+		const result = await promise;
+		expect(result.status).toBe('completed');
+		expect(result.steps.find((s) => s.name === 'after')?.output).toBe(
+			'timed-out',
+		);
+	});
+
+	it('waits forever (no timeoutAt) when timeout is omitted', async () => {
+		const { promise } = run(`
+			module.exports.main = async (corsair, payload, step) => {
+				await step.waitForEvent('decision', { event: 'x' });
+			};
+		`);
+		const result = await promise;
+		expect(result.status).toBe('waiting');
+		expect(result.waiter?.timeoutAt).toBeNull();
+	});
+});
+
 describe('step.sleepUntil — absolute-time pause', () => {
 	it('suspends until a future time', async () => {
 		const when = new Date(Date.now() + 60_000).toISOString();

--- a/packages/corsair/tests/step-suite.test.ts
+++ b/packages/corsair/tests/step-suite.test.ts
@@ -266,3 +266,27 @@ describe('step.sleepUntil — absolute-time pause', () => {
 		);
 	});
 });
+
+describe('interrupt brand is unforgeable by sandbox code', () => {
+	it('a workflow throwing a fake wait brand is a failed run, not waiting', async () => {
+		const { promise } = run(`
+			module.exports.main = async (corsair, payload, step) => {
+				throw { __corsairWait: true, stepId: 'st_x', event: 'evil' };
+			};
+		`);
+		const result = await promise;
+		expect(result.status).toBe('failed');
+		expect(result.waiter).toBeUndefined();
+	});
+
+	it('a workflow throwing a fake sleep brand is a failed run, not sleeping', async () => {
+		const { promise } = run(`
+			module.exports.main = async (corsair, payload, step) => {
+				throw { __corsairSleep: true, wakeAt: 0 };
+			};
+		`);
+		const result = await promise;
+		expect(result.status).toBe('failed');
+		expect(result.sleepUntil).toBeUndefined();
+	});
+});

--- a/packages/corsair/tests/tunnel.test.ts
+++ b/packages/corsair/tests/tunnel.test.ts
@@ -1,5 +1,6 @@
 import { createHmac, randomUUID } from 'node:crypto';
 import { CORSAIR_INTERNAL } from '../core';
+import type { RunResultPayload } from '../hub/contracts/tunnel';
 import { resetDeliveryReplayGuardForTests } from '../hub/internal/delivery-replay-guard';
 import { connectLinkAck, processCorsair } from '../tunnel/index';
 import { createTestDatabase } from './setup-db';
@@ -405,4 +406,20 @@ describe('processCorsair — probe tunnel', () => {
 			probe: { status: 'ok', value: 42 },
 		});
 	});
+});
+
+it('types a waiting run result with a waiter descriptor', () => {
+	const r: RunResultPayload = {
+		status: 'waiting',
+		steps: [],
+		waiter: {
+			stepId: 'st_abc',
+			name: 'decision',
+			seq: 1,
+			event: 'slack.block_actions',
+			match: { 'data.callback_id': 'refund_1' },
+			timeoutAt: '2026-08-13T00:00:00.000Z',
+		},
+	};
+	expect(r.waiter?.event).toBe('slack.block_actions');
 });

--- a/packages/corsair/tunnel/index.ts
+++ b/packages/corsair/tunnel/index.ts
@@ -27,6 +27,7 @@ import {
 	setWebhookTenantLink,
 } from '../webhooks/tenant-links';
 import { createAiStepCallback } from '../workflows/ai';
+import { createSendEventCallback } from '../workflows/events';
 import { executeWorkflowRun } from '../workflows/execute';
 import { runReadonlyProbe } from '../workflows/probe';
 
@@ -494,12 +495,21 @@ async function handleRunTunnel(
 					tenantId: payload.tenantId,
 				})
 			: undefined;
+		const sendEvent = internal.hub
+			? createSendEventCallback({
+					hub: internal.hub,
+					runId: payload.runId,
+					workflowId: payload.workflowId,
+					tenantId: payload.tenantId,
+				})
+			: undefined;
 		const result: RunResultPayload = await executeWorkflowRun({
 			corsair: tenantScopedCorsair,
 			code: payload.code,
 			payload: payload.trigger?.payload ?? null,
 			memoizedSteps: payload.memoizedSteps,
 			ai,
+			sendEvent,
 		});
 		// The envelope was processed successfully regardless of whether the workflow
 		// itself succeeded — Hub reads the run status/steps from `run` in the ack

--- a/packages/corsair/workflows/events.ts
+++ b/packages/corsair/workflows/events.ts
@@ -1,0 +1,38 @@
+import { hubApiPost } from '../hub/client/http';
+import type { HubConfig } from '../hub/types';
+import type { SendEventCallback } from './execute';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// step.sendEvent host capability
+//
+// The sandbox can't reach the network, so this host callback POSTs the emitted
+// event to Hub's /events endpoint, which buffers it, resolves matching waiters,
+// and dispatches event-triggered workflows. Auth is the same env key + tenant as
+// step.ai. Memoization (in step()) makes retries safe: a re-delivered attempt
+// replays the send step instead of re-emitting.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type SendEventContext = {
+	hub: HubConfig;
+	runId: string;
+	workflowId: string;
+	tenantId: string;
+};
+
+export function createSendEventCallback(
+	ctx: SendEventContext,
+): SendEventCallback {
+	return async (name, dataJson) => {
+		await hubApiPost<{ ok: true }>({
+			hub: ctx.hub,
+			path: `/events?tenantId=${encodeURIComponent(ctx.tenantId)}`,
+			body: {
+				runId: ctx.runId,
+				workflowId: ctx.workflowId,
+				name,
+				data: JSON.parse(dataJson) as unknown,
+			},
+			parseResponse: (payload) => payload as { ok: true },
+		});
+	};
+}

--- a/packages/corsair/workflows/execute.ts
+++ b/packages/corsair/workflows/execute.ts
@@ -48,6 +48,13 @@ export type AiStepRequest = {
  */
 export type AiStepCallback = (req: AiStepRequest) => Promise<string>;
 
+/** Host capability that emits one event to Hub. `dataJson` is the in-realm-
+ *  serialized event data. Absent when Hub isn't configured. */
+export type SendEventCallback = (
+	name: string,
+	dataJson: string,
+) => Promise<void>;
+
 /**
  * The `step.ai` sub-namespace. Callable for freeform text (`step.ai(name, opts)`),
  * with `.object`/`.enum`/`.bool` for typed inference. Each call is memoized like
@@ -296,6 +303,7 @@ function runWorkflowInSandbox(input: {
 	payload: unknown;
 	step: WorkflowStep;
 	ai: (kind: string, name: string, optsJson: string) => Promise<string>;
+	send: (name: string, dataJson: string) => Promise<void>;
 	timeoutMs: number;
 }): Promise<void> {
 	// Null-proto global object → `globalThis`'s prototype chain can't reach host
@@ -320,7 +328,7 @@ function runWorkflowInSandbox(input: {
 	// Realm-native `step`: built in-realm from host callbacks captured in a closure
 	// (not reachable as properties), so `step.constructor` is the realm's Function.
 	const makeStep = vm.runInContext(
-		`(function (hostRun, hostSleep, hostAi, corsairRef, hostWait) {
+		`(function (hostRun, hostSleep, hostAi, corsairRef, hostWait, hostSend) {
 			const step = function step(name, fn) { return hostRun(name, fn); };
 			step.sleep = function sleep(name, ms) { return hostSleep(name, ms); };
 			// Absolute-time pause: convert to a relative delay and reuse step.sleep so
@@ -373,6 +381,13 @@ function runWorkflowInSandbox(input: {
 			step.waitForEvent = function waitForEvent(name, opts) {
 				return hostWait(name, opts || {});
 			};
+			step.sendEvent = function sendEvent(name, data) {
+				return step(name, function () {
+					return hostSend(name, JSON.stringify(data === undefined ? null : data)).then(function () {
+						return null;
+					});
+				});
+			};
 			return step;
 		})`,
 		context,
@@ -390,6 +405,7 @@ function runWorkflowInSandbox(input: {
 				timeout?: string;
 			},
 		) => Promise<unknown>,
+		hostSend: (name: string, dataJson: string) => Promise<void>,
 	) => WorkflowStep;
 	const realmStep = makeStep(
 		(name, fn) => input.step(name, fn),
@@ -397,6 +413,7 @@ function runWorkflowInSandbox(input: {
 		(kind, name, optsJson) => input.ai(kind, name, optsJson),
 		hardenedCorsair,
 		(name, opts) => input.step.waitForEvent(name, opts),
+		(name, dataJson) => input.send(name, dataJson),
 	);
 
 	// Realm-native forwarding console (methods created in-realm; host sink hidden
@@ -492,6 +509,8 @@ export type ExecuteWorkflowRunInput = {
 	memoizedSteps?: Record<string, { output: unknown }>;
 	/** Runs one `step.ai` inference against Hub. Absent when Hub isn't configured. */
 	ai?: AiStepCallback;
+	/** Emits a `step.sendEvent`. Absent when Hub isn't configured. */
+	sendEvent?: SendEventCallback;
 	/** Max run time (sync + wall-clock) in ms. Defaults to {@link WORKFLOW_TIMEOUT_MS}. */
 	timeoutMs?: number;
 };
@@ -633,6 +652,17 @@ export async function executeWorkflowRun(
 		});
 	};
 
+	const sendBridge = (name: string, dataJson: string): Promise<void> => {
+		if (!input.sendEvent) {
+			return Promise.reject(
+				new Error(
+					'step.sendEvent is unavailable: Hub is not configured for this run',
+				),
+			);
+		}
+		return input.sendEvent(name, dataJson);
+	};
+
 	try {
 		await runWorkflowInSandbox({
 			code: input.code,
@@ -640,6 +670,7 @@ export async function executeWorkflowRun(
 			payload: input.payload,
 			step,
 			ai: aiBridge,
+			send: sendBridge,
 			timeoutMs: input.timeoutMs ?? WORKFLOW_TIMEOUT_MS,
 		});
 		// `main` returned without propagating the interrupt — a try/catch swallowed

--- a/packages/corsair/workflows/execute.ts
+++ b/packages/corsair/workflows/execute.ts
@@ -124,12 +124,18 @@ const FAILED_STEP_MARKER = '__corsairFailedStep';
 // workflows. Promote to a per-run config knob if long workflows land.
 const WORKFLOW_TIMEOUT_MS = 30_000;
 
+// Module-private symbol brands. Never exported, never placed on a global, so
+// sandbox code has no reference to them — it can't fabricate a branded object to
+// forge a durable interrupt (an ordinary `throw { ... }` stays a failed run).
+const SLEEP_BRAND = Symbol('corsairSleep');
+const WAIT_BRAND = Symbol('corsairWait');
+
 /**
  * Thrown by `step.sleep` to unwind `main` at the sleep boundary. Not an Error, so
  * workflow `try/catch` around real work won't accidentally swallow it.
  */
 class SleepInterrupt {
-	readonly __corsairSleep = true as const;
+	readonly [SLEEP_BRAND] = true;
 	constructor(
 		readonly wakeAt: number,
 		readonly stepName: string,
@@ -140,7 +146,7 @@ function isSleepInterrupt(value: unknown): value is SleepInterrupt {
 	return (
 		typeof value === 'object' &&
 		value !== null &&
-		(value as { __corsairSleep?: unknown }).__corsairSleep === true
+		(value as Record<PropertyKey, unknown>)[SLEEP_BRAND] === true
 	);
 }
 
@@ -167,7 +173,7 @@ export function parseDurationMs(s: string): number {
 /** Thrown by `step.waitForEvent` to unwind `main` at the wait boundary. Mirrors
  *  {@link SleepInterrupt}; not an Error so workflow try/catch won't swallow it. */
 class WaitInterrupt {
-	readonly __corsairWait = true as const;
+	readonly [WAIT_BRAND] = true;
 	constructor(
 		readonly stepId: string,
 		readonly stepName: string,
@@ -182,7 +188,7 @@ function isWaitInterrupt(value: unknown): value is WaitInterrupt {
 	return (
 		typeof value === 'object' &&
 		value !== null &&
-		(value as { __corsairWait?: unknown }).__corsairWait === true
+		(value as Record<PropertyKey, unknown>)[WAIT_BRAND] === true
 	);
 }
 

--- a/packages/corsair/workflows/execute.ts
+++ b/packages/corsair/workflows/execute.ts
@@ -98,6 +98,17 @@ export interface WorkflowStep {
 	 * that shares the op id with `step.ai`'s `returnObject`.
 	 */
 	corsair<T = unknown>(name: string, op: string, input?: unknown): Promise<T>;
+	/**
+	 * Durably suspends until a matching event arrives or `timeout` elapses.
+	 * Resolves to the event `{ name, data }` on a match, or `null` on timeout.
+	 * `match` is dot-path → value equalities against the event, all ANDed.
+	 */
+	waitForEvent<T = { name: string; data: unknown }>(
+		name: string,
+		opts: { event: string; match?: Record<string, unknown>; timeout?: string },
+	): Promise<T | null>;
+	/** Emits an event into the shared stream (durable, memoized like step.run). */
+	sendEvent(name: string, data: unknown): Promise<void>;
 }
 
 const FAILED_STEP_MARKER = '__corsairFailedStep';
@@ -123,6 +134,48 @@ function isSleepInterrupt(value: unknown): value is SleepInterrupt {
 		typeof value === 'object' &&
 		value !== null &&
 		(value as { __corsairSleep?: unknown }).__corsairSleep === true
+	);
+}
+
+/** Parses a duration string (`'30s'|'5m'|'8h'|'1d'`) to ms. Throws on garbage
+ *  so a malformed timeout surfaces as a failed step, not a silent forever-wait. */
+export function parseDurationMs(s: string): number {
+	const m = /^(\d+)(s|m|h|d)$/.exec(s.trim());
+	if (!m)
+		throw new Error(
+			`Invalid timeout "${s}": expected like "30s", "5m", "8h", "1d"`,
+		);
+	const n = Number(m[1]);
+	const factor =
+		m[2] === 's'
+			? 1_000
+			: m[2] === 'm'
+				? 60_000
+				: m[2] === 'h'
+					? 3_600_000
+					: 86_400_000;
+	return n * factor;
+}
+
+/** Thrown by `step.waitForEvent` to unwind `main` at the wait boundary. Mirrors
+ *  {@link SleepInterrupt}; not an Error so workflow try/catch won't swallow it. */
+class WaitInterrupt {
+	readonly __corsairWait = true as const;
+	constructor(
+		readonly stepId: string,
+		readonly stepName: string,
+		readonly seq: number,
+		readonly event: string,
+		readonly match: Record<string, unknown> | null,
+		readonly timeoutAt: string | null,
+	) {}
+}
+
+function isWaitInterrupt(value: unknown): value is WaitInterrupt {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		(value as { __corsairWait?: unknown }).__corsairWait === true
 	);
 }
 
@@ -267,7 +320,7 @@ function runWorkflowInSandbox(input: {
 	// Realm-native `step`: built in-realm from host callbacks captured in a closure
 	// (not reachable as properties), so `step.constructor` is the realm's Function.
 	const makeStep = vm.runInContext(
-		`(function (hostRun, hostSleep, hostAi, corsairRef) {
+		`(function (hostRun, hostSleep, hostAi, corsairRef, hostWait) {
 			const step = function step(name, fn) { return hostRun(name, fn); };
 			step.sleep = function sleep(name, ms) { return hostSleep(name, ms); };
 			// Absolute-time pause: convert to a relative delay and reuse step.sleep so
@@ -317,6 +370,9 @@ function runWorkflowInSandbox(input: {
 			ai.enum = verb('enum');
 			ai.bool = verb('bool');
 			step.ai = ai;
+			step.waitForEvent = function waitForEvent(name, opts) {
+				return hostWait(name, opts || {});
+			};
 			return step;
 		})`,
 		context,
@@ -326,12 +382,21 @@ function runWorkflowInSandbox(input: {
 		hostSleep: (name: string, ms: number) => Promise<void>,
 		hostAi: (kind: string, name: string, optsJson: string) => Promise<string>,
 		corsairRef: unknown,
+		hostWait: (
+			name: string,
+			opts: {
+				event: string;
+				match?: Record<string, unknown>;
+				timeout?: string;
+			},
+		) => Promise<unknown>,
 	) => WorkflowStep;
 	const realmStep = makeStep(
 		(name, fn) => input.step(name, fn),
 		(name, ms) => input.step.sleep(name, ms),
 		(kind, name, optsJson) => input.ai(kind, name, optsJson),
 		hardenedCorsair,
+		(name, opts) => input.step.waitForEvent(name, opts),
 	);
 
 	// Realm-native forwarding console (methods created in-realm; host sink hidden
@@ -444,11 +509,13 @@ export async function executeWorkflowRun(
 	// Set once step.sleep unwinds. If workflow-level try/catch swallows the throw,
 	// this lets the pause re-assert itself instead of silently continuing.
 	let pendingSleep: SleepInterrupt | null = null;
+	let pendingWait: WaitInterrupt | null = null;
 
 	const step = (async <T>(name: string, fn: () => Promise<T>): Promise<T> => {
-		// A prior sleep unwound but was swallowed — re-throw rather than run more
+		// A prior sleep/wait unwound but was swallowed — re-throw rather than run more
 		// work this attempt.
 		if (pendingSleep) throw pendingSleep;
+		if (pendingWait) throw pendingWait;
 		const current = seq++;
 		const stepId = computeStepId(name, current);
 
@@ -466,6 +533,7 @@ export async function executeWorkflowRun(
 			return output;
 		} catch (err) {
 			if (isSleepInterrupt(err)) throw err;
+			if (isWaitInterrupt(err)) throw err;
 			const message = toMessage(err);
 			steps.push({
 				stepId,
@@ -483,6 +551,7 @@ export async function executeWorkflowRun(
 
 	step.sleep = async (name: string, ms: number): Promise<void> => {
 		if (pendingSleep) throw pendingSleep;
+		if (pendingWait) throw pendingWait;
 		const current = seq++;
 		const stepId = computeStepId(name, current);
 		// Already slept on a prior attempt — the pause is satisfied, continue.
@@ -502,6 +571,35 @@ export async function executeWorkflowRun(
 		pendingSleep = new SleepInterrupt(Date.now() + delay, name);
 		throw pendingSleep;
 	};
+
+	step.waitForEvent = (async (
+		name: string,
+		opts: { event: string; match?: Record<string, unknown>; timeout?: string },
+	): Promise<unknown> => {
+		if (pendingSleep) throw pendingSleep;
+		if (pendingWait) throw pendingWait;
+		const current = seq++;
+		const stepId = computeStepId(name, current);
+		// Replay: Hub injected the matched event (or null on timeout) as this step's
+		// memoized output. Harden so the sandbox gets a safe view.
+		if (Object.hasOwn(memo, stepId)) {
+			return harden(memo[stepId]!.output ?? null, undefined);
+		}
+		// First encounter: no completed step is recorded (its output isn't known
+		// yet — Hub records it on resolution). Unwind with the waiter descriptor.
+		const timeoutAt = opts.timeout
+			? new Date(Date.now() + parseDurationMs(opts.timeout)).toISOString()
+			: null;
+		pendingWait = new WaitInterrupt(
+			stepId,
+			name,
+			current,
+			opts.event,
+			opts.match ?? null,
+			timeoutAt,
+		);
+		throw pendingWait;
+	}) as WorkflowStep['waitForEvent'];
 
 	// Bridges the realm's `step.ai` to the host `ai` capability: parse the
 	// in-realm-serialized opts and run one inference. Rejects clearly when Hub
@@ -555,6 +653,8 @@ export async function executeWorkflowRun(
 				sleepUntil: new Date(swallowed.wakeAt).toISOString(),
 			};
 		}
+		const swallowedWait = pendingWait as WaitInterrupt | null;
+		if (swallowedWait) return waitingResult(steps, swallowedWait);
 		return { status: 'completed', steps };
 	} catch (err) {
 		if (isSleepInterrupt(err)) {
@@ -564,6 +664,7 @@ export async function executeWorkflowRun(
 				sleepUntil: new Date(err.wakeAt).toISOString(),
 			};
 		}
+		if (isWaitInterrupt(err)) return waitingResult(steps, err);
 		const message = toMessage(err);
 		const failedStep =
 			err !== null && typeof err === 'object'
@@ -577,4 +678,22 @@ export async function executeWorkflowRun(
 			error: { message, ...(failedStep ? { failedStep } : {}) },
 		};
 	}
+}
+
+function waitingResult(
+	steps: RunStepResult[],
+	w: WaitInterrupt,
+): RunResultPayload {
+	return {
+		status: 'waiting',
+		steps,
+		waiter: {
+			stepId: w.stepId,
+			name: w.stepName,
+			seq: w.seq,
+			event: w.event,
+			match: w.match,
+			timeoutAt: w.timeoutAt,
+		},
+	};
 }


### PR DESCRIPTION
Adds the two coordinate primitives to the step library.

Stacked on #670 (base `feat/step-ai`). Retarget to `main` after #670 merges.

## What
- **`step.waitForEvent(name, { event, match?, timeout? })`** — durable pause until a matching event arrives, or `null` on timeout. Unwinds via `WaitInterrupt` (branded non-Error, mirrors `SleepInterrupt`); executor returns `status: 'waiting'` + a `WaiterDescriptor`. On resume the injected event is the memoized step output.
- **`step.sendEvent(name, data)`** — emit into the stream. Host capability POSTing the Hub `/events`; memoized so replay never re-emits.
- Contract: `'waiting'` on `RunResultPayload.status`, `'event'` on `RunTriggerType`, `WaiterDescriptor` type.

## Tests
- e2e two-phase: suspend → inject event → replay past the wait, plus the timeout→null branch.
- suite green (395 pass; 16 postgres-env, 4 skip).

Hub side: corsairdev/hub#63.