### PR TITLE
test(calendly): add unit tests for verifyCalendlyWebhookSignature

### DIFF
--- a/packages/calendly/webhooks/types.test.ts
+++ b/packages/calendly/webhooks/types.test.ts
@@ -45,10 +45,15 @@ describe('Calendly verifyCalendlyWebhookSignature Tests', () => {
 
 	it('should return invalid for wrong v1 signature', () => {
 		const timestamp = Math.floor(Date.now() / 1000).toString();
+		// Same-length hex so timingSafeEqual actually compares, not the length-mismatch path
+		const signature = crypto
+			.createHmac('sha256', 'a-different-key')
+			.update(`${timestamp}.${rawBody}`)
+			.digest('hex');
 
 		const result = verifyCalendlyWebhookSignature(
 			requestWith(
-				{ 'calendly-webhook-signature': `t=${timestamp},v1=wrong-signature` },
+				{ 'calendly-webhook-signature': `t=${timestamp},v1=${signature}` },
 				rawBody,
 			),
 			signingKey,

--- a/packages/calendly/webhooks/types.test.ts
+++ b/packages/calendly/webhooks/types.test.ts
@@ -6,9 +6,10 @@ describe('Calendly verifyCalendlyWebhookSignature Tests', () => {
 	const signingKey = 'my-signing-key';
 	const rawBody = 'body';
 
+	// WebhookRequest<unknown>: signature verification only reads rawBody/headers; the typed body is irrelevant here
 	const requestWith = (
 		headers: Record<string, string | string[] | undefined>,
-		rawBody: string,
+		rawBody?: string,
 	): WebhookRequest<unknown> => ({
 		headers,
 		rawBody,
@@ -82,7 +83,7 @@ describe('Calendly verifyCalendlyWebhookSignature Tests', () => {
 
 	it('should return invalid for missing raw body for signature verification', () => {
 		const result = verifyCalendlyWebhookSignature(
-			requestWith({ 'calendly-webhook-signature': 'my-valid-signature' }, ''),
+			requestWith({ 'calendly-webhook-signature': 'my-valid-signature' }),
 			signingKey,
 		);
 

--- a/packages/calendly/webhooks/types.test.ts
+++ b/packages/calendly/webhooks/types.test.ts
@@ -1,0 +1,131 @@
+import type { WebhookRequest } from 'corsair/core';
+import crypto from 'crypto';
+import { verifyCalendlyWebhookSignature } from './types';
+
+describe('Calendly verifyCalendlyWebhookSignature Tests', () => {
+	const signingKey = 'my-signing-key';
+	const rawBody = 'body';
+
+	const requestWith = (
+		headers: Record<string, string | string[] | undefined>,
+		rawBody: string,
+	): WebhookRequest<unknown> => ({
+		headers,
+		rawBody,
+		payload: {},
+	});
+
+	it('should fail close when signing key is missing', () => {
+		const result = verifyCalendlyWebhookSignature(
+			requestWith(
+				{ 'calendly-webhook-signature': 'my-valid-signature' },
+				rawBody,
+			),
+			'',
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing signing key',
+		});
+	});
+
+	it('should return invalid for missing Calendly-Webhook-Signature header', () => {
+		const result = verifyCalendlyWebhookSignature(
+			requestWith({}, rawBody),
+			signingKey,
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing Calendly-Webhook-Signature header',
+		});
+	});
+
+	it('should return invalid for wrong v1 signature', () => {
+		const timestamp = Math.floor(Date.now() / 1000).toString();
+
+		const result = verifyCalendlyWebhookSignature(
+			requestWith(
+				{ 'calendly-webhook-signature': `t=${timestamp},v1=wrong-signature` },
+				rawBody,
+			),
+			signingKey,
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid signature',
+		});
+	});
+
+	it('should return valid for correct t=<unix>,v1=<hex> over ${timestamp}.${rawBody} with a fresh timestamp', () => {
+		const timestamp = Math.floor(Date.now() / 1000).toString();
+
+		const signature = crypto
+			.createHmac('sha256', signingKey)
+			.update(`${timestamp}.${rawBody}`)
+			.digest('hex');
+
+		const result = verifyCalendlyWebhookSignature(
+			requestWith(
+				{ 'calendly-webhook-signature': `t=${timestamp},v1=${signature}` },
+				rawBody,
+			),
+			signingKey,
+		);
+
+		expect(result).toEqual({
+			valid: true,
+		});
+	});
+
+	it('should return invalid for missing raw body for signature verification', () => {
+		const result = verifyCalendlyWebhookSignature(
+			requestWith({ 'calendly-webhook-signature': 'my-valid-signature' }, ''),
+			signingKey,
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing raw body for signature verification',
+		});
+	});
+
+	it('should return invalid for malformed Calendly-Webhook-Signature header', () => {
+		const result = verifyCalendlyWebhookSignature(
+			requestWith(
+				{ 'calendly-webhook-signature': 'malformed-header' },
+				rawBody,
+			),
+			signingKey,
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Malformed Calendly-Webhook-Signature header',
+		});
+	});
+
+	it('should return invalid for stale timestamp', () => {
+		const staleTimestamp = (Math.floor(Date.now() / 1000) - 600).toString();
+
+		const signature = crypto
+			.createHmac('sha256', signingKey)
+			.update(`${staleTimestamp}.${rawBody}`)
+			.digest('hex');
+
+		const result = verifyCalendlyWebhookSignature(
+			requestWith(
+				{ 'calendly-webhook-signature': `t=${staleTimestamp},v1=${signature}` },
+				rawBody,
+			),
+			signingKey,
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Webhook timestamp is too old or invalid',
+		});
+	});
+});


### PR DESCRIPTION
## Description

Adds unit tests for `verifyCalendlyWebhookSignature` in `packages/calendly/webhooks/types.test.ts`.

Covers the four cases from the issue plus three additional branches present in the implementation:
- Missing signing key
- Missing `Calendly-Webhook-Signature` header
- Wrong `v1` signature (invalid)
- Correct `t=<unix>,v1=<hex>` signature over `${timestamp}.${rawBody}` with a fresh timestamp (valid)
- Missing raw body
- Malformed signature header (no `t=`/`v1=` pair)
- Stale timestamp (replay-attack window)

Follows the style of `packages/gitlab/webhooks/types.test.ts`.

Fixes #702

## Checklist
- [x] All the cases above pass under package jest
- [x] I have added or updated tests where applicable

## Screenshots / Demos (if applicable)
<img width="811" height="227" alt="Screenshot 2026-08-15 at 10 53 45 AM" src="https://github.com/user-attachments/assets/a33ea629-d14b-4fb1-8fae-c632840c486f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for webhook signature verification, including valid signatures, invalid signatures, malformed or missing headers, missing signing keys or request bodies, and stale timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->