### PR TITLE
Limit built integrations per account to 2

### DIFF
--- a/www/src/lib/integration-claim-limits.ts
+++ b/www/src/lib/integration-claim-limits.ts
@@ -1,3 +1,3 @@
-export const MAX_USER_BUILT_INTEGRATIONS = 10;
+export const MAX_USER_BUILT_INTEGRATIONS = 2;
 
 export type ClaimBlockReason = 'wip' | 'limit_reached';


### PR DESCRIPTION
## Description

Lowers the cap on how many integrations a single account can have built
from 10 to 2.

`MAX_USER_BUILT_INTEGRATIONS` in `www/src/lib/integration-claim-limits.ts`
is the single source of truth for the OSS contributor dashboard's claim
limit. Both enforcement points and both user-facing strings already read
from it, so this is a one-line change:

- `www/src/db/integration-status.ts` — `getUserClaimEligibility()` gates on
  `builtCount >= MAX_USER_BUILT_INTEGRATIONS` and returns
  `blockReason: 'limit_reached'`
- `www/src/server/api/routers/integrations.ts` — claim mutation throws
  `PRECONDITION_FAILED`
- `www/src/app/oss/claim-integration-button.tsx` — button tooltip

The two messages interpolate the constant, so they now read "the maximum
of 2 integrations" with no further edits.

## Checklist

- [ ] I have run `pnpm lint` and all checks pass
- [ ] I have run `pnpm typecheck` and there are no TypeScript errors
- [ ] I have run `pnpm build` and all packages build successfully
- [ ] I have run `pnpm test` and all tests pass
- [ ] I have added or updated tests where applicable
- [ ] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

n/a — no layout or copy changes beyond the interpolated number.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Reduced the maximum number of built-in integrations a user can claim from 10 to 2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->