### PR TITLE
fix(studio): label the PluginsPage scope and tenant selects

### DIFF
--- a/packages/studio/src/web/pages/PluginsPage.tsx
+++ b/packages/studio/src/web/pages/PluginsPage.tsx
@@ -217,6 +217,7 @@ function PluginsToolbar({
 						onChange={(e) =>
 							setScope(e.target.value === 'main' ? 'main' : 'tenant')
 						}
+						aria-label="Credential scope"
 						className="h-8 px-2 rounded-md text-xs bg-[var(--color-bg)] border border-[var(--color-border)] focus:outline-none focus:border-[var(--color-accent-dim)]"
 					>
 						<option value="main">Main (integration keys)</option>
@@ -225,6 +226,7 @@ function PluginsToolbar({
 					{scope === 'tenant' ? (
 						<select
 							value={activeTenant}
+							aria-label="Active tenant"
 							onChange={(e) => setActiveTenant(e.target.value)}
 							className="h-8 px-2 rounded-md text-xs bg-[var(--color-bg)] border border-[var(--color-border)] focus:outline-none focus:border-[var(--color-accent-dim)]"
 						>


### PR DESCRIPTION
## Description

Adds accessible names to the two unlabeled `<select>` elements on the Plugins page.

- View scope `<select>`: `aria-label="Credential scope"`
- Active tenant `<select>`: `aria-label="Active tenant"`

No visual or behavioral changes — labeling only. Create-tenant input labeling is a separate issue and is not addressed here.

Fixes #696 

## Checklist
- [x] scope select has an accessible name
- [x] tenant select has an accessible name
- [x] no visual redesign required


## Screenshots / Demos (if applicable)
`220:   aria-label="Credential scope"`
`229:  aria-label="Active tenant"`


## Additional Notes
Verified with:

`rg 'aria-label="Credential scope"|aria-label="Active tenant"' packages/studio/src/web/pages/PluginsPage.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added descriptive labels to the scope and active-tenant selectors on the Plugins page, improving navigation for assistive technology users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->