### PR TITLE
fix(intercom): fail closed on missing webhook secret

### DIFF
--- a/packages/intercom/webhooks/types.test.ts
+++ b/packages/intercom/webhooks/types.test.ts
@@ -1,0 +1,69 @@
+import type { WebhookRequest } from 'corsair/core';
+import crypto from 'crypto';
+
+import type { IntercomWebhookPayload } from './types';
+import { verifyIntercomWebhookSignature } from './types';
+
+describe('verifyIntercomWebhookSignature', () => {
+	const secret = 'my-intercom-client-secret';
+	const payload: IntercomWebhookPayload = {
+		type: 'notification_event',
+		topic: 'ping',
+		id: null,
+		app_id: 'app123',
+		created_at: 1700000000,
+		first_sent_at: 1700000000,
+		data: {
+			type: 'notification_event_data',
+			item: { type: 'ping', message: 'hello' },
+		},
+	};
+	const rawBody = JSON.stringify(payload);
+
+	const sign = (body: string) =>
+		`sha1=${crypto.createHmac('sha1', secret).update(body).digest('hex')}`;
+
+	const requestWith = (
+		headers: Record<string, string | string[]>,
+		body: string = rawBody,
+	): WebhookRequest<unknown> => ({
+		payload,
+		headers,
+		rawBody: body,
+	});
+
+	it('returns invalid when the secret is missing', () => {
+		const result = verifyIntercomWebhookSignature(
+			requestWith({ 'x-hub-signature': sign(rawBody) }),
+			'',
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('returns invalid when the x-hub-signature header is missing', () => {
+		const result = verifyIntercomWebhookSignature(requestWith({}), secret);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing x-hub-signature header',
+		});
+	});
+
+	it('returns valid for a correctly signed request', () => {
+		const result = verifyIntercomWebhookSignature(
+			requestWith({ 'x-hub-signature': sign(rawBody) }),
+			secret,
+		);
+		expect(result).toEqual({ valid: true, error: undefined });
+	});
+
+	it('returns invalid for a signature that does not match', () => {
+		const result = verifyIntercomWebhookSignature(
+			requestWith({ 'x-hub-signature': 'sha1=deadbeef' }),
+			secret,
+		);
+		expect(result.valid).toBe(false);
+	});
+});

--- a/packages/intercom/webhooks/types.ts
+++ b/packages/intercom/webhooks/types.ts
@@ -254,6 +254,10 @@ export function verifyIntercomWebhookSignature(
 		return { valid: false, error: 'Missing x-hub-signature header' };
 	}
 
+	if (!secret) {
+		return { valid: false, error: 'Missing webhook secret' };
+	}
+
 	const expectedSignature = `sha1=${crypto
 		.createHmac('sha1', secret)
 		.update(body)


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

`verifyIntercomWebhookSignature` computed an HMAC signature against an empty
secret instead of rejecting the request outright when no secret was
configured. Every other webhook plugin in this repo (typeform, stripe,
notion, spotify, gitlab, mailchimp, and ~25 others) already fails closed on
a missing secret with the same `{ valid: false, error: 'Missing webhook
secret' }` shape — Intercom (and Vercel, tracked separately in #712) were
the two outliers.

Fixes #711

## Checklist

- [x] I have run `pnpm typecheck` and there are no TypeScript errors
      (scoped to `@corsair-dev/intercom`)
- [x] I have run `pnpm test` and all tests pass (scoped to
      `@corsair-dev/intercom`; pre-existing unrelated failures in
      `api.test.ts` come from live Intercom API calls needing real
      credentials, confirmed present before this change via git-stash A/B)
- [x] I have added tests for the new guard
- [ ] Full-repo `pnpm lint`/`pnpm build` not run (no `lint` script exists
      at the package level; a full monorepo build was out of scope for a
      2-file fix — happy to run it if a maintainer wants it before merge)

## Additional Notes

No behavior change to the signature comparison path — only adds the
missing-secret guard before the HMAC is computed, matching the repo's
established pattern exactly.