### PR TITLE
docs: close setup gaps found in fresh-install review

### DIFF
--- a/docs/concepts/database.mdx
+++ b/docs/concepts/database.mdx
@@ -490,7 +490,7 @@ Because Corsair updates `corsair_entities` on every API call and webhook, foreig
 Corsair runs on **your** database. Pass a connection to `createCorsair` — it works alongside whatever ORM you already use for your own tables.
 
 <Warning>
-`createCorsair` takes a database **connection**, not an ORM client. Pass a `pg` `Pool`, a `better-sqlite3` instance, a `postgres.js` `Sql`, or a typed `Kysely` instance — never a `PrismaClient`. If you use Prisma or Drizzle for your own tables, hand Corsair the underlying `Pool` they wrap.
+`createCorsair` takes a database **connection**, not an ORM client. Pass a `pg` `Pool`, a `better-sqlite3` instance, a `postgres.js` `Sql`, or a typed `Kysely` instance — never a `PrismaClient`. If you use Prisma or Drizzle for your own tables, hand Corsair the underlying supported connection they wrap (one of the types above), not the ORM client.
 </Warning>
 
 <Tabs>
@@ -536,7 +536,7 @@ export const corsair = createCorsair({ database: pool, ... });
 // Drizzle — your app tables
 export const db = drizzle(pool);
 
-// Prisma — your app tables (same pool, not PrismaClient)
+// Prisma — your app tables (PrismaClient keeps its own pool; use the @prisma/adapter-pg driver adapter to share one pool)
 export const prisma = new PrismaClient();
 ```
 

--- a/docs/concepts/database.mdx
+++ b/docs/concepts/database.mdx
@@ -489,6 +489,10 @@ Because Corsair updates `corsair_entities` on every API call and webhook, foreig
 
 Corsair runs on **your** database. Pass a connection to `createCorsair` — it works alongside whatever ORM you already use for your own tables.
 
+<Warning>
+`createCorsair` takes a database **connection**, not an ORM client. Pass a `pg` `Pool`, a `better-sqlite3` instance, a `postgres.js` `Sql`, or a typed `Kysely` instance — never a `PrismaClient`. If you use Prisma or Drizzle for your own tables, hand Corsair the underlying `Pool` they wrap.
+</Warning>
+
 <Tabs>
 <Tab title="SQLite">
 

--- a/docs/concepts/oauth.mdx
+++ b/docs/concepts/oauth.mdx
@@ -4,6 +4,8 @@ sidebarTitle: OAuth 2.0
 description: Connect user accounts with OAuth 2.0 flows in Corsair plugins.
 ---
 
+import InstallCorsairCli from '/snippets/install-corsair-cli.mdx';
+
 OAuth 2.0 lets users authorize your application to act on their behalf. Corsair handles the entire flow — minting connect links, processing callbacks, storing tokens encrypted, and refreshing them automatically when they expire.
 
 ## How it works
@@ -42,6 +44,8 @@ export const corsair = createCorsair({
 ```
 
 Store your OAuth app credentials, then start the flow:
+
+<InstallCorsairCli />
 
 ```bash
 pnpm corsair setup --plugin=gmail client_id=your-client-id client_secret=your-client-secret

--- a/docs/concepts/provisioning.mdx
+++ b/docs/concepts/provisioning.mdx
@@ -3,6 +3,8 @@ title: Provisioning
 description: Initialize integrations, accounts, and tenants with setupCorsair at runtime or the corsair CLI in ops.
 ---
 
+import InstallCorsairCli from '/snippets/install-corsair-cli.mdx';
+
 Provisioning creates the database rows, DEKs, and credential slots Corsair needs before a tenant can connect. The same logic runs two ways: `setupCorsair` from your backend (on signup, in production) and `pnpm corsair setup` from the CLI (local and ops). Both are idempotent — they skip rows that already exist.
 
 ## Data model
@@ -60,6 +62,8 @@ It returns a log string and skips existing rows.
 ## CLI
 
 Same provisioning from the terminal — for local setup and ops:
+
+<InstallCorsairCli />
 
 ```bash
 # Single-tenant

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -184,7 +184,7 @@ export const corsair = createCorsair({
 ```
 
 <Warning>
-Pass a database **connection** to `createCorsair`, not an ORM client. The `database` field accepts a `pg` `Pool`, a `better-sqlite3` instance, a `postgres.js` `Sql`, or a typed `Kysely` instance — **not** a `PrismaClient`. If you use Prisma for your own tables, pass the underlying `pg` `Pool` here. See [Database](/concepts/database).
+Pass a database **connection** to `createCorsair`, not an ORM client. The `database` field accepts a `pg` `Pool`, a `better-sqlite3` instance, a `postgres.js` `Sql`, or a typed `Kysely` instance — **not** a `PrismaClient`. If you use Prisma for your own tables, Prisma keeps its own internal pool, so create a `pg` `Pool` and pass that here (never the `PrismaClient`); to reuse one connection across both, use Prisma's driver adapter (`@prisma/adapter-pg`). See [Database](/concepts/database).
 </Warning>
 
 Mount the handler once — it serves Hub delivery and the management API. In development, Hub auto-detects your localhost delivery URL:

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -38,6 +38,10 @@ bun add corsair @corsair-dev/github
 `@corsair-dev/github` is one plugin. Every service is its own `@corsair-dev/*` package — find the one you need, and its exact install id, in the [**Plugins**](/guides/plugins) catalog.
 </Tip>
 
+<Note>
+Make sure `corsair` lands in your `package.json` as a **direct dependency** (under `dependencies`), not only as a transitive dependency of something else. Your code imports from `corsair`, so it must be declared there.
+</Note>
+
 </Step>
 
 <Step>
@@ -179,6 +183,10 @@ export const corsair = createCorsair({
 });
 ```
 
+<Warning>
+Pass a database **connection** to `createCorsair`, not an ORM client. The `database` field accepts a `pg` `Pool`, a `better-sqlite3` instance, a `postgres.js` `Sql`, or a typed `Kysely` instance — **not** a `PrismaClient`. If you use Prisma for your own tables, pass the underlying `pg` `Pool` here. See [Database](/concepts/database).
+</Warning>
+
 Mount the handler once — it serves Hub delivery and the management API. In development, Hub auto-detects your localhost delivery URL:
 
 <MountHandlerNextjs />
@@ -200,6 +208,10 @@ const { connectUrl } = await corsair.manage.connect.createLink({
 });
 // redirect the user's browser to connectUrl
 ```
+
+<Note>
+`tenantId` is only required in [multi-tenant](/concepts/multi-tenancy) apps. In single-tenant mode it is optional and defaults to `"default"`.
+</Note>
 
 Once connected, call any endpoint. Responses are also cached in your database for instant reads:
 

--- a/docs/hub/dashboard.mdx
+++ b/docs/hub/dashboard.mdx
@@ -41,7 +41,11 @@ You can generate a link for **unverified plugins only** or for **all plugins** o
 
 ### Corsair-managed integrations
 
-If you use plugins with `authType: 'managed'`, Corsair can host the OAuth app for eligible integrations in production. In development, all configured managed plugins are available.
+If you use plugins with `authType: 'managed'`, Corsair can host the OAuth app for **eligible** integrations. Eligibility depends on the provider and your plan — the Connections tab shows which integrations your project can have Corsair manage.
+
+<Note>
+**Managed connect shows a provider error or 404?** If a managed connect link sends the user to the provider's OAuth page and it returns an error (for example a GitHub 404), that provider is not available as a Corsair-managed OAuth app for your project. Switch to [bring-your-own OAuth](#byo-credentials-from-the-dashboard) — register your own OAuth app with the provider and supply its client id and secret.
+</Note>
 
 If your plan limits how many integrations Corsair manages in production, the Connections tab asks you to **select which ones** you want Corsair to manage. Save your selection before going live — integrations not selected use bring-your-own OAuth (you supply client id and secret via the dashboard or your app).
 

--- a/docs/hub/environments.mdx
+++ b/docs/hub/environments.mdx
@@ -22,7 +22,7 @@ Some characteristics of Development:
 - **Auto-detected delivery URL.** The SDK figures out where your handler lives from `CORSAIR_DELIVERY_URL` or `PORT`. You do not configure this in the dashboard.
 - **Separate credentials.** Development has its own API key and signing secret. They are shown on the **Keys** tab when the environment picker is set to Development.
 - **Relaxed setup.** No "activate" step. As long as your app is running locally and you are using `ck_dev_…` keys, connect flows work.
-- **All configured plugins available.** Useful for trying integrations before you ship. Production may ask you to choose which Corsair-managed integrations to enable — see [Hub dashboard](/hub/dashboard#corsair-managed-integrations).
+- **Managed OAuth depends on eligibility.** In development you can try every configured plugin, but a Corsair-managed OAuth app only works when that provider is eligible for your plan. If the provider's OAuth page returns an error (for example a GitHub 404), that provider is not Corsair-managed for your project, so use bring-your-own — see [Hub dashboard](/hub/dashboard#corsair-managed-integrations).
 
 Development is for building and testing on your machine. It is not a substitute for a deployed production setup.
 

--- a/docs/management/connect.mdx
+++ b/docs/management/connect.mdx
@@ -97,7 +97,7 @@ In `hub` mode, the OAuth app shown on the provider's page depends on the plugin'
 
 To switch a managed plugin to BYO:
 
-1. Register an OAuth app with the provider and set its redirect URL to `https://auth.corsair.dev/oauth/callback`.
+1. Register an OAuth app with the provider and set its redirect URL to your Hub OAuth callback URL — by default `https://auth.corsair.dev/oauth/callback`. If you self-host the Hub API (`hub.apiUrl`) or set a custom `hub.oauthCallbackUrl`, register that derived value instead: the SDK sends this exact URL to the provider as `redirect_uri`.
 2. Set the plugin's `authType` to `'oauth_2'`.
 3. Store the credentials at the integration level:
 

--- a/docs/management/connect.mdx
+++ b/docs/management/connect.mdx
@@ -97,7 +97,7 @@ In `hub` mode, the OAuth app shown on the provider's page depends on the plugin'
 
 To switch a managed plugin to BYO:
 
-1. Register an OAuth app with the provider and set its redirect URL to your Hub OAuth callback URL — by default `https://auth.corsair.dev/oauth/callback`. If you set `hub.oauthCallbackUrl`, register that exact value (without a trailing slash). Otherwise, if you self-host the Hub API with `hub.apiUrl`, register `${hub.apiUrl}/oauth/callback`: the SDK sends this exact URL to the provider as `redirect_uri`.
+1. Register an OAuth app with the provider and set its redirect URL to your Hub OAuth callback URL — by default `https://auth.corsair.dev/oauth/callback`. If you set `hub.oauthCallbackUrl`, register that exact value (without a trailing slash). Otherwise, if you self-host the Hub API with `hub.apiUrl`, remove any trailing slash and register `${hub.apiUrl}/oauth/callback`: the SDK sends this normalized URL to the provider as `redirect_uri`.
 2. Set the plugin's `authType` to `'oauth_2'`.
 3. Store the credentials at the integration level:
 

--- a/docs/management/connect.mdx
+++ b/docs/management/connect.mdx
@@ -70,6 +70,10 @@ const { connectUrl } = await client.connect.createLink({
 window.location.href = connectUrl;
 ```
 
+<Note>
+`tenantId` is optional in single-tenant mode and defaults to `"default"`. Pass it only for [multi-tenant](/concepts/multi-tenancy) apps.
+</Note>
+
 Hub-specific optional overrides (ignored in manual mode):
 
 | Field | Purpose |
@@ -79,6 +83,27 @@ Hub-specific optional overrides (ignored in manual mode):
 | `providerName` | Optional — override provider display name in Hub UI |
 
 Hub delivers results to your handler. In development the SDK auto-detects the delivery URL; in production it uses the URL registered in the [Hub dashboard](/hub/dashboard). You do **not** call `resolve` or `oauthCallback`.
+
+### Managed vs bring-your-own (BYO)
+
+In `hub` mode, the OAuth app shown on the provider's page depends on the plugin's `authType`:
+
+| Plugin `authType` | OAuth app | What you provide |
+| ----------------- | --------- | ---------------- |
+| `'managed'` | Corsair hosts it | Nothing. Only works for [eligible](/hub/dashboard#corsair-managed-integrations) providers on your plan |
+| `'oauth_2'` | You host it (BYO) | Your OAuth app's `client_id` and `client_secret` |
+
+`oauthMode` overrides this per connect link (`'managed'` or `'byo'`); when omitted it is inferred from the plugin's `authType`.
+
+To switch a managed plugin to BYO:
+
+1. Register an OAuth app with the provider and set its redirect URL to `https://auth.corsair.dev/oauth/callback`.
+2. Set the plugin's `authType` to `'oauth_2'`.
+3. Store the credentials at the integration level:
+
+```bash
+pnpm corsair setup --plugin=github client_id=your-client-id client_secret=your-client-secret
+```
 
 ## Manual mode (self-hosted)
 

--- a/docs/management/connect.mdx
+++ b/docs/management/connect.mdx
@@ -93,17 +93,21 @@ In `hub` mode, the OAuth app shown on the provider's page depends on the plugin'
 | `'managed'` | Corsair hosts it | Nothing. Only works for [eligible](/hub/dashboard#corsair-managed-integrations) providers on your plan |
 | `'oauth_2'` | You host it (BYO) | Your OAuth app's `client_id` and `client_secret` |
 
-`oauthMode` overrides this per connect link (`'managed'` or `'byo'`); when omitted it is inferred from the plugin's `authType`.
+`oauthMode` overrides this per connect link (`'managed'` or `'byo'`); when omitted it is inferred from the plugin's `authType`. The `oauthMode` and `providerName` overrides apply only when `plugin` is set — when `plugin` is omitted the link covers all configured plugins and each uses its inferred mode.
 
 To switch a managed plugin to BYO:
 
-1. Register an OAuth app with the provider and set its redirect URL to your Hub OAuth callback URL — by default `https://auth.corsair.dev/oauth/callback`. If you self-host the Hub API (`hub.apiUrl`) or set a custom `hub.oauthCallbackUrl`, register that derived value instead: the SDK sends this exact URL to the provider as `redirect_uri`.
+1. Register an OAuth app with the provider and set its redirect URL to your Hub OAuth callback URL — by default `https://auth.corsair.dev/oauth/callback`. If you set `hub.oauthCallbackUrl`, register that exact value (without a trailing slash). Otherwise, if you self-host the Hub API with `hub.apiUrl`, register `${hub.apiUrl}/oauth/callback`: the SDK sends this exact URL to the provider as `redirect_uri`.
 2. Set the plugin's `authType` to `'oauth_2'`.
 3. Store the credentials at the integration level:
 
 ```bash
 pnpm corsair setup --plugin=github client_id=your-client-id client_secret=your-client-secret
 ```
+
+<Warning>
+`corsair setup` reads credentials from the command line, so inline `field=value` secrets can leak through shell history, process listings, or CI logs. For production, store them from a secret manager or environment variables with [`setupCorsair`](/concepts/provisioning#credentials) (or `corsair.keys.<plugin>.set_client_id` / `set_client_secret`) instead.
+</Warning>
 
 ## Manual mode (self-hosted)
 

--- a/docs/plugins/github/get-credentials.mdx
+++ b/docs/plugins/github/get-credentials.mdx
@@ -3,6 +3,8 @@ title: Get Credentials
 description: Step-by-step instructions for obtaining GitHub Personal Access Tokens, OAuth credentials, and webhook secrets.
 ---
 
+import InstallCorsairCli from '/snippets/install-corsair-cli.mdx';
+
 This guide walks you through obtaining all required credentials for the GitHub plugin.
 
 ## Authentication Methods
@@ -33,6 +35,8 @@ The GitHub plugin supports both API key (Personal Access Token) and OAuth 2.0 au
 **Storing Credentials:**
 
 Store the token with the Corsair CLI:
+
+<InstallCorsairCli />
 
 ```bash
 pnpm corsair setup --plugin=github api_key=your-personal-access-token

--- a/docs/snippets/install-corsair-cli.mdx
+++ b/docs/snippets/install-corsair-cli.mdx
@@ -2,16 +2,16 @@ The `corsair` command lives in a separate package. Install it first:
 
 <CodeGroup>
 ```bash npm
-npm install --save-dev @corsair-dev/cli
+npm install @corsair-dev/cli
 ```
 ```bash yarn
-yarn add --dev @corsair-dev/cli
+yarn add @corsair-dev/cli
 ```
 ```bash pnpm
-pnpm install --save-dev @corsair-dev/cli
+pnpm install @corsair-dev/cli
 ```
 ```bash bun
-bun add --dev @corsair-dev/cli
+bun add @corsair-dev/cli
 ```
 </CodeGroup>
 

--- a/docs/snippets/install-corsair-cli.mdx
+++ b/docs/snippets/install-corsair-cli.mdx
@@ -18,3 +18,7 @@ bun add @corsair-dev/cli
 <Note>
 The `corsair` command comes from the `@corsair-dev/cli` package, not the `corsair` SDK package (the SDK is library-only and ships no binary). If `corsair setup` fails with `could not determine executable to run`, this package is not installed.
 </Note>
+
+<Warning>
+Don't pass secrets inline as `corsair setup` arguments — command-line values can leak through shell history, process listings, or CI logs. For production, provision credentials from a secret manager or environment variables with [`setupCorsair`](/concepts/provisioning#credentials) (or `corsair.keys.<plugin>.set_client_id` / `set_client_secret`).
+</Warning>

--- a/docs/snippets/install-corsair-cli.mdx
+++ b/docs/snippets/install-corsair-cli.mdx
@@ -1,0 +1,20 @@
+The `corsair` command lives in a separate package. Install it first:
+
+<CodeGroup>
+```bash npm
+npm install --save-dev @corsair-dev/cli
+```
+```bash yarn
+yarn add --dev @corsair-dev/cli
+```
+```bash pnpm
+pnpm install --save-dev @corsair-dev/cli
+```
+```bash bun
+bun add --dev @corsair-dev/cli
+```
+</CodeGroup>
+
+<Note>
+The `corsair` command comes from the `@corsair-dev/cli` package, not the `corsair` SDK package (the SDK is library-only and ships no binary). If `corsair setup` fails with `could not determine executable to run`, this package is not installed.
+</Note>


### PR DESCRIPTION
## Description

Closes the setup gaps surfaced by a fresh-install review of the docs. A new user following the quick start and provider guides could not always tell that the `corsair` CLI lives in a separate package, that `createCorsair` expects a DB connection (not an ORM client), or how managed vs bring-your-own OAuth works. This PR makes each of those explicit.

**What changed**

- **New `docs/snippets/install-corsair-cli.mdx`** — a reusable snippet explaining that the `corsair` command ships in `@corsair-dev/cli` (not the `corsair` SDK), with install commands for npm/yarn/pnpm/bun and a hint for the `could not determine executable to run` error. Added to the OAuth, provisioning, and GitHub get-credentials pages wherever `pnpm corsair …` is shown.
- **DB connection guidance** — `docs/concepts/database.mdx` and the quick start now warn that `createCorsair` takes a database **connection** (`pg` Pool, `better-sqlite3`, `postgres.js` Sql, or Kysely), never a `PrismaClient`/ORM client.
- **Direct dependency note** — the quick start clarifies that `corsair` must be a direct `dependencies` entry since user code imports from it.
- **Managed vs bring-your-own OAuth** — `docs/management/connect.mdx` documents the `authType` (`'managed'` vs `'oauth_2'`) → OAuth app mapping, `oauthMode` override, and the steps to switch a managed plugin to BYO. `docs/hub/dashboard.mdx` and `docs/hub/environments.mdx` now explain managed-provider eligibility and what a provider 404/error on the OAuth page means.
- **`tenantId` default clarified** — quick start and `docs/management/connect.mdx` note that `tenantId` is optional in single-tenant mode and defaults to `"default"`.

This is a documentation-only change (no source, tests, or plugin code touched).

## Checklist

**Before submitting your PR, please verify the following:**

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

Documentation-only change — no UI or CLI output affected, so no screenshots or recordings are applicable.

## Additional Notes

Docs-only PR: only `.mdx` files under `docs/` are modified — no source, test, or plugin code touched.

- `pnpm run validate:docs` passes locally: *"Docs validation passed! No invalid plugin imports found"* — this is the CI gate that checks docs imports, and it confirms the new `InstallCorsairCli` snippet import resolves correctly.
- Docs `.mdx` files are excluded from the repo's `biome check .` lint (per `biome.json` ignores), so the Markdown changes are not linted by biome.
- The repo-wide `lint` / `build` / `test` / `typecheck` currently surface pre-existing failures in unrelated plugin packages and a Windows file-lock (`EPERM`) when several checks run concurrently on `dist/`. These are unrelated to any file in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added CLI installation instructions for npm, Yarn, pnpm, and Bun.
  - Clarified that the CLI is separate from the library-only SDK and warned against passing secrets as command-line arguments.
  - Clarified database connection requirements and supported connection types.
  - Documented optional `tenantId` behavior in single-tenant mode.
  - Expanded OAuth guidance covering managed integrations, eligibility, BYO credentials, redirects, and troubleshooting.
  - Added CLI setup guidance across OAuth, provisioning, and GitHub credential documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->