### PR TITLE
fix(studio): label the tenant input

### DIFF
--- a/packages/studio/src/web/pages/PluginsPage.tsx
+++ b/packages/studio/src/web/pages/PluginsPage.tsx
@@ -242,6 +242,7 @@ function PluginsToolbar({
 					<Input
 						value={newTenant}
 						onChange={(e) => setNewTenant(e.target.value)}
+						aria-label="New tenant ID"
 						placeholder="tenant-id"
 					/>
 					<Button


### PR DESCRIPTION
## Description

Adds an accessible name to the create-tenant input on `PluginsPage` so assistive technologies can identify the field without relying on its placeholder.

Fixes #718.

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] Hosted CI ran the full test suite and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

The Studio package test command passes locally. The root suite cannot complete cleanly in this environment because unrelated packages run live integration tests without their services or credentials: PostgreSQL is unavailable, HubSpot returns `Unauthorized`, and existing Jest/ESM package tests reject the built ESM output. GitHub's `CI Checks` job completed its Build and Run tests steps successfully on this commit. No new test or documentation is needed for this declarative one-line accessibility label; the upstream baseline lacks the label and the patched source contains it exactly once.

## Screenshots / Demos (if applicable)

No visual change. The input now exposes the accessible name `New tenant ID`.

## Additional Notes

- No dependencies or generated files changed.
- Implementation and validation were assisted by Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added a descriptive “New tenant ID” label to the tenant ID input for improved screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->