### PR TITLE
fix(gitlab): use constant-time comparison for X-Gitlab-Token

### DIFF
--- a/packages/gitlab/webhooks/types.test.ts
+++ b/packages/gitlab/webhooks/types.test.ts
@@ -55,8 +55,6 @@ describe('verifyGitlabWebhookSignature', () => {
 	});
 
 	it('should return invalid for a same-length token that differs', () => {
-		// Exercises the timingSafeEqual compare itself — 'not-the-secret' above is
-		// short enough that it never gets past the length guard.
 		const sameLength = 'my-super-secret-toXen';
 		expect(sameLength).toHaveLength(secret.length);
 		const result = verifyGitlabWebhookSignature(
@@ -97,8 +95,6 @@ describe('verifyGitlabWebhookSignature', () => {
 	});
 
 	it('should handle a multi-byte secret without throwing', () => {
-		// 'sécret' is 6 chars but 7 bytes: a char-length guard would let this
-		// through to timingSafeEqual, which throws on unequal buffer lengths.
 		const multiByte = 'sécret';
 		expect(
 			verifyGitlabWebhookSignature(

--- a/packages/gitlab/webhooks/types.test.ts
+++ b/packages/gitlab/webhooks/types.test.ts
@@ -85,6 +85,17 @@ describe('verifyGitlabWebhookSignature', () => {
 		expect(result).toEqual({ valid: true });
 	});
 
+	it('should reject a repeated token header when the first value is wrong', () => {
+		const result = verifyGitlabWebhookSignature(
+			requestWith({ 'x-gitlab-token': ['wrong', secret] }),
+			secret,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'X-Gitlab-Token does not match configured secret',
+		});
+	});
+
 	it('should handle a multi-byte secret without throwing', () => {
 		// 'sécret' is 6 chars but 7 bytes: a char-length guard would let this
 		// through to timingSafeEqual, which throws on unequal buffer lengths.

--- a/packages/gitlab/webhooks/types.test.ts
+++ b/packages/gitlab/webhooks/types.test.ts
@@ -54,11 +54,55 @@ describe('verifyGitlabWebhookSignature', () => {
 		});
 	});
 
+	it('should return invalid for a same-length token that differs', () => {
+		// Exercises the timingSafeEqual compare itself — 'not-the-secret' above is
+		// short enough that it never gets past the length guard.
+		const sameLength = 'my-super-secret-toXen';
+		expect(sameLength).toHaveLength(secret.length);
+		const result = verifyGitlabWebhookSignature(
+			requestWith({ 'x-gitlab-token': sameLength }),
+			secret,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'X-Gitlab-Token does not match configured secret',
+		});
+	});
+
 	it('should return valid when the token matches the configured secret', () => {
 		const result = verifyGitlabWebhookSignature(
 			requestWith({ 'x-gitlab-token': secret }),
 			secret,
 		);
 		expect(result).toEqual({ valid: true });
+	});
+
+	it('should use the first value of a repeated token header', () => {
+		const result = verifyGitlabWebhookSignature(
+			requestWith({ 'x-gitlab-token': [secret, 'ignored'] }),
+			secret,
+		);
+		expect(result).toEqual({ valid: true });
+	});
+
+	it('should handle a multi-byte secret without throwing', () => {
+		// 'sécret' is 6 chars but 7 bytes: a char-length guard would let this
+		// through to timingSafeEqual, which throws on unequal buffer lengths.
+		const multiByte = 'sécret';
+		expect(
+			verifyGitlabWebhookSignature(
+				requestWith({ 'x-gitlab-token': multiByte }),
+				multiByte,
+			),
+		).toEqual({ valid: true });
+		expect(
+			verifyGitlabWebhookSignature(
+				requestWith({ 'x-gitlab-token': 'secret' }),
+				multiByte,
+			),
+		).toEqual({
+			valid: false,
+			error: 'X-Gitlab-Token does not match configured secret',
+		});
 	});
 });

--- a/packages/gitlab/webhooks/types.ts
+++ b/packages/gitlab/webhooks/types.ts
@@ -1,10 +1,24 @@
-import { timingSafeEqual } from 'node:crypto';
+import { createHmac, timingSafeEqual } from 'node:crypto';
 import type {
 	CorsairWebhookMatcher,
 	RawWebhookRequest,
 	WebhookRequest,
 } from 'corsair/core';
 import { z } from 'zod';
+
+// Mixer only — not an auth key. HMAC both sides so timingSafeEqual always
+// sees 32-byte digests and never short-circuits on the secret's length.
+const TOKEN_COMPARE_KEY = Buffer.from('corsair-gitlab-webhook-token-v1');
+
+function tokensMatch(token: string, secret: string): boolean {
+	const tokenDigest = createHmac('sha256', TOKEN_COMPARE_KEY)
+		.update(token, 'utf8')
+		.digest();
+	const secretDigest = createHmac('sha256', TOKEN_COMPARE_KEY)
+		.update(secret, 'utf8')
+		.digest();
+	return timingSafeEqual(tokenDigest, secretDigest);
+}
 
 // ============================================================================
 // Base webhook payload
@@ -45,17 +59,7 @@ export function verifyGitlabWebhookSignature(
 		return { valid: false, error: 'Missing X-Gitlab-Token header' };
 	}
 
-	// Constant-time compare so response timing cannot leak the configured secret
-	// byte-by-byte. timingSafeEqual throws on unequal buffer lengths, hence the
-	// byte-length guard first — and it reuses the same error so a mismatch never
-	// reveals the secret's length.
-	const tokenBuffer = Buffer.from(token);
-	const secretBuffer = Buffer.from(secret);
-
-	if (
-		tokenBuffer.length !== secretBuffer.length ||
-		!timingSafeEqual(tokenBuffer, secretBuffer)
-	) {
+	if (!tokensMatch(token, secret)) {
 		return {
 			valid: false,
 			error: 'X-Gitlab-Token does not match configured secret',

--- a/packages/gitlab/webhooks/types.ts
+++ b/packages/gitlab/webhooks/types.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto';
 import type {
 	CorsairWebhookMatcher,
 	RawWebhookRequest,
@@ -37,13 +38,24 @@ export function verifyGitlabWebhookSignature(
 		return { valid: false, error: 'Missing webhook secret' };
 	}
 
-	const token = request.headers['x-gitlab-token'];
+	const rawToken = request.headers['x-gitlab-token'];
+	const token = Array.isArray(rawToken) ? rawToken[0] : rawToken;
 
 	if (!token) {
 		return { valid: false, error: 'Missing X-Gitlab-Token header' };
 	}
 
-	if (token !== secret) {
+	// Constant-time compare so response timing cannot leak the configured secret
+	// byte-by-byte. timingSafeEqual throws on unequal buffer lengths, hence the
+	// byte-length guard first — and it reuses the same error so a mismatch never
+	// reveals the secret's length.
+	const tokenBuffer = Buffer.from(token);
+	const secretBuffer = Buffer.from(secret);
+
+	if (
+		tokenBuffer.length !== secretBuffer.length ||
+		!timingSafeEqual(tokenBuffer, secretBuffer)
+	) {
 		return {
 			valid: false,
 			error: 'X-Gitlab-Token does not match configured secret',


### PR DESCRIPTION
## Description

`verifyGitlabWebhookSignature` (`packages/gitlab/webhooks/types.ts`) already fails closed on a
missing secret and a missing header, but the actual comparison was still `token !== secret`.
JS string equality short-circuits at the first differing byte, so response timing leaks the
configured webhook secret byte-by-byte to anyone who can POST to the webhook endpoint.

The compare HMACs both sides (mixer key, not an auth secret) and then
`crypto.timingSafeEqual` on the 32-byte digests, so timing cannot leak the secret
byte-by-byte _or_ its length. The existing error string
(`X-Gitlab-Token does not match configured secret`) is unchanged. Missing-secret
and missing-header paths are untouched.

Also unwraps a repeated `x-gitlab-token` header (`Array.isArray(raw) ? raw[0] : raw`) before
comparing. `WebhookRequest.headers` is typed `Record<string, string | string[] | undefined>`
(`packages/corsair/core/webhooks/index.ts:29`), so this is required to get a string, and it
matches the convention every other webhook verifier in the repo already uses.

No shared helper was extracted: `corsair/http` only exports HMAC-shaped verifiers
(`verifyHmacSignature`, `verifyHmacSignatureWithPrefix`, `verifySlackSignature`), none of which
fit a raw shared-secret compare.

Fixes #708

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

Two notes on the boxes above, so nothing is overstated:

**Lint.** `pnpm lint` reports 6 warnings, all pre-existing in `www/` and untouched by this PR;
`npx biome check` on the two changed files is clean.

**Tests.** In `packages/gitlab`, `api.test.ts` and `integration.test.ts` fail identically with
and without this change — they call the live GitLab API and need credentials CI does not have.
I verified this by stashing the change and re-running. The three suites that run offline all
pass.

**Docs.** No documentation change applies here — no public API, function signature, or error
string changed, so the existing docs stay accurate.

## Screenshots / Demos

https://gist.github.com/ambikeesshh/c9523b397dba62865b701c92bd4319fc

Recording of the verifier on this branch — `rg` from the issue, then the unit suite:

```
$ rg 'token !== secret' packages/gitlab/webhooks/types.ts
(no output)

$ npx jest webhooks/types.test.ts

PASS webhooks/types.test.ts
  verifyGitlabWebhookSignature
    ✓ should fail closed when secret is missing (2 ms)
    ✓ should fail closed when both secret and token header are missing
    ✓ should return invalid if the token header is missing (1 ms)
    ✓ should return invalid if the token does not match the secret
    ✓ should return invalid for a same-length token that differs
    ✓ should return valid when the token matches the configured secret
    ✓ should use the first value of a repeated token header
    ✓ should reject a repeated token header when the first value is wrong
    ✓ should handle a multi-byte secret without throwing

Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total
```

Nine cases. Length mismatch and value mismatch share the same error; the new
repeated-header case checks we fail closed when the first value is wrong.

## Additional Notes

No new dependencies, no breaking changes — `node:crypto` is stdlib.

**Follow-up, out of scope here:** `packages/telegram/webhooks/types.ts:285` compares its secret
token with `===` and has the identical timing leak. R1 limits a PR to one plugin, so it needs
its own PR — happy to open one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GitLab webhook signature verification for repeated headers and same-length mismatched tokens.
  - Added support for multi-byte secrets without errors.
  - Enhanced security by using constant-time, HMAC-based token comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->