### PR TITLE
docs: cover database, CLI, and managed OAuth fallback in agent setup prompt

### DIFF
--- a/docs/getting-started/set-up-with-your-agent.mdx
+++ b/docs/getting-started/set-up-with-your-agent.mdx
@@ -60,8 +60,6 @@ client_secret=...`), or the dashboard's BYO modal, per the plugin's Get
 Credentials guide. On Hub, register the redirect URL from the Keys tab
 (https://auth.corsair.dev/oauth/callback) with the provider — not a URL of my own —
 then set the scopes the guide lists and retry instead of giving up.
-
-Prefer Hub. Only set up manual, self-hosted mode if I ask for it.
 ```
 </CodeGroup>
 

--- a/docs/getting-started/set-up-with-your-agent.mdx
+++ b/docs/getting-started/set-up-with-your-agent.mdx
@@ -3,7 +3,7 @@ title: Set up with your agent
 description: Hand Corsair Hub to your coding agent. One prompt takes it from an empty app to a working, connected integration.
 ---
 
-The fastest way to add Corsair is to let your coding agent do it. Paste the prompt below into Claude Code, Cursor, Codex, or any MCP-capable agent — it talks you through the three choices that matter, wires the route, and doesn't stop until a real integration works.
+The fastest way to add Corsair is to let your coding agent do it. Paste the prompt below into Claude Code, Cursor, Codex, or any MCP-capable agent — it talks you through the choices that matter, wires the route, and doesn't stop until a real integration works.
 
 <CodeGroup>
 ```text Prompt
@@ -16,31 +16,47 @@ credential encrypted in my own database. Corsair Hub is the hosted piece that ow
 surfaces needing a public URL: the OAuth connect page, callbacks, and approvals. Hub
 relays those; it stores none of my credentials.
 
-Start by figuring out three things with me — chat about them, don't fire yes/no questions
-at me. First: am I connecting just my own app's tools, or my end users' accounts? The
-second is multi-tenant, and it's the common case, so lean that way if I'm unsure.
-Second: what framework am I on? That's what decides how the route gets mounted. Third:
-what database am I on? Corsair needs one before it can store a single credential.
+Start by figuring out four things with me — chat about them, don't fire yes/no questions
+at me. First: which service do we connect first — GitHub, Slack, Gmail, another plugin?
+Pick one to prove the loop; the rest can come later. Second: am I connecting just my own
+app's tools, or my end users' accounts? The second is multi-tenant, and it's the common
+case, so lean that way if I'm unsure. Third: what framework am I on? That's what decides
+how the route gets mounted. Fourth: what database am I on? Corsair needs one before it
+can store a single credential.
 
 Once that's clear, walk me through it. Read the intro and Hub pages listed at
-https://docs.corsair.dev/llms.txt so you understand the model first. Help me get a dev
-API key, a signing secret, and a KEK into my .env — I'll copy the keys from the Keys tab
-at https://hub.corsair.dev/dashboard, or you help me create a project if I don't have
-one. Create the four Corsair tables and wire the database following
+https://docs.corsair.dev/llms.txt so you understand the model first. Help me put three
+values in my .env — CORSAIR_DEV_API_KEY and CORSAIR_DEV_SIGNING_SECRET copied from the
+Keys tab at https://hub.corsair.dev/dashboard, plus CORSAIR_KEK generated with
+`openssl rand -base64 32`. Help me create a project first if I don't have one. Create
+the four Corsair tables and wire the database following
 https://docs.corsair.dev/concepts/database — pass createCorsair a pg Pool, a
 better-sqlite3 instance, a postgres.js Sql, or a Kysely instance; a PrismaClient won't
-typecheck. Install `corsair`, a plugin for each service I named, and `@corsair-dev/cli`
-— the CLI is its own package, and every `corsair setup` command needs it. Then wire the
-/api/corsair route using the page for my exact framework at
+typecheck. Install `corsair` and the plugin for the service we picked.
+`@corsair-dev/cli` is a separate package — add it only if we'll run `corsair setup`
+from the terminal to seed API keys or provision tenants; an OAuth connect provisions
+its account row on the first connect, so the plain Hub path doesn't need the CLI.
+Then wire the /api/corsair route using the page for my exact framework at
 https://docs.corsair.dev/adapters/handlers.
+
+Carry the tenancy answer into the code. My own tools → leave multiTenancy off and call
+plugins directly. My users' accounts → set multiTenancy: true, run every operation
+through `corsair.withTenant(id)`, and pass that same id as tenantId when minting the
+connect link — Corsair enforces this at the type level. Resolve tenantId from my auth
+session, never straight from the request body.
 
 Terms you'll come across: a tenant is one of my users; a plugin is one service; the
 delivery URL is where Hub sends results — it self-registers on the first request, and my
-dashboard's header dot turning green is how we know it worked. Don't stop at "the server
-runs" — mint a connect link, send me through it, and confirm a real API call returns
-data. If the provider's page 404s on Connect, the managed OAuth app isn't available on
-my plan — flip that plugin to `authType: 'oauth_2'` with my own client id and secret
-instead of giving up.
+dashboard's header dot turning green is how we know it worked. If I'm gating agent tool
+calls behind approvals, also create the `corsair_permissions` table from
+https://docs.corsair.dev/concepts/permissions — it's not one of the four core tables.
+Don't stop at "the server runs" — mint a connect link, send me through it, and confirm a
+real API call returns data. If the provider's page 404s on Connect, don't assume why —
+check the plugin and my plan in Hub first. If the managed OAuth app truly isn't
+available to me, flip that plugin to `authType: 'oauth_2'` with my own
+credentials: { clientId, clientSecret }, register
+https://auth.corsair.dev/oauth/callback with the provider, and set the scopes its
+credentials guide lists, instead of giving up.
 
 Prefer Hub. Only set up manual, self-hosted mode if I ask for it.
 ```

--- a/docs/getting-started/set-up-with-your-agent.mdx
+++ b/docs/getting-started/set-up-with-your-agent.mdx
@@ -53,10 +53,13 @@ https://docs.corsair.dev/concepts/permissions — it's not one of the four core 
 Don't stop at "the server runs" — mint a connect link, send me through it, and confirm a
 real API call returns data. If the provider's page 404s on Connect, don't assume why —
 check the plugin and my plan in Hub first. If the managed OAuth app truly isn't
-available to me, flip that plugin to `authType: 'oauth_2'` with my own
-credentials: { clientId, clientSecret }, register
-https://auth.corsair.dev/oauth/callback with the provider, and set the scopes its
-credentials guide lists, instead of giving up.
+available to me, flip that plugin to `authType: 'oauth_2'` and store my client id
+and secret the documented way — `corsair.keys.<plugin>.set_client_id` and
+`set_client_secret`, the CLI (`corsair setup --plugin=<id> client_id=...
+client_secret=...`), or the dashboard's BYO modal, per the plugin's Get
+Credentials guide. On Hub, register the redirect URL from the Keys tab
+(https://auth.corsair.dev/oauth/callback) with the provider — not a URL of my own —
+then set the scopes the guide lists and retry instead of giving up.
 
 Prefer Hub. Only set up manual, self-hosted mode if I ask for it.
 ```

--- a/docs/getting-started/set-up-with-your-agent.mdx
+++ b/docs/getting-started/set-up-with-your-agent.mdx
@@ -3,7 +3,7 @@ title: Set up with your agent
 description: Hand Corsair Hub to your coding agent. One prompt takes it from an empty app to a working, connected integration.
 ---
 
-The fastest way to add Corsair is to let your coding agent do it. Paste the prompt below into Claude Code, Cursor, Codex, or any MCP-capable agent — it talks you through the two choices that matter, wires the route, and doesn't stop until a real integration works.
+The fastest way to add Corsair is to let your coding agent do it. Paste the prompt below into Claude Code, Cursor, Codex, or any MCP-capable agent — it talks you through the three choices that matter, wires the route, and doesn't stop until a real integration works.
 
 <CodeGroup>
 ```text Prompt
@@ -16,22 +16,31 @@ credential encrypted in my own database. Corsair Hub is the hosted piece that ow
 surfaces needing a public URL: the OAuth connect page, callbacks, and approvals. Hub
 relays those; it stores none of my credentials.
 
-Start by figuring out two things with me — chat about them, don't fire yes/no questions
+Start by figuring out three things with me — chat about them, don't fire yes/no questions
 at me. First: am I connecting just my own app's tools, or my end users' accounts? The
 second is multi-tenant, and it's the common case, so lean that way if I'm unsure.
-Second: what framework am I on? That's what decides how the route gets mounted.
+Second: what framework am I on? That's what decides how the route gets mounted. Third:
+what database am I on? Corsair needs one before it can store a single credential.
 
 Once that's clear, walk me through it. Read the intro and Hub pages listed at
 https://docs.corsair.dev/llms.txt so you understand the model first. Help me get a dev
 API key, a signing secret, and a KEK into my .env — I'll copy the keys from the Keys tab
 at https://hub.corsair.dev/dashboard, or you help me create a project if I don't have
-one. Install `corsair` plus a plugin for each service I named, then wire the /api/corsair
-route using the page for my exact framework at https://docs.corsair.dev/adapters/handlers.
+one. Create the four Corsair tables and wire the database following
+https://docs.corsair.dev/concepts/database — pass createCorsair a pg Pool, a
+better-sqlite3 instance, a postgres.js Sql, or a Kysely instance; a PrismaClient won't
+typecheck. Install `corsair`, a plugin for each service I named, and `@corsair-dev/cli`
+— the CLI is its own package, and every `corsair setup` command needs it. Then wire the
+/api/corsair route using the page for my exact framework at
+https://docs.corsair.dev/adapters/handlers.
 
 Terms you'll come across: a tenant is one of my users; a plugin is one service; the
 delivery URL is where Hub sends results — it self-registers on the first request, and my
 dashboard's header dot turning green is how we know it worked. Don't stop at "the server
-runs" — mint a connect link, send me through it, and confirm a real API call returns data.
+runs" — mint a connect link, send me through it, and confirm a real API call returns
+data. If the provider's page 404s on Connect, the managed OAuth app isn't available on
+my plan — flip that plugin to `authType: 'oauth_2'` with my own client id and secret
+instead of giving up.
 
 Prefer Hub. Only set up manual, self-hosted mode if I ask for it.
 ```


### PR DESCRIPTION
## Description

Fixes three real gaps in the "Set up with your agent" prompt (`docs/getting-started/set-up-with-your-agent.mdx`). Each one was hit during a fresh manual setup of a Next.js app with Hub, and each is verified against the current source:

1. **Database step was missing.** The prompt jumped from Hub keys straight to wiring the `/api/corsair` route. `createCorsair` refuses to mint connect links without a database and KEK (`database_not_configured` in `packages/corsair/core/management/operations.ts`), and `CorsairDatabaseInput` (`packages/corsair/db/kysely/database.ts`) only accepts a pg `Pool`, a `better-sqlite3` instance, a postgres.js `Sql`, or a `Kysely` instance. Passing a `PrismaClient` is a common first instinct on Postgres projects and fails to typecheck. The prompt now asks about the database up front (third discovery question), points to `/concepts/database` for the four tables, and names the accepted connection types.

2. **CLI package was missing.** The prompt only said to install `corsair` and plugins, but the `corsair` package ships no binary. The CLI lives in `@corsair-dev/cli` (bin `corsair`), and every `corsair setup` / `corsair auth` command in the docs fails with `could not determine executable to run` unless that package is installed. The prompt now installs it alongside `corsair`.

3. **No fallback when managed OAuth 404s.** On plans without Corsair-managed integrations for a provider (GitHub on Hobby in our run), the connect page 404s and the flow dead-ends. The dashboard docs already describe the bring-your-own path (`authType: 'oauth_2'` with own client id/secret). The prompt now tells the agent to flip the plugin to `oauth_2` with the user's own credentials instead of giving up.

Also updated the page intro ("two choices" to "three choices") to stay consistent with the third question.

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

Docs-only change, no UI. `pnpm run validate:docs` passes.

## Additional Notes

Checklist notes, to be fully transparent:

- **lint:** biome's config ignores `docs/**` (running `biome check` on the edited file returns "paths were ignored"). Repo-wide `pnpm lint` fails on a fresh Windows checkout of plain `main` with the same 3810 CRLF-related errors, so it is pre-existing and unrelated to this change.
- **typecheck / build / test:** no TypeScript, package, or test files were touched, only one `.mdx` file. `pnpm run validate:docs` was run and passes.
- No new dependencies, no breaking changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the agent setup guide to cover first service, account scope, framework, and database selection.
  - Added database credentials, schema requirements, and supported client options.
  - Clarified optional CLI installation and the standard Hub setup flow.
  - Added multi-tenant configuration and tenant ID validation guidance.
  - Documented optional permissions-table setup.
  - Expanded OAuth troubleshooting with custom credentials and callback registration.
  - Retained real API-call verification guidance and removed the previous default preference for Hub over self-hosted setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->