### PR TITLE
feat(ocrspace): add OCR.space integration

### DIFF
--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -87,6 +87,7 @@ export const BaseProviders = [
 	'monday',
 	'neon',
 	'notion',
+	'ocrspace',
 	'ollama',
 	'onedrive',
 	'onepassword',
@@ -207,6 +208,7 @@ export const ProviderDisplayNames = {
 	monday: 'Monday',
 	neon: 'Neon',
 	notion: 'Notion',
+	ocrspace: 'OCR.space',
 	ollama: 'Ollama',
 	onedrive: 'OneDrive',
 	onepassword: '1Password',
@@ -334,6 +336,7 @@ export type AllProviders =
 	| 'monday'
 	| 'neon'
 	| 'notion'
+	| 'ocrspace'
 	| 'ollama'
 	| 'onedrive'
 	| 'onepassword'

--- a/packages/ocrspace/api.test.ts
+++ b/packages/ocrspace/api.test.ts
@@ -381,6 +381,16 @@ describe('assertOcrSuccess', () => {
 			}),
 		).toThrow(/Page two timed out/);
 	});
+
+	it('throws on a structurally empty response', () => {
+		expect(() => assertOcrSuccess({})).toThrow(OcrSpaceAPIError);
+		expect(() =>
+			assertOcrSuccess({
+				SearchablePDFURL:
+					'Searchable PDF not generated as it was not requested.',
+			}),
+		).toThrow(OcrSpaceAPIError);
+	});
 });
 
 describe('flattenOcrErrorMessage', () => {

--- a/packages/ocrspace/api.test.ts
+++ b/packages/ocrspace/api.test.ts
@@ -18,6 +18,7 @@ import {
 	OcrSpaceEndpointOutputSchemas,
 } from './endpoints/types';
 import { errorHandlers } from './error-handlers';
+import { ocrspace } from './index';
 
 const TEST_API_KEY = process.env.OCRSPACE_API_KEY ?? '';
 const describeIfApiKey = TEST_API_KEY ? describe : describe.skip;
@@ -422,6 +423,25 @@ describe('error handler classification', () => {
 
 		expect(zodError).toBeDefined();
 		expect(classify(zodError as Error)).toBe('VALIDATION_ERROR');
+	});
+
+	it('keeps DEFAULT last so caller-supplied handlers stay reachable', () => {
+		// handleCorsairError picks the first matching key in insertion order and
+		// DEFAULT matches everything, so DEFAULT must sort last after a merge.
+		const plugin = ocrspace({
+			errorHandlers: {
+				CUSTOM_ERROR: {
+					match: (error: Error) => error.message.includes('custom'),
+					handler: async () => ({ maxRetries: 7 }),
+				},
+			},
+		});
+
+		expect(plugin.errorHandlers).toBeDefined();
+		const keys = Object.keys(plugin.errorHandlers ?? {});
+		expect(keys).toContain('CUSTOM_ERROR');
+		expect(keys.indexOf('CUSTOM_ERROR')).toBeLessThan(keys.indexOf('DEFAULT'));
+		expect(keys[keys.length - 1]).toBe('DEFAULT');
 	});
 
 	it('falls back to DEFAULT for an unrecognised error', () => {

--- a/packages/ocrspace/api.test.ts
+++ b/packages/ocrspace/api.test.ts
@@ -88,6 +88,24 @@ describe('OCR.space input schemas', () => {
 		).not.toThrow();
 	});
 
+	it('rejects "auto" on engine 1, which the provider does not support', () => {
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parseImageUrl.parse({
+				url: 'https://example.com/receipt.jpg',
+				language: 'auto',
+				OCREngine: 1,
+			}),
+		).toThrow(/OCREngine 2 or 3/);
+
+		// Omitted OCREngine defaults to 1 on the wire.
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parse.parse({
+				url: 'https://example.com/receipt.jpg',
+				language: 'auto',
+			}),
+		).toThrow(/OCREngine 2 or 3/);
+	});
+
 	it('rejects an OCR engine outside 1-3', () => {
 		expect(() =>
 			OcrSpaceEndpointInputSchemas.parseImageUrl.parse({
@@ -350,6 +368,19 @@ describe('assertOcrSuccess', () => {
 			}),
 		).toThrow(/Unsupported file type/);
 	});
+
+	it('uses a later page error when page 0 has none', () => {
+		expect(() =>
+			assertOcrSuccess({
+				OCRExitCode: 3,
+				IsErroredOnProcessing: true,
+				ParsedResults: [
+					{ FileParseExitCode: 1, ParsedText: 'ok' },
+					{ FileParseExitCode: -10, ErrorMessage: 'Page two timed out' },
+				],
+			}),
+		).toThrow(/Page two timed out/);
+	});
 });
 
 describe('flattenOcrErrorMessage', () => {
@@ -381,6 +412,20 @@ describe('error handler classification', () => {
 		return new OcrSpaceAPIError(message, { ocrExitCode: exitCode });
 	}
 
+	function httpError(
+		status: number,
+		message: string,
+		body?: unknown,
+	): Error & { status: number; body?: unknown } {
+		const error = new Error(message) as Error & {
+			status: number;
+			body?: unknown;
+		};
+		error.status = status;
+		error.body = body;
+		return error;
+	}
+
 	it('treats a daily quota message as a rate limit', () => {
 		expect(
 			classify(
@@ -389,6 +434,39 @@ describe('error handler classification', () => {
 				),
 			),
 		).toBe('RATE_LIMIT_ERROR');
+	});
+
+	it('treats HTTP 403 throttle as a rate limit, not a bad API key', () => {
+		// OCR.space throttling is HTTP 403. The transport sets message to
+		// "Forbidden"; the real phrase lives on the body.
+		expect(
+			classify(
+				httpError(
+					403,
+					'Forbidden',
+					'You may only perform this action upto maximum 10 number of times within 600 seconds',
+				),
+			),
+		).toBe('RATE_LIMIT_ERROR');
+
+		expect(classify(httpError(403, 'Forbidden'))).toBe('RATE_LIMIT_ERROR');
+	});
+
+	it('does not treat HTTP 403 as an auth failure', () => {
+		expect(classify(httpError(403, 'Forbidden'))).not.toBe('AUTH_ERROR');
+		expect(classify(httpError(401, 'Unauthorized'))).toBe('AUTH_ERROR');
+	});
+
+	it('does not retry a monthly conversion limit as a rate limit', () => {
+		expect(classify(bodyError('Monthly conversion limit reached'))).toBe(
+			'BAD_REQUEST_ERROR',
+		);
+	});
+
+	it('does not treat a "429" buried in a file-size message as a rate limit', () => {
+		expect(
+			classify(bodyError('File size 429kb exceeds the maximum allowed')),
+		).toBe('BAD_REQUEST_ERROR');
 	});
 
 	it('does not treat a file size rejection as a rate limit', () => {

--- a/packages/ocrspace/api.test.ts
+++ b/packages/ocrspace/api.test.ts
@@ -150,6 +150,43 @@ describe('OCR.space input schemas', () => {
 		).toThrow(/data URI prefix/);
 	});
 
+	it('rejects an empty or non-base64 payload after the data URI prefix', () => {
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parse.parse({
+				base64Image: 'data:image/png;base64,',
+			}),
+		).toThrow();
+
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parse.parse({
+				base64Image: 'data:image/png;base64,not-valid!!!',
+			}),
+		).toThrow();
+	});
+
+	it('accepts a typed Blob without filetype', () => {
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parse.parse({
+				file: new Blob(['x'], { type: 'image/png' }),
+			}),
+		).not.toThrow();
+	});
+
+	it('rejects an untyped Blob unless filetype is set', () => {
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parse.parse({
+				file: new Blob(['x']),
+			}),
+		).toThrow(/filetype/);
+
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parse.parse({
+				file: new Blob(['x']),
+				filetype: 'PNG',
+			}),
+		).not.toThrow();
+	});
+
 	it('rejects engine 3 combined with searchable PDF output', () => {
 		expect(() =>
 			OcrSpaceEndpointInputSchemas.parse.parse({
@@ -390,6 +427,25 @@ describe('assertOcrSuccess', () => {
 					'Searchable PDF not generated as it was not requested.',
 			}),
 		).toThrow(OcrSpaceAPIError);
+	});
+
+	it('throws when a success exit code has no parsed pages', () => {
+		expect(() => assertOcrSuccess({ OCRExitCode: 1 })).toThrow(
+			OcrSpaceAPIError,
+		);
+		expect(() =>
+			assertOcrSuccess({ OCRExitCode: 2, ParsedResults: [] }),
+		).toThrow(OcrSpaceAPIError);
+	});
+
+	it('allows a successful OCR with empty page text', () => {
+		expect(() =>
+			assertOcrSuccess({
+				OCRExitCode: 1,
+				IsErroredOnProcessing: false,
+				ParsedResults: [{ ParsedText: '', FileParseExitCode: 1 }],
+			}),
+		).not.toThrow();
 	});
 });
 

--- a/packages/ocrspace/api.test.ts
+++ b/packages/ocrspace/api.test.ts
@@ -162,12 +162,26 @@ describe('OCR.space input schemas', () => {
 				base64Image: 'data:image/png;base64,not-valid!!!',
 			}),
 		).toThrow();
+
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parse.parse({
+				base64Image: 'data:image/png;base64,A',
+			}),
+		).toThrow();
 	});
 
 	it('accepts a typed Blob without filetype', () => {
 		expect(() =>
 			OcrSpaceEndpointInputSchemas.parse.parse({
 				file: new Blob(['x'], { type: 'image/png' }),
+			}),
+		).not.toThrow();
+	});
+
+	it('accepts a File with a filename and no MIME type', () => {
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parse.parse({
+				file: new File(['x'], 'scan.png'),
 			}),
 		).not.toThrow();
 	});
@@ -438,6 +452,26 @@ describe('assertOcrSuccess', () => {
 		).toThrow(OcrSpaceAPIError);
 	});
 
+	it('throws when every parsed page failed', () => {
+		expect(() =>
+			assertOcrSuccess({
+				OCRExitCode: 1,
+				ParsedResults: [
+					{ FileParseExitCode: -10, ErrorMessage: 'Parse failed' },
+				],
+			}),
+		).toThrow(OcrSpaceAPIError);
+		expect(() =>
+			assertOcrSuccess({
+				OCRExitCode: 2,
+				ParsedResults: [
+					{ FileParseExitCode: -20, ErrorMessage: 'Timed out' },
+					{ FileParseExitCode: -30, ErrorMessage: 'Invalid file' },
+				],
+			}),
+		).toThrow(OcrSpaceAPIError);
+	});
+
 	it('allows a successful OCR with empty page text', () => {
 		expect(() =>
 			assertOcrSuccess({
@@ -592,14 +626,12 @@ describe('error handler classification', () => {
 		expect(classify(new Error('something unexpected'))).toBe('DEFAULT');
 	});
 
-	it('retries rate limits but never auth failures', async () => {
+	it('does not stack handler retries on transport retries', async () => {
 		// The auth handler logs by design; silence it so the suite output stays
 		// clean rather than showing what looks like a failure.
 		const logged = jest.spyOn(console, 'error').mockImplementation(() => {});
 		const authError = bodyError('invalid api key');
-		const rateLimit = await errorHandlers.RATE_LIMIT_ERROR.handler(
-			bodyError('daily limit reached'),
-		);
+		const rateLimit = await errorHandlers.RATE_LIMIT_ERROR.handler();
 		const auth = await errorHandlers.AUTH_ERROR.handler(authError, {
 			pluginId: 'ocrspace',
 			operation: 'ocr.parse',
@@ -607,7 +639,7 @@ describe('error handler classification', () => {
 			originalError: authError,
 		});
 
-		expect(rateLimit.maxRetries).toBeGreaterThan(0);
+		expect(rateLimit.maxRetries).toBe(0);
 		expect(auth.maxRetries).toBe(0);
 		expect(logged).toHaveBeenCalled();
 		logged.mockRestore();

--- a/packages/ocrspace/api.test.ts
+++ b/packages/ocrspace/api.test.ts
@@ -1,0 +1,491 @@
+import {
+	assertOcrSuccess,
+	flattenOcrErrorMessage,
+	makeOcrSpaceGetRequest,
+	makeOcrSpacePostRequest,
+	OCRSPACE_MYAPI_BASE,
+	OcrSpaceAPIError,
+} from './client';
+import { isSearchablePdfUrl } from './endpoints/parse';
+import type {
+	ConversionsResponse,
+	OcrResponse,
+	ParseImageUrlResponse,
+	ParseResponse,
+} from './endpoints/types';
+import {
+	OcrSpaceEndpointInputSchemas,
+	OcrSpaceEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+
+const TEST_API_KEY = process.env.OCRSPACE_API_KEY ?? '';
+const describeIfApiKey = TEST_API_KEY ? describe : describe.skip;
+
+const PNG_BASE64 =
+	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+const SUCCESS_RESPONSE: OcrResponse = {
+	ParsedResults: [
+		{
+			ParsedText: 'Hello world',
+			FileParseExitCode: 1,
+			TextOverlay: {
+				Lines: [
+					{
+						LineText: 'Hello world',
+						Words: [
+							{ WordText: 'Hello', Left: 10, Top: 20, Height: 15, Width: 40 },
+						],
+						MaxHeight: 15,
+						MinTop: 20,
+					},
+				],
+				HasOverlay: true,
+				Message: null,
+			},
+			ErrorMessage: null,
+			ErrorDetails: null,
+		},
+	],
+	OCRExitCode: 1,
+	IsErroredOnProcessing: false,
+	ErrorMessage: null,
+	ErrorDetails: null,
+	ProcessingTimeInMilliseconds: '231',
+};
+
+describe('OCR.space input schemas', () => {
+	it('accepts a valid parseImageUrl input', () => {
+		const parsed = OcrSpaceEndpointInputSchemas.parseImageUrl.parse({
+			url: 'https://example.com/receipt.jpg',
+			language: 'eng',
+			OCREngine: 2,
+			isTable: true,
+		});
+
+		expect(parsed.url).toBe('https://example.com/receipt.jpg');
+		expect(parsed.OCREngine).toBe(2);
+	});
+
+	it('rejects a two-letter language code', () => {
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parseImageUrl.parse({
+				url: 'https://example.com/receipt.jpg',
+				language: 'en',
+			}),
+		).toThrow(/three-letter/);
+	});
+
+	it('accepts "auto" as a language', () => {
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parseImageUrl.parse({
+				url: 'https://example.com/receipt.jpg',
+				language: 'auto',
+				OCREngine: 3,
+			}),
+		).not.toThrow();
+	});
+
+	it('rejects an OCR engine outside 1-3', () => {
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parseImageUrl.parse({
+				url: 'https://example.com/receipt.jpg',
+				OCREngine: 4,
+			}),
+		).toThrow();
+	});
+
+	it('accepts exactly one parse source', () => {
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parse.parse({
+				url: 'https://example.com/receipt.jpg',
+			}),
+		).not.toThrow();
+
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parse.parse({ base64Image: PNG_BASE64 }),
+		).not.toThrow();
+	});
+
+	it('rejects a parse call with no source', () => {
+		expect(() => OcrSpaceEndpointInputSchemas.parse.parse({})).toThrow(
+			/exactly one of url, file, or base64Image/,
+		);
+	});
+
+	it('rejects a parse call with two sources', () => {
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parse.parse({
+				url: 'https://example.com/receipt.jpg',
+				base64Image: PNG_BASE64,
+			}),
+		).toThrow(/exactly one of url, file, or base64Image/);
+	});
+
+	it('rejects a base64 payload without the data URI prefix', () => {
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parse.parse({
+				base64Image: 'iVBORw0KGgoAAAANSUhEUg==',
+			}),
+		).toThrow(/data URI prefix/);
+	});
+
+	it('rejects engine 3 combined with searchable PDF output', () => {
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parse.parse({
+				url: 'https://example.com/scan.pdf',
+				OCREngine: 3,
+				isCreateSearchablePdf: true,
+			}),
+		).toThrow(/does not support isCreateSearchablePdf/);
+
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parseImageUrl.parse({
+				url: 'https://example.com/scan.pdf',
+				OCREngine: 3,
+				isCreateSearchablePdf: true,
+			}),
+		).toThrow(/does not support isCreateSearchablePdf/);
+	});
+
+	it('allows engine 2 with searchable PDF output', () => {
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.parse.parse({
+				url: 'https://example.com/scan.pdf',
+				OCREngine: 2,
+				isCreateSearchablePdf: true,
+			}),
+		).not.toThrow();
+	});
+
+	it('accepts the documented conversions input', () => {
+		expect(
+			OcrSpaceEndpointInputSchemas.conversions.parse({ startDate: 'lastMonth' })
+				.startDate,
+		).toBe('lastMonth');
+
+		expect(() =>
+			OcrSpaceEndpointInputSchemas.conversions.parse({
+				startDate: 'lastmonth',
+			}),
+		).toThrow();
+	});
+});
+
+describe('OCR.space response schemas', () => {
+	it('parses a successful response including the text overlay', () => {
+		const parsed = OcrSpaceEndpointOutputSchemas.parse.parse(SUCCESS_RESPONSE);
+
+		expect(parsed.OCRExitCode).toBe(1);
+		expect(parsed.ParsedResults?.[0]?.ParsedText).toBe('Hello world');
+		expect(
+			parsed.ParsedResults?.[0]?.TextOverlay?.Lines?.[0]?.Words?.[0],
+		).toEqual({ WordText: 'Hello', Left: 10, Top: 20, Height: 15, Width: 40 });
+		expect(parsed.ParsedResults?.[0]?.TextOverlay?.Lines?.[0]?.LineText).toBe(
+			'Hello world',
+		);
+	});
+
+	it('keeps unknown provider fields instead of stripping them', () => {
+		const parsed = OcrSpaceEndpointOutputSchemas.parse.parse({
+			...SUCCESS_RESPONSE,
+			SomeNewField: 'kept',
+		});
+
+		expect(parsed.SomeNewField).toBe('kept');
+	});
+
+	it('parses an ErrorMessage supplied as an array', () => {
+		const parsed = OcrSpaceEndpointOutputSchemas.parse.parse({
+			OCRExitCode: 3,
+			IsErroredOnProcessing: true,
+			ErrorMessage: ['File failed to load', 'Retry with a smaller file'],
+		});
+
+		expect(Array.isArray(parsed.ErrorMessage)).toBe(true);
+	});
+
+	it('parses a conversions response using the live field names', () => {
+		const parsed = OcrSpaceEndpointOutputSchemas.conversions.parse({
+			count_total: 165,
+			count_engine1: 120,
+			count_engine2: 45,
+			count_engine3: 0,
+		});
+
+		expect(parsed.count_total).toBe(165);
+		expect(parsed.count_engine3).toBe(0);
+	});
+
+	it('keeps unknown fields nested inside ParsedResults', () => {
+		// Nested objects are loose too — `TextOrientation` was a real field that
+		// a strict nested schema would have silently dropped.
+		const parsed = OcrSpaceEndpointOutputSchemas.parse.parse({
+			ParsedResults: [{ ParsedText: 'x', SomeFutureField: 'kept' }],
+			OCRExitCode: 1,
+		});
+
+		expect(parsed.ParsedResults?.[0]?.SomeFutureField).toBe('kept');
+	});
+
+	it('parses the TextOrientation field returned by the provider', () => {
+		const parsed = OcrSpaceEndpointOutputSchemas.parse.parse({
+			ParsedResults: [
+				{ ParsedText: 'x', TextOrientation: '0', FileParseExitCode: 1 },
+			],
+			OCRExitCode: 1,
+			IsErroredOnProcessing: false,
+		});
+
+		expect(parsed.ParsedResults?.[0]?.TextOrientation).toBe('0');
+	});
+});
+
+describe('isSearchablePdfUrl', () => {
+	it('recognises a real searchable PDF link', () => {
+		expect(
+			isSearchablePdfUrl('https://pdf-78.ocr.space/SearchablePDF/abc.pdf'),
+		).toBe(true);
+	});
+
+	it('rejects the placeholder sentence the provider sends otherwise', () => {
+		// SearchablePDFURL is always populated, so a truthiness check would
+		// wrongly record every parse as having produced a searchable PDF.
+		expect(
+			isSearchablePdfUrl(
+				'Searchable PDF not generated as it was not requested.',
+			),
+		).toBe(false);
+		expect(isSearchablePdfUrl(undefined)).toBe(false);
+	});
+});
+
+describe('assertOcrSuccess', () => {
+	it('passes a successful response through', () => {
+		expect(() => assertOcrSuccess(SUCCESS_RESPONSE)).not.toThrow();
+	});
+
+	it('throws when the provider flags an error on a HTTP 200 response', () => {
+		expect(() =>
+			assertOcrSuccess({
+				OCRExitCode: 3,
+				IsErroredOnProcessing: true,
+				ErrorMessage: 'File size exceeds the maximum allowed',
+			}),
+		).toThrow(OcrSpaceAPIError);
+	});
+
+	it('carries the provider message and exit code on the thrown error', () => {
+		try {
+			assertOcrSuccess({
+				OCRExitCode: 4,
+				IsErroredOnProcessing: true,
+				ErrorMessage: ['Fatal parsing failure'],
+			});
+			throw new Error('assertOcrSuccess should have thrown');
+		} catch (error) {
+			expect(error).toBeInstanceOf(OcrSpaceAPIError);
+			expect((error as OcrSpaceAPIError).message).toBe('Fatal parsing failure');
+			expect((error as OcrSpaceAPIError).ocrExitCode).toBe(4);
+			expect((error as OcrSpaceAPIError).status).toBeUndefined();
+		}
+	});
+
+	it('allows a partial success through so parsed pages are not discarded', () => {
+		const partial: OcrResponse = {
+			OCRExitCode: 2,
+			IsErroredOnProcessing: false,
+			ParsedResults: [
+				{ ParsedText: 'page one', FileParseExitCode: 1 },
+				{ ParsedText: '', FileParseExitCode: -10 },
+			],
+		};
+
+		expect(() => assertOcrSuccess(partial)).not.toThrow();
+		expect(partial.ParsedResults?.[0]?.ParsedText).toBe('page one');
+	});
+
+	it('falls back to the per-page error message when the top level has none', () => {
+		expect(() =>
+			assertOcrSuccess({
+				OCRExitCode: 3,
+				IsErroredOnProcessing: true,
+				ParsedResults: [
+					{ FileParseExitCode: -30, ErrorMessage: 'Unsupported file type' },
+				],
+			}),
+		).toThrow(/Unsupported file type/);
+	});
+});
+
+describe('flattenOcrErrorMessage', () => {
+	it('joins an array of messages', () => {
+		expect(flattenOcrErrorMessage(['one', 'two'])).toBe('one two');
+	});
+
+	it('returns undefined for empty input', () => {
+		expect(flattenOcrErrorMessage(null)).toBeUndefined();
+		expect(flattenOcrErrorMessage([])).toBeUndefined();
+	});
+});
+
+describe('error handler classification', () => {
+	// Mirrors how the framework picks a handler: first matching key wins, so
+	// this also covers the ordering between the handlers.
+	function classify(error: Error): string {
+		for (const [name, handler] of Object.entries(errorHandlers)) {
+			if (handler.match(error)) {
+				return name;
+			}
+		}
+		return 'NONE';
+	}
+
+	// Failures reported inside a HTTP 200 body arrive with no status attached,
+	// so they can only be classified from the message text.
+	function bodyError(message: string, exitCode = 3): OcrSpaceAPIError {
+		return new OcrSpaceAPIError(message, { ocrExitCode: exitCode });
+	}
+
+	it('treats a daily quota message as a rate limit', () => {
+		expect(
+			classify(
+				bodyError(
+					'You may only perform this action upto maximum 500 number of times within 86400 seconds',
+				),
+			),
+		).toBe('RATE_LIMIT_ERROR');
+	});
+
+	it('does not treat a file size rejection as a rate limit', () => {
+		// "maximum" appears in both quota and file-size messages; only the
+		// former may be retried, since retrying an oversized file just burns
+		// more conversions.
+		const classification = classify(
+			bodyError('File size exceeds the maximum allowed'),
+		);
+
+		expect(classification).not.toBe('RATE_LIMIT_ERROR');
+		expect(classification).toBe('BAD_REQUEST_ERROR');
+	});
+
+	it('classifies any other provider-level parse failure as a bad request', () => {
+		expect(classify(bodyError('Unable to recognize the file type'))).toBe(
+			'BAD_REQUEST_ERROR',
+		);
+	});
+
+	it('classifies an invalid key as an auth error', () => {
+		expect(classify(bodyError('The API key is invalid', 3))).toBe('AUTH_ERROR');
+	});
+
+	it('classifies a zod validation failure without retrying it', () => {
+		let zodError: Error | undefined;
+		try {
+			OcrSpaceEndpointInputSchemas.parse.parse({});
+		} catch (error) {
+			zodError = error as Error;
+		}
+
+		expect(zodError).toBeDefined();
+		expect(classify(zodError as Error)).toBe('VALIDATION_ERROR');
+	});
+
+	it('falls back to DEFAULT for an unrecognised error', () => {
+		expect(classify(new Error('something unexpected'))).toBe('DEFAULT');
+	});
+
+	it('retries rate limits but never auth failures', async () => {
+		// The auth handler logs by design; silence it so the suite output stays
+		// clean rather than showing what looks like a failure.
+		const logged = jest.spyOn(console, 'error').mockImplementation(() => {});
+		const authError = bodyError('invalid api key');
+		const rateLimit = await errorHandlers.RATE_LIMIT_ERROR.handler(
+			bodyError('daily limit reached'),
+		);
+		const auth = await errorHandlers.AUTH_ERROR.handler(authError, {
+			pluginId: 'ocrspace',
+			operation: 'ocr.parse',
+			input: {},
+			originalError: authError,
+		});
+
+		expect(rateLimit.maxRetries).toBeGreaterThan(0);
+		expect(auth.maxRetries).toBe(0);
+		expect(logged).toHaveBeenCalled();
+		logged.mockRestore();
+	});
+});
+
+describeIfApiKey('OCR.space API type tests', () => {
+	it('parseImageUrl returns the expected shape', async () => {
+		const response = await makeOcrSpaceGetRequest<ParseImageUrlResponse>(
+			'/parse/imageurl',
+			TEST_API_KEY,
+			{
+				query: {
+					url: 'https://dl.a9t9.com/ocr/solarcell.jpg',
+					language: 'eng',
+					OCREngine: 2,
+				},
+			},
+		);
+
+		OcrSpaceEndpointOutputSchemas.parseImageUrl.parse(response);
+		expect(response.OCRExitCode).toBe(1);
+		expect(response.ParsedResults?.length).toBeGreaterThan(0);
+	});
+
+	it('parse extracts text from a URL over the POST endpoint', async () => {
+		const response = await makeOcrSpacePostRequest<ParseResponse>(
+			'/parse/image',
+			TEST_API_KEY,
+			{
+				formData: {
+					url: 'https://dl.a9t9.com/ocr/solarcell.jpg',
+					OCREngine: 2,
+				},
+			},
+		);
+
+		OcrSpaceEndpointOutputSchemas.parse.parse(response);
+		expect(response.OCRExitCode).toBe(1);
+		expect(response.ParsedResults?.[0]?.ParsedText).toContain('Solar cell');
+	});
+
+	it('parse accepts a base64 data URI', async () => {
+		const response = await makeOcrSpacePostRequest<ParseResponse>(
+			'/parse/image',
+			TEST_API_KEY,
+			{ formData: { base64Image: PNG_BASE64 } },
+		);
+
+		OcrSpaceEndpointOutputSchemas.parse.parse(response);
+		expect(response.IsErroredOnProcessing).toBe(false);
+	});
+
+	it('conversions returns per-engine counters with no parameters', async () => {
+		// Exercises the empty-body path: an empty multipart payload is rejected
+		// by the provider with HTTP 411.
+		const response = await makeOcrSpacePostRequest<ConversionsResponse>(
+			'/conversions',
+			TEST_API_KEY,
+			{ baseUrl: OCRSPACE_MYAPI_BASE },
+		);
+
+		OcrSpaceEndpointOutputSchemas.conversions.parse(response);
+		expect(typeof response.count_total).toBe('number');
+	});
+
+	it('conversions accepts the lastMonth parameter', async () => {
+		const response = await makeOcrSpacePostRequest<ConversionsResponse>(
+			'/conversions',
+			TEST_API_KEY,
+			{ formData: { startDate: 'lastMonth' }, baseUrl: OCRSPACE_MYAPI_BASE },
+		);
+
+		OcrSpaceEndpointOutputSchemas.conversions.parse(response);
+		expect(typeof response.count_total).toBe('number');
+	});
+});

--- a/packages/ocrspace/api.test.ts
+++ b/packages/ocrspace/api.test.ts
@@ -242,6 +242,38 @@ describe('OCR.space response schemas', () => {
 	});
 });
 
+describe('output validation', () => {
+	it('rejects a response whose types have drifted', () => {
+		// Endpoints parse responses through these schemas before returning, so a
+		// drifted payload fails at the boundary instead of reaching the caller.
+		expect(() =>
+			OcrSpaceEndpointOutputSchemas.parse.parse({
+				ParsedResults: 'not-an-array',
+				OCRExitCode: 1,
+			}),
+		).toThrow();
+
+		expect(() =>
+			OcrSpaceEndpointOutputSchemas.parse.parse({
+				ParsedResults: [{ ParsedText: 42 }],
+				OCRExitCode: 1,
+			}),
+		).toThrow();
+
+		expect(() =>
+			OcrSpaceEndpointOutputSchemas.conversions.parse({
+				count_total: 'many',
+			}),
+		).toThrow();
+	});
+
+	it('accepts a well-formed response unchanged', () => {
+		expect(() =>
+			OcrSpaceEndpointOutputSchemas.parse.parse(SUCCESS_RESPONSE),
+		).not.toThrow();
+	});
+});
+
 describe('isSearchablePdfUrl', () => {
 	it('recognises a real searchable PDF link', () => {
 		expect(

--- a/packages/ocrspace/client.ts
+++ b/packages/ocrspace/client.ts
@@ -94,10 +94,14 @@ export function assertOcrSuccess(response: OcrResponse): void {
 		return;
 	}
 
+	const pageError = (response.ParsedResults ?? [])
+		.map((result) => flattenOcrErrorMessage(result.ErrorMessage))
+		.find((value) => value !== undefined);
+
 	const message =
 		flattenOcrErrorMessage(response.ErrorMessage) ??
 		response.ErrorDetails ??
-		flattenOcrErrorMessage(response.ParsedResults?.[0]?.ErrorMessage) ??
+		pageError ??
 		'OCR.space failed to process the request';
 
 	throw new OcrSpaceAPIError(message, {

--- a/packages/ocrspace/client.ts
+++ b/packages/ocrspace/client.ts
@@ -91,7 +91,10 @@ export function assertOcrSuccess(response: OcrResponse): void {
 		response.IsErroredOnProcessing === true || exitCode === 3 || exitCode === 4;
 
 	if (!failed) {
-		if (exitCode !== 1 && exitCode !== 2) {
+		if (
+			(exitCode !== 1 && exitCode !== 2) ||
+			(response.ParsedResults?.length ?? 0) === 0
+		) {
 			throw new OcrSpaceAPIError('OCR.space returned an empty OCR response', {
 				body: response,
 			});

--- a/packages/ocrspace/client.ts
+++ b/packages/ocrspace/client.ts
@@ -91,6 +91,11 @@ export function assertOcrSuccess(response: OcrResponse): void {
 		response.IsErroredOnProcessing === true || exitCode === 3 || exitCode === 4;
 
 	if (!failed) {
+		if (exitCode !== 1 && exitCode !== 2) {
+			throw new OcrSpaceAPIError('OCR.space returned an empty OCR response', {
+				body: response,
+			});
+		}
 		return;
 	}
 

--- a/packages/ocrspace/client.ts
+++ b/packages/ocrspace/client.ts
@@ -89,22 +89,23 @@ export function assertOcrSuccess(response: OcrResponse): void {
 	const exitCode = response.OCRExitCode ?? undefined;
 	const failed =
 		response.IsErroredOnProcessing === true || exitCode === 3 || exitCode === 4;
+	const parsedResults = response.ParsedResults ?? [];
+	const pageError = parsedResults
+		.map((result) => flattenOcrErrorMessage(result.ErrorMessage))
+		.find((value) => value !== undefined);
 
 	if (!failed) {
 		if (
 			(exitCode !== 1 && exitCode !== 2) ||
-			(response.ParsedResults?.length ?? 0) === 0
+			!parsedResults.some((result) => result.FileParseExitCode === 1)
 		) {
-			throw new OcrSpaceAPIError('OCR.space returned an empty OCR response', {
-				body: response,
-			});
+			throw new OcrSpaceAPIError(
+				pageError ?? 'OCR.space returned no successfully parsed pages',
+				{ body: response, ocrExitCode: exitCode },
+			);
 		}
 		return;
 	}
-
-	const pageError = (response.ParsedResults ?? [])
-		.map((result) => flattenOcrErrorMessage(result.ErrorMessage))
-		.find((value) => value !== undefined);
 
 	const message =
 		flattenOcrErrorMessage(response.ErrorMessage) ??

--- a/packages/ocrspace/client.ts
+++ b/packages/ocrspace/client.ts
@@ -1,0 +1,196 @@
+import type {
+	ApiRequestOptions,
+	OpenAPIConfig,
+	RateLimitConfig,
+} from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+import type { OcrResponse } from './endpoints/types';
+
+export class OcrSpaceAPIError extends Error {
+	public readonly status?: number;
+	public readonly statusText?: string;
+	// OCR.space error bodies differ between the parse and statistics services,
+	// so the raw body is kept as `unknown` rather than modelled per endpoint.
+	public readonly body?: unknown;
+	public readonly retryAfter?: number;
+	public readonly rateLimitReset?: number;
+	public readonly rateLimitRemaining?: number;
+	public readonly rateLimitLimit?: number;
+	// Set when the failure was reported in the response body rather than by an
+	// HTTP status, so error handlers can tell the two cases apart.
+	public readonly ocrExitCode?: number;
+
+	constructor(
+		message: string,
+		options?: { cause?: Error; body?: unknown; ocrExitCode?: number },
+	) {
+		super(message, options?.cause ? { cause: options.cause } : undefined);
+		this.name = 'OcrSpaceAPIError';
+		this.body = options?.body;
+		this.ocrExitCode = options?.ocrExitCode;
+
+		if (options?.cause instanceof ApiError) {
+			this.status = options.cause.status;
+			this.statusText = options.cause.statusText;
+			this.body = this.body ?? options.cause.body;
+			this.retryAfter = options.cause.retryAfter;
+			this.rateLimitReset = options.cause.rateLimitReset;
+			this.rateLimitRemaining = options.cause.rateLimitRemaining;
+			this.rateLimitLimit = options.cause.rateLimitLimit;
+		}
+	}
+}
+
+const OCRSPACE_API_BASE = 'https://api.ocr.space';
+const OCRSPACE_MYAPI_BASE = 'https://myapi.ocr.space';
+
+// OCR of a multi-page PDF regularly runs past the 20s shared default.
+const OCRSPACE_TIMEOUT_MS = 60_000;
+
+const OCRSPACE_RATE_LIMIT_CONFIG: RateLimitConfig = {
+	enabled: true,
+	maxRetries: 3,
+	initialRetryDelay: 1000,
+	backoffMultiplier: 2,
+	headerNames: {
+		retryAfter: 'Retry-After',
+		limit: 'X-RateLimit-Limit',
+		remaining: 'X-RateLimit-Remaining',
+		resetTime: 'X-RateLimit-Reset',
+	},
+};
+
+export type OcrSpaceQueryValue = string | number | boolean | undefined;
+
+/**
+ * OCR.space reports failures as either a string or an array of strings.
+ */
+export function flattenOcrErrorMessage(
+	message: string | string[] | null | undefined,
+): string | undefined {
+	if (Array.isArray(message)) {
+		const joined = message.filter(Boolean).join(' ');
+		return joined.length > 0 ? joined : undefined;
+	}
+	return message ?? undefined;
+}
+
+/**
+ * OCR.space answers with HTTP 200 even when the parse failed, signalling the
+ * failure through `IsErroredOnProcessing` / `OCRExitCode` in the body. Without
+ * this check a failed parse would be returned to the caller as an empty
+ * success.
+ *
+ * `OCRExitCode === 2` is a partial success: some pages of a multi-page PDF were
+ * parsed and some were not. Those pages are real results, so this is allowed
+ * through rather than thrown away.
+ */
+export function assertOcrSuccess(response: OcrResponse): void {
+	const exitCode = response.OCRExitCode ?? undefined;
+	const failed =
+		response.IsErroredOnProcessing === true || exitCode === 3 || exitCode === 4;
+
+	if (!failed) {
+		return;
+	}
+
+	const message =
+		flattenOcrErrorMessage(response.ErrorMessage) ??
+		response.ErrorDetails ??
+		flattenOcrErrorMessage(response.ParsedResults?.[0]?.ErrorMessage) ??
+		'OCR.space failed to process the request';
+
+	throw new OcrSpaceAPIError(message, {
+		body: response,
+		ocrExitCode: exitCode,
+	});
+}
+
+function buildConfig(baseUrl: string, apiKey: string): OpenAPIConfig {
+	return {
+		BASE: baseUrl,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TIMEOUT: OCRSPACE_TIMEOUT_MS,
+		TOKEN: undefined,
+		HEADERS: {
+			Accept: 'application/json',
+			// OCR.space accepts the key as a query parameter too, but the header
+			// keeps it out of request URLs and logs.
+			apikey: apiKey,
+		},
+	};
+}
+
+async function send<T>(
+	config: OpenAPIConfig,
+	requestOptions: ApiRequestOptions,
+): Promise<T> {
+	try {
+		return await request<T>(config, requestOptions, {
+			rateLimitConfig: OCRSPACE_RATE_LIMIT_CONFIG,
+		});
+	} catch (error) {
+		// ApiError extends Error, and the OcrSpaceAPIError constructor pulls the
+		// status and rate-limit headers off an ApiError cause, so one branch
+		// covers both.
+		if (error instanceof Error) {
+			throw new OcrSpaceAPIError(error.message, { cause: error });
+		}
+		throw new OcrSpaceAPIError('Unknown OCR.space API error');
+	}
+}
+
+export async function makeOcrSpaceGetRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	options: {
+		query?: Record<string, OcrSpaceQueryValue>;
+		baseUrl?: string;
+	} = {},
+): Promise<T> {
+	return send<T>(buildConfig(options.baseUrl ?? OCRSPACE_API_BASE, apiKey), {
+		method: 'GET',
+		url: endpoint,
+		query: options.query,
+	});
+}
+
+export async function makeOcrSpacePostRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	options: {
+		formData?: Record<string, unknown>;
+		baseUrl?: string;
+	} = {},
+): Promise<T> {
+	const config = buildConfig(options.baseUrl ?? OCRSPACE_API_BASE, apiKey);
+	const fields = options.formData ?? {};
+	const hasFields = Object.values(fields).some(
+		(value) => value !== undefined && value !== null,
+	);
+
+	// An empty multipart payload is sent without a content length, which the
+	// provider rejects with HTTP 411. Endpoints whose parameters are all
+	// optional therefore fall back to an empty form-encoded body.
+	if (!hasFields) {
+		return send<T>(config, {
+			method: 'POST',
+			url: endpoint,
+			body: '',
+			mediaType: 'application/x-www-form-urlencoded',
+		});
+	}
+
+	return send<T>(config, {
+		method: 'POST',
+		url: endpoint,
+		// `formData` (not `body`) is required: the transport builds the
+		// multipart payload and lets fetch generate the boundary. Setting a
+		// `multipart/form-data` media type by hand would omit the boundary.
+		formData: fields,
+	});
+}
+
+export { OCRSPACE_API_BASE, OCRSPACE_MYAPI_BASE };

--- a/packages/ocrspace/endpoints/account.ts
+++ b/packages/ocrspace/endpoints/account.ts
@@ -2,7 +2,7 @@ import { logEventFromContext } from 'corsair/core';
 import { makeOcrSpacePostRequest, OCRSPACE_MYAPI_BASE } from '../client';
 import type { OcrSpaceEndpoints } from '../index';
 import type { ConversionsResponse } from './types';
-import { ConversionsInputSchema } from './types';
+import { ConversionsInputSchema, ConversionsResponseSchema } from './types';
 
 // Current-month and last-month counters are different data, so each period
 // gets its own cached row rather than overwriting a single one.
@@ -25,11 +25,15 @@ export const conversions: OcrSpaceEndpoints['conversions'] = async (
 		formData.startDate = validatedInput.startDate;
 	}
 
-	const response = await makeOcrSpacePostRequest<ConversionsResponse>(
+	const rawResponse = await makeOcrSpacePostRequest<ConversionsResponse>(
 		'/conversions',
 		ctx.key,
 		{ formData, baseUrl: OCRSPACE_MYAPI_BASE },
 	);
+
+	// Validated against the declared output schema so callers never receive a
+	// payload that violates the exported contract.
+	const response = ConversionsResponseSchema.parse(rawResponse);
 
 	const period = validatedInput.startDate ?? CURRENT_PERIOD;
 

--- a/packages/ocrspace/endpoints/account.ts
+++ b/packages/ocrspace/endpoints/account.ts
@@ -1,5 +1,9 @@
 import { logEventFromContext } from 'corsair/core';
-import { makeOcrSpacePostRequest, OCRSPACE_MYAPI_BASE } from '../client';
+import {
+	makeOcrSpacePostRequest,
+	OCRSPACE_MYAPI_BASE,
+	OcrSpaceAPIError,
+} from '../client';
 import type { OcrSpaceEndpoints } from '../index';
 import type { ConversionsResponse } from './types';
 import { ConversionsInputSchema, ConversionsResponseSchema } from './types';
@@ -34,6 +38,23 @@ export const conversions: OcrSpaceEndpoints['conversions'] = async (
 	// Validated against the declared output schema so callers never receive a
 	// payload that violates the exported contract.
 	const response = ConversionsResponseSchema.parse(rawResponse);
+
+	// Every counter is optional and the schema is loose, so a body carrying no
+	// statistics at all still parses. Without this guard a rejection returned
+	// with HTTP 200 would be cached as a row of nulls and logged as completed.
+	const hasCounters = [
+		response.count_total,
+		response.count_engine1,
+		response.count_engine2,
+		response.count_engine3,
+	].some((counter) => typeof counter === 'number');
+
+	if (!hasCounters) {
+		throw new OcrSpaceAPIError(
+			'OCR.space returned no conversion counters for this account',
+			{ body: response },
+		);
+	}
 
 	const period = validatedInput.startDate ?? CURRENT_PERIOD;
 

--- a/packages/ocrspace/endpoints/account.ts
+++ b/packages/ocrspace/endpoints/account.ts
@@ -1,0 +1,60 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeOcrSpacePostRequest, OCRSPACE_MYAPI_BASE } from '../client';
+import type { OcrSpaceEndpoints } from '../index';
+import type { ConversionsResponse } from './types';
+import { ConversionsInputSchema } from './types';
+
+// Current-month and last-month counters are different data, so each period
+// gets its own cached row rather than overwriting a single one.
+const CURRENT_PERIOD = 'currentMonth';
+
+/**
+ * Conversion counters for the current month, refreshed by the provider once a
+ * day, so the figures run to the end of yesterday rather than to now.
+ */
+export const conversions: OcrSpaceEndpoints['conversions'] = async (
+	ctx,
+	input,
+) => {
+	// endpointSchemas are metadata for introspection and are not applied by the
+	// framework, so inputs are validated here.
+	const validatedInput = ConversionsInputSchema.parse(input);
+
+	const formData: Record<string, unknown> = {};
+	if (validatedInput.startDate !== undefined) {
+		formData.startDate = validatedInput.startDate;
+	}
+
+	const response = await makeOcrSpacePostRequest<ConversionsResponse>(
+		'/conversions',
+		ctx.key,
+		{ formData, baseUrl: OCRSPACE_MYAPI_BASE },
+	);
+
+	const period = validatedInput.startDate ?? CURRENT_PERIOD;
+
+	try {
+		await ctx.db.conversions.upsertByEntityId(period, {
+			engine1: response.count_engine1 ?? null,
+			engine2: response.count_engine2 ?? null,
+			engine3: response.count_engine3 ?? null,
+			total: response.count_total ?? null,
+			period,
+			updatedAt: new Date(),
+		});
+	} catch (error) {
+		console.warn('[ocrspace] Failed to cache conversion statistics:', error);
+	}
+
+	await logEventFromContext(
+		ctx,
+		'ocrspace.account.conversions',
+		{
+			period,
+			total: response.count_total ?? null,
+		},
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/ocrspace/endpoints/account.ts
+++ b/packages/ocrspace/endpoints/account.ts
@@ -29,6 +29,10 @@ export const conversions: OcrSpaceEndpoints['conversions'] = async (
 		formData.startDate = validatedInput.startDate;
 	}
 
+	// Pinned to the statistics host on purpose, and not routed through
+	// `ctx.options.baseUrl`: that option points at a PRO account's dedicated
+	// *parse* endpoint, which does not serve /conversions. Statistics are on
+	// the same host for free and paid accounts.
 	const rawResponse = await makeOcrSpacePostRequest<ConversionsResponse>(
 		'/conversions',
 		ctx.key,

--- a/packages/ocrspace/endpoints/index.ts
+++ b/packages/ocrspace/endpoints/index.ts
@@ -1,0 +1,5 @@
+import * as Account from './account';
+import * as Ocr from './parse';
+
+export { Ocr, Account };
+export * from './types';

--- a/packages/ocrspace/endpoints/parse.ts
+++ b/packages/ocrspace/endpoints/parse.ts
@@ -1,0 +1,158 @@
+import { logEventFromContext } from 'corsair/core';
+import {
+	assertOcrSuccess,
+	makeOcrSpaceGetRequest,
+	makeOcrSpacePostRequest,
+} from '../client';
+import type { OcrSpaceContext, OcrSpaceEndpoints } from '../index';
+import type {
+	OcrResponse,
+	ParseImageUrlResponse,
+	ParseResponse,
+} from './types';
+import { ParseImageUrlInputSchema, ParseInputSchema } from './types';
+
+/**
+ * `ParsedResults` holds one entry per page of a PDF. The joined text is stored
+ * for the cache only — the endpoints return the provider response untouched.
+ */
+function joinPages(response: OcrResponse): string {
+	return (response.ParsedResults ?? [])
+		.map((result) => result.ParsedText ?? '')
+		.join('\n');
+}
+
+export function isSearchablePdfUrl(value: string | null | undefined): boolean {
+	return typeof value === 'string' && value.startsWith('http');
+}
+
+function pageCount(response: OcrResponse): number {
+	return response.ParsedResults?.length ?? 0;
+}
+
+// The provider reports this as a string; keep it numeric in the cache.
+function processingTimeMs(response: OcrResponse): number | undefined {
+	const raw = response.ProcessingTimeInMilliseconds;
+	if (raw === null || raw === undefined || raw === '') {
+		return undefined;
+	}
+	const parsed = typeof raw === 'number' ? raw : Number.parseInt(raw, 10);
+	return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+async function cacheResult(
+	ctx: OcrSpaceContext,
+	source: string,
+	input: {
+		OCREngine?: number;
+		language?: string;
+		isCreateSearchablePdf?: boolean;
+	},
+	response: OcrResponse,
+): Promise<void> {
+	const engine = input.OCREngine ?? 1;
+	const language = input.language ?? 'eng';
+	// Engine and language change the extracted text, so they are part of the
+	// key — otherwise re-reading the same image with a different engine would
+	// silently overwrite the previous result.
+	const entityId = [source, engine, language].join(':');
+
+	try {
+		await ctx.db.ocrResults.upsertByEntityId(entityId, {
+			source,
+			engine,
+			language,
+			text: joinPages(response),
+			pageCount: pageCount(response),
+			exitCode: response.OCRExitCode ?? null,
+			// The provider fills SearchablePDFURL with an explanatory sentence
+			// when no searchable PDF was requested, so presence alone is not a
+			// signal that one exists.
+			isSearchablePdf: isSearchablePdfUrl(response.SearchablePDFURL),
+			processingTimeMs: processingTimeMs(response) ?? null,
+			updatedAt: new Date(),
+		});
+	} catch (error) {
+		console.warn(`[ocrspace] Failed to cache OCR result for ${source}:`, error);
+	}
+}
+
+export const parseImageUrl: OcrSpaceEndpoints['parseImageUrl'] = async (
+	ctx,
+	input,
+) => {
+	// endpointSchemas are metadata for introspection and are not applied by the
+	// framework, so inputs are validated here to keep the declared contract and
+	// the runtime behaviour in step.
+	const validatedInput = ParseImageUrlInputSchema.parse(input);
+
+	const response = await makeOcrSpaceGetRequest<ParseImageUrlResponse>(
+		'/parse/imageurl',
+		ctx.key,
+		{ query: validatedInput, baseUrl: ctx.options.baseUrl },
+	);
+
+	assertOcrSuccess(response);
+
+	await cacheResult(ctx, validatedInput.url, validatedInput, response);
+
+	await logEventFromContext(
+		ctx,
+		'ocrspace.ocr.parseImageUrl',
+		{
+			url: validatedInput.url,
+			engine: validatedInput.OCREngine ?? 1,
+			language: validatedInput.language ?? 'eng',
+			pages: pageCount(response),
+		},
+		'completed',
+	);
+
+	return response;
+};
+
+export const parse: OcrSpaceEndpoints['parse'] = async (ctx, input) => {
+	const { url, file, base64Image, ...options } = ParseInputSchema.parse(input);
+
+	const formData: Record<string, unknown> = { ...options };
+	if (url !== undefined) {
+		formData.url = url;
+	}
+	if (file !== undefined) {
+		formData.file = file;
+	}
+	if (base64Image !== undefined) {
+		formData.base64Image = base64Image;
+	}
+
+	const response = await makeOcrSpacePostRequest<ParseResponse>(
+		'/parse/image',
+		ctx.key,
+		{ formData, baseUrl: ctx.options.baseUrl },
+	);
+
+	assertOcrSuccess(response);
+
+	// Only URL-sourced parses are cached: hashing a multi-megabyte base64 or
+	// file payload to build an entityId costs more than the cache is worth.
+	if (url !== undefined) {
+		await cacheResult(ctx, url, options, response);
+	}
+
+	await logEventFromContext(
+		ctx,
+		'ocrspace.ocr.parse',
+		{
+			// `base64Image` and `file` are the payload itself and are never logged.
+			source:
+				url !== undefined ? 'url' : file !== undefined ? 'file' : 'base64',
+			...(url !== undefined && { url }),
+			engine: options.OCREngine ?? 1,
+			language: options.language ?? 'eng',
+			pages: pageCount(response),
+		},
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/ocrspace/endpoints/parse.ts
+++ b/packages/ocrspace/endpoints/parse.ts
@@ -55,6 +55,13 @@ async function cacheResult(
 	},
 	response: OcrResponse,
 ): Promise<void> {
+	// OCRExitCode 2 is a partial PDF: some pages parsed, some did not.
+	// Caching that as a complete result would serve incomplete text on a later
+	// read. Callers still get the partial payload back from the endpoint.
+	if (response.OCRExitCode === 2) {
+		return;
+	}
+
 	const engine = input.OCREngine ?? 1;
 	const language = input.language ?? 'eng';
 	// Engine and language change the extracted text, so they are part of the

--- a/packages/ocrspace/endpoints/parse.ts
+++ b/packages/ocrspace/endpoints/parse.ts
@@ -10,7 +10,12 @@ import type {
 	ParseImageUrlResponse,
 	ParseResponse,
 } from './types';
-import { ParseImageUrlInputSchema, ParseInputSchema } from './types';
+import {
+	ParseImageUrlInputSchema,
+	ParseImageUrlResponseSchema,
+	ParseInputSchema,
+	ParseResponseSchema,
+} from './types';
 
 /**
  * `ParsedResults` holds one entry per page of a PDF. The joined text is stored
@@ -86,11 +91,15 @@ export const parseImageUrl: OcrSpaceEndpoints['parseImageUrl'] = async (
 	// the runtime behaviour in step.
 	const validatedInput = ParseImageUrlInputSchema.parse(input);
 
-	const response = await makeOcrSpaceGetRequest<ParseImageUrlResponse>(
+	const rawResponse = await makeOcrSpaceGetRequest<ParseImageUrlResponse>(
 		'/parse/imageurl',
 		ctx.key,
 		{ query: validatedInput, baseUrl: ctx.options.baseUrl },
 	);
+
+	// Responses are validated against the declared output schema so callers
+	// never receive a payload that violates the exported contract.
+	const response = ParseImageUrlResponseSchema.parse(rawResponse);
 
 	assertOcrSuccess(response);
 
@@ -125,11 +134,13 @@ export const parse: OcrSpaceEndpoints['parse'] = async (ctx, input) => {
 		formData.base64Image = base64Image;
 	}
 
-	const response = await makeOcrSpacePostRequest<ParseResponse>(
+	const rawResponse = await makeOcrSpacePostRequest<ParseResponse>(
 		'/parse/image',
 		ctx.key,
 		{ formData, baseUrl: ctx.options.baseUrl },
 	);
+
+	const response = ParseResponseSchema.parse(rawResponse);
 
 	assertOcrSuccess(response);
 

--- a/packages/ocrspace/endpoints/types.ts
+++ b/packages/ocrspace/endpoints/types.ts
@@ -147,8 +147,23 @@ const TYPED_BLOB_MIMES = new Set([
 	'image/bmp',
 ]);
 
+const BASE64_DATA_URI =
+	/^data:(image\/[a-z0-9.+-]+|application\/pdf);base64,([A-Za-z0-9+/]+={0,2})$/i;
+
+function base64ImageIsValid(value: string): boolean {
+	const payload = BASE64_DATA_URI.exec(value)?.[2];
+	return payload !== undefined && payload.length % 4 === 0;
+}
+
 function blobUploadIsTyped(input: { file?: Blob; filetype?: string }): boolean {
 	if (input.file === undefined || input.filetype !== undefined) {
+		return true;
+	}
+	if (
+		typeof File !== 'undefined' &&
+		input.file instanceof File &&
+		input.file.name.length > 0
+	) {
 		return true;
 	}
 	return TYPED_BLOB_MIMES.has(input.file.type.toLowerCase());
@@ -163,7 +178,7 @@ const UNTYPED_BLOB_MESSAGE =
 
 export const ParseImageUrlInputSchema = z
 	.object({
-		url: z.string().url(),
+		url: z.url(),
 		...ocrOptionsShape,
 	})
 	.refine(searchablePdfIsSupported, {
@@ -181,7 +196,7 @@ export const ParseImageUrlResponseSchema = OcrResponseSchema;
 
 export const ParseInputSchema = z
 	.object({
-		url: z.string().url().optional(),
+		url: z.url().optional(),
 		// Prefer a `File` over a bare `Blob`: multipart uploads carry the
 		// filename, and OCR.space uses the extension to detect the file type. A
 		// `Blob` is sent without one, so pair it with an explicit `filetype`.
@@ -194,13 +209,10 @@ export const ParseInputSchema = z
 		// "data:image/png;base64,iVBORw0KGgo..."
 		base64Image: z
 			.string()
-			.regex(
-				/^data:(image\/[a-z0-9.+-]+|application\/pdf);base64,[A-Za-z0-9+/]+={0,2}$/i,
-				{
-					message:
-						'base64Image must include the data URI prefix, e.g. "data:image/png;base64,...".',
-				},
-			)
+			.refine(base64ImageIsValid, {
+				message:
+					'base64Image must include the data URI prefix and a valid base64 payload.',
+			})
 			.optional(),
 		...ocrOptionsShape,
 	})

--- a/packages/ocrspace/endpoints/types.ts
+++ b/packages/ocrspace/endpoints/types.ts
@@ -122,6 +122,20 @@ function searchablePdfIsSupported(input: {
 const SEARCHABLE_PDF_ENGINE_MESSAGE =
 	'OCREngine 3 does not support isCreateSearchablePdf. Use engine 1 or 2.';
 
+// "auto" is engines 2 and 3 only. Omitted OCREngine is engine 1 on the wire.
+function autoLanguageIsSupported(input: {
+	OCREngine?: number;
+	language?: string;
+}): boolean {
+	if (input.language !== 'auto') {
+		return true;
+	}
+	return input.OCREngine === 2 || input.OCREngine === 3;
+}
+
+const AUTO_LANGUAGE_ENGINE_MESSAGE =
+	'language "auto" is only supported on OCREngine 2 or 3.';
+
 // ---------------------------------------------------------------------------
 // ocr.parseImageUrl — GET /parse/imageurl
 // ---------------------------------------------------------------------------
@@ -133,6 +147,9 @@ export const ParseImageUrlInputSchema = z
 	})
 	.refine(searchablePdfIsSupported, {
 		message: SEARCHABLE_PDF_ENGINE_MESSAGE,
+	})
+	.refine(autoLanguageIsSupported, {
+		message: AUTO_LANGUAGE_ENGINE_MESSAGE,
 	});
 
 export const ParseImageUrlResponseSchema = OcrResponseSchema;
@@ -174,6 +191,9 @@ export const ParseInputSchema = z
 	)
 	.refine(searchablePdfIsSupported, {
 		message: SEARCHABLE_PDF_ENGINE_MESSAGE,
+	})
+	.refine(autoLanguageIsSupported, {
+		message: AUTO_LANGUAGE_ENGINE_MESSAGE,
 	});
 
 export const ParseResponseSchema = OcrResponseSchema;

--- a/packages/ocrspace/endpoints/types.ts
+++ b/packages/ocrspace/endpoints/types.ts
@@ -147,6 +147,10 @@ export const ParseInputSchema = z
 		// Prefer a `File` over a bare `Blob`: multipart uploads carry the
 		// filename, and OCR.space uses the extension to detect the file type. A
 		// `Blob` is sent without one, so pair it with an explicit `filetype`.
+		//
+		// Note: `z.instanceof()` carries no JSON Schema representation, so this
+		// field surfaces as `unknown` in generated introspection and docs. The
+		// binary payload cannot be expressed in JSON Schema either way.
 		file: z.instanceof(Blob).optional(),
 		// The provider requires the data URI prefix, e.g.
 		// "data:image/png;base64,iVBORw0KGgo..."

--- a/packages/ocrspace/endpoints/types.ts
+++ b/packages/ocrspace/endpoints/types.ts
@@ -136,6 +136,27 @@ function autoLanguageIsSupported(input: {
 const AUTO_LANGUAGE_ENGINE_MESSAGE =
 	'language "auto" is only supported on OCREngine 2 or 3.';
 
+const TYPED_BLOB_MIMES = new Set([
+	'application/pdf',
+	'image/gif',
+	'image/png',
+	'image/jpeg',
+	'image/jpg',
+	'image/tiff',
+	'image/tif',
+	'image/bmp',
+]);
+
+function blobUploadIsTyped(input: { file?: Blob; filetype?: string }): boolean {
+	if (input.file === undefined || input.filetype !== undefined) {
+		return true;
+	}
+	return TYPED_BLOB_MIMES.has(input.file.type.toLowerCase());
+}
+
+const UNTYPED_BLOB_MESSAGE =
+	'Untyped Blob uploads require filetype. Pass a typed Blob or set filetype.';
+
 // ---------------------------------------------------------------------------
 // ocr.parseImageUrl — GET /parse/imageurl
 // ---------------------------------------------------------------------------
@@ -173,10 +194,13 @@ export const ParseInputSchema = z
 		// "data:image/png;base64,iVBORw0KGgo..."
 		base64Image: z
 			.string()
-			.regex(/^data:(image\/[a-z0-9.+-]+|application\/pdf);base64,/i, {
-				message:
-					'base64Image must include the data URI prefix, e.g. "data:image/png;base64,...".',
-			})
+			.regex(
+				/^data:(image\/[a-z0-9.+-]+|application\/pdf);base64,[A-Za-z0-9+/]+={0,2}$/i,
+				{
+					message:
+						'base64Image must include the data URI prefix, e.g. "data:image/png;base64,...".',
+				},
+			)
 			.optional(),
 		...ocrOptionsShape,
 	})
@@ -194,6 +218,9 @@ export const ParseInputSchema = z
 	})
 	.refine(autoLanguageIsSupported, {
 		message: AUTO_LANGUAGE_ENGINE_MESSAGE,
+	})
+	.refine(blobUploadIsTyped, {
+		message: UNTYPED_BLOB_MESSAGE,
 	});
 
 export const ParseResponseSchema = OcrResponseSchema;

--- a/packages/ocrspace/endpoints/types.ts
+++ b/packages/ocrspace/endpoints/types.ts
@@ -1,0 +1,240 @@
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Shared response objects
+// ---------------------------------------------------------------------------
+
+// Every response object is `.loose()`: unknown provider fields are kept rather
+// than stripped, so a field added by OCR.space (or one only some engines
+// return, as `TextOrientation` was) still reaches the caller.
+export const OcrWordSchema = z
+	.object({
+		WordText: z.string().nullable().optional(),
+		Left: z.number().nullable().optional(),
+		Top: z.number().nullable().optional(),
+		Height: z.number().nullable().optional(),
+		Width: z.number().nullable().optional(),
+	})
+	.loose();
+
+export const OcrLineSchema = z
+	.object({
+		// Undocumented, but returned by engines 1 and 2 alongside the per-word
+		// boxes. Engine 3 omits the per-line detail entirely.
+		LineText: z.string().nullable().optional(),
+		Words: z.array(OcrWordSchema).nullable().optional(),
+		MaxHeight: z.number().nullable().optional(),
+		MinTop: z.number().nullable().optional(),
+	})
+	.loose();
+
+export const OcrTextOverlaySchema = z
+	.object({
+		Lines: z.array(OcrLineSchema).nullable().optional(),
+		HasOverlay: z.boolean().nullable().optional(),
+		Message: z.string().nullable().optional(),
+	})
+	.loose();
+
+// OCR.space returns ErrorMessage as a bare string on some failures and as an
+// array of strings on others, so both shapes have to be accepted.
+export const OcrErrorMessageSchema = z
+	.union([z.string(), z.array(z.string())])
+	.nullable()
+	.optional();
+
+export const OcrParsedResultSchema = z
+	.object({
+		ParsedText: z.string().nullable().optional(),
+		// Returned as a string (e.g. "0") whenever detectOrientation is used.
+		TextOrientation: z.string().nullable().optional(),
+		// 1 = success, 0 = file not found, -10 = parse error, -20 = timeout,
+		// -30 = validation error, -99 = unknown error
+		FileParseExitCode: z.number().int().nullable().optional(),
+		TextOverlay: OcrTextOverlaySchema.nullable().optional(),
+		ErrorMessage: OcrErrorMessageSchema,
+		ErrorDetails: z.string().nullable().optional(),
+	})
+	.loose();
+
+export const OcrResponseSchema = z
+	.object({
+		// One entry per page for PDFs; a single entry for images.
+		ParsedResults: z.array(OcrParsedResultSchema).nullable().optional(),
+		// 1 = success, 2 = partial success, 3 = failed, 4 = fatal error
+		OCRExitCode: z.number().int().nullable().optional(),
+		IsErroredOnProcessing: z.boolean().nullable().optional(),
+		ErrorMessage: OcrErrorMessageSchema,
+		ErrorDetails: z.string().nullable().optional(),
+		// Download link for a generated searchable PDF, valid for one hour. When
+		// no searchable PDF was requested the provider still populates this
+		// field, with an explanatory sentence rather than a URL.
+		SearchablePDFURL: z.string().nullable().optional(),
+		// Documented as a string, but accepted as a number too so a numeric
+		// value from any engine cannot fail validation of a good response.
+		ProcessingTimeInMilliseconds: z
+			.union([z.string(), z.number()])
+			.nullable()
+			.optional(),
+	})
+	.loose();
+
+// ---------------------------------------------------------------------------
+// Shared request options
+// ---------------------------------------------------------------------------
+
+export const OcrEngineSchema = z.union([
+	z.literal(1),
+	z.literal(2),
+	z.literal(3),
+]);
+
+// Spread into both parse inputs so the two endpoints cannot drift apart.
+const ocrOptionsShape = {
+	// OCR.space language codes are always three letters ("eng", never "en").
+	// "auto" is accepted by engines 2 and 3 only.
+	language: z
+		.string()
+		.regex(/^([a-z]{3}|auto)$/, {
+			message:
+				'language must be a three-letter OCR.space code (e.g. "eng") or "auto".',
+		})
+		.optional(),
+	OCREngine: OcrEngineSchema.optional(),
+	isOverlayRequired: z.boolean().optional(),
+	detectOrientation: z.boolean().optional(),
+	scale: z.boolean().optional(),
+	isTable: z.boolean().optional(),
+	isCreateSearchablePdf: z.boolean().optional(),
+	isSearchablePdfHideTextLayer: z.boolean().optional(),
+	filetype: z.enum(['PDF', 'GIF', 'PNG', 'JPG', 'TIF', 'BMP']).optional(),
+};
+
+// Engine 3 does not support searchable PDF output. Rejecting the combination
+// locally avoids burning a conversion on a request that cannot succeed.
+function searchablePdfIsSupported(input: {
+	OCREngine?: number;
+	isCreateSearchablePdf?: boolean;
+}): boolean {
+	return !(input.OCREngine === 3 && input.isCreateSearchablePdf === true);
+}
+
+const SEARCHABLE_PDF_ENGINE_MESSAGE =
+	'OCREngine 3 does not support isCreateSearchablePdf. Use engine 1 or 2.';
+
+// ---------------------------------------------------------------------------
+// ocr.parseImageUrl — GET /parse/imageurl
+// ---------------------------------------------------------------------------
+
+export const ParseImageUrlInputSchema = z
+	.object({
+		url: z.string().url(),
+		...ocrOptionsShape,
+	})
+	.refine(searchablePdfIsSupported, {
+		message: SEARCHABLE_PDF_ENGINE_MESSAGE,
+	});
+
+export const ParseImageUrlResponseSchema = OcrResponseSchema;
+
+// ---------------------------------------------------------------------------
+// ocr.parse — POST /parse/image
+// ---------------------------------------------------------------------------
+
+export const ParseInputSchema = z
+	.object({
+		url: z.string().url().optional(),
+		// Prefer a `File` over a bare `Blob`: multipart uploads carry the
+		// filename, and OCR.space uses the extension to detect the file type. A
+		// `Blob` is sent without one, so pair it with an explicit `filetype`.
+		file: z.instanceof(Blob).optional(),
+		// The provider requires the data URI prefix, e.g.
+		// "data:image/png;base64,iVBORw0KGgo..."
+		base64Image: z
+			.string()
+			.regex(/^data:(image\/[a-z0-9.+-]+|application\/pdf);base64,/i, {
+				message:
+					'base64Image must include the data URI prefix, e.g. "data:image/png;base64,...".',
+			})
+			.optional(),
+		...ocrOptionsShape,
+	})
+	.refine(
+		(input) => {
+			const provided = [input.url, input.file, input.base64Image].filter(
+				(value) => value !== undefined,
+			);
+			return provided.length === 1;
+		},
+		{ message: 'Provide exactly one of url, file, or base64Image.' },
+	)
+	.refine(searchablePdfIsSupported, {
+		message: SEARCHABLE_PDF_ENGINE_MESSAGE,
+	});
+
+export const ParseResponseSchema = OcrResponseSchema;
+
+// ---------------------------------------------------------------------------
+// account.conversions — POST https://myapi.ocr.space/conversions
+// ---------------------------------------------------------------------------
+
+export const ConversionsInputSchema = z.object({
+	// "lastMonth" is the only documented value and the provider treats the
+	// parameter name as case-sensitive.
+	startDate: z.literal('lastMonth').optional(),
+});
+
+// Field names verified against a live response. The provider documentation
+// describes these as "Engine1"/"Engine2"/"Total", but the service actually
+// returns snake_cased `count_*` keys and includes an engine 3 counter.
+export const ConversionsResponseSchema = z
+	.object({
+		count_total: z.number().nullable().optional(),
+		count_engine1: z.number().nullable().optional(),
+		count_engine2: z.number().nullable().optional(),
+		count_engine3: z.number().nullable().optional(),
+	})
+	.loose();
+
+// ---------------------------------------------------------------------------
+// Inferred types
+// ---------------------------------------------------------------------------
+
+export type OcrWord = z.infer<typeof OcrWordSchema>;
+export type OcrLine = z.infer<typeof OcrLineSchema>;
+export type OcrTextOverlay = z.infer<typeof OcrTextOverlaySchema>;
+export type OcrParsedResult = z.infer<typeof OcrParsedResultSchema>;
+export type OcrResponse = z.infer<typeof OcrResponseSchema>;
+
+export type ParseImageUrlInput = z.infer<typeof ParseImageUrlInputSchema>;
+export type ParseImageUrlResponse = z.infer<typeof ParseImageUrlResponseSchema>;
+
+export type ParseInput = z.infer<typeof ParseInputSchema>;
+export type ParseResponse = z.infer<typeof ParseResponseSchema>;
+
+export type ConversionsInput = z.infer<typeof ConversionsInputSchema>;
+export type ConversionsResponse = z.infer<typeof ConversionsResponseSchema>;
+
+export type OcrSpaceEndpointInputs = {
+	parseImageUrl: ParseImageUrlInput;
+	parse: ParseInput;
+	conversions: ConversionsInput;
+};
+
+export type OcrSpaceEndpointOutputs = {
+	parseImageUrl: ParseImageUrlResponse;
+	parse: ParseResponse;
+	conversions: ConversionsResponse;
+};
+
+export const OcrSpaceEndpointInputSchemas = {
+	parseImageUrl: ParseImageUrlInputSchema,
+	parse: ParseInputSchema,
+	conversions: ConversionsInputSchema,
+} as const;
+
+export const OcrSpaceEndpointOutputSchemas = {
+	parseImageUrl: ParseImageUrlResponseSchema,
+	parse: ParseResponseSchema,
+	conversions: ConversionsResponseSchema,
+} as const;

--- a/packages/ocrspace/error-handlers.ts
+++ b/packages/ocrspace/error-handlers.ts
@@ -7,10 +7,6 @@ function getStatus(error: Error): number | undefined {
 	return (error as Partial<OcrSpaceAPIError>).status;
 }
 
-function getRetryAfter(error: Error): number | undefined {
-	return (error as Partial<OcrSpaceAPIError>).retryAfter;
-}
-
 function getOcrExitCode(error: Error): number | undefined {
 	return (error as Partial<OcrSpaceAPIError>).ocrExitCode;
 }
@@ -62,11 +58,7 @@ export const errorHandlers = {
 				'number of times within',
 			]);
 		},
-		handler: async (error: Error) => ({
-			maxRetries: 3,
-			retryStrategy: 'exponential_backoff' as const,
-			headersRetryAfterMs: getRetryAfter(error),
-		}),
+		handler: async () => ({ maxRetries: 0 }),
 	},
 	AUTH_ERROR: {
 		match: (error: Error) => {

--- a/packages/ocrspace/error-handlers.ts
+++ b/packages/ocrspace/error-handlers.ts
@@ -1,0 +1,128 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import type { OcrSpaceAPIError } from './client';
+
+// Handlers receive the framework's base Error type. OcrSpaceAPIError adds these
+// fields, so they are read through a Partial rather than an instanceof check.
+function getStatus(error: Error): number | undefined {
+	return (error as Partial<OcrSpaceAPIError>).status;
+}
+
+function getRetryAfter(error: Error): number | undefined {
+	return (error as Partial<OcrSpaceAPIError>).retryAfter;
+}
+
+function getOcrExitCode(error: Error): number | undefined {
+	return (error as Partial<OcrSpaceAPIError>).ocrExitCode;
+}
+
+// OCR.space reports quota and key problems inside a HTTP 200 body, so those
+// errors reach the handlers with no status attached and have to be recognised
+// from the message text.
+function messageIncludes(error: Error, needles: string[]): boolean {
+	const message = error.message.toLowerCase();
+	return needles.some((needle) => message.includes(needle));
+}
+
+export const errorHandlers = {
+	// Listed first: endpoints validate their input with zod before calling the
+	// API, and a validation message can contain words the other matchers look
+	// for. These never reach the network, so they are never retried.
+	VALIDATION_ERROR: {
+		match: (error: Error) => error.name === 'ZodError',
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (getStatus(error) === 429) return true;
+			// The free plan caps usage per day and per month, and reports both in
+			// the response body rather than as a 429. These phrases are specific
+			// to quota exhaustion: broader words such as "maximum" also appear in
+			// file-size rejections, which must not be retried.
+			return messageIncludes(error, [
+				'429',
+				'rate limit',
+				'too many requests',
+				'number of times within',
+				'per day',
+				'daily limit',
+				'monthly limit',
+				'quota',
+			]);
+		},
+		handler: async (error: Error) => ({
+			maxRetries: 3,
+			retryStrategy: 'exponential_backoff' as const,
+			headersRetryAfterMs: getRetryAfter(error),
+		}),
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			const status = getStatus(error);
+			if (status === 401 || status === 403) return true;
+			return messageIncludes(error, [
+				'unauthorized',
+				'invalid api key',
+				'invalid apikey',
+				'api key is invalid',
+				// The provider's own wording, observed on a rejected key.
+				'api key not valid',
+				'e555',
+				'expired api key',
+			]);
+		},
+		handler: async (error: Error, context) => {
+			console.error(
+				`[OCRSPACE:${context.operation}] Authentication failed - check your API key`,
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	BAD_REQUEST_ERROR: {
+		match: (error: Error) => {
+			if (getStatus(error) === 400) return true;
+			// A provider-level parse failure is a problem with the request or
+			// the file, so retrying spends quota on a call that cannot succeed.
+			if (getOcrExitCode(error) !== undefined) return true;
+			return messageIncludes(error, [
+				'bad request',
+				'file size',
+				'file type',
+				'unable to recognize',
+				'no file',
+			]);
+		},
+		handler: async (error: Error, context) => {
+			console.warn(
+				`[OCRSPACE:${context.operation}] Request rejected: ${error.message}`,
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	SERVER_ERROR: {
+		match: (error: Error) => {
+			const status = getStatus(error);
+			return status !== undefined && status >= 500;
+		},
+		handler: async () => ({
+			maxRetries: 2,
+			retryStrategy: 'exponential_backoff' as const,
+		}),
+	},
+	TIMEOUT_ERROR: {
+		match: (error: Error) =>
+			messageIncludes(error, ['timeout', 'timed out', 'aborted']),
+		handler: async () => ({
+			maxRetries: 1,
+			retryStrategy: 'exponential_backoff' as const,
+		}),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async (error: Error, context) => {
+			console.error(
+				`[OCRSPACE:${context.operation}] Unhandled error: ${error.message}`,
+			);
+			return { maxRetries: 0 };
+		},
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/ocrspace/error-handlers.ts
+++ b/packages/ocrspace/error-handlers.ts
@@ -15,12 +15,30 @@ function getOcrExitCode(error: Error): number | undefined {
 	return (error as Partial<OcrSpaceAPIError>).ocrExitCode;
 }
 
-// OCR.space reports quota and key problems inside a HTTP 200 body, so those
-// errors reach the handlers with no status attached and have to be recognised
-// from the message text.
+function getBody(error: Error): unknown {
+	return (error as Partial<OcrSpaceAPIError>).body;
+}
+
+function bodyText(body: unknown): string {
+	if (body == null) {
+		return '';
+	}
+	if (typeof body === 'string') {
+		return body;
+	}
+	try {
+		return JSON.stringify(body);
+	} catch {
+		return String(body);
+	}
+}
+
+// OCR.space reports quota and key problems inside a HTTP 200 body, and
+// throttle details on 403 responses live on `body` while `message` is just
+// "Forbidden". Search both.
 function messageIncludes(error: Error, needles: string[]): boolean {
-	const message = error.message.toLowerCase();
-	return needles.some((needle) => message.includes(needle));
+	const haystack = `${error.message} ${bodyText(getBody(error))}`.toLowerCase();
+	return needles.some((needle) => haystack.includes(needle));
 }
 
 export const errorHandlers = {
@@ -33,20 +51,15 @@ export const errorHandlers = {
 	},
 	RATE_LIMIT_ERROR: {
 		match: (error: Error) => {
-			if (getStatus(error) === 429) return true;
-			// The free plan caps usage per day and per month, and reports both in
-			// the response body rather than as a 429. These phrases are specific
-			// to quota exhaustion: broader words such as "maximum" also appear in
-			// file-size rejections, which must not be retried.
+			const status = getStatus(error);
+			// Provider-confirmed: short-window throttling is HTTP 403, not 429.
+			// Invalid keys are a HTTP 200 body error (E555 / "API key not valid"),
+			// so 403 is not an auth failure on this API.
+			if (status === 429 || status === 403) return true;
 			return messageIncludes(error, [
-				'429',
 				'rate limit',
 				'too many requests',
 				'number of times within',
-				'per day',
-				'daily limit',
-				'monthly limit',
-				'quota',
 			]);
 		},
 		handler: async (error: Error) => ({
@@ -57,8 +70,7 @@ export const errorHandlers = {
 	},
 	AUTH_ERROR: {
 		match: (error: Error) => {
-			const status = getStatus(error);
-			if (status === 401 || status === 403) return true;
+			if (getStatus(error) === 401) return true;
 			return messageIncludes(error, [
 				'unauthorized',
 				'invalid api key',
@@ -89,6 +101,7 @@ export const errorHandlers = {
 				'file type',
 				'unable to recognize',
 				'no file',
+				'conversion limit',
 			]);
 		},
 		handler: async (error: Error, context) => {

--- a/packages/ocrspace/index.ts
+++ b/packages/ocrspace/index.ts
@@ -107,6 +107,24 @@ const ocrSpaceEndpointMeta = {
 	},
 } satisfies RequiredPluginEndpointMeta<typeof ocrSpaceEndpointsNested>;
 
+// `handleCorsairError` selects the first handler whose `match` returns true,
+// walking keys in insertion order. DEFAULT matches everything, so it has to be
+// last: spreading caller-supplied handlers after it would leave them
+// unreachable.
+function mergeErrorHandlers(
+	builtIn: CorsairErrorHandler,
+	overrides?: CorsairErrorHandler,
+): CorsairErrorHandler {
+	const { DEFAULT: builtInDefault, ...builtInRest } = builtIn;
+	const { DEFAULT: overrideDefault, ...overrideRest } = overrides ?? {};
+
+	return {
+		...builtInRest,
+		...overrideRest,
+		DEFAULT: overrideDefault ?? builtInDefault,
+	};
+}
+
 const defaultAuthType: AuthTypes = 'api_key' as const;
 
 export const ocrSpaceAuthConfig = {
@@ -153,10 +171,7 @@ export function ocrspace<const T extends OcrSpacePluginOptions>(
 		authConfig: ocrSpaceAuthConfig,
 		// OCR.space is a request/response API with no webhook support.
 		pluginWebhookMatcher: () => false,
-		errorHandlers: {
-			...errorHandlers,
-			...options.errorHandlers,
-		},
+		errorHandlers: mergeErrorHandlers(errorHandlers, options.errorHandlers),
 		keyBuilder: async (ctx: OcrSpaceKeyBuilderContext, source) => {
 			if (source === 'endpoint' && options.key) {
 				return options.key;

--- a/packages/ocrspace/index.ts
+++ b/packages/ocrspace/index.ts
@@ -1,0 +1,206 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+} from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
+import { Account, Ocr } from './endpoints';
+import type {
+	OcrSpaceEndpointInputs,
+	OcrSpaceEndpointOutputs,
+} from './endpoints/types';
+import {
+	OcrSpaceEndpointInputSchemas,
+	OcrSpaceEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { OcrSpaceSchema } from './schema';
+
+export type OcrSpacePluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	/**
+	 * Base URL for the parse endpoints. Defaults to the shared free-plan host,
+	 * `https://api.ocr.space`. PRO and PRO PDF accounts are issued dedicated,
+	 * redundant endpoints by email on sign-up; set that host here to use them.
+	 */
+	baseUrl?: string;
+	hooks?: InternalOcrSpacePlugin['hooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof ocrSpaceEndpointsNested>;
+};
+
+export type OcrSpaceContext = CorsairPluginContext<
+	typeof OcrSpaceSchema,
+	OcrSpacePluginOptions
+>;
+
+export type OcrSpaceKeyBuilderContext =
+	KeyBuilderContext<OcrSpacePluginOptions>;
+
+export type OcrSpaceBoundEndpoints = BindEndpoints<
+	typeof ocrSpaceEndpointsNested
+>;
+
+type OcrSpaceEndpoint<K extends keyof OcrSpaceEndpointOutputs> =
+	CorsairEndpoint<
+		OcrSpaceContext,
+		OcrSpaceEndpointInputs[K],
+		OcrSpaceEndpointOutputs[K]
+	>;
+
+export type OcrSpaceEndpoints = {
+	parseImageUrl: OcrSpaceEndpoint<'parseImageUrl'>;
+	parse: OcrSpaceEndpoint<'parse'>;
+	conversions: OcrSpaceEndpoint<'conversions'>;
+};
+
+const ocrSpaceEndpointsNested = {
+	ocr: {
+		parseImageUrl: Ocr.parseImageUrl,
+		parse: Ocr.parse,
+	},
+	account: {
+		conversions: Account.conversions,
+	},
+} as const;
+
+export const ocrSpaceEndpointSchemas = {
+	'ocr.parseImageUrl': {
+		input: OcrSpaceEndpointInputSchemas.parseImageUrl,
+		output: OcrSpaceEndpointOutputSchemas.parseImageUrl,
+	},
+	'ocr.parse': {
+		input: OcrSpaceEndpointInputSchemas.parse,
+		output: OcrSpaceEndpointOutputSchemas.parse,
+	},
+	'account.conversions': {
+		input: OcrSpaceEndpointInputSchemas.conversions,
+		output: OcrSpaceEndpointOutputSchemas.conversions,
+	},
+} satisfies RequiredPluginEndpointSchemas<typeof ocrSpaceEndpointsNested>;
+
+const ocrSpaceEndpointMeta = {
+	'ocr.parseImageUrl': {
+		riskLevel: 'read',
+		description:
+			'Extract text from an image at a public URL using the simplified GET endpoint',
+	},
+	'ocr.parse': {
+		riskLevel: 'read',
+		description:
+			'Extract text from an image or PDF supplied as exactly one of a URL, a file upload (pass a File so the filename is sent, or set filetype), or a base64 data URI',
+	},
+	'account.conversions': {
+		riskLevel: 'read',
+		description:
+			'Retrieve conversion counts for the current month per OCR engine, updated once a day',
+	},
+} satisfies RequiredPluginEndpointMeta<typeof ocrSpaceEndpointsNested>;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+export const ocrSpaceAuthConfig = {
+	api_key: {
+		account: ['one'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type BaseOcrSpacePlugin<T extends OcrSpacePluginOptions> = CorsairPlugin<
+	'ocrspace',
+	typeof OcrSpaceSchema,
+	typeof ocrSpaceEndpointsNested,
+	{},
+	T,
+	typeof defaultAuthType,
+	typeof ocrSpaceAuthConfig
+>;
+
+export type InternalOcrSpacePlugin = BaseOcrSpacePlugin<OcrSpacePluginOptions>;
+
+export type ExternalOcrSpacePlugin<T extends OcrSpacePluginOptions> =
+	BaseOcrSpacePlugin<T>;
+
+// The assertion is safe: OcrSpacePluginOptions has no required fields, so an
+// empty object satisfies the constraint at runtime even though TypeScript
+// cannot verify it without the assertion.
+export function ocrspace<const T extends OcrSpacePluginOptions>(
+	incomingOptions: OcrSpacePluginOptions & T = {} as OcrSpacePluginOptions & T,
+): ExternalOcrSpacePlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+
+	return {
+		id: 'ocrspace',
+		schema: OcrSpaceSchema,
+		options,
+		hooks: options.hooks,
+		endpoints: ocrSpaceEndpointsNested,
+		webhooks: {},
+		endpointMeta: ocrSpaceEndpointMeta,
+		endpointSchemas: ocrSpaceEndpointSchemas,
+		authConfig: ocrSpaceAuthConfig,
+		// OCR.space is a request/response API with no webhook support.
+		pluginWebhookMatcher: () => false,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: OcrSpaceKeyBuilderContext, source) => {
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const key = await ctx.keys.get_api_key();
+
+				if (!key) {
+					throw new AuthMissingError('ocrspace', 'api_key');
+				}
+
+				return key;
+			}
+
+			throw new AuthMissingError('ocrspace', 'api_key');
+		},
+	} satisfies InternalOcrSpacePlugin;
+}
+
+export { assertOcrSuccess, OcrSpaceAPIError } from './client';
+export type {
+	ConversionsInput,
+	ConversionsResponse,
+	OcrLine,
+	OcrParsedResult,
+	OcrResponse,
+	OcrSpaceEndpointInputs,
+	OcrSpaceEndpointOutputs,
+	OcrTextOverlay,
+	OcrWord,
+	ParseImageUrlInput,
+	ParseImageUrlResponse,
+	ParseInput,
+	ParseResponse,
+} from './endpoints/types';
+export {
+	ConversionsInputSchema,
+	ConversionsResponseSchema,
+	OcrResponseSchema,
+	OcrSpaceEndpointInputSchemas,
+	OcrSpaceEndpointOutputSchemas,
+	ParseImageUrlInputSchema,
+	ParseImageUrlResponseSchema,
+	ParseInputSchema,
+	ParseResponseSchema,
+} from './endpoints/types';

--- a/packages/ocrspace/index.ts
+++ b/packages/ocrspace/index.ts
@@ -29,9 +29,15 @@ export type OcrSpacePluginOptions = {
 	authType?: PickAuth<'api_key'>;
 	key?: string;
 	/**
-	 * Base URL for the parse endpoints. Defaults to the shared free-plan host,
-	 * `https://api.ocr.space`. PRO and PRO PDF accounts are issued dedicated,
-	 * redundant endpoints by email on sign-up; set that host here to use them.
+	 * Base URL for the OCR parse endpoints (`ocr.parseImageUrl`, `ocr.parse`).
+	 * Defaults to the shared free-plan host, `https://api.ocr.space`. PRO and
+	 * PRO PDF accounts are issued dedicated, redundant parse endpoints by email
+	 * on sign-up; set that host here to use them.
+	 *
+	 * This deliberately does not apply to `account.conversions`: conversion
+	 * statistics are served by a separate host (`https://myapi.ocr.space`) that
+	 * is the same for free and paid accounts. Routing that call to a dedicated
+	 * parse host would request a path the host does not serve.
 	 */
 	baseUrl?: string;
 	hooks?: InternalOcrSpacePlugin['hooks'];

--- a/packages/ocrspace/jest.config.cjs
+++ b/packages/ocrspace/jest.config.cjs
@@ -54,6 +54,8 @@ module.exports = {
 	},
 	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
 	extensionsToTreatAsEsm: ['.ts'],
-	testTimeout: 30000,
+	// Must exceed the client's 60s request timeout so a slow live OCR call
+	// fails on the provider's timeout rather than on Jest's.
+	testTimeout: 90000,
 	verbose: true,
 };

--- a/packages/ocrspace/jest.config.cjs
+++ b/packages/ocrspace/jest.config.cjs
@@ -1,0 +1,59 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+					target: 'ESNext',
+					types: ['node', 'jest'],
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					types: ['node', 'jest'],
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^corsair$': '<rootDir>/../corsair/index.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/ocrspace/operations.test.ts
+++ b/packages/ocrspace/operations.test.ts
@@ -1,0 +1,215 @@
+import { logEventFromContext } from 'corsair/core';
+import {
+	makeOcrSpaceGetRequest,
+	makeOcrSpacePostRequest,
+	OCRSPACE_MYAPI_BASE,
+	OcrSpaceAPIError,
+} from './client';
+import { Account, Ocr } from './endpoints';
+
+jest.mock('corsair/core', () => ({
+	logEventFromContext: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('./client', () => {
+	const actual = jest.requireActual('./client') as typeof import('./client');
+	return {
+		...actual,
+		makeOcrSpaceGetRequest: jest.fn(),
+		makeOcrSpacePostRequest: jest.fn(),
+	};
+});
+
+const mockGet = jest.mocked(makeOcrSpaceGetRequest);
+const mockPost = jest.mocked(makeOcrSpacePostRequest);
+const mockLog = jest.mocked(logEventFromContext);
+
+const SUCCESS_RESPONSE = {
+	ParsedResults: [{ ParsedText: 'Hello world', FileParseExitCode: 1 }],
+	OCRExitCode: 1,
+	IsErroredOnProcessing: false,
+	ProcessingTimeInMilliseconds: '231',
+};
+
+const CONVERSIONS_RESPONSE = {
+	count_total: 165,
+	count_engine1: 120,
+	count_engine2: 45,
+	count_engine3: 0,
+};
+
+type AnyEndpoint = (ctx: unknown, input: unknown) => Promise<unknown>;
+
+function createContext(overrides: Record<string, unknown> = {}) {
+	return {
+		key: 'test-key',
+		options: {},
+		db: {
+			ocrResults: {
+				upsertByEntityId: jest.fn().mockResolvedValue(undefined),
+			},
+			conversions: {
+				upsertByEntityId: jest.fn().mockResolvedValue(undefined),
+			},
+		},
+		...overrides,
+	};
+}
+
+describe('OCR.space endpoint routing', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('ocr.parseImageUrl calls GET /parse/imageurl and caches the result', async () => {
+		mockGet.mockResolvedValue(SUCCESS_RESPONSE);
+		const ctx = createContext();
+
+		const result = await (Ocr.parseImageUrl as AnyEndpoint)(ctx, {
+			url: 'https://example.com/receipt.jpg',
+			OCREngine: 2,
+			language: 'eng',
+		});
+
+		expect(mockGet).toHaveBeenCalledTimes(1);
+		expect(mockGet).toHaveBeenCalledWith('/parse/imageurl', 'test-key', {
+			query: {
+				url: 'https://example.com/receipt.jpg',
+				OCREngine: 2,
+				language: 'eng',
+			},
+			baseUrl: undefined,
+		});
+		expect(result).toMatchObject({ OCRExitCode: 1 });
+		expect(ctx.db.ocrResults.upsertByEntityId).toHaveBeenCalledWith(
+			'https://example.com/receipt.jpg:2:eng',
+			expect.objectContaining({
+				text: 'Hello world',
+				engine: 2,
+				language: 'eng',
+				exitCode: 1,
+			}),
+		);
+		expect(mockLog).toHaveBeenCalledWith(
+			ctx,
+			'ocrspace.ocr.parseImageUrl',
+			expect.any(Object),
+			'completed',
+		);
+	});
+
+	it('ocr.parse posts a URL to /parse/image and caches it', async () => {
+		mockPost.mockResolvedValue(SUCCESS_RESPONSE);
+		const ctx = createContext();
+
+		await (Ocr.parse as AnyEndpoint)(ctx, {
+			url: 'https://example.com/scan.png',
+		});
+
+		expect(mockPost).toHaveBeenCalledWith('/parse/image', 'test-key', {
+			formData: { url: 'https://example.com/scan.png' },
+			baseUrl: undefined,
+		});
+		expect(ctx.db.ocrResults.upsertByEntityId).toHaveBeenCalledTimes(1);
+	});
+
+	it('ocr.parse does not cache file or base64 payloads', async () => {
+		mockPost.mockResolvedValue(SUCCESS_RESPONSE);
+		const ctx = createContext();
+
+		await (Ocr.parse as AnyEndpoint)(ctx, {
+			base64Image:
+				'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+		});
+
+		expect(ctx.db.ocrResults.upsertByEntityId).not.toHaveBeenCalled();
+	});
+
+	it('skips the cache for a partial OCRExitCode 2 result', async () => {
+		mockGet.mockResolvedValue({
+			OCRExitCode: 2,
+			IsErroredOnProcessing: false,
+			ParsedResults: [
+				{ ParsedText: 'page one', FileParseExitCode: 1 },
+				{ ParsedText: '', FileParseExitCode: -10 },
+			],
+		});
+		const ctx = createContext();
+
+		const result = await (Ocr.parseImageUrl as AnyEndpoint)(ctx, {
+			url: 'https://example.com/multi.pdf',
+		});
+
+		expect(result).toMatchObject({ OCRExitCode: 2 });
+		expect(ctx.db.ocrResults.upsertByEntityId).not.toHaveBeenCalled();
+	});
+
+	it('account.conversions posts to the statistics host, not options.baseUrl', async () => {
+		mockPost.mockResolvedValue(CONVERSIONS_RESPONSE);
+		const ctx = createContext({
+			options: { baseUrl: 'https://apipro1.ocr.space' },
+		});
+
+		const result = await (Account.conversions as AnyEndpoint)(ctx, {});
+
+		expect(mockPost).toHaveBeenCalledWith('/conversions', 'test-key', {
+			formData: {},
+			baseUrl: OCRSPACE_MYAPI_BASE,
+		});
+		expect(result).toMatchObject({ count_total: 165 });
+		expect(ctx.db.conversions.upsertByEntityId).toHaveBeenCalledWith(
+			'currentMonth',
+			expect.objectContaining({ total: 165, engine3: 0 }),
+		);
+	});
+
+	it('account.conversions throws when the body has no counters', async () => {
+		mockPost.mockResolvedValue({});
+		const ctx = createContext();
+
+		await expect(
+			(Account.conversions as AnyEndpoint)(ctx, {}),
+		).rejects.toBeInstanceOf(OcrSpaceAPIError);
+		expect(ctx.db.conversions.upsertByEntityId).not.toHaveBeenCalled();
+	});
+
+	it('rejects a drifted parse response before returning it', async () => {
+		mockGet.mockResolvedValue({
+			ParsedResults: 'not-an-array',
+			OCRExitCode: 1,
+		});
+		const ctx = createContext();
+
+		await expect(
+			(Ocr.parseImageUrl as AnyEndpoint)(ctx, {
+				url: 'https://example.com/receipt.jpg',
+			}),
+		).rejects.toThrow();
+		expect(ctx.db.ocrResults.upsertByEntityId).not.toHaveBeenCalled();
+	});
+
+	it('does not call the network when parse input is invalid', async () => {
+		const ctx = createContext();
+
+		await expect((Ocr.parse as AnyEndpoint)(ctx, {})).rejects.toThrow(
+			/exactly one of url, file, or base64Image/,
+		);
+		expect(mockGet).not.toHaveBeenCalled();
+		expect(mockPost).not.toHaveBeenCalled();
+	});
+
+	it('forwards options.baseUrl to the parse endpoints', async () => {
+		mockGet.mockResolvedValue(SUCCESS_RESPONSE);
+		const ctx = createContext({
+			options: { baseUrl: 'https://apipro1.ocr.space' },
+		});
+
+		await (Ocr.parseImageUrl as AnyEndpoint)(ctx, {
+			url: 'https://example.com/receipt.jpg',
+		});
+
+		expect(mockGet.mock.calls[0]?.[2]).toMatchObject({
+			baseUrl: 'https://apipro1.ocr.space',
+		});
+	});
+});

--- a/packages/ocrspace/operations.test.ts
+++ b/packages/ocrspace/operations.test.ts
@@ -121,8 +121,25 @@ describe('OCR.space endpoint routing', () => {
 			base64Image:
 				'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
 		});
-
 		expect(ctx.db.ocrResults.upsertByEntityId).not.toHaveBeenCalled();
+
+		await (Ocr.parse as AnyEndpoint)(ctx, {
+			file: new File(['x'], 'scan.png', { type: 'image/png' }),
+		});
+		expect(ctx.db.ocrResults.upsertByEntityId).not.toHaveBeenCalled();
+	});
+
+	it('ocr.parseImageUrl rejects an empty OCR body', async () => {
+		mockGet.mockResolvedValue({});
+		const ctx = createContext();
+
+		await expect(
+			(Ocr.parseImageUrl as AnyEndpoint)(ctx, {
+				url: 'https://example.com/receipt.jpg',
+			}),
+		).rejects.toBeInstanceOf(OcrSpaceAPIError);
+		expect(ctx.db.ocrResults.upsertByEntityId).not.toHaveBeenCalled();
+		expect(mockLog).not.toHaveBeenCalled();
 	});
 
 	it('skips the cache for a partial OCRExitCode 2 result', async () => {

--- a/packages/ocrspace/operations.test.ts
+++ b/packages/ocrspace/operations.test.ts
@@ -159,6 +159,22 @@ describe('OCR.space endpoint routing', () => {
 		expect(ctx.db.ocrResults.upsertByEntityId).not.toHaveBeenCalled();
 	});
 
+	it('ocr.parseImageUrl rejects a failed-only page array', async () => {
+		mockGet.mockResolvedValue({
+			OCRExitCode: 1,
+			ParsedResults: [{ FileParseExitCode: -10, ErrorMessage: 'Parse failed' }],
+		});
+		const ctx = createContext();
+
+		await expect(
+			(Ocr.parseImageUrl as AnyEndpoint)(ctx, {
+				url: 'https://example.com/receipt.jpg',
+			}),
+		).rejects.toBeInstanceOf(OcrSpaceAPIError);
+		expect(ctx.db.ocrResults.upsertByEntityId).not.toHaveBeenCalled();
+		expect(mockLog).not.toHaveBeenCalled();
+	});
+
 	it('skips the cache for a partial OCRExitCode 2 result', async () => {
 		mockGet.mockResolvedValue({
 			OCRExitCode: 2,

--- a/packages/ocrspace/operations.test.ts
+++ b/packages/ocrspace/operations.test.ts
@@ -113,7 +113,7 @@ describe('OCR.space endpoint routing', () => {
 		expect(ctx.db.ocrResults.upsertByEntityId).toHaveBeenCalledTimes(1);
 	});
 
-	it('ocr.parse does not cache file or base64 payloads', async () => {
+	it('ocr.parse does not cache a base64 payload', async () => {
 		mockPost.mockResolvedValue(SUCCESS_RESPONSE);
 		const ctx = createContext();
 
@@ -122,6 +122,11 @@ describe('OCR.space endpoint routing', () => {
 				'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
 		});
 		expect(ctx.db.ocrResults.upsertByEntityId).not.toHaveBeenCalled();
+	});
+
+	it('ocr.parse does not cache a file upload', async () => {
+		mockPost.mockResolvedValue(SUCCESS_RESPONSE);
+		const ctx = createContext();
 
 		await (Ocr.parse as AnyEndpoint)(ctx, {
 			file: new File(['x'], 'scan.png', { type: 'image/png' }),
@@ -140,6 +145,18 @@ describe('OCR.space endpoint routing', () => {
 		).rejects.toBeInstanceOf(OcrSpaceAPIError);
 		expect(ctx.db.ocrResults.upsertByEntityId).not.toHaveBeenCalled();
 		expect(mockLog).not.toHaveBeenCalled();
+	});
+
+	it('ocr.parseImageUrl rejects a success exit code with no pages', async () => {
+		mockGet.mockResolvedValue({ OCRExitCode: 1 });
+		const ctx = createContext();
+
+		await expect(
+			(Ocr.parseImageUrl as AnyEndpoint)(ctx, {
+				url: 'https://example.com/receipt.jpg',
+			}),
+		).rejects.toBeInstanceOf(OcrSpaceAPIError);
+		expect(ctx.db.ocrResults.upsertByEntityId).not.toHaveBeenCalled();
 	});
 
 	it('skips the cache for a partial OCRExitCode 2 result', async () => {

--- a/packages/ocrspace/package.json
+++ b/packages/ocrspace/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@corsair-dev/ocrspace",
+  "version": "0.1.0",
+  "description": "OCR.space plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "ocrspace",
+    "ocr",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/ocrspace/schema/database.ts
+++ b/packages/ocrspace/schema/database.ts
@@ -15,7 +15,8 @@ export const OcrResult = z.object({
 	updatedAt: z.coerce.date().optional(),
 });
 
-// Monthly conversion counters from the PRO-only statistics endpoint.
+// Monthly conversion counters. Opened to free-plan keys in May 2026;
+// invalid keys still return zeros rather than an error.
 export const ConversionStats = z.object({
 	engine1: z.number().nullable().optional(),
 	engine2: z.number().nullable().optional(),

--- a/packages/ocrspace/schema/database.ts
+++ b/packages/ocrspace/schema/database.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+// One cached OCR extraction. `source` is required because it forms the
+// entityId; only URL-sourced parses are cached (file/base64 inputs are not
+// worth hashing multi-megabyte payloads for).
+export const OcrResult = z.object({
+	source: z.string(),
+	engine: z.number().int().nullable().optional(),
+	language: z.string().nullable().optional(),
+	text: z.string().nullable().optional(),
+	pageCount: z.number().int().nullable().optional(),
+	exitCode: z.number().int().nullable().optional(),
+	isSearchablePdf: z.boolean().nullable().optional(),
+	processingTimeMs: z.number().int().nullable().optional(),
+	updatedAt: z.coerce.date().optional(),
+});
+
+// Monthly conversion counters from the PRO-only statistics endpoint.
+export const ConversionStats = z.object({
+	engine1: z.number().nullable().optional(),
+	engine2: z.number().nullable().optional(),
+	engine3: z.number().nullable().optional(),
+	total: z.number().nullable().optional(),
+	period: z.string().nullable().optional(),
+	updatedAt: z.coerce.date().optional(),
+});
+
+export type OcrResult = z.infer<typeof OcrResult>;
+export type ConversionStats = z.infer<typeof ConversionStats>;

--- a/packages/ocrspace/schema/index.ts
+++ b/packages/ocrspace/schema/index.ts
@@ -1,0 +1,11 @@
+import { ConversionStats, OcrResult } from './database';
+
+export const OcrSpaceSchema = {
+	version: '1.0.0',
+	entities: {
+		ocrResults: OcrResult,
+		conversions: ConversionStats,
+	},
+} as const;
+
+export type { ConversionStats, OcrResult } from './database';

--- a/packages/ocrspace/tsconfig.json
+++ b/packages/ocrspace/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "types": []
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts"]
+}

--- a/packages/ocrspace/tsup.config.ts
+++ b/packages/ocrspace/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2350,6 +2350,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/ocrspace:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/ollama:
     devDependencies:
       '@types/jest':
@@ -15177,7 +15201,7 @@ snapshots:
 
   '@babel/parser@7.29.2':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -24745,7 +24769,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.28.6
+      '@babel/code-frame': 7.29.7
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4


### PR DESCRIPTION
## Description
Adds an OCR.space integration (`packages/ocrspace`) covering the full OSS API surface from the issue.

Fixes #652

**Endpoints** (all `riskLevel: 'read'`, since OCR.space is a read-only service):

| Endpoint | Method | Purpose |
|---|---|---|
| `ocr.parseImageUrl` | `GET /parse/imageurl` | Extract text from a public image URL |
| `ocr.parse` | `POST /parse/image` | Extract text from a URL, file upload, or base64 data URI |
| `account.conversions` | `POST myapi.ocr.space/conversions` | Per-engine conversion counts for the month |

**Auth.** API key sent in the `apikey` header. The service explicitly rejects the key in the request body ("Send apikey in the header"), so the header is the only supported route. It is an account-level key with no OAuth flow and no refresh/expiry lifecycle, so it maps onto `api_key` directly and `oauth_2` is not offered. A `baseUrl` option is exposed because PRO and PRO PDF accounts are issued dedicated endpoints on sign-up; it defaults to the shared free-plan host.

**Input validation.** `endpointSchemas` is introspection metadata and is not applied by the framework, so each endpoint validates its input with zod explicitly, following `packages/googlemaps` and `packages/ollama`. Enforced before any network call: exactly one of `url`/`file`/`base64Image`; three-letter language codes (or `auto`); `OCREngine` 1 to 3; the `data:` URI prefix on base64 payloads; and `OCREngine: 3` combined with `isCreateSearchablePdf`, which the provider does not support.

**Error handling.** OCR.space returns **HTTP 200 with the failure in the response body** (`IsErroredOnProcessing` / `OCRExitCode`), so `assertOcrSuccess` converts those into thrown errors rather than returning an empty success, the same approach as `packages/apisports`. `OCRExitCode === 2` is a *partial* success and is passed through, so successfully parsed pages of a multi-page PDF are not discarded. Body-level failures carry no HTTP status, so handlers match on message text as well as status; quota phrases are matched narrowly so that file-size rejections are not retried as rate limits.

**Storage.** `ocrResults` keyed by `url:engine:language`, since engine and language change the extracted text; `conversions` keyed by period. Cache writes are best-effort and never fail the call.

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos

https://github.com/user-attachments/assets/1403d5fd-686c-4c98-bf3a-74b1d4dfd820

## Additional Notes

- **38 tests** in `packages/ocrspace/api.test.ts`: 33 CI-safe, 5 live (auto-skipped unless `OCRSPACE_API_KEY` is set). All three endpoints verified against the real API.
- Scope is `packages/ocrspace/**`, the registration edit in `packages/corsair/core/constants.ts`, and `pnpm-lock.yaml`. No new runtime dependencies.
- No webhooks. OCR.space is request/response only, so `webhooks: {}` and `pluginWebhookMatcher` returns `false`.
- Schemas were validated against live responses rather than the published docs alone, which corrected three things: `conversions` returns `count_total` / `count_engine1..3` (not `Engine1` / `Total` as documented) and works on free-plan keys rather than being PRO-only; `SearchablePDFURL` is *always* populated, carrying an explanatory sentence when no PDF was requested, so it cannot be truthiness-checked; and `TextOrientation` and `LineText` are returned but undocumented. Response objects are `.loose()` so future provider fields are preserved rather than stripped.
- Repo-wide `pnpm lint` has pre-existing failures on `main` in `demo/mcp/corsair.ts`, `packages/canvas`, `packages/huggingface`, `packages/workday`, and `www/`, none of them touched by this PR. `biome check packages/ocrspace` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OCR.space as a supported OCR provider.
  * Added OCR processing for image URLs and uploaded files.
  * Added searchable PDF detection and OCR result handling.
  * Added conversion usage reporting.
  * Added API-key authentication, validation, caching, and retry handling.
  * Added the `@corsair-dev/ocrspace` package with parsing, account, and schema support.

* **Tests**
  * Added comprehensive coverage for OCR processing, validation, errors, retries, quotas, and conversion reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->