### PR TITLE
a11y(www): label the OSS GitHub username input

### DIFF
--- a/www/src/app/oss/github-username-callout.tsx
+++ b/www/src/app/oss/github-username-callout.tsx
@@ -47,12 +47,15 @@ export function GithubUsernameCallout() {
 				className="flex flex-wrap items-center gap-2"
 			>
 				<input
+					id="oss-github-username"
 					type="text"
 					name="username"
 					required
 					value={username}
 					onChange={(event) => setUsername(event.target.value)}
 					placeholder="octocat"
+					aria-label="GitHub username"
+					autoComplete="username"
 					className="min-w-[200px] flex-1 rounded-lg border border-border/70 bg-background px-3 py-2 text-sm shadow-sm transition-all focus:border-border focus:ring-2 focus:ring-foreground/5 focus:outline-none"
 				/>
 				<Button


### PR DESCRIPTION
## Description

The OSS GitHub username field only had a placeholder (`octocat`) and no accessible name. Nearby copy does not count as a label.

Adds `aria-label="GitHub username"` (and a matching `id`) without restyling the callout.

Closes #721

## Check

- [x] `aria-label="GitHub username"` is on the input
- [x] No visual restyle of the callout


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved the GitHub username input with a descriptive label and identifier for assistive technologies.
  * Enabled browser autofill support for username entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->