### PR TITLE
fix(studio): add aria labels for selects

### DIFF
--- a/packages/studio/src/web/pages/DatabasePage.tsx
+++ b/packages/studio/src/web/pages/DatabasePage.tsx
@@ -134,6 +134,7 @@ export function DatabasePage() {
 					</label>
 					<select
 						value={selectedTenant ?? ''}
+						aria-label="Tenant"
 						onChange={(e) => setSelectedTenant(e.target.value)}
 						className="h-8 min-w-[220px] px-2 rounded-md text-xs bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text)] focus:outline-none focus:border-[var(--color-accent-dim)]"
 					>
@@ -158,6 +159,7 @@ export function DatabasePage() {
 					<div className="flex items-center gap-2">
 						<select
 							value={sortField}
+							aria-label="Sort field"
 							onChange={(e) =>
 								setSortField(e.target.value as 'created_at' | 'updated_at')
 							}


### PR DESCRIPTION
## Description

Adds accessible names to the tenant `<select>` and sort-field `<select>` on the Database page.
- Tenant `<select>`: associated with the visible "Tenant" label via  `aria-label="Tenant"`
- Sort field `<select>`: `aria-label="Sort field"`

No visual or behavioral changes — labeling only. Search input labeling is a separate issue and is not addressed here.

Fixes #695

## Checklist
- [x] tenant select has an accessible name
- [x] sort select has an accessible name
- [x] no visual redesign required

## Screenshots / Demos (if applicable)

`137:   aria-label="Tenant"`
`162:   aria-label="Sort field"`

## Additional Notes
Verified with:
`rg 'aria-label="Tenant"|aria-label="Sort field"' packages/studio/src/web/pages/DatabasePage.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added descriptive labels to the tenant and sort-field selectors on the Database page, improving support for screen readers and other assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->