### PR TITLE
test(box): add unit tests for verifyBoxWebhookSignature

### DIFF
--- a/packages/box/webhooks/types.test.ts
+++ b/packages/box/webhooks/types.test.ts
@@ -1,0 +1,108 @@
+import type { WebhookRequest } from 'corsair/core';
+import crypto from 'crypto';
+import type { BoxWebhookPayload } from './types';
+import { verifyBoxWebhookSignature } from './types';
+
+describe('Tests for verifyBoxWebhookSignature', () => {
+	const secret = 'my-secret';
+	const payload: BoxWebhookPayload = {
+		type: 'webhook_event',
+		id: 'unq-id',
+		created_at: 'date',
+		trigger: 'trigger',
+		webhook: {
+			id: 'webhook-id',
+			type: 'webhook',
+		},
+		created_by: {
+			id: 'created-by-id',
+			login: 'login',
+			name: 'alex',
+			type: 'random',
+		},
+		source: {},
+		additional_info: {},
+	};
+
+	const requestWith = (
+		headers: Record<string, string | string[]>,
+	): WebhookRequest<BoxWebhookPayload> => ({
+		payload,
+		headers,
+		rawBody: JSON.stringify(payload),
+	});
+
+	it('should fail closed when secret is missing', () => {
+		const result = verifyBoxWebhookSignature(
+			requestWith({
+				'box-signature-primary': 'valid-signature',
+				'box-delivery-timestamp': new Date().toISOString(),
+			}),
+			'',
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('should fail closed when box-signature-primary header is missing', () => {
+		const result = verifyBoxWebhookSignature(
+			requestWith({
+				'box-delivery-timestamp': new Date().toISOString(),
+			}),
+			secret,
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing box-signature-primary header',
+		});
+	});
+
+	it('should return invalid when box-signature-primary is invalid', () => {
+		const timestamp = new Date().toISOString();
+		const rawBody = JSON.stringify(payload);
+
+		const wrongSignature = crypto
+			.createHmac('sha256', 'wrong-secret')
+			.update(timestamp + rawBody)
+			.digest('base64');
+
+		const result = verifyBoxWebhookSignature(
+			requestWith({
+				'box-signature-primary': wrongSignature,
+				'box-delivery-timestamp': new Date().toISOString(),
+			}),
+			secret,
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid signature',
+		});
+	});
+
+	it('should return valid when box-signature-primary is correctly computed', () => {
+		const timestamp = new Date().toISOString();
+		const rawBody = JSON.stringify(payload);
+		const signature = crypto
+			.createHmac('sha256', secret)
+			.update(timestamp + rawBody)
+			.digest('base64');
+
+		const result = verifyBoxWebhookSignature(
+			requestWith({
+				'box-signature-primary': signature,
+				'box-delivery-timestamp': timestamp,
+			}),
+			secret,
+		);
+
+		expect(result).toEqual({
+			valid: true,
+			error: undefined,
+		});
+	});
+});

--- a/packages/box/webhooks/types.test.ts
+++ b/packages/box/webhooks/types.test.ts
@@ -73,7 +73,7 @@ describe('Tests for verifyBoxWebhookSignature', () => {
 		const result = verifyBoxWebhookSignature(
 			requestWith({
 				'box-signature-primary': wrongSignature,
-				'box-delivery-timestamp': new Date().toISOString(),
+				'box-delivery-timestamp': timestamp,
 			}),
 			secret,
 		);


### PR DESCRIPTION
## Description
Adds `packages/box/webhooks/types.test.ts` for `verifyBoxWebhookSignature`, covering the cases from the linked issue: missing secret, missing `box-signature-primary` header, invalid signature, and a valid signature computed via HMAC-SHA256 over `timestamp + rawBody`.


Follows the style of `packages/gitlab/webhooks/types.test.ts`.

Fixes #698 

## Checklist
- [x] missing secret → fail closed with Missing webhook secret
- [x] missing box-signature-primary header
- [x] wrong signature → invalid
- [x] correct HMAC-SHA256 over timestamp + rawBody (base64) with a fresh box-delivery-timestamp → valid
- [x] I have added or updated tests where applicable

## Screenshots / Demos (if applicable)
<img width="559" height="172" alt="Screenshot 2026-08-14 at 3 13 18 PM" src="https://github.com/user-attachments/assets/466eb662-a520-4793-ba92-8e569ab9a085" />

## Additional Notes
No breaking changes, no new dependencies. `crypto` is used only within the test file to construct valid/invalid HMAC signatures for assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for Box webhook signature verification.
  * Added validation scenarios for missing secrets, absent signature headers, invalid signatures, and valid signatures.
  * Improved verification of expected validation results and error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->