### PR TITLE
fix: use timingSafeEqual for Instagram verify_token

### DIFF
--- a/packages/instagram/webhooks/challenge.test.ts
+++ b/packages/instagram/webhooks/challenge.test.ts
@@ -1,0 +1,60 @@
+import { url_verification } from './challenge';
+
+type ChallengeContext = Parameters<typeof url_verification.handler>[0];
+type ChallengeRequest = Parameters<typeof url_verification.handler>[1];
+
+function createContext(webhookVerifyToken: string | undefined) {
+	return {
+		options: { webhookVerifyToken },
+		$getAccountId: jest.fn().mockResolvedValue('account-id'),
+	} as unknown as ChallengeContext;
+}
+
+function createRequest(verifyToken: string): ChallengeRequest {
+	return {
+		query: {
+			'hub.mode': 'subscribe',
+			'hub.verify_token': verifyToken,
+			'hub.challenge': 'challenge-value',
+		},
+		payload: {},
+	} as unknown as ChallengeRequest;
+}
+
+describe('instagram url_verification', () => {
+	it('succeeds when the verify token matches', async () => {
+		const result = await url_verification.handler(
+			createContext('verify-token'),
+			createRequest('verify-token'),
+		);
+
+		expect(result).toMatchObject({
+			success: true,
+			returnToSender: { validationToken: 'challenge-value' },
+		});
+	});
+
+	it('rejects a same-length token that does not match', async () => {
+		const result = await url_verification.handler(
+			createContext('verify-token'),
+			createRequest('verify-taken'),
+		);
+
+		expect(result).toEqual({
+			success: false,
+			error: 'Invalid verification token',
+		});
+	});
+
+	it('rejects a length mismatch without throwing', async () => {
+		const result = await url_verification.handler(
+			createContext('verify-token'),
+			createRequest('short'),
+		);
+
+		expect(result).toEqual({
+			success: false,
+			error: 'Invalid verification token',
+		});
+	});
+});

--- a/packages/instagram/webhooks/challenge.ts
+++ b/packages/instagram/webhooks/challenge.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto';
 import { logEventFromContext } from 'corsair/core';
 import type { InstagramWebhooks } from '../index';
 import {
@@ -5,7 +6,7 @@ import {
 	extractMetaWebhookChallenge,
 	InstagramUrlVerificationEventSchema,
 } from './types';
-import { timingSafeEqual } from 'node:crypto';
+
 export const url_verification: InstagramWebhooks['url_verification'] = {
 	match: createInstagramWebhookMatcher('url_verification'),
 	handler: async (ctx, request) => {
@@ -22,19 +23,19 @@ export const url_verification: InstagramWebhooks['url_verification'] = {
 		}
 
 		const expectedVerifyToken = ctx.options.webhookVerifyToken;
-		const a = Buffer.from(challengeRequest.verifyToken || ''); 
-    const b = Buffer.from(expectedVerifyToken || '');
+		const a = Buffer.from(challengeRequest.verifyToken || '');
+		const b = Buffer.from(expectedVerifyToken || '');
+		if (
+			!expectedVerifyToken ||
+			a.length !== b.length ||
+			!timingSafeEqual(a, b)
+		) {
+			return {
+				success: false,
+				error: 'Invalid verification token',
+			};
+		}
 
-    if (
-        !expectedVerifyToken ||
-        a.length !== b.length ||
-        !timingSafeEqual(a, b)
-    ) {
-        return {
-      success: false,
-      error: 'Invalid verification token',
-    };
-  }
 		const event = InstagramUrlVerificationEventSchema.parse({
 			type: 'url_verification',
 			challenge: challengeRequest.challenge,

--- a/packages/instagram/webhooks/challenge.ts
+++ b/packages/instagram/webhooks/challenge.ts
@@ -22,15 +22,19 @@ export const url_verification: InstagramWebhooks['url_verification'] = {
 		}
 
 		const expectedVerifyToken = ctx.options.webhookVerifyToken;
-		const a = Buffer.from(challengeRequest.verifyToken || '');
-const b = Buffer.from(expectedVerifyToken || '');
-if (!expectedVerifyToken || a.length !== b.length || !timingSafeEqual(a, b)) {
-			return {
-				success: false,
-				error: 'Invalid verification token',
-			};
-		}
+		const a = Buffer.from(challengeRequest.verifyToken || ''); 
+    const b = Buffer.from(expectedVerifyToken || '');
 
+    if (
+        !expectedVerifyToken ||
+        a.length !== b.length ||
+        !timingSafeEqual(a, b)
+    ) {
+        return {
+      success: false,
+      error: 'Invalid verification token',
+    };
+  }
 		const event = InstagramUrlVerificationEventSchema.parse({
 			type: 'url_verification',
 			challenge: challengeRequest.challenge,

--- a/packages/instagram/webhooks/challenge.ts
+++ b/packages/instagram/webhooks/challenge.ts
@@ -5,7 +5,7 @@ import {
 	extractMetaWebhookChallenge,
 	InstagramUrlVerificationEventSchema,
 } from './types';
-
+import { timingSafeEqual } from 'node:crypto';
 export const url_verification: InstagramWebhooks['url_verification'] = {
 	match: createInstagramWebhookMatcher('url_verification'),
 	handler: async (ctx, request) => {
@@ -22,10 +22,9 @@ export const url_verification: InstagramWebhooks['url_verification'] = {
 		}
 
 		const expectedVerifyToken = ctx.options.webhookVerifyToken;
-		if (
-			!expectedVerifyToken ||
-			challengeRequest.verifyToken !== expectedVerifyToken
-		) {
+		const a = Buffer.from(challengeRequest.verifyToken || '');
+const b = Buffer.from(expectedVerifyToken || '');
+if (!expectedVerifyToken || a.length !== b.length || !timingSafeEqual(a, b)) {
 			return {
 				success: false,
 				error: 'Invalid verification token',


### PR DESCRIPTION

<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

Fixes #692

Replace direct string comparison with timingSafeEqual to prevent timing attacks on Instagram webhook verification.

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)
<img width="1106" height="177" alt="Screenshot 2026-08-15 at 12 10 43 AM" src="https://github.com/user-attachments/assets/e8506932-d80b-44c0-8c42-f6366edfe9e0" />

## Additional Notes

<!-- Any other information that reviewers should know? (e.g. breaking changes, new dependencies) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Security

- Improved webhook verification with timing-safe token comparison.
- Requests with missing, mismatched, or incorrectly sized tokens are rejected.
- Valid webhook verification continues to work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->