### PR TITLE
feat a11y(studio): label the OperationsPage filter input

### DIFF
--- a/packages/studio/src/web/pages/OperationsPage.tsx
+++ b/packages/studio/src/web/pages/OperationsPage.tsx
@@ -128,6 +128,7 @@ export function OperationsPage({ tenant }: { tenant: string }) {
 					className="h-8 px-2 rounded-md text-xs bg-[var(--color-bg)] border border-[var(--color-border)] focus:outline-none focus:border-[var(--color-accent-dim)]"
 					value={filter}
 					onChange={(e) => setFilter(e.target.value)}
+					aria-label="Filter Operations"
 				/>
 
 				<div className="flex-1 min-h-0 overflow-auto border border-[var(--color-border)] rounded-lg">

--- a/packages/studio/src/web/pages/OperationsPage.tsx
+++ b/packages/studio/src/web/pages/OperationsPage.tsx
@@ -128,7 +128,7 @@ export function OperationsPage({ tenant }: { tenant: string }) {
 					className="h-8 px-2 rounded-md text-xs bg-[var(--color-bg)] border border-[var(--color-border)] focus:outline-none focus:border-[var(--color-accent-dim)]"
 					value={filter}
 					onChange={(e) => setFilter(e.target.value)}
-					aria-label="Filter Operations"
+					aria-label="Filter operations"
 				/>
 
 				<div className="flex-1 min-h-0 overflow-auto border border-[var(--color-border)] rounded-lg">


### PR DESCRIPTION
### Description

Adds an accessible label to the filter input on the `OperationsPage` in `packages/studio/src/web/pages` to improve accessibility (`a11y`) and screen reader compatibility.

Fixes #716

### Checklist

* [x] Filter input on `OperationsPage` has an accessible label (`aria-label` / `<label>`)
- [x] Label verified via `rg 'aria-label="Filter operations"' packages/studio/src/web/pages/OperationsPage.tsx`
* [x] Typecheck passes with zero errors (`pnpm --filter @corsair-dev/studio typecheck`)

### Screenshots / Demos
<img width="1800" height="192" alt="Screenshot 2026-08-15 at 10 52 37 PM" src="https://github.com/user-attachments/assets/4d409971-2fb3-4207-ac07-a0cf74140f70" />


### Tests

* Ran `pnpm --filter @corsair-dev/studio typecheck` to verify TypeScript types compile cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added an accessible label to the operations filter input, improving usability for screen reader users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->