### PR TITLE
fix(studio): label the ScriptPage tenant select and script textarea

### DIFF
--- a/packages/studio/src/web/pages/ScriptPage.tsx
+++ b/packages/studio/src/web/pages/ScriptPage.tsx
@@ -82,6 +82,7 @@ export function ScriptPage({ tenant }: { tenant: string }) {
 							value={activeTenant}
 							onChange={(e) => setActiveTenant(e.target.value)}
 							className="h-8 px-2 rounded-md text-xs bg-[var(--color-bg)] border border-[var(--color-border)] focus:outline-none focus:border-[var(--color-accent-dim)]"
+							aria-label="Active Tenant"
 						>
 							<option value="">Select tenant</option>
 							{tenants.map((tenantId) => (
@@ -111,6 +112,7 @@ export function ScriptPage({ tenant }: { tenant: string }) {
 						value={code}
 						onChange={(e) => setCode(e.target.value)}
 						spellCheck={false}
+						aria-label="Script Source"
 					/>
 				</Card>
 			</Section>


### PR DESCRIPTION
### Description

Adds accessible labels (`aria-label`) to the tenant select dropdown and script textarea on the `ScriptPage` in `packages/studio/src/web/pages/ScriptPage.tsx` to improve accessibility (`a11y`) and screen reader compatibility.

Fixes #694 

### Checklist

* [x] Tenant select dropdown and script textarea on `ScriptPage` have accessible labels (`aria-label`)
* [x] Labels verified via `rg 'aria-label' packages/studio/src/web/pages/ScriptPage.tsx`
* [x] Typecheck passes with zero errors (`pnpm --filter @corsair-dev/studio typecheck`)

### Screenshots / Demos
<img width="971" height="241" alt="Screenshot 2026-08-17 at 5 02 03 PM" src="https://github.com/user-attachments/assets/be89e5f4-b305-47c8-9404-e5a41ab18bd4" />

<img width="1241" height="408" alt="Screenshot 2026-08-17 at 12 50 49 PM" src="https://github.com/user-attachments/assets/6c13cd78-44b8-4d1a-87db-0c4d1ca1e958" />


### Tests

* Ran `pnpm --filter @corsair-dev/studio typecheck` to verify TypeScript types compile cleanly.

**Accessibility Improvements**

* Added accessible labels to the tenant select element and script textarea on the `ScriptPage`, improving usability for screen reader users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Accessibility Improvements

- Added accessible labels to the tenant selector and script source text area, improving usability with screen readers and assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->