### PR TITLE
fix(linear): return error when webhook secret is missing 

### DIFF
--- a/packages/linear/webhooks/types.test.ts
+++ b/packages/linear/webhooks/types.test.ts
@@ -1,0 +1,102 @@
+import type { WebhookRequest } from 'corsair/core';
+import { verifyHmacSignature } from 'corsair/http';
+import { verifyLinearWebhookSignature } from './types';
+
+jest.mock('corsair/http', () => ({
+	verifyHmacSignature: jest.fn(),
+}));
+
+describe('verifyLinearWebhookSignature', () => {
+	const validRequest: WebhookRequest<unknown> = {
+		payload: { action: 'create', type: 'Issue' },
+		headers: { 'linear-signature': 'dummy_sig' },
+		rawBody: JSON.stringify({ action: 'create', type: 'Issue' }),
+	};
+
+	it('should return error when webhookSecret is an empty string', () => {
+		const result = verifyLinearWebhookSignature(validRequest, '');
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('should return error when webhookSecret is undefined', () => {
+		const result = verifyLinearWebhookSignature(validRequest, undefined);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('should return error when rawBody is missing', () => {
+		const requestWithoutBody: WebhookRequest<unknown> = {
+			...validRequest,
+			rawBody: '',
+		};
+		const result = verifyLinearWebhookSignature(requestWithoutBody, 'secret');
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing raw body for signature verification',
+		});
+	});
+
+	it('should return error when linear-signature header is missing', () => {
+		const requestWithoutHeader: WebhookRequest<unknown> = {
+			payload: { action: 'create', type: 'Issue' },
+			headers: {},
+			rawBody: JSON.stringify({ action: 'create', type: 'Issue' }),
+		};
+		const result = verifyLinearWebhookSignature(requestWithoutHeader, 'secret');
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing linear-signature header',
+		});
+	});
+
+	it('should return error when signature is invalid', () => {
+		jest.mocked(verifyHmacSignature).mockReturnValue(false);
+
+		const result = verifyLinearWebhookSignature(validRequest, 'secret');
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid signature',
+		});
+	});
+
+	it('should accept a valid signature', () => {
+		jest.mocked(verifyHmacSignature).mockReturnValue(true);
+
+		const result = verifyLinearWebhookSignature(validRequest, 'secret');
+		expect(result).toEqual({
+			valid: true,
+		});
+		expect(verifyHmacSignature).toHaveBeenCalledWith(
+			validRequest.rawBody,
+			'secret',
+			'dummy_sig',
+		);
+	});
+
+	it('should accept a valid signature when header is passed as an array', () => {
+		jest.mocked(verifyHmacSignature).mockReturnValue(true);
+
+		const requestWithArrayHeader: WebhookRequest<unknown> = {
+			...validRequest,
+			headers: { 'linear-signature': ['array_sig_1', 'array_sig_2'] },
+		};
+
+		const result = verifyLinearWebhookSignature(
+			requestWithArrayHeader,
+			'secret',
+		);
+		expect(result).toEqual({
+			valid: true,
+		});
+		expect(verifyHmacSignature).toHaveBeenCalledWith(
+			validRequest.rawBody,
+			'secret',
+			'array_sig_1',
+		);
+	});
+});

--- a/packages/linear/webhooks/types.ts
+++ b/packages/linear/webhooks/types.ts
@@ -287,7 +287,7 @@ export function verifyLinearWebhookSignature(
 	webhookSecret?: string,
 ): { valid: boolean; error?: string } {
 	if (!webhookSecret) {
-		return { valid: false };
+		return { valid: false, error: 'Missing webhook secret' };
 	}
 
 	const rawBody = request.rawBody;


### PR DESCRIPTION
## Description

Adds validation for missing webhook secret and corresponding unit tests for `verifyLinearWebhookSignature` in `packages/linear/webhooks/types.ts` and `packages/linear/webhooks/types.test.ts`.

Covers missing secret cases along with additional signature verification branches present in the implementation:

* Missing webhook secret (empty string `''`)
* Missing webhook secret (`undefined`)
* Missing raw body (`rawBody`)
* Missing `linear-signature` header
* Invalid HMAC signature

Follows the style of existing webhook tests.

Fixes #687 

## Checklist

* [x] Missing webhook secret returns error: `'Missing webhook secret'`
* [x] Other failure paths unchanged
* [x] All test cases pass under package jest (`pnpm --filter linear test -- webhooks/types.test.ts`)
* [x] Code formatted using Biome (`npx @biomejs/biome check --write packages/linear/webhooks/types.test.ts`)
* [x] I have added or updated tests where applicable

## Screenshots / Demos

<img width="1317" height="568" alt="Screenshot 2026-08-17 at 2 34 22 PM" src="https://github.com/user-attachments/assets/c619aa07-6643-4d48-8d44-73f85c15a5d8" />


## Tests

Added comprehensive unit test coverage in `packages/linear/webhooks/types.test.ts` testing empty/undefined secrets, missing request body, missing `linear-signature` header, invalid signatures, and successful signature verifications (including array headers).

### Bug Fixes

* Improved Linear webhook signature validation by reporting a clear error (`'Missing webhook secret'`) when the webhook secret is missing.
* Preserved existing error handling for missing request bodies, missing signature headers, and invalid signatures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Webhook signature verification now clearly reports when a webhook secret is missing.
  - Improved handling and validation of webhook signatures across common request scenarios.

- **Accessibility**
  - Added accessible labels to the tenant selector and script source editor.

- **Tests**
  - Expanded coverage for valid, invalid, incomplete, and array-valued webhook signature inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->