### PR TITLE
fix(studio): label the ChatPage message textarea

### DIFF
--- a/packages/studio/src/web/pages/ChatPage.tsx
+++ b/packages/studio/src/web/pages/ChatPage.tsx
@@ -559,6 +559,7 @@ export function ChatPage({ tenant }: { tenant: string }) {
 							value={input}
 							onChange={(e) => setInput(e.target.value)}
 							onKeyDown={onKeyDown}
+							aria-label="Chat message"
 							placeholder="Ask about your integrations… (Ctrl+Enter to send)"
 							disabled={streaming || chatLoading}
 						/>


### PR DESCRIPTION
## Description

Fixes #717.

The Chat composer relied on its `placeholder` for an accessible name. Placeholder text is only the last-resort fallback in the [AccName spec](https://w3c.github.io/accname/#step2E) and is applied inconsistently across screen readers, so the field had no stable name.

Adds `aria-label="Chat message"` to the `Textarea` in `packages/studio/src/web/pages/ChatPage.tsx`, matching the existing labels on the conversation `select` ("Active chat") and the Send button — same approach as #740 and #742. One line, no styling changes.

`Textarea` (`components/Primitives.tsx:44`) spreads `...rest` onto the native `<textarea>` and is typed as `React.TextareaHTMLAttributes<HTMLTextAreaElement>`, so the attribute reaches the DOM with no change to the primitive.

## Verification

Checked against the live studio UI in Chromium via the browser accessibility tree:

| | Accessible name of the composer |
| --- | --- |
| before | `textbox "Ask about your integrations… (Ctrl+Enter to send)"` |
| after | `textbox "Chat message"` |

No page errors, and no other control on the page changed.

## Checklist

- [x] I have run `pnpm lint` and all checks pass — exit 0 (6 pre-existing warnings elsewhere, none in this file)
- [x] I have run `pnpm typecheck` and there are no TypeScript errors — exit 0
- [x] I have run `pnpm build` and all packages build successfully — exit 0, 128/128 tasks
- [ ] I have run `pnpm test` and all tests pass — **see note below**
- [ ] I have added or updated tests where applicable — n/a, see note
- [ ] I have added or updated necessary documentation — n/a, no user-facing behaviour change

**On `pnpm test`:** it does not pass in my local environment, and does not pass on a clean `main` either — identical results both ways (17 suites / 103 tests failing). Every failure is `Could not locate the bindings file … better_sqlite3.node` in `packages/corsair`: `better-sqlite3` cannot compile against my local Node 26 because its C++ uses V8 APIs that were removed (`Object::GetPrototype`, `Context::GetIsolate`). This is unrelated to the change here, which touches only `packages/studio` web UI. Happy to re-run on Node 22 if you'd like that confirmed.

**On tests for this change:** `packages/studio` currently has no test setup (no test files, no vitest/testing-library/jsdom), so there is nothing to extend. Adding a test framework felt well outside the scope of a one-line a11y fix, and matches how #740 and #742 shipped. I verified via the browser accessibility tree instead, as above.

## Additional Notes

No breaking changes, no new dependencies.

While checking for sibling instances of this bug I found that 8 further form controls in `packages/studio/src/web` still have no accessible name — most of them sharing one root cause in `OperationInputForm`, where `FieldLabel` renders a `<label>` as a sibling of the input with no `htmlFor`. I've written that up separately as #746 rather than widening this PR, and I'd be glad to take it on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added an accessible label to the chat message input for improved screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->