### PR TITLE
fix(instagram): return error when app secret is missing 

### DIFF
--- a/packages/instagram/webhooks/types.test.ts
+++ b/packages/instagram/webhooks/types.test.ts
@@ -1,8 +1,9 @@
+import { createHmac } from 'node:crypto';
 import type { WebhookRequest } from 'corsair/core';
 import { verifyInstagramWebhookSignature } from './types';
 
 describe('verifyInstagramWebhookSignature', () => {
-	const validRequest: WebhookRequest<unknown> = {
+	const validRequest: WebhookRequest = {
 		payload: { object: 'instagram', entry: [] },
 		headers: { 'x-hub-signature-256': 'sha256=dummy_sig' },
 		rawBody: JSON.stringify({ object: 'instagram', entry: [] }),
@@ -25,7 +26,7 @@ describe('verifyInstagramWebhookSignature', () => {
 	});
 
 	it('should return error when rawBody is missing', () => {
-		const requestWithoutBody: WebhookRequest<unknown> = {
+		const requestWithoutBody: WebhookRequest = {
 			...validRequest,
 			rawBody: '',
 		};
@@ -40,7 +41,7 @@ describe('verifyInstagramWebhookSignature', () => {
 	});
 
 	it('should return error when x-hub-signature-256 header is missing', () => {
-		const requestWithoutHeader: WebhookRequest<unknown> = {
+		const requestWithoutHeader: WebhookRequest = {
 			payload: { object: 'instagram', entry: [] },
 			headers: {},
 			rawBody: JSON.stringify({ object: 'instagram', entry: [] }),
@@ -60,6 +61,20 @@ describe('verifyInstagramWebhookSignature', () => {
 		expect(result).toEqual({
 			valid: false,
 			error: 'Invalid signature',
+		});
+	});
+
+	it('should accept a matching sha256 signature', () => {
+		const rawBody = '{"ok":true}';
+		const secret = 'secret';
+		const digest = createHmac('sha256', secret).update(rawBody).digest('hex');
+		const request: WebhookRequest = {
+			payload: { ok: true },
+			headers: { 'x-hub-signature-256': `sha256=${digest}` },
+			rawBody,
+		};
+		expect(verifyInstagramWebhookSignature(request, secret)).toEqual({
+			valid: true,
 		});
 	});
 });

--- a/packages/instagram/webhooks/types.test.ts
+++ b/packages/instagram/webhooks/types.test.ts
@@ -1,0 +1,65 @@
+import type { WebhookRequest } from 'corsair/core';
+import { verifyInstagramWebhookSignature } from './types';
+
+describe('verifyInstagramWebhookSignature', () => {
+	const validRequest: WebhookRequest<unknown> = {
+		payload: { object: 'instagram', entry: [] },
+		headers: { 'x-hub-signature-256': 'sha256=dummy_sig' },
+		rawBody: JSON.stringify({ object: 'instagram', entry: [] }),
+	};
+
+	it('should return error when appSecret is an empty string', () => {
+		const result = verifyInstagramWebhookSignature(validRequest, '');
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing app secret',
+		});
+	});
+
+	it('should return error when appSecret is null', () => {
+		const result = verifyInstagramWebhookSignature(validRequest, null);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing app secret',
+		});
+	});
+
+	it('should return error when rawBody is missing', () => {
+		const requestWithoutBody: WebhookRequest<unknown> = {
+			...validRequest,
+			rawBody: '',
+		};
+		const result = verifyInstagramWebhookSignature(
+			requestWithoutBody,
+			'secret',
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing raw body for signature verification',
+		});
+	});
+
+	it('should return error when x-hub-signature-256 header is missing', () => {
+		const requestWithoutHeader: WebhookRequest<unknown> = {
+			payload: { object: 'instagram', entry: [] },
+			headers: {},
+			rawBody: JSON.stringify({ object: 'instagram', entry: [] }),
+		};
+		const result = verifyInstagramWebhookSignature(
+			requestWithoutHeader,
+			'secret',
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing x-hub-signature-256 header',
+		});
+	});
+
+	it('should return error when signature is invalid', () => {
+		const result = verifyInstagramWebhookSignature(validRequest, 'secret');
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid signature',
+		});
+	});
+});

--- a/packages/instagram/webhooks/types.ts
+++ b/packages/instagram/webhooks/types.ts
@@ -254,7 +254,7 @@ export function verifyInstagramWebhookSignature(
 	appSecret: string | null,
 ): { valid: boolean; error?: string } {
 	if (!appSecret) {
-		return { valid: false };
+		return { valid: false, error: 'Missing app secret' };
 	}
 
 	let rawBody = request.rawBody;


### PR DESCRIPTION
## Description

Adds validation for missing app secret and corresponding unit tests for `verifyInstagramWebhookSignature` in `packages/instagram/webhooks/types.ts` and `packages/instagram/webhooks/types.test.ts`.

Covers missing secret cases along with additional signature verification branches present in the implementation:

* Missing app secret (empty string `''`)
* Missing app secret (`null`)
* Missing raw body (`rawBody`)
* Missing `x-hub-signature-256` header
* Invalid HMAC SHA-256 signature

Follows the style of existing webhook tests (such as `packages/gitlab/webhooks/types.test.ts`).

Fixes #690

---

### Checklist

- [x] Missing app secret returns error: 'Missing app secret'
- [x] Other failure paths unchanged
- [x] All 5 test cases pass under package jest (`pnpm --filter instagram test -- webhooks/types.test.ts`)
- [x] Code formatted using Biome (`npx @biomejs/biome check --write packages/instagram/webhooks/types.test.ts`)
- [x] I have added or updated tests where applicable

---

## Screenshots / Demos

https://github.com/user-attachments/assets/57ecd70c-3b3a-4952-9b75-b496aadfecb2

<img width="1129" height="216" alt="Screenshot 2026-08-15 at 3 29 07 PM" src="https://github.com/user-attachments/assets/57ecd70c-3b3a-4952-9b75-b496aadfecb2" />

#### Tests

* Added comprehensive unit test coverage in `packages/instagram/webhooks/types.test.ts` testing empty/null secrets, missing request body, missing `x-hub-signature-256` header, and invalid signatures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Instagram webhook signature validation by reporting a clear error when the app secret is missing.
  * Added consistent invalid-result handling for missing request bodies, missing signature headers, and invalid signatures.
  * Confirmed valid signatures are accepted when they match the expected SHA-256 signature.

* **Tests**
  * Added coverage for missing configuration, incomplete requests, invalid signatures, and successful signature verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
