### PR TITLE
fix(studio): give the remaining form controls an accessible name

### DIFF
--- a/packages/studio/src/web/components/OperationInputForm.tsx
+++ b/packages/studio/src/web/components/OperationInputForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
 import type { FormFieldSchema } from '../api';
 import { Button, Input, Textarea } from './Primitives';
 
@@ -74,12 +74,17 @@ function formValueToJson(value: FormValue): unknown {
 function FieldLabel({
 	name,
 	schema,
+	htmlFor,
 }: {
 	name: string;
 	schema: FormFieldSchema;
+	htmlFor?: string;
 }) {
 	return (
-		<label className="block text-xs font-medium text-[var(--color-text)] mb-1">
+		<label
+			htmlFor={htmlFor}
+			className="block text-xs font-medium text-[var(--color-text)] mb-1"
+		>
 			{name}
 			{!schema.optional && (
 				<span className="text-[var(--color-err)] ml-0.5">*</span>
@@ -98,10 +103,12 @@ function FieldLabel({
 // ─────────────────────────────────────────────────────────────────────────────
 
 function StringField({
+	id,
 	schema,
 	value,
 	onChange,
 }: {
+	id: string;
 	schema: Extract<FormFieldSchema, { kind: 'string' }>;
 	value: FormValue;
 	onChange: (v: FormValue) => void;
@@ -109,6 +116,7 @@ function StringField({
 	if (schema.enum && schema.enum.length > 0) {
 		return (
 			<select
+				id={id}
 				className="w-full h-8 px-2 rounded-md text-xs bg-[var(--color-bg)] border border-[var(--color-border)] focus:outline-none focus:border-[var(--color-accent-dim)]"
 				value={String(value ?? '')}
 				onChange={(e) => onChange(e.target.value)}
@@ -124,6 +132,7 @@ function StringField({
 	}
 	return (
 		<Input
+			id={id}
 			type="text"
 			value={String(value ?? '')}
 			onChange={(e) => onChange(e.target.value)}
@@ -136,14 +145,17 @@ function StringField({
 // ─────────────────────────────────────────────────────────────────────────────
 
 function NumberField({
+	id,
 	value,
 	onChange,
 }: {
+	id: string;
 	value: FormValue;
 	onChange: (v: FormValue) => void;
 }) {
 	return (
 		<Input
+			id={id}
 			type="number"
 			value={value === null || value === undefined ? '' : String(value)}
 			onChange={(e) => {
@@ -159,15 +171,18 @@ function NumberField({
 // ─────────────────────────────────────────────────────────────────────────────
 
 function BooleanField({
+	id,
 	value,
 	onChange,
 }: {
+	id: string;
 	value: FormValue;
 	onChange: (v: FormValue) => void;
 }) {
 	return (
 		<label className="inline-flex items-center gap-2 text-xs cursor-pointer">
 			<input
+				id={id}
 				type="checkbox"
 				className="accent-[var(--color-accent)]"
 				checked={!!value}
@@ -302,17 +317,29 @@ function FieldRenderer({
 	onChange,
 	path = '',
 }: FieldRendererProps) {
+	const id = useId();
+	// object/array render nested fields with their own labels — no single control to point at
+	const isLeaf = schema.kind !== 'object' && schema.kind !== 'array';
 	return (
 		<div>
-			<FieldLabel name={name} schema={schema} />
+			<FieldLabel
+				name={name}
+				schema={schema}
+				htmlFor={isLeaf ? id : undefined}
+			/>
 			{schema.kind === 'string' && (
-				<StringField schema={schema} value={value} onChange={onChange} />
+				<StringField
+					id={id}
+					schema={schema}
+					value={value}
+					onChange={onChange}
+				/>
 			)}
 			{schema.kind === 'number' && (
-				<NumberField value={value} onChange={onChange} />
+				<NumberField id={id} value={value} onChange={onChange} />
 			)}
 			{schema.kind === 'boolean' && (
-				<BooleanField value={value} onChange={onChange} />
+				<BooleanField id={id} value={value} onChange={onChange} />
 			)}
 			{schema.kind === 'object' && (
 				<ObjectField
@@ -332,6 +359,7 @@ function FieldRenderer({
 			)}
 			{schema.kind === 'literal' && (
 				<Input
+					id={id}
 					type="text"
 					value={String(value ?? schema.value)}
 					disabled
@@ -340,6 +368,7 @@ function FieldRenderer({
 			)}
 			{schema.kind === 'unknown' && (
 				<Input
+					id={id}
 					type="text"
 					placeholder="(unsupported field type — use JSON editor)"
 					disabled
@@ -431,6 +460,7 @@ export function JsonFallbackEditor({
 				value={value}
 				onChange={(e) => handleChange(e.target.value)}
 				rows={rows}
+				aria-label="JSON input"
 				className="font-mono"
 			/>
 			{localError && (

--- a/packages/studio/src/web/components/OperationInputForm.tsx
+++ b/packages/studio/src/web/components/OperationInputForm.tsx
@@ -80,11 +80,9 @@ function FieldLabel({
 	schema: FormFieldSchema;
 	htmlFor?: string;
 }) {
-	return (
-		<label
-			htmlFor={htmlFor}
-			className="block text-xs font-medium text-[var(--color-text)] mb-1"
-		>
+	const className = 'block text-xs font-medium text-[var(--color-text)] mb-1';
+	const body = (
+		<>
 			{name}
 			{!schema.optional && (
 				<span className="text-[var(--color-err)] ml-0.5">*</span>
@@ -94,8 +92,16 @@ function FieldLabel({
 					{schema.description}
 				</span>
 			)}
-		</label>
+		</>
 	);
+	if (htmlFor) {
+		return (
+			<label htmlFor={htmlFor} className={className}>
+				{body}
+			</label>
+		);
+	}
+	return <div className={className}>{body}</div>;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -180,7 +186,7 @@ function BooleanField({
 	onChange: (v: FormValue) => void;
 }) {
 	return (
-		<label className="inline-flex items-center gap-2 text-xs cursor-pointer">
+		<div className="inline-flex items-center gap-2 text-xs">
 			<input
 				id={id}
 				type="checkbox"
@@ -191,7 +197,7 @@ function BooleanField({
 			<span className="text-[var(--color-text-muted)]">
 				{value ? 'true' : 'false'}
 			</span>
-		</label>
+		</div>
 	);
 }
 

--- a/packages/studio/src/web/pages/PluginDetail.tsx
+++ b/packages/studio/src/web/pages/PluginDetail.tsx
@@ -193,6 +193,7 @@ export function PluginDetail({
 									<Input
 										value={manualCode}
 										onChange={(e) => setManualCode(e.target.value)}
+										aria-label="OAuth code"
 										placeholder="OAuth code…"
 									/>
 									<Button

--- a/packages/studio/src/web/pages/ScriptPage.tsx
+++ b/packages/studio/src/web/pages/ScriptPage.tsx
@@ -80,6 +80,7 @@ export function ScriptPage({ tenant }: { tenant: string }) {
 					<Card className="p-3 flex items-center gap-2">
 						<select
 							value={activeTenant}
+							aria-label="Tenant"
 							onChange={(e) => setActiveTenant(e.target.value)}
 							className="h-8 px-2 rounded-md text-xs bg-[var(--color-bg)] border border-[var(--color-border)] focus:outline-none focus:border-[var(--color-accent-dim)]"
 						>
@@ -110,6 +111,7 @@ export function ScriptPage({ tenant }: { tenant: string }) {
 						rows={14}
 						value={code}
 						onChange={(e) => setCode(e.target.value)}
+						aria-label="Script"
 						spellCheck={false}
 					/>
 				</Card>


### PR DESCRIPTION
## Description

Fixes #746. Follow-up to #717 / #740 / #741 / #742 / #743 / #747.

Sweeping `packages/studio/src/web`, the remaining unnamed form controls fell into two groups:

**1. `OperationInputForm` (root cause, covers most of them)**

`FieldLabel` rendered a `<label>` as a *sibling* of the control with no `htmlFor`, so the visible label contributed nothing to the accessible name of any generated operation-input field.

- `FieldRenderer` now calls `useId()` and passes it as `htmlFor` to `FieldLabel` and as `id` to every leaf control: the enum `<select>`, string/number `Input`, the boolean checkbox, and the disabled literal/unknown `Input`s.
- `object` / `array` group labels get no `htmlFor` — they render nested `FieldRenderer`s that are each labelled themselves, so there is no single control for the group header to point at.
- `JsonFallbackEditor` textarea: `aria-label="JSON input"`.

**2. One-off sites** — `aria-label`, same approach as #740 / #742 / #747:

| File | Control | Label |
| --- | --- | --- |
| `pages/ScriptPage.tsx` | tenant `<select>` | `Tenant` |
| `pages/ScriptPage.tsx` | script `Textarea` | `Script` |
| `pages/PluginDetail.tsx` | manual OAuth code `Input` | `OAuth code` |

`pages/PluginsPage.tsx:244` from the issue table was already fixed by #743 (`aria-label="New tenant ID"`), so it is not touched here.

`Input` / `Textarea` (`components/Primitives.tsx`) spread `...rest` onto the native element, so `id` / `aria-label` reach the DOM with no change to the primitives. No styling changes.

## Verification

- Issue's check command now shows `htmlFor`/`aria-label` at all listed sites.
- `packages/studio` has no test setup, so I rendered `OperationInputForm` with `react-dom/server` (string, enum, number, boolean, and array-of-string fields) and asserted every leaf `<label for>` resolves to a control `id` — 5/5 linked, no dangling `for`. `JsonFallbackEditor` renders with `aria-label="JSON input"`.

## Checklist

- [x] `biome check packages/studio/src/web` — clean
- [x] `tsc --noEmit` in `packages/studio` — exit 0
- [ ] `pnpm build` / `pnpm test` — not run locally: `better-sqlite3` does not compile on my Node 26 (same environment note as #747); change is confined to `packages/studio` web UI
- [ ] Tests — n/a, no test setup in `packages/studio` (see Verification)
- [ ] Docs — n/a, no user-facing behaviour change

## Additional Notes

No breaking changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved label and input associations across operation forms.
  * Added accessible names to OAuth code, tenant selector, and script editing fields.
  * Enhanced accessibility for string, number, boolean, literal, and fallback inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->