### PR TITLE
feat(twochat): add 2Chat plugin (contacts, account usage, webhooks)

### DIFF
--- a/demo/testing/package.json
+++ b/demo/testing/package.json
@@ -48,6 +48,7 @@
     "@corsair-dev/vapi": "workspace:*",
     "@corsair-dev/xquik": "workspace:*",
     "@corsair-dev/instagram": "workspace:*",
+    "@corsair-dev/twochat": "workspace:*",
     "@tanstack/react-query": "^5.62.14",
     "@trpc/client": "^11.0.0",
     "@trpc/react-query": "^11.0.0",

--- a/demo/testing/package.json
+++ b/demo/testing/package.json
@@ -48,7 +48,6 @@
     "@corsair-dev/vapi": "workspace:*",
     "@corsair-dev/xquik": "workspace:*",
     "@corsair-dev/instagram": "workspace:*",
-    "@corsair-dev/twochat": "workspace:*",
     "@tanstack/react-query": "^5.62.14",
     "@trpc/client": "^11.0.0",
     "@trpc/react-query": "^11.0.0",

--- a/demo/testing/src/server/corsair.ts
+++ b/demo/testing/src/server/corsair.ts
@@ -12,6 +12,7 @@ import { onedrive } from '@corsair-dev/onedrive';
 import { sharepoint } from '@corsair-dev/sharepoint';
 import { slack } from '@corsair-dev/slack';
 import { twilio } from '@corsair-dev/twilio';
+import { twochat } from '@corsair-dev/twochat';
 import { vapi } from '@corsair-dev/vapi';
 import { createCorsair } from 'corsair';
 
@@ -62,6 +63,9 @@ export const corsair = createCorsair({
 		vapi({
 			key: process.env.VAPI_API_KEY,
 			webhookSecret: process.env.VAPI_WEBHOOK_SECRET,
+		}),
+		twochat({
+			key: process.env.TWOCHAT_API_KEY,
 		}),
 		instagram(),
 	],

--- a/demo/testing/src/server/corsair.ts
+++ b/demo/testing/src/server/corsair.ts
@@ -12,7 +12,6 @@ import { onedrive } from '@corsair-dev/onedrive';
 import { sharepoint } from '@corsair-dev/sharepoint';
 import { slack } from '@corsair-dev/slack';
 import { twilio } from '@corsair-dev/twilio';
-import { twochat } from '@corsair-dev/twochat';
 import { vapi } from '@corsair-dev/vapi';
 import { createCorsair } from 'corsair';
 
@@ -63,9 +62,6 @@ export const corsair = createCorsair({
 		vapi({
 			key: process.env.VAPI_API_KEY,
 			webhookSecret: process.env.VAPI_WEBHOOK_SECRET,
-		}),
-		twochat({
-			key: process.env.TWOCHAT_API_KEY,
 		}),
 		instagram(),
 	],

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -29,8 +29,8 @@ export const BaseProviders = [
 	'alphavantage',
 	'alttextai',
 	'amara',
-	'ambientweather',
 	'ambee',
+	'ambientweather',
 	'amcards',
 	'amplitude',
 	'apibible',
@@ -42,10 +42,10 @@ export const BaseProviders = [
 	'bluesky',
 	'boloforms',
 	'box',
-	'canvas',
 	'cal',
 	'calendly',
 	'canva',
+	'canvas',
 	'cloudflare',
 	'cloudinary',
 	'confluence',
@@ -123,6 +123,7 @@ export const BaseProviders = [
 	'twilio',
 	'twitter',
 	'twitterapiio',
+	'twochat',
 	'typeform',
 	'vapi',
 	'vercel',
@@ -154,8 +155,8 @@ export const ProviderDisplayNames = {
 	alphavantage: 'Alpha Vantage',
 	alttextai: 'AltText.ai',
 	amara: 'Amara',
-	ambientweather: 'Ambient Weather',
 	ambee: 'Ambee',
+	ambientweather: 'Ambient Weather',
 	amcards: 'AMcards',
 	amplitude: 'Amplitude',
 	apibible: 'API.Bible',
@@ -167,10 +168,10 @@ export const ProviderDisplayNames = {
 	bluesky: 'Bluesky',
 	boloforms: 'Boloforms',
 	box: 'Box',
-	canvas: 'Canvas LMS',
 	cal: 'Cal',
 	calendly: 'Calendly',
 	canva: 'Canva',
+	canvas: 'Canvas LMS',
 	cloudflare: 'Cloudflare',
 	cloudinary: 'Cloudinary',
 	confluence: 'Confluence',
@@ -248,6 +249,7 @@ export const ProviderDisplayNames = {
 	twilio: 'Twilio',
 	twitter: 'Twitter',
 	twitterapiio: 'Twitter API IO',
+	twochat: 'TwoChat',
 	typeform: 'Typeform',
 	vapi: 'Vapi',
 	vercel: 'Vercel',
@@ -301,8 +303,8 @@ export type AllProviders =
 	| 'box'
 	| 'cal'
 	| 'calendly'
-	| 'canvas'
 	| 'canva'
+	| 'canvas'
 	| 'cloudflare'
 	| 'cloudinary'
 	| 'confluence'
@@ -380,6 +382,7 @@ export type AllProviders =
 	| 'twilio'
 	| 'twitter'
 	| 'twitterapiio'
+	| 'twochat'
 	| 'typeform'
 	| 'vapi'
 	| 'vercel'

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -29,8 +29,8 @@ export const BaseProviders = [
 	'alphavantage',
 	'alttextai',
 	'amara',
-	'ambee',
 	'ambientweather',
+	'ambee',
 	'amcards',
 	'amplitude',
 	'apibible',
@@ -42,10 +42,10 @@ export const BaseProviders = [
 	'bluesky',
 	'boloforms',
 	'box',
+	'canvas',
 	'cal',
 	'calendly',
 	'canva',
-	'canvas',
 	'cloudflare',
 	'cloudinary',
 	'confluence',
@@ -155,8 +155,8 @@ export const ProviderDisplayNames = {
 	alphavantage: 'Alpha Vantage',
 	alttextai: 'AltText.ai',
 	amara: 'Amara',
-	ambee: 'Ambee',
 	ambientweather: 'Ambient Weather',
+	ambee: 'Ambee',
 	amcards: 'AMcards',
 	amplitude: 'Amplitude',
 	apibible: 'API.Bible',
@@ -168,10 +168,10 @@ export const ProviderDisplayNames = {
 	bluesky: 'Bluesky',
 	boloforms: 'Boloforms',
 	box: 'Box',
+	canvas: 'Canvas LMS',
 	cal: 'Cal',
 	calendly: 'Calendly',
 	canva: 'Canva',
-	canvas: 'Canvas LMS',
 	cloudflare: 'Cloudflare',
 	cloudinary: 'Cloudinary',
 	confluence: 'Confluence',
@@ -303,8 +303,8 @@ export type AllProviders =
 	| 'box'
 	| 'cal'
 	| 'calendly'
-	| 'canva'
 	| 'canvas'
+	| 'canva'
 	| 'cloudflare'
 	| 'cloudinary'
 	| 'confluence'

--- a/packages/twochat/api.test.ts
+++ b/packages/twochat/api.test.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import * as client from './client';
 import { TwoChatAPIError } from './client';
 import { createContact } from './endpoints/create-contact';
@@ -370,5 +371,31 @@ describe('TwoChat plugin', () => {
 		const err = new TwoChatAPIError('forbidden', '403', { cause });
 		expect(err.status).toBe(403);
 		expect(errorHandlers.PERMISSION_ERROR.match(err, mockContext)).toBe(true);
+	});
+});
+
+const LIVE_API_KEY = process.env.TWOCHAT_API_KEY;
+const describeLive = LIVE_API_KEY ? describe : describe.skip;
+
+describeLive('TwoChat live API integration', () => {
+	it('fetches real account API usage info', async () => {
+		const { makeTwoChatRequest } = jest.requireActual(
+			'./client',
+		) as typeof import('./client');
+		const response = await makeTwoChatRequest<any>('open/info', LIVE_API_KEY!);
+		expect(response.success).toBe(true);
+		expect(response.account).toBeDefined();
+	});
+
+	it('lists webhooks from live 2Chat account', async () => {
+		const { makeTwoChatRequest } = jest.requireActual(
+			'./client',
+		) as typeof import('./client');
+		const response = await makeTwoChatRequest<any>(
+			'open/webhooks',
+			LIVE_API_KEY!,
+		);
+		expect(response.success).toBe(true);
+		expect(Array.isArray(response.webhooks)).toBe(true);
 	});
 });

--- a/packages/twochat/api.test.ts
+++ b/packages/twochat/api.test.ts
@@ -1,0 +1,204 @@
+import {
+	TwoChatEndpointInputSchemas,
+	TwoChatEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { twochat, twochatAuthConfig } from './index';
+
+describe('TwoChat plugin', () => {
+	// ─── Initialisation ────────────────────────────────────────────────────────
+
+	it('initializes plugin with id = twochat', () => {
+		const instance = twochat({ key: 'test-api-key' });
+		expect(instance.id).toBe('twochat');
+	});
+
+	it('stores the provided key in options', () => {
+		const instance = twochat({ key: 'test-api-key' });
+		expect(instance.options?.key).toBe('test-api-key');
+	});
+
+	it('defaults authType to api_key', () => {
+		const instance = twochat();
+		expect((instance.options as any)?.authType).toBe('api_key');
+	});
+
+	it('authConfig only exposes api_key — no oauth_2', () => {
+		expect(twochatAuthConfig).toHaveProperty('api_key');
+		expect(twochatAuthConfig).not.toHaveProperty('oauth_2');
+	});
+
+	it('webhooks object is empty (no incoming webhooks per spec)', () => {
+		const instance = twochat();
+		expect(instance.webhooks).toEqual({});
+	});
+
+	// ─── Endpoint registration ─────────────────────────────────────────────────
+
+	it('registers contacts.createContact endpoint', () => {
+		const instance = twochat();
+		expect(instance.endpoints!.contacts.createContact).toBeDefined();
+	});
+
+	it('registers contacts.listContacts endpoint', () => {
+		const instance = twochat();
+		expect(instance.endpoints!.contacts.listContacts).toBeDefined();
+	});
+
+	it('registers account.getApiUsageInfo endpoint', () => {
+		const instance = twochat();
+		expect(instance.endpoints!.account.getApiUsageInfo).toBeDefined();
+	});
+
+	it('registers account.testApiKey endpoint', () => {
+		const instance = twochat();
+		expect(instance.endpoints!.account.testApiKey).toBeDefined();
+	});
+
+	it('registers webhookSubscriptions.listWebhooks endpoint', () => {
+		const instance = twochat();
+		expect(instance.endpoints!.webhookSubscriptions.listWebhooks).toBeDefined();
+	});
+
+	// ─── Endpoint meta ─────────────────────────────────────────────────────────
+
+	it('createContact is write risk', () => {
+		const meta = (twochat() as any).endpointMeta;
+		expect(meta['contacts.createContact'].riskLevel).toBe('write');
+	});
+
+	it('all read endpoints have read risk', () => {
+		const meta = (twochat() as any).endpointMeta;
+		expect(meta['contacts.listContacts'].riskLevel).toBe('read');
+		expect(meta['account.getApiUsageInfo'].riskLevel).toBe('read');
+		expect(meta['account.testApiKey'].riskLevel).toBe('read');
+		expect(meta['webhookSubscriptions.listWebhooks'].riskLevel).toBe('read');
+	});
+
+	// ─── Schema validation — valid data ────────────────────────────────────────
+
+	it('parses a valid createContact response', () => {
+		const result = TwoChatEndpointOutputSchemas.createContact.parse({
+			success: true,
+			contact: {
+				uuid: 'CON123',
+				first_name: 'John',
+				contact_details: [{ type: 'E', value: 'john@example.com' }],
+			},
+		});
+		expect(result.contact.first_name).toBe('John');
+	});
+
+	it('parses a valid getApiUsageInfo response', () => {
+		const result = TwoChatEndpointOutputSchemas.getApiUsageInfo.parse({
+			success: true,
+			account: { uuid: 'ACC123', on_trial: false, blocked: false },
+			limits: { requests_per_minute: 80 },
+			usage: {
+				api_request_count: 100,
+				max_api_request_count: 500000,
+				number_check_count: 50,
+				max_number_check_count: 500000,
+			},
+		});
+		expect(result.usage?.api_request_count).toBe(100);
+	});
+
+	it('parses a valid listContacts response', () => {
+		const result = TwoChatEndpointOutputSchemas.listContacts.parse({
+			results: [{ uuid: 'CON123', first_name: 'Jane' }],
+			page_number: 0,
+			results_per_page: 30,
+		});
+		expect(result.results.length).toBe(1);
+	});
+
+	it('parses a valid listWebhooks response', () => {
+		const result = TwoChatEndpointOutputSchemas.listWebhooks.parse({
+			webhooks: [
+				{
+					uuid: 'WHKabc123',
+					event_name: 'whatsapp.message.received',
+					hook_url: 'https://example.com/webhook',
+				},
+			],
+		});
+		expect(result.webhooks[0]?.uuid).toBe('WHKabc123');
+	});
+
+	// ─── Schema validation — rejection on invalid data ─────────────────────────
+
+	it('rejects createContact input missing first_name', () => {
+		expect(() =>
+			TwoChatEndpointInputSchemas.createContact.parse({
+				contact_details: [{ type: 'E', value: 'x@x.com' }],
+			}),
+		).toThrow();
+	});
+
+	it('rejects createContact input with empty contact_details', () => {
+		expect(() =>
+			TwoChatEndpointInputSchemas.createContact.parse({
+				first_name: 'John',
+				contact_details: [],
+			}),
+		).toThrow();
+	});
+
+	it('accepts listContacts input with no params (uses defaults)', () => {
+		expect(() =>
+			TwoChatEndpointInputSchemas.listContacts.parse({}),
+		).not.toThrow();
+	});
+
+	it('rejects listContacts results_per_page > 100', () => {
+		expect(() =>
+			TwoChatEndpointInputSchemas.listContacts.parse({ results_per_page: 200 }),
+		).toThrow();
+	});
+
+	// ─── Webhook plugin matcher ─────────────────────────────────────────────────
+
+	it('pluginWebhookMatcher always returns false (no incoming webhooks)', () => {
+		const instance = twochat();
+		const matcher = instance.pluginWebhookMatcher!;
+		expect(matcher({ headers: { 'x-2chat-signature': 'sig' }, body: {} })).toBe(
+			false,
+		);
+		expect(matcher({ headers: {}, body: {} })).toBe(false);
+	});
+
+	// ─── Error handlers ────────────────────────────────────────────────────────
+
+	const mockCtx = {
+		pluginId: 'twochat',
+		operation: 'test',
+		input: {},
+		originalError: new Error(''),
+	};
+
+	it('RATE_LIMIT_ERROR matches rate_limited message', () => {
+		const err = new Error('rate_limited: too many requests');
+		expect(errorHandlers.RATE_LIMIT_ERROR.match(err, mockCtx)).toBe(true);
+	});
+
+	it('AUTH_ERROR matches unauthorized message', () => {
+		const err = new Error('unauthorized: invalid_auth');
+		expect(errorHandlers.AUTH_ERROR.match(err, mockCtx)).toBe(true);
+	});
+
+	it('PERMISSION_ERROR matches forbidden message', () => {
+		const err = new Error('forbidden: permission_denied');
+		expect(errorHandlers.PERMISSION_ERROR.match(err, mockCtx)).toBe(true);
+	});
+
+	it('NETWORK_ERROR matches fetch failed', () => {
+		const err = new Error('fetch failed');
+		expect(errorHandlers.NETWORK_ERROR.match(err, mockCtx)).toBe(true);
+	});
+
+	it('DEFAULT matches any error', () => {
+		const err = new Error('some unknown error');
+		expect(errorHandlers.DEFAULT.match(err, mockCtx)).toBe(true);
+	});
+});

--- a/packages/twochat/api.test.ts
+++ b/packages/twochat/api.test.ts
@@ -1,4 +1,5 @@
 import * as client from './client';
+import { TwoChatAPIError } from './client';
 import { createContact } from './endpoints/create-contact';
 import { getApiUsageInfo } from './endpoints/get-api-usage-info';
 import { listContacts } from './endpoints/list-contacts';
@@ -28,6 +29,8 @@ jest.mock('corsair/core', () => {
 		logEventFromContext: jest.fn().mockResolvedValue(undefined),
 	};
 });
+
+import { logEventFromContext } from 'corsair/core';
 
 describe('TwoChat plugin', () => {
 	const mockContext: any = {
@@ -125,6 +128,12 @@ describe('TwoChat plugin', () => {
 					contact_detail: [{ type: 'PH', value: '+1234567890' }],
 				},
 			},
+		);
+		expect(logEventFromContext).toHaveBeenCalledWith(
+			mockContext,
+			'twochat.contacts.createContact',
+			{ first_name: 'Alice' },
+			'completed',
 		);
 		expect(result).toEqual(mockResponse);
 	});
@@ -312,5 +321,54 @@ describe('TwoChat plugin', () => {
 		expect(errorHandlers.DEFAULT.match(err, mockContext)).toBe(true);
 		const res = await errorHandlers.DEFAULT.handler(err, mockContext);
 		expect(res.maxRetries).toBe(0);
+	});
+
+	// ─── Status-code based error handler matching ───────────────────────────────
+	// Build real ApiError instances so TwoChatAPIError's `instanceof ApiError`
+	// guard fires and the status/retryAfter fields get copied correctly.
+
+	function makeApiError(
+		status: number,
+		message: string,
+		retryAfter?: number,
+	): Error {
+		const { ApiError } = jest.requireActual(
+			'corsair/http',
+		) as typeof import('corsair/http');
+		const req = { method: 'GET' as const, url: '/test' };
+		const res = {
+			url: 'https://api.p.2chat.io/test',
+			ok: false,
+			status,
+			statusText: String(status),
+			body: {},
+		};
+		const rateLimitInfo = retryAfter !== undefined ? { retryAfter } : undefined;
+		return new ApiError(req, res, message, rateLimitInfo);
+	}
+
+	it('RATE_LIMIT_ERROR matches a 429 TwoChatAPIError and forwards retryAfter', async () => {
+		const cause = makeApiError(429, 'rate limited', 30_000);
+		const err = new TwoChatAPIError('rate limited', '429', { cause });
+		expect(err.status).toBe(429);
+		expect(err.retryAfter).toBe(30_000);
+		expect(errorHandlers.RATE_LIMIT_ERROR.match(err, mockContext)).toBe(true);
+		const res = await errorHandlers.RATE_LIMIT_ERROR.handler(err, mockContext);
+		expect(res.maxRetries).toBe(5);
+		expect((res as any).headersRetryAfterMs).toBe(30_000);
+	});
+
+	it('AUTH_ERROR matches a 401 TwoChatAPIError', () => {
+		const cause = makeApiError(401, 'unauthorized');
+		const err = new TwoChatAPIError('unauthorized', '401', { cause });
+		expect(err.status).toBe(401);
+		expect(errorHandlers.AUTH_ERROR.match(err, mockContext)).toBe(true);
+	});
+
+	it('PERMISSION_ERROR matches a 403 TwoChatAPIError', () => {
+		const cause = makeApiError(403, 'forbidden');
+		const err = new TwoChatAPIError('forbidden', '403', { cause });
+		expect(err.status).toBe(403);
+		expect(errorHandlers.PERMISSION_ERROR.match(err, mockContext)).toBe(true);
 	});
 });

--- a/packages/twochat/api.test.ts
+++ b/packages/twochat/api.test.ts
@@ -1,3 +1,9 @@
+import * as client from './client';
+import { createContact } from './endpoints/create-contact';
+import { getApiUsageInfo } from './endpoints/get-api-usage-info';
+import { listContacts } from './endpoints/list-contacts';
+import { listWebhooks } from './endpoints/list-webhooks';
+import { testApiKey } from './endpoints/test-api-key';
 import {
 	TwoChatEndpointInputSchemas,
 	TwoChatEndpointOutputSchemas,
@@ -5,8 +11,38 @@ import {
 import { errorHandlers } from './error-handlers';
 import { twochat, twochatAuthConfig } from './index';
 
+// Mock client.makeTwoChatRequest to verify endpoint behavioral dispatch
+jest.mock('./client', () => {
+	const actual = jest.requireActual('./client');
+	return {
+		...actual,
+		makeTwoChatRequest: jest.fn(),
+	};
+});
+
+// Mock logEventFromContext
+jest.mock('corsair/core', () => {
+	const actual = jest.requireActual('corsair/core');
+	return {
+		...actual,
+		logEventFromContext: jest.fn().mockResolvedValue(undefined),
+	};
+});
+
 describe('TwoChat plugin', () => {
-	// ─── Initialisation ────────────────────────────────────────────────────────
+	const mockContext: any = {
+		key: 'test-api-key-123',
+		pluginId: 'twochat',
+		operation: 'test',
+		input: {},
+		originalError: new Error(''),
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	// ─── Initialisation & Structure ────────────────────────────────────────────
 
 	it('initializes plugin with id = twochat', () => {
 		const instance = twochat({ key: 'test-api-key' });
@@ -33,100 +69,184 @@ describe('TwoChat plugin', () => {
 		expect(instance.webhooks).toEqual({});
 	});
 
-	// ─── Endpoint registration ─────────────────────────────────────────────────
+	// ─── Endpoint Registration & Risk Metadata ─────────────────────────────────
 
-	it('registers contacts.createContact endpoint', () => {
+	it('registers all 5 endpoints on the plugin instance', () => {
 		const instance = twochat();
 		expect(instance.endpoints!.contacts.createContact).toBeDefined();
-	});
-
-	it('registers contacts.listContacts endpoint', () => {
-		const instance = twochat();
 		expect(instance.endpoints!.contacts.listContacts).toBeDefined();
-	});
-
-	it('registers account.getApiUsageInfo endpoint', () => {
-		const instance = twochat();
 		expect(instance.endpoints!.account.getApiUsageInfo).toBeDefined();
-	});
-
-	it('registers account.testApiKey endpoint', () => {
-		const instance = twochat();
 		expect(instance.endpoints!.account.testApiKey).toBeDefined();
-	});
-
-	it('registers webhookSubscriptions.listWebhooks endpoint', () => {
-		const instance = twochat();
 		expect(instance.endpoints!.webhookSubscriptions.listWebhooks).toBeDefined();
 	});
 
-	// ─── Endpoint meta ─────────────────────────────────────────────────────────
-
-	it('createContact is write risk', () => {
+	it('assigns correct risk levels to all endpoints', () => {
 		const meta = (twochat() as any).endpointMeta;
 		expect(meta['contacts.createContact'].riskLevel).toBe('write');
-	});
-
-	it('all read endpoints have read risk', () => {
-		const meta = (twochat() as any).endpointMeta;
 		expect(meta['contacts.listContacts'].riskLevel).toBe('read');
 		expect(meta['account.getApiUsageInfo'].riskLevel).toBe('read');
 		expect(meta['account.testApiKey'].riskLevel).toBe('read');
 		expect(meta['webhookSubscriptions.listWebhooks'].riskLevel).toBe('read');
 	});
 
-	// ─── Schema validation — valid data ────────────────────────────────────────
+	// ─── Endpoint Execution & Behavioral Tests ─────────────────────────────────
 
-	it('parses a valid createContact response', () => {
-		const result = TwoChatEndpointOutputSchemas.createContact.parse({
+	it('createContact calls POST /open/contacts with correct payload', async () => {
+		const mockResponse = {
 			success: true,
 			contact: {
-				uuid: 'CON123',
-				first_name: 'John',
-				contact_details: [{ type: 'E', value: 'john@example.com' }],
+				uuid: 'CON_123',
+				first_name: 'Alice',
+				details: [{ type: 'PH' as const, value: '+1234567890' }],
 			},
-		});
-		expect(result.contact.first_name).toBe('John');
+		};
+		(client.makeTwoChatRequest as jest.Mock).mockResolvedValueOnce(
+			mockResponse,
+		);
+
+		const input = {
+			first_name: 'Alice',
+			last_name: 'Smith',
+			contact_details: [{ type: 'PH' as const, value: '+1234567890' }],
+		};
+
+		const result = await createContact(mockContext, input);
+
+		expect(client.makeTwoChatRequest).toHaveBeenCalledWith(
+			'open/contacts',
+			'test-api-key-123',
+			{
+				method: 'POST',
+				body: {
+					first_name: 'Alice',
+					last_name: 'Smith',
+					profile_pic_url: undefined,
+					channel_uuid: undefined,
+					contact_detail: [{ type: 'PH', value: '+1234567890' }],
+				},
+			},
+		);
+		expect(result).toEqual(mockResponse);
 	});
 
-	it('parses a valid getApiUsageInfo response', () => {
-		const result = TwoChatEndpointOutputSchemas.getApiUsageInfo.parse({
+	it('listContacts calls GET /open/contacts with pagination parameters', async () => {
+		const mockResponse = {
 			success: true,
-			account: { uuid: 'ACC123', on_trial: false, blocked: false },
-			limits: { requests_per_minute: 80 },
-			usage: {
-				api_request_count: 100,
-				max_api_request_count: 500000,
-				number_check_count: 50,
-				max_number_check_count: 500000,
+			page: 1,
+			count: 1,
+			contacts: [{ uuid: 'CON_1', first_name: 'Bob' }],
+		};
+		(client.makeTwoChatRequest as jest.Mock).mockResolvedValueOnce(
+			mockResponse,
+		);
+
+		const result = await listContacts(mockContext, {
+			page_number: 1,
+			results_per_page: 20,
+		});
+
+		expect(client.makeTwoChatRequest).toHaveBeenCalledWith(
+			'open/contacts',
+			'test-api-key-123',
+			{
+				method: 'GET',
+				query: {
+					page_number: 1,
+					results_per_page: 20,
+				},
 			},
-		});
-		expect(result.usage?.api_request_count).toBe(100);
+		);
+		expect(result).toEqual(mockResponse);
 	});
 
-	it('parses a valid listContacts response', () => {
-		const result = TwoChatEndpointOutputSchemas.listContacts.parse({
-			results: [{ uuid: 'CON123', first_name: 'Jane' }],
-			page_number: 0,
-			results_per_page: 30,
-		});
-		expect(result.results.length).toBe(1);
+	it('getApiUsageInfo calls GET /open/info', async () => {
+		const mockResponse = {
+			success: true,
+			account: { uuid: 'ACC_1', name: 'Pro Plan' },
+			limits: { requests_per_minute: 100 },
+			usage: {
+				api_requests_available: 1950,
+				api_requests_plan_default: 2000,
+				number_check_requests_available: 100,
+				number_check_requests_plan_default: 100,
+			},
+		};
+		(client.makeTwoChatRequest as jest.Mock).mockResolvedValueOnce(
+			mockResponse,
+		);
+
+		const result = await getApiUsageInfo(mockContext, {});
+
+		expect(client.makeTwoChatRequest).toHaveBeenCalledWith(
+			'open/info',
+			'test-api-key-123',
+			{ method: 'GET' },
+		);
+		expect(result).toEqual(mockResponse);
 	});
 
-	it('parses a valid listWebhooks response', () => {
-		const result = TwoChatEndpointOutputSchemas.listWebhooks.parse({
+	it('testApiKey calls GET /open/info to validate credentials', async () => {
+		const mockResponse = {
+			success: true,
+			account: { uuid: 'ACC_1', on_trial: false, blocked: false },
+		};
+		(client.makeTwoChatRequest as jest.Mock).mockResolvedValueOnce(
+			mockResponse,
+		);
+
+		const result = await testApiKey(mockContext, {});
+
+		expect(client.makeTwoChatRequest).toHaveBeenCalledWith(
+			'open/info',
+			'test-api-key-123',
+			{ method: 'GET' },
+		);
+		expect(result).toEqual(mockResponse);
+	});
+
+	it('listWebhooks calls GET /open/webhooks', async () => {
+		const mockResponse = {
+			success: true,
 			webhooks: [
 				{
-					uuid: 'WHKabc123',
+					uuid: 'WHK_1',
 					event_name: 'whatsapp.message.received',
 					hook_url: 'https://example.com/webhook',
 				},
 			],
-		});
-		expect(result.webhooks[0]?.uuid).toBe('WHKabc123');
+		};
+		(client.makeTwoChatRequest as jest.Mock).mockResolvedValueOnce(
+			mockResponse,
+		);
+
+		const result = await listWebhooks(mockContext, {});
+
+		expect(client.makeTwoChatRequest).toHaveBeenCalledWith(
+			'open/webhooks',
+			'test-api-key-123',
+			{ method: 'GET' },
+		);
+		expect(result).toEqual(mockResponse);
 	});
 
-	// ─── Schema validation — rejection on invalid data ─────────────────────────
+	// ─── Zod Schema Validation ─────────────────────────────────────────────────
+
+	it('parses valid output payloads', () => {
+		const contactRes = TwoChatEndpointOutputSchemas.createContact.parse({
+			success: true,
+			contact: { uuid: 'CON_1', first_name: 'John' },
+		});
+		expect(contactRes.contact.first_name).toBe('John');
+
+		const usageRes = TwoChatEndpointOutputSchemas.getApiUsageInfo.parse({
+			success: true,
+			usage: {
+				api_requests_available: 1999,
+				api_requests_plan_default: 2000,
+			},
+		});
+		expect(usageRes.usage?.api_requests_available).toBe(1999);
+	});
 
 	it('rejects createContact input missing first_name', () => {
 		expect(() =>
@@ -145,60 +265,52 @@ describe('TwoChat plugin', () => {
 		).toThrow();
 	});
 
-	it('accepts listContacts input with no params (uses defaults)', () => {
+	it('accepts listContacts input with no params and uses defaults', () => {
 		expect(() =>
 			TwoChatEndpointInputSchemas.listContacts.parse({}),
 		).not.toThrow();
 	});
 
-	it('rejects listContacts results_per_page > 100', () => {
+	it('rejects listContacts results_per_page exceeding max of 100', () => {
 		expect(() =>
 			TwoChatEndpointInputSchemas.listContacts.parse({ results_per_page: 200 }),
 		).toThrow();
 	});
 
-	// ─── Webhook plugin matcher ─────────────────────────────────────────────────
+	// ─── Error Handlers ────────────────────────────────────────────────────────
 
-	it('pluginWebhookMatcher always returns false (no incoming webhooks)', () => {
-		const instance = twochat();
-		const matcher = instance.pluginWebhookMatcher!;
-		expect(matcher({ headers: { 'x-2chat-signature': 'sig' }, body: {} })).toBe(
-			false,
-		);
-		expect(matcher({ headers: {}, body: {} })).toBe(false);
-	});
-
-	// ─── Error handlers ────────────────────────────────────────────────────────
-
-	const mockCtx = {
-		pluginId: 'twochat',
-		operation: 'test',
-		input: {},
-		originalError: new Error(''),
-	};
-
-	it('RATE_LIMIT_ERROR matches rate_limited message', () => {
+	it('RATE_LIMIT_ERROR matches 429 and rate_limited messages', async () => {
 		const err = new Error('rate_limited: too many requests');
-		expect(errorHandlers.RATE_LIMIT_ERROR.match(err, mockCtx)).toBe(true);
+		expect(errorHandlers.RATE_LIMIT_ERROR.match(err, mockContext)).toBe(true);
+		const res = await errorHandlers.RATE_LIMIT_ERROR.handler(err, mockContext);
+		expect(res.maxRetries).toBe(5);
 	});
 
-	it('AUTH_ERROR matches unauthorized message', () => {
-		const err = new Error('unauthorized: invalid_auth');
-		expect(errorHandlers.AUTH_ERROR.match(err, mockCtx)).toBe(true);
+	it('AUTH_ERROR matches 401 and unauthorized messages', async () => {
+		const err = new Error('unauthorized: invalid_key');
+		expect(errorHandlers.AUTH_ERROR.match(err, mockContext)).toBe(true);
+		const res = await errorHandlers.AUTH_ERROR.handler(err, mockContext);
+		expect(res.maxRetries).toBe(0);
 	});
 
-	it('PERMISSION_ERROR matches forbidden message', () => {
+	it('PERMISSION_ERROR matches 403 and forbidden messages', async () => {
 		const err = new Error('forbidden: permission_denied');
-		expect(errorHandlers.PERMISSION_ERROR.match(err, mockCtx)).toBe(true);
+		expect(errorHandlers.PERMISSION_ERROR.match(err, mockContext)).toBe(true);
+		const res = await errorHandlers.PERMISSION_ERROR.handler(err, mockContext);
+		expect(res.maxRetries).toBe(0);
 	});
 
-	it('NETWORK_ERROR matches fetch failed', () => {
+	it('NETWORK_ERROR matches connection errors', async () => {
 		const err = new Error('fetch failed');
-		expect(errorHandlers.NETWORK_ERROR.match(err, mockCtx)).toBe(true);
+		expect(errorHandlers.NETWORK_ERROR.match(err, mockContext)).toBe(true);
+		const res = await errorHandlers.NETWORK_ERROR.handler(err, mockContext);
+		expect(res.maxRetries).toBe(3);
 	});
 
-	it('DEFAULT matches any error', () => {
-		const err = new Error('some unknown error');
-		expect(errorHandlers.DEFAULT.match(err, mockCtx)).toBe(true);
+	it('DEFAULT catches any unhandled error', async () => {
+		const err = new Error('unexpected error');
+		expect(errorHandlers.DEFAULT.match(err, mockContext)).toBe(true);
+		const res = await errorHandlers.DEFAULT.handler(err, mockContext);
+		expect(res.maxRetries).toBe(0);
 	});
 });

--- a/packages/twochat/api.test.ts
+++ b/packages/twochat/api.test.ts
@@ -175,10 +175,10 @@ describe('TwoChat plugin', () => {
 			account: { uuid: 'ACC_1', name: 'Pro Plan' },
 			limits: { requests_per_minute: 100 },
 			usage: {
-				api_requests_available: 1950,
-				api_requests_plan_default: 2000,
-				number_check_requests_available: 100,
-				number_check_requests_plan_default: 100,
+				api_request_count: 1950,
+				max_api_request_count: 2000,
+				number_check_count: 100,
+				max_number_check_count: 100,
 			},
 		};
 		(client.makeTwoChatRequest as jest.Mock).mockResolvedValueOnce(
@@ -251,11 +251,11 @@ describe('TwoChat plugin', () => {
 		const usageRes = TwoChatEndpointOutputSchemas.getApiUsageInfo.parse({
 			success: true,
 			usage: {
-				api_requests_available: 1999,
-				api_requests_plan_default: 2000,
+				api_request_count: 77112,
+				max_api_request_count: 500000,
 			},
 		});
-		expect(usageRes.usage?.api_requests_available).toBe(1999);
+		expect(usageRes.usage?.api_request_count).toBe(77112);
 	});
 
 	it('rejects createContact input missing first_name', () => {

--- a/packages/twochat/api.test.ts
+++ b/packages/twochat/api.test.ts
@@ -239,6 +239,112 @@ describe('TwoChat plugin', () => {
 		expect(result).toEqual(mockResponse);
 	});
 
+	function cacheCtx() {
+		const contacts = {
+			upsertByEntityId: jest.fn().mockResolvedValue(undefined),
+		};
+		const accounts = {
+			upsertByEntityId: jest.fn().mockResolvedValue(undefined),
+		};
+		const webhookSubscriptions = {
+			upsertByEntityId: jest.fn().mockResolvedValue(undefined),
+		};
+		return {
+			ctx: {
+				...mockContext,
+				db: { contacts, accounts, webhookSubscriptions },
+			},
+			contacts,
+			accounts,
+			webhookSubscriptions,
+		};
+	}
+
+	it('listContacts caches each contact', async () => {
+		(client.makeTwoChatRequest as jest.Mock).mockResolvedValueOnce({
+			success: true,
+			page: 0,
+			count: 1,
+			contacts: [{ uuid: 'CON_1', first_name: 'Bob' }],
+		});
+		const { ctx, contacts } = cacheCtx();
+		await listContacts(ctx, {});
+		expect(contacts.upsertByEntityId).toHaveBeenCalledWith(
+			'CON_1',
+			expect.objectContaining({ uuid: 'CON_1', first_name: 'Bob' }),
+		);
+	});
+
+	it('createContact caches the created contact', async () => {
+		(client.makeTwoChatRequest as jest.Mock).mockResolvedValueOnce({
+			success: true,
+			contact: { uuid: 'CON_123', first_name: 'Alice' },
+		});
+		const { ctx, contacts } = cacheCtx();
+		await createContact(ctx, {
+			first_name: 'Alice',
+			contact_details: [{ type: 'PH', value: '+1234567890' }],
+		});
+		expect(contacts.upsertByEntityId).toHaveBeenCalledWith(
+			'CON_123',
+			expect.objectContaining({ uuid: 'CON_123', first_name: 'Alice' }),
+		);
+	});
+
+	it('getApiUsageInfo caches the account', async () => {
+		(client.makeTwoChatRequest as jest.Mock).mockResolvedValueOnce({
+			success: true,
+			account: { uuid: 'ACC_1', name: 'Pro Plan' },
+			limits: { requests_per_minute: 100 },
+		});
+		const { ctx, accounts } = cacheCtx();
+		await getApiUsageInfo(ctx, {});
+		expect(accounts.upsertByEntityId).toHaveBeenCalledWith(
+			'ACC_1',
+			expect.objectContaining({
+				uuid: 'ACC_1',
+				name: 'Pro Plan',
+				requests_per_minute: 100,
+			}),
+		);
+	});
+
+	it('listWebhooks caches each webhook', async () => {
+		(client.makeTwoChatRequest as jest.Mock).mockResolvedValueOnce({
+			success: true,
+			webhooks: [
+				{
+					uuid: 'WHK_1',
+					event_name: 'whatsapp.message.received',
+					hook_url: 'https://example.com/webhook',
+				},
+			],
+		});
+		const { ctx, webhookSubscriptions } = cacheCtx();
+		await listWebhooks(ctx, {});
+		expect(webhookSubscriptions.upsertByEntityId).toHaveBeenCalledWith(
+			'WHK_1',
+			expect.objectContaining({
+				uuid: 'WHK_1',
+				event_name: 'whatsapp.message.received',
+			}),
+		);
+	});
+
+	it('cache write failures do not fail the API call', async () => {
+		(client.makeTwoChatRequest as jest.Mock).mockResolvedValueOnce({
+			success: true,
+			page: 0,
+			count: 1,
+			contacts: [{ uuid: 'CON_1', first_name: 'Bob' }],
+		});
+		const { ctx, contacts } = cacheCtx();
+		contacts.upsertByEntityId.mockRejectedValueOnce(new Error('db down'));
+		await expect(listContacts(ctx, {})).resolves.toMatchObject({
+			contacts: [{ uuid: 'CON_1', first_name: 'Bob' }],
+		});
+	});
+
 	// ─── Zod Schema Validation ─────────────────────────────────────────────────
 
 	it('parses valid output payloads', () => {

--- a/packages/twochat/client.test.ts
+++ b/packages/twochat/client.test.ts
@@ -1,0 +1,100 @@
+import { request } from 'corsair/http';
+import { makeTwoChatRequest, TwoChatAPIError } from './client';
+
+// Mock corsair/http so we can control request() without real HTTP
+jest.mock('corsair/http', () => {
+	const actual = jest.requireActual('corsair/http');
+	return { ...actual, request: jest.fn() };
+});
+
+const mockRequest = request as jest.Mock;
+
+describe('makeTwoChatRequest — error wrapping', () => {
+	beforeEach(() => jest.clearAllMocks());
+
+	it('wraps a 429 ApiError into TwoChatAPIError preserving status and retryAfter', async () => {
+		// ApiError cannot be instantiated directly without real ApiRequestOptions /
+		// ApiResult, so we construct a plain Error that looks like an ApiError.
+		const apiErr = Object.assign(new Error('rate limited'), {
+			name: 'ApiError',
+			status: 429,
+			statusText: 'Too Many Requests',
+			body: { message: 'rate limited' },
+			retryAfter: 5_000,
+			url: 'https://api.p.2chat.io/open/info',
+			request: {},
+		});
+		// Make it pass the `instanceof ApiError` check
+		Object.setPrototypeOf(
+			apiErr,
+			// eslint-disable-next-line @typescript-eslint/no-require-imports
+			require('corsair/http').ApiError.prototype,
+		);
+		mockRequest.mockRejectedValueOnce(apiErr);
+
+		let thrown: unknown;
+		try {
+			await makeTwoChatRequest('open/info', 'key');
+		} catch (e) {
+			thrown = e;
+		}
+
+		expect(thrown).toBeInstanceOf(TwoChatAPIError);
+		const err = thrown as TwoChatAPIError;
+		expect(err.status).toBe(429);
+		expect(err.retryAfter).toBe(5_000);
+		expect(err.code).toBe('429');
+	});
+
+	it('wraps a 401 ApiError into TwoChatAPIError with status 401', async () => {
+		const apiErr = Object.assign(new Error('unauthorized'), {
+			name: 'ApiError',
+			status: 401,
+			statusText: 'Unauthorized',
+			body: {},
+			url: 'https://api.p.2chat.io/open/info',
+			request: {},
+		});
+		Object.setPrototypeOf(
+			apiErr,
+			// eslint-disable-next-line @typescript-eslint/no-require-imports
+			require('corsair/http').ApiError.prototype,
+		);
+		mockRequest.mockRejectedValueOnce(apiErr);
+
+		let thrown: unknown;
+		try {
+			await makeTwoChatRequest('open/info', 'key');
+		} catch (e) {
+			thrown = e;
+		}
+
+		expect(thrown).toBeInstanceOf(TwoChatAPIError);
+		expect((thrown as TwoChatAPIError).status).toBe(401);
+	});
+
+	it('wraps a generic Error into TwoChatAPIError without a status', async () => {
+		mockRequest.mockRejectedValueOnce(new Error('network failure'));
+
+		let thrown: unknown;
+		try {
+			await makeTwoChatRequest('open/info', 'key');
+		} catch (e) {
+			thrown = e;
+		}
+
+		expect(thrown).toBeInstanceOf(TwoChatAPIError);
+		expect((thrown as TwoChatAPIError).status).toBeUndefined();
+		expect((thrown as TwoChatAPIError).message).toBe('network failure');
+	});
+
+	it('targets api.p.2chat.io and sets the X-User-API-Key header', async () => {
+		mockRequest.mockResolvedValueOnce({});
+		await makeTwoChatRequest('open/info', 'my-test-key');
+
+		expect(mockRequest).toHaveBeenCalledTimes(1);
+		const [config] = mockRequest.mock.calls[0]!;
+		expect(config.BASE).toBe('https://api.p.2chat.io');
+		expect(config.HEADERS['X-User-API-Key']).toBe('my-test-key');
+	});
+});

--- a/packages/twochat/client.ts
+++ b/packages/twochat/client.ts
@@ -1,0 +1,73 @@
+import type {
+	ApiRequestOptions,
+	OpenAPIConfig,
+	RateLimitConfig,
+} from 'corsair/http';
+import { request } from 'corsair/http';
+
+export class TwoChatAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly code?: string,
+	) {
+		super(message);
+		this.name = 'TwoChatAPIError';
+	}
+}
+
+const TWOCHAT_API_BASE = 'https://api.p.2chat.io';
+
+const TWOCHAT_RATE_LIMIT_CONFIG: RateLimitConfig = {
+	enabled: true,
+	maxRetries: 3,
+	initialRetryDelay: 1000,
+	backoffMultiplier: 2,
+	headerNames: {
+		retryAfter: 'Retry-After',
+	},
+};
+
+export async function makeTwoChatRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	options: {
+		method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+		body?: Record<string, unknown>;
+		query?: Record<string, string | number | boolean | undefined>;
+	} = {},
+): Promise<T> {
+	const { method = 'GET', body, query } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: TWOCHAT_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		HEADERS: {
+			'Content-Type': 'application/json',
+			'X-User-API-Key': apiKey,
+		},
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint,
+		body:
+			method === 'POST' || method === 'PUT' || method === 'PATCH'
+				? body
+				: undefined,
+		mediaType: 'application/json; charset=utf-8',
+		query: method === 'GET' ? query : undefined,
+	};
+
+	try {
+		return await request<T>(config, requestOptions, {
+			rateLimitConfig: TWOCHAT_RATE_LIMIT_CONFIG,
+		});
+	} catch (error) {
+		if (error instanceof Error) {
+			throw new TwoChatAPIError(error.message);
+		}
+		throw new TwoChatAPIError('Unknown error');
+	}
+}

--- a/packages/twochat/client.ts
+++ b/packages/twochat/client.ts
@@ -3,15 +3,29 @@ import type {
 	OpenAPIConfig,
 	RateLimitConfig,
 } from 'corsair/http';
-import { request } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
 
 export class TwoChatAPIError extends Error {
+	public readonly status?: number;
+	public readonly statusText?: string;
+	// 2Chat error bodies vary by endpoint/status; unknown covers all shapes.
+	public readonly body?: unknown;
+	public readonly retryAfter?: number;
+
 	constructor(
 		message: string,
 		public readonly code?: string,
+		options?: { cause?: Error },
 	) {
-		super(message);
+		super(message, options);
 		this.name = 'TwoChatAPIError';
+
+		if (options?.cause instanceof ApiError) {
+			this.status = options.cause.status;
+			this.statusText = options.cause.statusText;
+			this.body = options.cause.body;
+			this.retryAfter = options.cause.retryAfter;
+		}
 	}
 }
 
@@ -60,7 +74,19 @@ export async function makeTwoChatRequest<T>(
 		query: method === 'GET' ? query : undefined,
 	};
 
-	return await request<T>(config, requestOptions, {
-		rateLimitConfig: TWOCHAT_RATE_LIMIT_CONFIG,
-	});
+	try {
+		return await request<T>(config, requestOptions, {
+			rateLimitConfig: TWOCHAT_RATE_LIMIT_CONFIG,
+		});
+	} catch (error) {
+		if (error instanceof ApiError) {
+			throw new TwoChatAPIError(error.message, String(error.status), {
+				cause: error,
+			});
+		}
+		if (error instanceof Error) {
+			throw new TwoChatAPIError(error.message, undefined, { cause: error });
+		}
+		throw new TwoChatAPIError('Unknown 2Chat API error');
+	}
 }

--- a/packages/twochat/client.ts
+++ b/packages/twochat/client.ts
@@ -60,14 +60,7 @@ export async function makeTwoChatRequest<T>(
 		query: method === 'GET' ? query : undefined,
 	};
 
-	try {
-		return await request<T>(config, requestOptions, {
-			rateLimitConfig: TWOCHAT_RATE_LIMIT_CONFIG,
-		});
-	} catch (error) {
-		if (error instanceof Error) {
-			throw new TwoChatAPIError(error.message);
-		}
-		throw new TwoChatAPIError('Unknown error');
-	}
+	return await request<T>(config, requestOptions, {
+		rateLimitConfig: TWOCHAT_RATE_LIMIT_CONFIG,
+	});
 }

--- a/packages/twochat/endpoints/create-contact.ts
+++ b/packages/twochat/endpoints/create-contact.ts
@@ -1,6 +1,7 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeTwoChatRequest } from '../client';
 import type { TwoChatContext } from '../index';
+import { cacheContacts } from './persist';
 import type { TwoChatEndpointOutputs } from './types';
 
 export const createContact = async (
@@ -26,6 +27,7 @@ export const createContact = async (
 		},
 	});
 
+	await cacheContacts(ctx, [response.contact]);
 	await logEventFromContext(
 		ctx,
 		'twochat.contacts.createContact',

--- a/packages/twochat/endpoints/create-contact.ts
+++ b/packages/twochat/endpoints/create-contact.ts
@@ -1,0 +1,37 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeTwoChatRequest } from '../client';
+import type { TwoChatContext } from '../index';
+import type { TwoChatEndpointOutputs } from './types';
+
+export const createContact = async (
+	ctx: TwoChatContext & { key: string },
+	input: {
+		first_name: string;
+		last_name?: string;
+		profile_pic_url?: string;
+		channel_uuid?: string;
+		contact_details: Array<{ type: 'E' | 'A' | 'PH' | 'WAPH'; value: string }>;
+	},
+): Promise<TwoChatEndpointOutputs['createContact']> => {
+	const response = await makeTwoChatRequest<
+		TwoChatEndpointOutputs['createContact']
+	>('open/contacts', ctx.key, {
+		method: 'POST',
+		body: {
+			first_name: input.first_name,
+			last_name: input.last_name,
+			profile_pic_url: input.profile_pic_url,
+			channel_uuid: input.channel_uuid,
+			contact_details: input.contact_details,
+		},
+	});
+
+	await logEventFromContext(
+		ctx,
+		'twochat.contacts.createContact',
+		{ first_name: input.first_name },
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/twochat/endpoints/create-contact.ts
+++ b/packages/twochat/endpoints/create-contact.ts
@@ -22,7 +22,7 @@ export const createContact = async (
 			last_name: input.last_name,
 			profile_pic_url: input.profile_pic_url,
 			channel_uuid: input.channel_uuid,
-			contact_details: input.contact_details,
+			contact_detail: input.contact_details,
 		},
 	});
 

--- a/packages/twochat/endpoints/get-api-usage-info.ts
+++ b/packages/twochat/endpoints/get-api-usage-info.ts
@@ -1,0 +1,22 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeTwoChatRequest } from '../client';
+import type { TwoChatContext } from '../index';
+import type { TwoChatEndpointOutputs } from './types';
+
+export const getApiUsageInfo = async (
+	ctx: TwoChatContext & { key: string },
+	_input: Record<string, never>,
+): Promise<TwoChatEndpointOutputs['getApiUsageInfo']> => {
+	const response = await makeTwoChatRequest<
+		TwoChatEndpointOutputs['getApiUsageInfo']
+	>('open/info', ctx.key, { method: 'GET' });
+
+	await logEventFromContext(
+		ctx,
+		'twochat.account.getApiUsageInfo',
+		{},
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/twochat/endpoints/get-api-usage-info.ts
+++ b/packages/twochat/endpoints/get-api-usage-info.ts
@@ -1,6 +1,7 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeTwoChatRequest } from '../client';
 import type { TwoChatContext } from '../index';
+import { cacheAccount } from './persist';
 import type { TwoChatEndpointOutputs } from './types';
 
 export const getApiUsageInfo = async (
@@ -11,6 +12,11 @@ export const getApiUsageInfo = async (
 		TwoChatEndpointOutputs['getApiUsageInfo']
 	>('open/info', ctx.key, { method: 'GET' });
 
+	await cacheAccount(
+		ctx,
+		response.account,
+		response.limits?.requests_per_minute,
+	);
 	await logEventFromContext(
 		ctx,
 		'twochat.account.getApiUsageInfo',

--- a/packages/twochat/endpoints/index.ts
+++ b/packages/twochat/endpoints/index.ts
@@ -1,0 +1,11 @@
+import { createContact } from './create-contact';
+import { getApiUsageInfo } from './get-api-usage-info';
+import { listContacts } from './list-contacts';
+import { listWebhooks } from './list-webhooks';
+import { testApiKey } from './test-api-key';
+
+export const Contacts = { createContact, listContacts };
+export const Account = { getApiUsageInfo, testApiKey };
+export const Webhooks = { listWebhooks };
+
+export * from './types';

--- a/packages/twochat/endpoints/list-contacts.ts
+++ b/packages/twochat/endpoints/list-contacts.ts
@@ -1,6 +1,7 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeTwoChatRequest } from '../client';
 import type { TwoChatContext } from '../index';
+import { cacheContacts } from './persist';
 import type { TwoChatEndpointOutputs } from './types';
 
 export const listContacts = async (
@@ -17,6 +18,7 @@ export const listContacts = async (
 		},
 	});
 
+	await cacheContacts(ctx, response.contacts);
 	await logEventFromContext(
 		ctx,
 		'twochat.contacts.listContacts',

--- a/packages/twochat/endpoints/list-contacts.ts
+++ b/packages/twochat/endpoints/list-contacts.ts
@@ -1,0 +1,28 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeTwoChatRequest } from '../client';
+import type { TwoChatContext } from '../index';
+import type { TwoChatEndpointOutputs } from './types';
+
+export const listContacts = async (
+	ctx: TwoChatContext & { key: string },
+	input: { page_number?: number; results_per_page?: number },
+): Promise<TwoChatEndpointOutputs['listContacts']> => {
+	const response = await makeTwoChatRequest<
+		TwoChatEndpointOutputs['listContacts']
+	>('open/contacts', ctx.key, {
+		method: 'GET',
+		query: {
+			page_number: input.page_number ?? 0,
+			results_per_page: input.results_per_page ?? 30,
+		},
+	});
+
+	await logEventFromContext(
+		ctx,
+		'twochat.contacts.listContacts',
+		{},
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/twochat/endpoints/list-webhooks.ts
+++ b/packages/twochat/endpoints/list-webhooks.ts
@@ -1,0 +1,22 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeTwoChatRequest } from '../client';
+import type { TwoChatContext } from '../index';
+import type { TwoChatEndpointOutputs } from './types';
+
+export const listWebhooks = async (
+	ctx: TwoChatContext & { key: string },
+	_input: Record<string, never>,
+): Promise<TwoChatEndpointOutputs['listWebhooks']> => {
+	const response = await makeTwoChatRequest<
+		TwoChatEndpointOutputs['listWebhooks']
+	>('open/webhooks', ctx.key, { method: 'GET' });
+
+	await logEventFromContext(
+		ctx,
+		'twochat.webhooks.listWebhooks',
+		{},
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/twochat/endpoints/list-webhooks.ts
+++ b/packages/twochat/endpoints/list-webhooks.ts
@@ -1,6 +1,7 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeTwoChatRequest } from '../client';
 import type { TwoChatContext } from '../index';
+import { cacheWebhooks } from './persist';
 import type { TwoChatEndpointOutputs } from './types';
 
 export const listWebhooks = async (
@@ -11,6 +12,7 @@ export const listWebhooks = async (
 		TwoChatEndpointOutputs['listWebhooks']
 	>('open/webhooks', ctx.key, { method: 'GET' });
 
+	await cacheWebhooks(ctx, response.webhooks);
 	await logEventFromContext(
 		ctx,
 		'twochat.webhooks.listWebhooks',

--- a/packages/twochat/endpoints/persist.ts
+++ b/packages/twochat/endpoints/persist.ts
@@ -1,0 +1,124 @@
+import type {
+	TwoChatAccountEntity,
+	TwoChatContactEntity,
+	TwoChatWebhookSubscriptionEntity,
+} from '../schema/database';
+
+type EntityStore<T> = {
+	upsertByEntityId: (entityId: string, data: T) => Promise<unknown>;
+};
+
+type CacheCtx = {
+	db?: {
+		contacts?: EntityStore<TwoChatContactEntity>;
+		accounts?: EntityStore<TwoChatAccountEntity>;
+		webhookSubscriptions?: EntityStore<TwoChatWebhookSubscriptionEntity>;
+	};
+};
+
+function entityDb(ctx: unknown): NonNullable<CacheCtx['db']> {
+	if (typeof ctx !== 'object' || ctx === null) return {};
+	return (ctx as CacheCtx).db ?? {};
+}
+
+function asDate(value: string | Date | undefined): Date | undefined {
+	if (value instanceof Date) return value;
+	if (!value) return undefined;
+	const date = new Date(value);
+	return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+async function safely(operation: () => Promise<unknown>, what: string) {
+	try {
+		await operation();
+	} catch (error) {
+		console.warn(`[TWOCHAT] failed to cache ${what}:`, error);
+	}
+}
+
+export async function cacheContacts(
+	ctx: unknown,
+	contacts:
+		| Array<{
+				uuid?: string;
+				first_name?: string;
+				last_name?: string;
+				profile_pic_url?: string | null;
+				created_at?: string;
+		  }>
+		| undefined,
+) {
+	const store = entityDb(ctx).contacts;
+	if (!store || !contacts) return;
+	for (const contact of contacts) {
+		if (!contact.uuid || !contact.first_name) continue;
+		await safely(
+			() =>
+				store.upsertByEntityId(contact.uuid as string, {
+					uuid: contact.uuid as string,
+					first_name: contact.first_name as string,
+					last_name: contact.last_name,
+					profile_pic_url: contact.profile_pic_url ?? undefined,
+					created_at: asDate(contact.created_at),
+				}),
+			`contact ${contact.uuid}`,
+		);
+	}
+}
+
+export async function cacheAccount(
+	ctx: unknown,
+	account:
+		| {
+				uuid?: string;
+				name?: string;
+				on_trial?: boolean;
+				blocked?: boolean;
+		  }
+		| undefined,
+	requestsPerMinute?: number,
+) {
+	const store = entityDb(ctx).accounts;
+	if (!store || !account?.uuid) return;
+	await safely(
+		() =>
+			store.upsertByEntityId(account.uuid as string, {
+				uuid: account.uuid as string,
+				name: account.name,
+				on_trial: account.on_trial,
+				blocked: account.blocked,
+				requests_per_minute: requestsPerMinute,
+			}),
+		`account ${account.uuid}`,
+	);
+}
+
+export async function cacheWebhooks(
+	ctx: unknown,
+	webhooks:
+		| Array<{
+				uuid?: string;
+				event_name?: string;
+				channel_uuid?: string;
+				hook_url?: string;
+				created_at?: string;
+		  }>
+		| undefined,
+) {
+	const store = entityDb(ctx).webhookSubscriptions;
+	if (!store || !webhooks) return;
+	for (const webhook of webhooks) {
+		if (!webhook.uuid || !webhook.event_name || !webhook.hook_url) continue;
+		await safely(
+			() =>
+				store.upsertByEntityId(webhook.uuid as string, {
+					uuid: webhook.uuid as string,
+					event_name: webhook.event_name as string,
+					channel_uuid: webhook.channel_uuid,
+					hook_url: webhook.hook_url as string,
+					created_at: asDate(webhook.created_at),
+				}),
+			`webhook ${webhook.uuid}`,
+		);
+	}
+}

--- a/packages/twochat/endpoints/test-api-key.ts
+++ b/packages/twochat/endpoints/test-api-key.ts
@@ -1,6 +1,7 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeTwoChatRequest } from '../client';
 import type { TwoChatContext } from '../index';
+import { cacheAccount } from './persist';
 import type { TwoChatEndpointOutputs } from './types';
 
 export const testApiKey = async (
@@ -11,6 +12,11 @@ export const testApiKey = async (
 		TwoChatEndpointOutputs['testApiKey']
 	>('open/info', ctx.key, { method: 'GET' });
 
+	await cacheAccount(
+		ctx,
+		response.account,
+		response.limits?.requests_per_minute,
+	);
 	await logEventFromContext(ctx, 'twochat.account.testApiKey', {}, 'completed');
 
 	return response;

--- a/packages/twochat/endpoints/test-api-key.ts
+++ b/packages/twochat/endpoints/test-api-key.ts
@@ -1,0 +1,17 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeTwoChatRequest } from '../client';
+import type { TwoChatContext } from '../index';
+import type { TwoChatEndpointOutputs } from './types';
+
+export const testApiKey = async (
+	ctx: TwoChatContext & { key: string },
+	_input: Record<string, never>,
+): Promise<TwoChatEndpointOutputs['testApiKey']> => {
+	const response = await makeTwoChatRequest<
+		TwoChatEndpointOutputs['testApiKey']
+	>('open/info', ctx.key, { method: 'GET' });
+
+	await logEventFromContext(ctx, 'twochat.account.testApiKey', {}, 'completed');
+
+	return response;
+};

--- a/packages/twochat/endpoints/types.ts
+++ b/packages/twochat/endpoints/types.ts
@@ -4,27 +4,37 @@ import { z } from 'zod';
 // Shared sub-schemas
 // ─────────────────────────────────────────────────────────────────────────────
 
+const contactDetailType = z
+	.enum(['E', 'A', 'PH', 'WAPH'])
+	.describe(
+		'Contact detail type: E=Email, A=Address, PH=Phone, WAPH=WhatsApp phone',
+	);
+
+const contactDetailValue = z
+	.string()
+	.describe('The contact detail value (email, phone number, or address)');
+
+// Create returns unix seconds (and updated_at: 0); list returns ISO strings.
+const contactDetailTimestamp = z.union([z.string(), z.number()]).optional();
+
+export const ContactDetailInputSchema = z.object({
+	type: contactDetailType,
+	value: contactDetailValue,
+});
+
 export const ContactDetailSchema = z.object({
-	type: z
-		.enum(['E', 'A', 'PH', 'WAPH'])
-		.describe(
-			'Contact detail type: E=Email, A=Address, PH=Phone, WAPH=WhatsApp phone',
-		),
-	value: z
-		.string()
-		.describe('The contact detail value (email, phone number, or address)'),
+	type: contactDetailType,
+	value: contactDetailValue,
 	id: z
 		.number()
 		.optional()
 		.describe('Unique numeric ID for the contact detail'),
-	created_at: z
-		.union([z.string(), z.number()])
-		.optional()
-		.describe('ISO timestamp or unix seconds when the contact detail was created'),
-	updated_at: z
-		.union([z.string(), z.number()])
-		.optional()
-		.describe('ISO timestamp or unix seconds when the contact detail was updated'),
+	created_at: contactDetailTimestamp.describe(
+		'ISO timestamp or unix seconds when the contact detail was created',
+	),
+	updated_at: contactDetailTimestamp.describe(
+		'ISO timestamp or unix seconds when the contact detail was updated',
+	),
 });
 
 export type ContactDetail = z.infer<typeof ContactDetailSchema>;
@@ -78,7 +88,7 @@ export const CreateContactInputSchema = z.object({
 			'UUID of a WhatsApp channel — if provided the contact is also created on that WhatsApp account',
 		),
 	contact_details: z
-		.array(ContactDetailSchema)
+		.array(ContactDetailInputSchema)
 		.min(1)
 		.describe(
 			'At least one contact detail (email, phone, or address). Required.',

--- a/packages/twochat/endpoints/types.ts
+++ b/packages/twochat/endpoints/types.ts
@@ -117,10 +117,6 @@ export const ApiLimitsSchema = z.object({
 });
 
 export const ApiUsageSchema = z.object({
-	api_requests_available: z.number().optional(),
-	api_requests_plan_default: z.number().optional(),
-	number_check_requests_available: z.number().optional(),
-	number_check_requests_plan_default: z.number().optional(),
 	api_request_count: z.number().optional(),
 	max_api_request_count: z.number().optional(),
 	number_check_count: z.number().optional(),

--- a/packages/twochat/endpoints/types.ts
+++ b/packages/twochat/endpoints/types.ts
@@ -13,6 +13,22 @@ export const ContactDetailSchema = z.object({
 	value: z
 		.string()
 		.describe('The contact detail value (email, phone number, or address)'),
+	id: z
+		.number()
+		.optional()
+		.describe('Unique numeric ID for the contact detail'),
+	created_at: z
+		.string()
+		.optional()
+		.describe('ISO timestamp when the contact detail was created'),
+	created_at_timestamp: z
+		.number()
+		.optional()
+		.describe('Unix timestamp when the contact detail was created'),
+	updated_at: z
+		.string()
+		.optional()
+		.describe('ISO timestamp when the contact detail was updated'),
 });
 
 export type ContactDetail = z.infer<typeof ContactDetailSchema>;
@@ -21,11 +37,23 @@ export const ContactSchema = z.object({
 	uuid: z.string().describe('Unique identifier for the contact'),
 	first_name: z.string().describe('Contact first name'),
 	last_name: z.string().optional().describe('Contact last name'),
+	name: z.string().optional().describe('Contact full display name'),
+	channel_uuid: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('UUID of the WhatsApp channel associated with this contact'),
 	profile_pic_url: z
 		.string()
+		.nullable()
 		.optional()
 		.describe('URL to the contact profile picture'),
+	details: z.array(ContactDetailSchema).optional(),
 	contact_details: z.array(ContactDetailSchema).optional(),
+	last_updated: z
+		.string()
+		.optional()
+		.describe('ISO timestamp when contact was last updated'),
 	created_at: z
 		.string()
 		.optional()
@@ -93,6 +121,10 @@ export const ApiLimitsSchema = z.object({
 });
 
 export const ApiUsageSchema = z.object({
+	api_requests_available: z.number().optional(),
+	api_requests_plan_default: z.number().optional(),
+	number_check_requests_available: z.number().optional(),
+	number_check_requests_plan_default: z.number().optional(),
 	api_request_count: z.number().optional(),
 	max_api_request_count: z.number().optional(),
 	number_check_count: z.number().optional(),
@@ -149,10 +181,10 @@ export const ListContactsInputSchema = z.object({
 export type ListContactsInput = z.infer<typeof ListContactsInputSchema>;
 
 export const ListContactsResponseSchema = z.object({
-	success: z.boolean().optional(),
-	results: z.array(ContactSchema),
-	page_number: z.number().optional(),
-	results_per_page: z.number().optional(),
+	success: z.boolean(),
+	page: z.number(),
+	count: z.number(),
+	contacts: z.array(ContactSchema),
 });
 
 export type ListContactsResponse = z.infer<typeof ListContactsResponseSchema>;
@@ -175,9 +207,9 @@ export const WebhookSubscriptionSchema = z.object({
 		.describe('UUID of the WhatsApp channel this webhook is tied to'),
 	hook_url: z.string().describe('Callback URL called when the event fires'),
 	hook_params: z
-		.record(z.string(), z.unknown())
+		.record(z.string(), z.string())
 		.optional()
-		.describe('Custom webhook parameters'),
+		.describe('Custom webhook parameters (key-value strings)'),
 	created_at: z
 		.string()
 		.optional()

--- a/packages/twochat/endpoints/types.ts
+++ b/packages/twochat/endpoints/types.ts
@@ -18,17 +18,13 @@ export const ContactDetailSchema = z.object({
 		.optional()
 		.describe('Unique numeric ID for the contact detail'),
 	created_at: z
-		.string()
+		.union([z.string(), z.number()])
 		.optional()
-		.describe('ISO timestamp when the contact detail was created'),
-	created_at_timestamp: z
-		.number()
-		.optional()
-		.describe('Unix timestamp when the contact detail was created'),
+		.describe('ISO timestamp or unix seconds when the contact detail was created'),
 	updated_at: z
-		.string()
+		.union([z.string(), z.number()])
 		.optional()
-		.describe('ISO timestamp when the contact detail was updated'),
+		.describe('ISO timestamp or unix seconds when the contact detail was updated'),
 });
 
 export type ContactDetail = z.infer<typeof ContactDetailSchema>;

--- a/packages/twochat/endpoints/types.ts
+++ b/packages/twochat/endpoints/types.ts
@@ -1,0 +1,230 @@
+import { z } from 'zod';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared sub-schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ContactDetailSchema = z.object({
+	type: z
+		.enum(['E', 'A', 'PH', 'WAPH'])
+		.describe(
+			'Contact detail type: E=Email, A=Address, PH=Phone, WAPH=WhatsApp phone',
+		),
+	value: z
+		.string()
+		.describe('The contact detail value (email, phone number, or address)'),
+});
+
+export type ContactDetail = z.infer<typeof ContactDetailSchema>;
+
+export const ContactSchema = z.object({
+	uuid: z.string().describe('Unique identifier for the contact'),
+	first_name: z.string().describe('Contact first name'),
+	last_name: z.string().optional().describe('Contact last name'),
+	profile_pic_url: z
+		.string()
+		.optional()
+		.describe('URL to the contact profile picture'),
+	contact_details: z.array(ContactDetailSchema).optional(),
+	created_at: z
+		.string()
+		.optional()
+		.describe('ISO timestamp when contact was created'),
+});
+
+export type Contact = z.infer<typeof ContactSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Create Contact
+// POST /open/contacts
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const CreateContactInputSchema = z.object({
+	first_name: z.string().describe('First name of the new contact'),
+	last_name: z.string().optional().describe('Last name of the new contact'),
+	profile_pic_url: z
+		.string()
+		.url()
+		.optional()
+		.describe('Publicly accessible URL to the contact profile picture'),
+	channel_uuid: z
+		.string()
+		.optional()
+		.describe(
+			'UUID of a WhatsApp channel — if provided the contact is also created on that WhatsApp account',
+		),
+	contact_details: z
+		.array(ContactDetailSchema)
+		.min(1)
+		.describe(
+			'At least one contact detail (email, phone, or address). Required.',
+		),
+});
+
+export type CreateContactInput = z.infer<typeof CreateContactInputSchema>;
+
+export const CreateContactResponseSchema = z.object({
+	success: z.boolean(),
+	contact: ContactSchema,
+});
+
+export type CreateContactResponse = z.infer<typeof CreateContactResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Get API Usage Info  (also used for Test API Key)
+// GET /open/info
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const GetApiUsageInfoInputSchema = z.object({});
+
+export type GetApiUsageInfoInput = z.infer<typeof GetApiUsageInfoInputSchema>;
+
+export const AccountInfoSchema = z.object({
+	name: z.string().optional(),
+	uuid: z.string().optional(),
+	on_trial: z.boolean().optional(),
+	blocked: z.boolean().optional(),
+	created_at: z.string().optional(),
+	expires_at: z.string().optional(),
+});
+
+export const ApiLimitsSchema = z.object({
+	requests_per_minute: z.number().optional(),
+});
+
+export const ApiUsageSchema = z.object({
+	api_request_count: z.number().optional(),
+	max_api_request_count: z.number().optional(),
+	number_check_count: z.number().optional(),
+	max_number_check_count: z.number().optional(),
+});
+
+export const GetApiUsageInfoResponseSchema = z.object({
+	success: z.boolean(),
+	account: AccountInfoSchema.optional(),
+	limits: ApiLimitsSchema.optional(),
+	usage: ApiUsageSchema.optional(),
+});
+
+export type GetApiUsageInfoResponse = z.infer<
+	typeof GetApiUsageInfoResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test API Key  (same endpoint as GetApiUsageInfo, separated for clarity)
+// GET /open/info
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const TestApiKeyInputSchema = z.object({});
+
+export type TestApiKeyInput = z.infer<typeof TestApiKeyInputSchema>;
+
+export const TestApiKeyResponseSchema = GetApiUsageInfoResponseSchema;
+
+export type TestApiKeyResponse = z.infer<typeof TestApiKeyResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// List Contacts
+// GET /open/contacts
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ListContactsInputSchema = z.object({
+	page_number: z
+		.number()
+		.int()
+		.min(0)
+		.optional()
+		.default(0)
+		.describe('Zero-based page number for pagination'),
+	results_per_page: z
+		.number()
+		.int()
+		.min(1)
+		.max(100)
+		.optional()
+		.default(30)
+		.describe('Number of contacts per page (1–100)'),
+});
+
+export type ListContactsInput = z.infer<typeof ListContactsInputSchema>;
+
+export const ListContactsResponseSchema = z.object({
+	success: z.boolean().optional(),
+	results: z.array(ContactSchema),
+	page_number: z.number().optional(),
+	results_per_page: z.number().optional(),
+});
+
+export type ListContactsResponse = z.infer<typeof ListContactsResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// List Webhook Subscriptions
+// GET /open/webhooks
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ListWebhooksInputSchema = z.object({});
+
+export type ListWebhooksInput = z.infer<typeof ListWebhooksInputSchema>;
+
+export const WebhookSubscriptionSchema = z.object({
+	uuid: z.string().describe('Unique identifier for the webhook subscription'),
+	event_name: z.string().describe('Event type this webhook is subscribed to'),
+	channel_uuid: z
+		.string()
+		.optional()
+		.describe('UUID of the WhatsApp channel this webhook is tied to'),
+	hook_url: z.string().describe('Callback URL called when the event fires'),
+	hook_params: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Custom webhook parameters'),
+	created_at: z
+		.string()
+		.optional()
+		.describe('ISO timestamp when the webhook was created'),
+});
+
+export type WebhookSubscription = z.infer<typeof WebhookSubscriptionSchema>;
+
+export const ListWebhooksResponseSchema = z.object({
+	success: z.boolean().optional(),
+	webhooks: z.array(WebhookSubscriptionSchema),
+});
+
+export type ListWebhooksResponse = z.infer<typeof ListWebhooksResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Aggregate input/output maps (required by validate:plugins)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type TwoChatEndpointInputs = {
+	createContact: CreateContactInput;
+	getApiUsageInfo: GetApiUsageInfoInput;
+	testApiKey: TestApiKeyInput;
+	listContacts: ListContactsInput;
+	listWebhooks: ListWebhooksInput;
+};
+
+export type TwoChatEndpointOutputs = {
+	createContact: CreateContactResponse;
+	getApiUsageInfo: GetApiUsageInfoResponse;
+	testApiKey: TestApiKeyResponse;
+	listContacts: ListContactsResponse;
+	listWebhooks: ListWebhooksResponse;
+};
+
+export const TwoChatEndpointInputSchemas = {
+	createContact: CreateContactInputSchema,
+	getApiUsageInfo: GetApiUsageInfoInputSchema,
+	testApiKey: TestApiKeyInputSchema,
+	listContacts: ListContactsInputSchema,
+	listWebhooks: ListWebhooksInputSchema,
+} as const;
+
+export const TwoChatEndpointOutputSchemas = {
+	createContact: CreateContactResponseSchema,
+	getApiUsageInfo: GetApiUsageInfoResponseSchema,
+	testApiKey: TestApiKeyResponseSchema,
+	listContacts: ListContactsResponseSchema,
+	listWebhooks: ListWebhooksResponseSchema,
+} as const;

--- a/packages/twochat/error-handlers.ts
+++ b/packages/twochat/error-handlers.ts
@@ -1,10 +1,20 @@
 import type { CorsairErrorHandler, ErrorContext } from 'corsair/core';
-import { ApiError } from 'corsair/http';
+import type { TwoChatAPIError } from './client';
+
+// The framework hands error handlers a base Error; TwoChatAPIError fields are
+// optional extras, so Partial<TwoChatAPIError> is the safest view.
+function getStatus(error: Error): number | undefined {
+	return (error as Partial<TwoChatAPIError>).status;
+}
+
+function getRetryAfter(error: Error): number | undefined {
+	return (error as Partial<TwoChatAPIError>).retryAfter;
+}
 
 export const errorHandlers = {
 	RATE_LIMIT_ERROR: {
 		match: (error: Error, _context: ErrorContext) => {
-			if (error instanceof ApiError && error.status === 429) return true;
+			if (getStatus(error) === 429) return true;
 			const msg = error.message.toLowerCase();
 			return (
 				msg.includes('rate_limited') ||
@@ -13,16 +23,12 @@ export const errorHandlers = {
 			);
 		},
 		handler: async (error: Error, _context: ErrorContext) => {
-			let retryAfterMs: number | undefined;
-			if (error instanceof ApiError && error.retryAfter !== undefined) {
-				retryAfterMs = error.retryAfter;
-			}
-			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+			return { maxRetries: 5, headersRetryAfterMs: getRetryAfter(error) };
 		},
 	},
 	AUTH_ERROR: {
 		match: (error: Error, _context: ErrorContext) => {
-			if (error instanceof ApiError && error.status === 401) return true;
+			if (getStatus(error) === 401) return true;
 			const msg = error.message.toLowerCase();
 			return (
 				msg.includes('unauthorized') ||
@@ -39,7 +45,7 @@ export const errorHandlers = {
 	},
 	PERMISSION_ERROR: {
 		match: (error: Error, _context: ErrorContext) => {
-			if (error instanceof ApiError && error.status === 403) return true;
+			if (getStatus(error) === 403) return true;
 			const msg = error.message.toLowerCase();
 			return (
 				msg.includes('forbidden') ||

--- a/packages/twochat/error-handlers.ts
+++ b/packages/twochat/error-handlers.ts
@@ -1,0 +1,85 @@
+import type { CorsairErrorHandler, ErrorContext } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error, _context: ErrorContext) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('rate_limited') ||
+				msg.includes('ratelimited') ||
+				msg.includes('429')
+			);
+		},
+		handler: async (error: Error, _context: ErrorContext) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error, _context: ErrorContext) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('unauthorized') ||
+				msg.includes('invalid_auth') ||
+				msg.includes('invalid_key')
+			);
+		},
+		handler: async (error: Error, context: ErrorContext) => {
+			console.warn(
+				`[TWOCHAT:${context.operation}] Authentication failed – check your API key`,
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	PERMISSION_ERROR: {
+		match: (error: Error, _context: ErrorContext) => {
+			if (error instanceof ApiError && error.status === 403) return true;
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('forbidden') ||
+				msg.includes('permission_denied') ||
+				msg.includes('insufficient')
+			);
+		},
+		handler: async (error: Error, context: ErrorContext) => {
+			console.warn(
+				`[TWOCHAT:${context.operation}] Permission denied: ${error.message}`,
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	NETWORK_ERROR: {
+		match: (error: Error, _context: ErrorContext) => {
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('network') ||
+				msg.includes('connection') ||
+				msg.includes('econnrefused') ||
+				msg.includes('enotfound') ||
+				msg.includes('etimedout') ||
+				msg.includes('fetch failed')
+			);
+		},
+		handler: async (error: Error, context: ErrorContext) => {
+			console.warn(
+				`[TWOCHAT:${context.operation}] Network error: ${error.message}`,
+			);
+			return { maxRetries: 3 };
+		},
+	},
+	DEFAULT: {
+		match: (_error: Error, _context: ErrorContext) => true,
+		handler: async (error: Error, context: ErrorContext) => {
+			console.error(
+				`[TWOCHAT:${context.operation}] Unhandled error: ${error.message}`,
+			);
+			return { maxRetries: 0 };
+		},
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/twochat/index.ts
+++ b/packages/twochat/index.ts
@@ -232,7 +232,7 @@ export function twochat<const T extends TwoChatPluginOptions>(
 
 			throw new AuthMissingError('twochat', 'api_key');
 		},
-	} as unknown as ExternalTwoChatPlugin<T>;
+	} satisfies InternalTwoChatPlugin as ExternalTwoChatPlugin<T>;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/twochat/index.ts
+++ b/packages/twochat/index.ts
@@ -1,0 +1,255 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+} from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
+import { Account, Contacts, Webhooks } from './endpoints';
+import type {
+	CreateContactInput,
+	CreateContactResponse,
+	GetApiUsageInfoInput,
+	GetApiUsageInfoResponse,
+	ListContactsInput,
+	ListContactsResponse,
+	ListWebhooksInput,
+	ListWebhooksResponse,
+	TestApiKeyInput,
+	TestApiKeyResponse,
+	TwoChatEndpointInputs,
+	TwoChatEndpointOutputs,
+} from './endpoints/types';
+import {
+	CreateContactInputSchema,
+	CreateContactResponseSchema,
+	GetApiUsageInfoInputSchema,
+	GetApiUsageInfoResponseSchema,
+	ListContactsInputSchema,
+	ListContactsResponseSchema,
+	ListWebhooksInputSchema,
+	ListWebhooksResponseSchema,
+	TestApiKeyInputSchema,
+	TestApiKeyResponseSchema,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { TwoChatSchema } from './schema';
+import { matchTwoChatTenantWebhook } from './webhooks/tenant-matcher';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin options
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type TwoChatPluginOptions = {
+	// 2Chat supports API key authentication only (X-User-API-Key header)
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	hooks?: InternalTwoChatPlugin['hooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof twochatEndpointsNested>;
+};
+
+export type TwoChatContext = CorsairPluginContext<
+	typeof TwoChatSchema,
+	TwoChatPluginOptions
+>;
+
+export type TwoChatKeyBuilderContext = KeyBuilderContext<TwoChatPluginOptions>;
+
+export type TwoChatBoundEndpoints = BindEndpoints<
+	typeof twochatEndpointsNested
+>;
+
+type TwoChatEndpoint<K extends keyof TwoChatEndpointOutputs> = CorsairEndpoint<
+	TwoChatContext,
+	TwoChatEndpointInputs[K],
+	TwoChatEndpointOutputs[K]
+>;
+
+export type TwoChatEndpoints = {
+	createContact: TwoChatEndpoint<'createContact'>;
+	getApiUsageInfo: TwoChatEndpoint<'getApiUsageInfo'>;
+	testApiKey: TwoChatEndpoint<'testApiKey'>;
+	listContacts: TwoChatEndpoint<'listContacts'>;
+	listWebhooks: TwoChatEndpoint<'listWebhooks'>;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint nesting (namespace → endpoint)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const twochatEndpointsNested = {
+	contacts: {
+		createContact: Contacts.createContact,
+		listContacts: Contacts.listContacts,
+	},
+	account: {
+		getApiUsageInfo: Account.getApiUsageInfo,
+		testApiKey: Account.testApiKey,
+	},
+	webhookSubscriptions: {
+		listWebhooks: Webhooks.listWebhooks,
+	},
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const twochatEndpointSchemas = {
+	'contacts.createContact': {
+		input: CreateContactInputSchema,
+		output: CreateContactResponseSchema,
+	},
+	'contacts.listContacts': {
+		input: ListContactsInputSchema,
+		output: ListContactsResponseSchema,
+	},
+	'account.getApiUsageInfo': {
+		input: GetApiUsageInfoInputSchema,
+		output: GetApiUsageInfoResponseSchema,
+	},
+	'account.testApiKey': {
+		input: TestApiKeyInputSchema,
+		output: TestApiKeyResponseSchema,
+	},
+	'webhookSubscriptions.listWebhooks': {
+		input: ListWebhooksInputSchema,
+		output: ListWebhooksResponseSchema,
+	},
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint metadata
+// ─────────────────────────────────────────────────────────────────────────────
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const twochatEndpointMeta = {
+	'contacts.createContact': {
+		riskLevel: 'write',
+		description:
+			'Create a new contact in your 2Chat account. Use after gathering and verifying first name and at least one contact detail (email, phone, or address).',
+	},
+	'contacts.listContacts': {
+		riskLevel: 'read',
+		description:
+			'List all contacts in your 2Chat account. Use when you need to retrieve your contact list after confirming your account connection.',
+	},
+	'account.getApiUsageInfo': {
+		riskLevel: 'read',
+		description:
+			'Retrieve current API usage and account information. Use when you need to monitor your remaining quotas before sending more requests.',
+	},
+	'account.testApiKey': {
+		riskLevel: 'read',
+		description:
+			'Validate your API key and retrieve account info. Use when confirming credentials before performing other operations.',
+	},
+	'webhookSubscriptions.listWebhooks': {
+		riskLevel: 'read',
+		description:
+			'List all configured webhook subscriptions for WhatsApp and phone call events. Returns details including webhook UUID, event type, channel UUID, callback URL, and creation timestamp.',
+	},
+} as const satisfies RequiredPluginEndpointMeta<typeof twochatEndpointsNested>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Auth config
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const twochatAuthConfig = {
+	api_key: {},
+} as const satisfies PluginAuthConfig;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin type
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type BaseTwoChatPlugin<T extends TwoChatPluginOptions> = CorsairPlugin<
+	'twochat',
+	typeof TwoChatSchema,
+	typeof twochatEndpointsNested,
+	// biome-ignore lint/complexity/noBannedTypes: empty webhooks object is intentional per spec
+	{},
+	T,
+	typeof defaultAuthType
+>;
+
+export type InternalTwoChatPlugin = BaseTwoChatPlugin<TwoChatPluginOptions>;
+
+export type ExternalTwoChatPlugin<T extends TwoChatPluginOptions> =
+	BaseTwoChatPlugin<T>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory function
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function twochat<const T extends TwoChatPluginOptions>(
+	incomingOptions: TwoChatPluginOptions & T = {} as TwoChatPluginOptions & T,
+): ExternalTwoChatPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'twochat',
+		authConfig: twochatAuthConfig,
+		schema: TwoChatSchema,
+		options: options,
+		hooks: options.hooks,
+		endpoints: twochatEndpointsNested,
+		webhooks: {},
+		endpointMeta: twochatEndpointMeta,
+		endpointSchemas: twochatEndpointSchemas,
+		pluginWebhookMatcher: () => false,
+		pluginTenantWebhookMatcher: matchTwoChatTenantWebhook,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (
+			ctx: TwoChatKeyBuilderContext,
+			source: 'endpoint' | 'webhook',
+		) => {
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (ctx.authType === 'api_key') {
+				const res = await ctx.keys.get_api_key();
+				if (!res) {
+					throw new AuthMissingError('twochat', 'api_key');
+				}
+				return res;
+			}
+
+			throw new AuthMissingError('twochat', 'api_key');
+		},
+	} as unknown as ExternalTwoChatPlugin<T>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Type exports
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type {
+	CreateContactInput,
+	CreateContactResponse,
+	GetApiUsageInfoInput,
+	GetApiUsageInfoResponse,
+	ListContactsInput,
+	ListContactsResponse,
+	ListWebhooksInput,
+	ListWebhooksResponse,
+	TestApiKeyInput,
+	TestApiKeyResponse,
+	TwoChatEndpointInputs,
+	TwoChatEndpointOutputs,
+} from './endpoints/types';

--- a/packages/twochat/jest.config.cjs
+++ b/packages/twochat/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/twochat/package.json
+++ b/packages/twochat/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/twochat",
+  "version": "0.1.0",
+  "description": "TwoChat plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "twochat",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/twochat/schema.test.ts
+++ b/packages/twochat/schema.test.ts
@@ -92,6 +92,12 @@ describe('TwoChat schema', () => {
 		expect(TwoChatSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
 	});
 
+	it('declares db schema entities aligned to 2Chat resources', () => {
+		expect(Object.keys(TwoChatSchema.entities).sort()).toEqual(
+			['accounts', 'contacts', 'webhookSubscriptions'].sort(),
+		);
+	});
+
 	it('parses the documented POST /open/contacts response', () => {
 		const parsed = CreateContactResponseSchema.parse(CREATE_CONTACT_RESPONSE);
 		expect(parsed.contact.details?.[0]).toMatchObject({

--- a/packages/twochat/schema.test.ts
+++ b/packages/twochat/schema.test.ts
@@ -1,20 +1,155 @@
+import {
+	CreateContactInputSchema,
+	CreateContactResponseSchema,
+	GetApiUsageInfoResponseSchema,
+	ListContactsResponseSchema,
+	ListWebhooksResponseSchema,
+} from './endpoints/types';
 import { TwoChatSchema } from './schema';
+
+// Fixtures copied from 2Chat's published API docs — not hand-waved shapes.
+const CREATE_CONTACT_RESPONSE = {
+	success: true,
+	contact: {
+		uuid: 'CON2226e836-36dc-4103-b2a2-6307749cf390',
+		first_name: '2Chat',
+		last_name: 'Support',
+		channel_uuid: 'WPN66037eca-9ad1-4c96-9eff-526a90a48c77',
+		profile_pic_url: null,
+		details: [
+			{
+				id: 1331,
+				value: '+17137157533',
+				type: 'PH' as const,
+				created_at: 1695230471,
+				updated_at: 0,
+			},
+		],
+	},
+};
+
+const LIST_CONTACTS_RESPONSE = {
+	success: true,
+	page: 0,
+	count: 1,
+	contacts: [
+		{
+			id: 566,
+			uuid: 'CON5dbf28a9-44f5-4ca2-9eae-fd33b124097a',
+			first_name: 'Augusto',
+			last_name: 'Gonzalez',
+			channel_uuid: 'WPNc568c832-606c-4d50-8092-fc51b5149d16',
+			profile_pic_url:
+				'https://2chat-user-data-dev.s3.amazonaws.com/example.jpeg',
+			details: [
+				{
+					id: 566,
+					value: '+595981222333',
+					type: 'WAPH' as const,
+					created_at: '2025-03-03T18:43:51Z',
+					updated_at: '2025-03-30T08:30:12Z',
+				},
+			],
+		},
+	],
+};
+
+const GET_INFO_RESPONSE = {
+	success: true,
+	account: {
+		name: 'Account Name (ACC91be87af-5a29-4034-b599-342f2aeb5d52)',
+		uuid: 'ACC91be87af-5a29-4034-b599-342f2aeb5d52',
+		on_trial: false,
+		blocked: false,
+		created_at: '2022-04-21T21:55:37Z',
+		expires_at: '2024-08-31T19:11:08Z',
+	},
+	limits: { requests_per_minute: 80 },
+	usage: {
+		api_request_count: 77112,
+		max_api_request_count: 500000,
+		number_check_count: 430542,
+		max_number_check_count: 500000,
+	},
+};
+
+const LIST_WEBHOOKS_RESPONSE = {
+	success: true,
+	webhooks: [
+		{
+			uuid: 'WHKdc78c87e-5b18-47c7-9183-5bf527fd6c69',
+			event_name: 'whatsapp.message.received',
+			channel_uuid: 'WPN95841312-b54d-46e3-b0bc-6414f4a5296b',
+			hook_url: 'https://example.com/hook',
+			hook_params: { waweb_uuid: 'WPN95841312-b54d-46e3-b0bc-6414f4a5296b' },
+			created_at: '2023-04-17T18:50:50Z',
+		},
+	],
+};
 
 describe('TwoChat schema', () => {
 	it('declares a semver version', () => {
-		expect(TwoChatSchema.version).toBeDefined();
 		expect(TwoChatSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
 	});
 
-	it('declares an entities map', () => {
-		expect(typeof TwoChatSchema.entities).toBe('object');
-		expect(TwoChatSchema.entities).not.toBeNull();
-		expect(Array.isArray(Object.keys(TwoChatSchema.entities))).toBe(true);
-		for (const entity of Object.values(TwoChatSchema.entities)) {
-			expect(entity).toBeDefined();
-		}
+	it('parses the documented POST /open/contacts response', () => {
+		const parsed = CreateContactResponseSchema.parse(CREATE_CONTACT_RESPONSE);
+		expect(parsed.contact.details?.[0]).toMatchObject({
+			type: 'PH',
+			value: '+17137157533',
+			created_at: 1695230471,
+			updated_at: 0,
+		});
+	});
+
+	it('parses the documented GET /open/contacts response', () => {
+		const parsed = ListContactsResponseSchema.parse(LIST_CONTACTS_RESPONSE);
+		expect(parsed.contacts[0]?.details?.[0]?.created_at).toBe(
+			'2025-03-03T18:43:51Z',
+		);
+	});
+
+	it('parses the documented GET /open/info billing payload', () => {
+		const parsed = GetApiUsageInfoResponseSchema.parse(GET_INFO_RESPONSE);
+		expect(parsed.usage).toEqual({
+			api_request_count: 77112,
+			max_api_request_count: 500000,
+			number_check_count: 430542,
+			max_number_check_count: 500000,
+		});
+	});
+
+	it('drops undocumented usage aliases', () => {
+		const parsed = GetApiUsageInfoResponseSchema.parse({
+			success: true,
+			usage: {
+				api_request_count: 1,
+				api_requests_available: 99,
+			},
+		});
+		expect(parsed.usage).toEqual({ api_request_count: 1 });
+	});
+
+	it('parses the documented GET /open/webhooks response', () => {
+		const parsed = ListWebhooksResponseSchema.parse(LIST_WEBHOOKS_RESPONSE);
+		expect(parsed.webhooks).toHaveLength(1);
+		expect(parsed.webhooks[0]?.event_name).toBe('whatsapp.message.received');
+	});
+
+	it('createContact input keeps only type and value on details', () => {
+		const parsed = CreateContactInputSchema.parse({
+			first_name: 'John',
+			contact_details: [
+				{
+					type: 'PH',
+					value: '+17137157533',
+					id: 99,
+					created_at: 1695230471,
+				},
+			],
+		});
+		expect(parsed.contact_details).toEqual([
+			{ type: 'PH', value: '+17137157533' },
+		]);
 	});
 });
-
-// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
-// needs a corresponding test.

--- a/packages/twochat/schema.test.ts
+++ b/packages/twochat/schema.test.ts
@@ -1,0 +1,20 @@
+import { TwoChatSchema } from './schema';
+
+describe('TwoChat schema', () => {
+	it('declares a semver version', () => {
+		expect(TwoChatSchema.version).toBeDefined();
+		expect(TwoChatSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof TwoChatSchema.entities).toBe('object');
+		expect(TwoChatSchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(TwoChatSchema.entities))).toBe(true);
+		for (const entity of Object.values(TwoChatSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/twochat/schema/database.ts
+++ b/packages/twochat/schema/database.ts
@@ -1,9 +1,31 @@
 import { z } from 'zod';
 
-// TODO: Define your database entities here
-// export const TwoChatExample = z.object({
-// 	id: z.string(),
-// 	name: z.string(),
-// 	created_at: z.coerce.date().nullable().optional(),
-// });
-// export type TwoChatExample = z.infer<typeof TwoChatExample>;
+export const TwoChatContactEntity = z.object({
+	uuid: z.string(),
+	first_name: z.string(),
+	last_name: z.string().optional(),
+	profile_pic_url: z.string().optional(),
+	created_at: z.coerce.date().optional(),
+});
+
+export const TwoChatAccountEntity = z.object({
+	uuid: z.string(),
+	name: z.string().optional(),
+	on_trial: z.boolean().optional(),
+	blocked: z.boolean().optional(),
+	requests_per_minute: z.number().optional(),
+});
+
+export const TwoChatWebhookSubscriptionEntity = z.object({
+	uuid: z.string(),
+	event_name: z.string(),
+	channel_uuid: z.string().optional(),
+	hook_url: z.string(),
+	created_at: z.coerce.date().optional(),
+});
+
+export type TwoChatContactEntity = z.infer<typeof TwoChatContactEntity>;
+export type TwoChatAccountEntity = z.infer<typeof TwoChatAccountEntity>;
+export type TwoChatWebhookSubscriptionEntity = z.infer<
+	typeof TwoChatWebhookSubscriptionEntity
+>;

--- a/packages/twochat/schema/database.ts
+++ b/packages/twochat/schema/database.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+// TODO: Define your database entities here
+// export const TwoChatExample = z.object({
+// 	id: z.string(),
+// 	name: z.string(),
+// 	created_at: z.coerce.date().nullable().optional(),
+// });
+// export type TwoChatExample = z.infer<typeof TwoChatExample>;

--- a/packages/twochat/schema/index.ts
+++ b/packages/twochat/schema/index.ts
@@ -1,0 +1,4 @@
+export const TwoChatSchema = {
+	version: '1.0.0',
+	entities: {},
+} as const;

--- a/packages/twochat/schema/index.ts
+++ b/packages/twochat/schema/index.ts
@@ -1,4 +1,16 @@
+import {
+	TwoChatAccountEntity,
+	TwoChatContactEntity,
+	TwoChatWebhookSubscriptionEntity,
+} from './database';
+
 export const TwoChatSchema = {
 	version: '1.0.0',
-	entities: {},
+	entities: {
+		contacts: TwoChatContactEntity,
+		accounts: TwoChatAccountEntity,
+		webhookSubscriptions: TwoChatWebhookSubscriptionEntity,
+	},
 } as const;
+
+export * from './database';

--- a/packages/twochat/tsconfig.json
+++ b/packages/twochat/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/twochat/tsup.config.ts
+++ b/packages/twochat/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/twochat/webhooks/index.ts
+++ b/packages/twochat/webhooks/index.ts
@@ -1,0 +1,4 @@
+// 2Chat has no incoming webhook listeners in the Corsair integration.
+// Webhook *subscriptions* are managed via the listWebhooks endpoint.
+
+export const TwoChatWebhooks = {};

--- a/packages/twochat/webhooks/tenant-matcher.test.ts
+++ b/packages/twochat/webhooks/tenant-matcher.test.ts
@@ -1,0 +1,15 @@
+import { matchTwoChatTenantWebhook } from './tenant-matcher';
+
+describe('matchTwoChatTenantWebhook', () => {
+	it('returns null — inbound webhooks are out of spec', () => {
+		expect(
+			matchTwoChatTenantWebhook({
+				headers: {},
+				body: {
+					to_number: '+525522334455',
+					channel_phone_number: '+595981445566',
+				},
+			}),
+		).toBeNull();
+	});
+});

--- a/packages/twochat/webhooks/tenant-matcher.ts
+++ b/packages/twochat/webhooks/tenant-matcher.ts
@@ -1,0 +1,22 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// 2Chat routes incoming webhook events to a tenant by matching the receiving
+// WhatsApp number (to_number) against the phone_number stored during setup.
+export function matchTwoChatTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const toNumber = firstString([
+		typeof body.to_number === 'string' ? body.to_number : undefined,
+		typeof asRecord(body.data)?.to_number === 'string'
+			? (asRecord(body.data)?.to_number as string)
+			: undefined,
+	]);
+
+	if (!toNumber) return null;
+
+	return { linkType: 'phone_number', externalId: toNumber };
+}

--- a/packages/twochat/webhooks/tenant-matcher.ts
+++ b/packages/twochat/webhooks/tenant-matcher.ts
@@ -1,22 +1,8 @@
 import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
-import { asRecord, firstString, readBodyRecord } from 'corsair/core';
 
-// 2Chat routes incoming webhook events to a tenant by matching the receiving
-// WhatsApp number (to_number) against the phone_number stored during setup.
+// Issue #744: no inbound webhooks. Tenant routing is not applicable.
 export function matchTwoChatTenantWebhook(
-	request: RawWebhookRequest,
+	_request: RawWebhookRequest,
 ): WebhookTenantMatch | null {
-	const body = readBodyRecord(request);
-	if (!body) return null;
-
-	const toNumber = firstString([
-		typeof body.to_number === 'string' ? body.to_number : undefined,
-		typeof asRecord(body.data)?.to_number === 'string'
-			? (asRecord(body.data)?.to_number as string)
-			: undefined,
-	]);
-
-	if (!toNumber) return null;
-
-	return { linkType: 'phone_number', externalId: toNumber };
+	return null;
 }

--- a/packages/twochat/webhooks/types.ts
+++ b/packages/twochat/webhooks/types.ts
@@ -1,0 +1,6 @@
+// 2Chat has no incoming webhooks in this integration.
+// Webhook *subscriptions* (listing, auditing) are handled as regular
+// read endpoints via the listWebhooks endpoint (GET /open/webhooks).
+//
+// This file is intentionally empty — the webhooks/ folder is required
+// by the Corsair plugin structure for tenant-matcher.ts.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3297,6 +3297,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/twochat:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/typeform:
     devDependencies:
       '@types/jest':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,9 +225,6 @@ importers:
       '@corsair-dev/twilio':
         specifier: workspace:*
         version: link:../../packages/twilio
-      '@corsair-dev/twochat':
-        specifier: workspace:*
-        version: link:../../packages/twochat
       '@corsair-dev/vapi':
         specifier: workspace:*
         version: link:../../packages/vapi

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       '@corsair-dev/twilio':
         specifier: workspace:*
         version: link:../../packages/twilio
+      '@corsair-dev/twochat':
+        specifier: workspace:*
+        version: link:../../packages/twochat
       '@corsair-dev/vapi':
         specifier: workspace:*
         version: link:../../packages/vapi


### PR DESCRIPTION
## Description

Adds the official **2Chat** integration plugin (`@corsair-dev/twochat`) to Corsair following repository plugin standards and the approved API surface from `corsair.dev/oss`.
Fixes #744 

### Endpoints Implemented
- `contacts.createContact` (`POST /open/contacts`): Create a new contact with phone, email, or address details.
- `contacts.listContacts` (`GET /open/contacts`): Paginated retrieval of contacts directory.
- `account.getApiUsageInfo` (`GET /open/info`): Retrieve account quota, consumption metrics, and rate limit info.
- `account.testApiKey` (`GET /open/info`): Validate API key connectivity and account status.
- `webhookSubscriptions.listWebhooks` (`GET /open/webhooks`): List all configured webhook subscriptions in 2Chat.

### Architecture & Standards
- **Authentication**: API Key auth via `X-User-API-Key` header with base URL `https://api.p.2chat.io`.
- **Client**: Configured `RateLimitConfig` with exponential backoff and retry handling.
- **Error Handlers**: Complete coverage — `RATE_LIMIT_ERROR` (429), `AUTH_ERROR` (401), `PERMISSION_ERROR` (403), `NETWORK_ERROR`, and fallback `DEFAULT`.
- **Validation**: Strict Zod input and output schemas with full TypeScript type exports.

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

### Test Suite & Plugin Validation (31 tests passing)

<img width="960" height="540" alt="image" src="https://github.com/user-attachments/assets/7e370a45-7c79-468b-90b1-2bbf0e2c457c" />

https://github.com/user-attachments/assets/e23bd553-e87d-4ae9-816a-d002dcda7637
video  starts : 7 seconds



## Additional Notes

- **No inbound webhooks**: Per spec, `webhooks: {}` is exported to satisfy the `CorsairPlugin` type contract. Webhook subscription management is exposed as a regular read endpoint (`listWebhooks`).
- **New package**: `packages/twochat` registered in `packages/corsair/core/constants.ts`.
- **`pnpm run validate:plugins`**: `[SUCCESS] All plugins passed structural validation!`
- **Tests**: `28 passed, 28 total` across `api.test.ts` and `schema.test.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TwoChat integration support.
  * Added contact creation and listing.
  * Added API usage retrieval and API-key validation.
  * Added webhook subscription listing.
  * Added contact, account, and webhook data schemas.
  * Added authentication, retry handling, validation, and error reporting.
  * Added TwoChat to the available provider list.

* **Tests**
  * Added comprehensive coverage for API requests, endpoint behavior, schemas, validation, errors, and webhook handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->