### PR TITLE
fix(intercom): return error when webhook secret is missing

### DIFF
--- a/packages/intercom/webhooks/types.test.ts
+++ b/packages/intercom/webhooks/types.test.ts
@@ -1,0 +1,120 @@
+import type { WebhookRequest } from 'corsair/core';
+import crypto from 'crypto';
+import type { IntercomWebhookPayload } from './types';
+import { verifyIntercomWebhookSignature } from './types';
+
+const secret = 'my-intercom-client-secret';
+const payload: IntercomWebhookPayload = {
+	type: 'notification_event',
+	topic: 'ping',
+	id: null,
+	app_id: 'app123',
+	created_at: 1700000000,
+	first_sent_at: 1700000000,
+	data: {
+		type: 'notification_event_data',
+		item: { type: 'ping', message: 'hello' },
+	},
+};
+const rawBody = JSON.stringify(payload);
+
+function sign(key: string, body: string = rawBody): string {
+	return `sha1=${crypto.createHmac('sha1', key).update(body).digest('hex')}`;
+}
+
+function requestWith(
+	headers: Record<string, string | string[] | undefined>,
+	body: string = rawBody,
+): WebhookRequest<unknown> {
+	return {
+		payload,
+		headers,
+		rawBody: body,
+	};
+}
+
+describe('verifyIntercomWebhookSignature', () => {
+	it('returns an error when the secret is an empty string', () => {
+		const result = verifyIntercomWebhookSignature(
+			requestWith({ 'x-hub-signature': sign(secret) }),
+			'',
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('returns an error when the secret is missing (undefined)', () => {
+		const result = verifyIntercomWebhookSignature(
+			requestWith({ 'x-hub-signature': sign(secret) }),
+			undefined as unknown as string,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('returns an error when the secret is only whitespace', () => {
+		const result = verifyIntercomWebhookSignature(
+			requestWith({ 'x-hub-signature': sign(secret) }),
+			'   ',
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('returns an error when both secret and signature header are missing', () => {
+		const result = verifyIntercomWebhookSignature(requestWith({}), '');
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('returns an error when the x-hub-signature header is missing', () => {
+		const result = verifyIntercomWebhookSignature(requestWith({}), secret);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing x-hub-signature header',
+		});
+	});
+
+	it('returns valid for a correctly signed request', () => {
+		const result = verifyIntercomWebhookSignature(
+			requestWith({ 'x-hub-signature': sign(secret) }),
+			secret,
+		);
+		expect(result).toEqual({ valid: true, error: undefined });
+	});
+
+	it('accepts the signature header when provided as an array', () => {
+		const result = verifyIntercomWebhookSignature(
+			requestWith({ 'x-hub-signature': [sign(secret)] }),
+			secret,
+		);
+		expect(result).toEqual({ valid: true, error: undefined });
+	});
+
+	it('returns invalid for a signature that does not match', () => {
+		const result = verifyIntercomWebhookSignature(
+			requestWith({ 'x-hub-signature': sign('a-different-secret') }),
+			secret,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid signature',
+		});
+	});
+
+	it('returns invalid when the signature length does not match', () => {
+		const result = verifyIntercomWebhookSignature(
+			requestWith({ 'x-hub-signature': 'sha1=too-short' }),
+			secret,
+		);
+		expect(result.valid).toBe(false);
+	});
+});

--- a/packages/intercom/webhooks/types.ts
+++ b/packages/intercom/webhooks/types.ts
@@ -244,6 +244,10 @@ export function verifyIntercomWebhookSignature(
 ): { valid: boolean; error?: string } {
 	// Use rawBody for signature verification to match the original hashed bytes
 	const body = request.rawBody ?? JSON.stringify(request.payload);
+	if (!secret) {
+		return { valid: false, error: 'Missing webhook secret' };
+	}
+
 	const signatureHeader = request.headers['x-hub-signature'];
 	// x-hub-signature can be a string or string[]
 	const signature = Array.isArray(signatureHeader)

--- a/packages/intercom/webhooks/types.ts
+++ b/packages/intercom/webhooks/types.ts
@@ -243,10 +243,11 @@ export function verifyIntercomWebhookSignature(
 	secret: string,
 ): { valid: boolean; error?: string } {
 	// Use rawBody for signature verification to match the original hashed bytes
-	const body = request.rawBody ?? JSON.stringify(request.payload);
-	if (!secret) {
+	if (!secret?.trim()) {
 		return { valid: false, error: 'Missing webhook secret' };
 	}
+
+	const body = request.rawBody ?? JSON.stringify(request.payload);
 
 	const signatureHeader = request.headers['x-hub-signature'];
 	// x-hub-signature can be a string or string[]


### PR DESCRIPTION
## Description

Fixes #711.

`verifyIntercomWebhookSignature` had no empty-secret guard, so a missing secret fell through to HMAC-SHA1 with an empty key. Anyone can forge that.

This fails closed first:

```ts
if (!secret) {
  return { valid: false, error: 'Missing webhook secret' };
}
```

HMAC / `timingSafeEqual` is unchanged.

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

Webhook signature verification is unit-tested (no live Intercom call). Passing proof:

- Change: https://github.com/corsairdev/corsair/blob/d7cc57b52c92a157ddaf4eabf2545eaf36ae74fe/packages/intercom/webhooks/types.ts
- CI Checks: https://github.com/corsairdev/corsair/actions/runs/31990351808

## Additional Notes

This is the spec'd bug fix from #711 (not a new integration). Same issue as draft #753 — land one and close the other.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook signature verification when the signing secret is missing or blank.
  * Ensured missing signature headers, invalid signatures, and mismatched signature lengths are handled correctly.

* **Tests**
  * Added comprehensive coverage for valid, invalid, missing, empty, and whitespace-only verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->