### PR TITLE
fix(oss): add aria-label to search input

### DIFF
--- a/www/src/app/oss/integration-search.tsx
+++ b/www/src/app/oss/integration-search.tsx
@@ -55,6 +55,7 @@ export function IntegrationSearch({ defaultValue }: { defaultValue: string }) {
 			/>
 			<input
 				type="search"
+				aria-label="Search integrations"
 				value={value}
 				onChange={(event) => handleChange(event.target.value)}
 				placeholder="Search integrations..."


### PR DESCRIPTION
## Description

Adds `aria-label="Search integrations"` to the integration search input on `/oss` (`www/src/app/oss/integration-search.tsx`). 

Previously, the input only had a visual icon and placeholder text without an accessible name for screen readers and accessibility tools.

Fixes #720 

## Checklist



- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [ ] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

<img width="605" height="317" alt="image" src="https://github.com/user-attachments/assets/47ad03b7-ca96-454f-8cfb-b6c600931261" />

## Additional Notes

No visual layout or styling changes were made; this is strictly an accessibility enhancement.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added an accessible label to the integrations search field, improving usability for screen reader users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->