### PR TITLE
fix(onedrive): use constant-time comparison for clientState

### DIFF
--- a/packages/onedrive/webhooks/types.test.ts
+++ b/packages/onedrive/webhooks/types.test.ts
@@ -68,10 +68,21 @@ describe('verifyOnedriveClientState', () => {
 
 	it('should return invalid without throwing when clientState is a non-string truthy value', () => {
 		// Truthy non-string values (e.g. number) can arrive in untrusted webhook payloads
-		// at runtime despite TypeScript types. Buffer.from(String(...)) must handle these safely.
+		// at runtime despite TypeScript types. Reject them instead of coercing.
 		const result = verifyOnedriveClientState(
 			{ clientState: 12345 as unknown as string },
 			expectedClientState,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'clientState mismatch',
+		});
+	});
+
+	it('should not treat a numeric clientState as equal to its string form', () => {
+		const result = verifyOnedriveClientState(
+			{ clientState: 12345 as unknown as string },
+			'12345',
 		);
 		expect(result).toEqual({
 			valid: false,

--- a/packages/onedrive/webhooks/types.test.ts
+++ b/packages/onedrive/webhooks/types.test.ts
@@ -54,4 +54,17 @@ describe('verifyOnedriveClientState', () => {
 			error: 'clientState mismatch',
 		});
 	});
+
+	it('should return invalid without throwing when clientState is a non-string truthy value', () => {
+		// Truthy non-string values (e.g. number) can arrive in untrusted webhook payloads
+		// at runtime despite TypeScript types. Buffer.from(String(...)) must handle these safely.
+		const result = verifyOnedriveClientState(
+			{ clientState: 12345 as unknown as string },
+			expectedClientState,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'clientState mismatch',
+		});
+	});
 });

--- a/packages/onedrive/webhooks/types.test.ts
+++ b/packages/onedrive/webhooks/types.test.ts
@@ -22,6 +22,17 @@ describe('verifyOnedriveClientState', () => {
 		});
 	});
 
+	it('should return invalid when clientState is an empty string', () => {
+		const result = verifyOnedriveClientState(
+			{ clientState: '' },
+			expectedClientState,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing clientState in notification',
+		});
+	});
+
 	it('should return valid for matching clientState', () => {
 		const result = verifyOnedriveClientState(
 			{ clientState: 'secret-client-state-12345' },

--- a/packages/onedrive/webhooks/types.test.ts
+++ b/packages/onedrive/webhooks/types.test.ts
@@ -1,0 +1,57 @@
+import { verifyOnedriveClientState } from './types';
+
+describe('verifyOnedriveClientState', () => {
+	const expectedClientState = 'secret-client-state-12345';
+
+	it('should return invalid when clientState is missing in notification', () => {
+		const result = verifyOnedriveClientState({}, expectedClientState);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing clientState in notification',
+		});
+	});
+
+	it('should return invalid when clientState is null in notification', () => {
+		const result = verifyOnedriveClientState(
+			{ clientState: null },
+			expectedClientState,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing clientState in notification',
+		});
+	});
+
+	it('should return valid for matching clientState', () => {
+		const result = verifyOnedriveClientState(
+			{ clientState: 'secret-client-state-12345' },
+			expectedClientState,
+		);
+		expect(result).toEqual({
+			valid: true,
+			error: undefined,
+		});
+	});
+
+	it('should return invalid when clientState values mismatch with same length', () => {
+		const result = verifyOnedriveClientState(
+			{ clientState: 'secret-client-state-99999' },
+			expectedClientState,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'clientState mismatch',
+		});
+	});
+
+	it('should return invalid when clientState values mismatch with different length', () => {
+		const result = verifyOnedriveClientState(
+			{ clientState: 'short' },
+			expectedClientState,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'clientState mismatch',
+		});
+	});
+});

--- a/packages/onedrive/webhooks/types.ts
+++ b/packages/onedrive/webhooks/types.ts
@@ -186,7 +186,7 @@ export function verifyOnedriveClientState(
 	if (!notification.clientState) {
 		return { valid: false, error: 'Missing clientState in notification' };
 	}
-	const aBuf = Buffer.from(notification.clientState);
+	const aBuf = Buffer.from(String(notification.clientState));
 	const bBuf = Buffer.from(expectedClientState);
 	if (aBuf.length !== bBuf.length) {
 		return { valid: false, error: 'clientState mismatch' };

--- a/packages/onedrive/webhooks/types.ts
+++ b/packages/onedrive/webhooks/types.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'node:crypto';
 import type { CorsairWebhookMatcher, RawWebhookRequest } from 'corsair/core';
 import { z } from 'zod';
 
@@ -185,7 +186,12 @@ export function verifyOnedriveClientState(
 	if (!notification.clientState) {
 		return { valid: false, error: 'Missing clientState in notification' };
 	}
-	const isValid = notification.clientState === expectedClientState;
+	const aBuf = Buffer.from(notification.clientState);
+	const bBuf = Buffer.from(expectedClientState);
+	if (aBuf.length !== bBuf.length) {
+		return { valid: false, error: 'clientState mismatch' };
+	}
+	const isValid = crypto.timingSafeEqual(aBuf, bBuf);
 	return {
 		valid: isValid,
 		error: isValid ? undefined : 'clientState mismatch',

--- a/packages/onedrive/webhooks/types.ts
+++ b/packages/onedrive/webhooks/types.ts
@@ -186,7 +186,10 @@ export function verifyOnedriveClientState(
 	if (!notification.clientState) {
 		return { valid: false, error: 'Missing clientState in notification' };
 	}
-	const aBuf = Buffer.from(String(notification.clientState));
+	if (typeof notification.clientState !== 'string') {
+		return { valid: false, error: 'clientState mismatch' };
+	}
+	const aBuf = Buffer.from(notification.clientState);
 	const bBuf = Buffer.from(expectedClientState);
 	if (aBuf.length !== bBuf.length) {
 		return { valid: false, error: 'clientState mismatch' };


### PR DESCRIPTION
## Description

This PR fixes a timing side-channel vulnerability in the OneDrive plugin's webhook verification logic ([#705](https://github.com/corsairdev/corsair/issues/705)). 

`verifyOnedriveClientState` previously used JavaScript strict string comparison (`notification.clientState === expectedClientState`), which short-circuits on the first character difference and enables timing side-channel attacks.

Key changes:
- Imported `crypto` from `node:crypto` in `packages/onedrive/webhooks/types.ts`.
- Converted `notification.clientState` and `expectedClientState` to `Buffer` instances.
- Added an explicit Buffer length guard (`aBuf.length !== bBuf.length`) returning `{ valid: false, error: 'clientState mismatch' }` before calling `crypto.timingSafeEqual` (preventing runtime `TypeError` exceptions when Buffer lengths differ).
- Used `crypto.timingSafeEqual(aBuf, bBuf)` for constant-time comparison when lengths match.
- Left the missing `clientState` check and error string (`'Missing clientState in notification'`) unchanged.
- Added comprehensive unit tests in `packages/onedrive/webhooks/types.test.ts`.

Fixes #705

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

https://github.com/corsairdev/corsair/pull/732

## Additional Notes

Non-breaking security enhancement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OneDrive webhook client-state validation for greater security and reliability.
  * Ensured invalid, missing, null, non-string, and mismatched states are rejected consistently without unexpected errors.
  * Strengthened comparisons to reduce risks associated with timing-based attacks.

* **Tests**
  * Added coverage for valid and invalid states, differing state lengths, validation messages, and non-string inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
