### PR TITLE
test(typeform): add unit tests for verifyTypeformWebhookSignature

### DIFF
--- a/packages/typeform/webhooks/types.test.ts
+++ b/packages/typeform/webhooks/types.test.ts
@@ -1,0 +1,91 @@
+import type { WebhookRequest } from 'corsair/core';
+import crypto from 'crypto';
+
+import type { TypeformWebhookPayload } from './types';
+import { verifyTypeformWebhookSignature } from './types';
+
+describe('verifyTypeformWebhookSignature', () => {
+	const secret = 'my-typeform-signing-secret';
+	const payload: TypeformWebhookPayload = {
+		event_id: 'EVT_1',
+		event_type: 'form_response',
+		form_response: {
+			form_id: 'frm1',
+			token: 'tok1',
+			submitted_at: '2026-01-01T00:00:00.000Z',
+			landed_at: '2026-01-01T00:00:00.000Z',
+		},
+	};
+	const rawBody = JSON.stringify(payload);
+
+	const sign = (body: string) =>
+		crypto.createHmac('sha256', secret).update(body).digest('base64');
+
+	const requestWith = (
+		headers: Record<string, string | string[]>,
+		body: string = rawBody,
+	): WebhookRequest<TypeformWebhookPayload> => ({
+		payload,
+		headers,
+		rawBody: body,
+	});
+
+	it('returns invalid when secret is missing', () => {
+		const result = verifyTypeformWebhookSignature(
+			requestWith({ 'typeform-signature': `sha256=${sign(rawBody)}` }),
+			'',
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('returns invalid when the signature header is missing', () => {
+		const result = verifyTypeformWebhookSignature(requestWith({}), secret);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing Typeform-Signature header',
+		});
+	});
+
+	it('returns invalid for a malformed signature header', () => {
+		const result = verifyTypeformWebhookSignature(
+			requestWith({ 'typeform-signature': 'deadbeef' }),
+			secret,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid signature format',
+		});
+	});
+
+	it('returns invalid when the signature does not match', () => {
+		const result = verifyTypeformWebhookSignature(
+			requestWith({ 'typeform-signature': 'sha256=not-a-valid-hmac' }),
+			secret,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid signature',
+		});
+	});
+
+	it('returns valid when the HMAC matches the compact body', () => {
+		const result = verifyTypeformWebhookSignature(
+			requestWith({ 'typeform-signature': `sha256=${sign(rawBody)}` }),
+			secret,
+		);
+		expect(result).toEqual({ valid: true });
+	});
+
+	it('returns valid when the HMAC only matches with a trailing newline', () => {
+		const result = verifyTypeformWebhookSignature(
+			requestWith({
+				'typeform-signature': `sha256=${sign(rawBody + '\n')}`,
+			}),
+			secret,
+		);
+		expect(result).toEqual({ valid: true });
+	});
+});


### PR DESCRIPTION
## Description

Adds `packages/typeform/webhooks/types.test.ts` with unit tests for `verifyTypeformWebhookSignature`, covering:
- missing secret (fails closed with `Missing webhook secret`)
- missing `Typeform-Signature` header
- malformed signature header (no `sha256=` prefix)
- a valid `sha256=` HMAC over the compact body (accepted)
- a case that only matches with the trailing newline (the `body\n` candidate)

Fixes #727

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

N/A ? test-only change. Local verification: `pnpm --filter @corsair-dev/typeform exec jest webhooks/types.test.ts` passes 6/6. See CI run: https://github.com/corsairdev/corsair/actions

## Additional Notes

No verifier changes; the existing candidate-matching logic is proven correct by the tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for Typeform webhook signature verification.
  * Tests now cover missing credentials, malformed or mismatched signatures, valid compact payloads, and payloads ending with a newline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->