### PR TITLE
fix(studio): add accessible labels to database search and sort direction toggle

### DIFF
--- a/packages/studio/src/web/pages/DatabasePage.tsx
+++ b/packages/studio/src/web/pages/DatabasePage.tsx
@@ -150,6 +150,7 @@ export function DatabasePage() {
 					</div>
 					<div className="ml-auto w-[260px]">
 						<Input
+							aria-label="Search records"
 							placeholder="Search all payload fields…"
 							value={search}
 							onChange={(e) => setSearch(e.target.value)}
@@ -168,6 +169,7 @@ export function DatabasePage() {
 						</select>
 						<button
 							type="button"
+							aria-label="Sort direction"
 							onClick={() =>
 								setSortDirection((current) =>
 									current === 'asc' ? 'desc' : 'asc',

--- a/packages/studio/src/web/pages/DatabasePage.tsx
+++ b/packages/studio/src/web/pages/DatabasePage.tsx
@@ -169,7 +169,7 @@ export function DatabasePage() {
 						</select>
 						<button
 							type="button"
-							aria-label="Sort direction"
+							aria-label={`Sort direction: ${sortDirection}`}
 							onClick={() =>
 								setSortDirection((current) =>
 									current === 'asc' ? 'desc' : 'asc',


### PR DESCRIPTION
## Description

Adds `aria-label="Search records"` to the search input and `aria-label="Sort direction"` to the ASC/DESC sort direction toggle button in Studio (`packages/studio/src/web/pages/DatabasePage.tsx`). 

These interactive elements previously lacked accessible names for screen readers.
fixes #719 

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [ ] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

<img width="867" height="364" alt="image" src="https://github.com/user-attachments/assets/074d0197-9492-4383-86eb-57a82acf5d75" />
<img width="867" height="464" alt="image" src="https://github.com/user-attachments/assets/adac79b3-78ed-4ba9-9346-2cf8565ecd39" />


## Additional Notes

- Select controls were left unchanged.
- No visual CSS styling modifications were made.
- Verified via `rg 'aria-label="Search records"|aria-label="Sort direction' packages/studio/src/web/pages/DatabasePage.tsx`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added accessible labels to the database record search field and sort-direction control, including the current sort direction for clearer screen reader support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->