### PR TITLE
fix(oss): limit each person to 2 claimed integrations

### DIFF
--- a/www/src/app/oss/[slug]/integration-claim-callout.tsx
+++ b/www/src/app/oss/[slug]/integration-claim-callout.tsx
@@ -14,7 +14,6 @@ export function IntegrationClaimCallout({
 	points,
 	session,
 	canClaimAnother = true,
-	wipIntegrationName,
 	claimBlockReason,
 }: {
 	integrationId: string;
@@ -23,7 +22,6 @@ export function IntegrationClaimCallout({
 	points: number;
 	session: boolean;
 	canClaimAnother?: boolean;
-	wipIntegrationName?: string | null;
 	claimBlockReason?: ClaimBlockReason | null;
 }) {
 	return (
@@ -54,7 +52,6 @@ export function IntegrationClaimCallout({
 								integrationSlug={integrationSlug}
 								size="lg"
 								disabled={!canClaimAnother}
-								wipIntegrationName={wipIntegrationName}
 								claimBlockReason={claimBlockReason}
 							/>
 						) : (

--- a/www/src/app/oss/[slug]/integration-detail-sections.tsx
+++ b/www/src/app/oss/[slug]/integration-detail-sections.tsx
@@ -92,7 +92,6 @@ export async function IntegrationHeaderSection({
 						points={integration.points}
 						session={Boolean(session)}
 						canClaimAnother={integration.canClaimAnother}
-						wipIntegrationName={integration.wipIntegrationName}
 						claimBlockReason={integration.claimBlockReason}
 					/>
 				) : null}

--- a/www/src/app/oss/claim-integration-button.tsx
+++ b/www/src/app/oss/claim-integration-button.tsx
@@ -12,20 +12,11 @@ import { cn } from '@/lib/utils';
 
 import { claimIntegration } from '@/server/actions/claim-integration';
 
-export function wipClaimTooltipMessage(integrationName: string) {
-	return `Please complete ${integrationName} before claiming your next integration`;
-}
-
 export function claimBlockTooltipMessage(
 	blockReason: ClaimBlockReason | null | undefined,
-	wipIntegrationName?: string | null,
 ) {
-	if (blockReason === 'wip' && wipIntegrationName) {
-		return wipClaimTooltipMessage(wipIntegrationName);
-	}
-
 	if (blockReason === 'limit_reached') {
-		return `You've built the maximum of ${MAX_USER_BUILT_INTEGRATIONS} integrations`;
+		return `You've claimed the maximum of ${MAX_USER_BUILT_INTEGRATIONS} integrations`;
 	}
 
 	return undefined;
@@ -61,7 +52,6 @@ export function ClaimIntegrationButton({
 	integrationId,
 	integrationSlug,
 	disabled = false,
-	wipIntegrationName,
 	claimBlockReason,
 	size = 'sm',
 	className,
@@ -69,7 +59,6 @@ export function ClaimIntegrationButton({
 	integrationId: string;
 	integrationSlug: string;
 	disabled?: boolean;
-	wipIntegrationName?: string | null;
 	claimBlockReason?: ClaimBlockReason | null;
 	size?: 'sm' | 'lg';
 	className?: string;
@@ -78,7 +67,7 @@ export function ClaimIntegrationButton({
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState('');
 	const tooltip = disabled
-		? claimBlockTooltipMessage(claimBlockReason, wipIntegrationName)
+		? claimBlockTooltipMessage(claimBlockReason)
 		: undefined;
 
 	const handleClick = async () => {

--- a/www/src/app/oss/integration-card.tsx
+++ b/www/src/app/oss/integration-card.tsx
@@ -37,7 +37,6 @@ type IntegrationCardProps = {
 	session: boolean;
 	index?: number;
 	activeSlug?: string;
-	wipIntegrationName?: string | null;
 	claimBlockReason?: ClaimBlockReason | null;
 };
 
@@ -74,7 +73,6 @@ export function IntegrationCard({
 	session,
 	index,
 	activeSlug,
-	wipIntegrationName,
 	claimBlockReason,
 }: IntegrationCardProps) {
 	const isActive = activeSlug === integration.slug;
@@ -163,7 +161,6 @@ export function IntegrationCard({
 						integrationId={integration.id}
 						integrationSlug={integration.slug}
 						disabled={integration.userCanClaim === false}
-						wipIntegrationName={wipIntegrationName}
 						claimBlockReason={claimBlockReason}
 					/>
 				) : null}

--- a/www/src/app/oss/oss-sections.tsx
+++ b/www/src/app/oss/oss-sections.tsx
@@ -147,7 +147,6 @@ export async function OssIntegrationsSection({
 							integration={integration}
 							session={Boolean(session)}
 							index={startIndex + index + 1}
-							wipIntegrationName={integrationsData.wipIntegrationName}
 							claimBlockReason={integrationsData.claimBlockReason}
 						/>
 					))}

--- a/www/src/db/integration-status.ts
+++ b/www/src/db/integration-status.ts
@@ -5,11 +5,8 @@ import { user } from '@/db/auth-schema';
 import type { IntegrationPhase, IntegrationReleaseReason } from '@/db/schema';
 import { integrationStatus, integrations } from '@/db/schema';
 import type { ClaimBlockReason } from '@/lib/integration-claim-limits';
-import { MAX_USER_BUILT_INTEGRATIONS } from '@/lib/integration-claim-limits';
-import {
-	isIntegrationActivelyClaimed,
-	isWipPhase,
-} from '@/lib/integration-phases';
+import { canClaimMore } from '@/lib/integration-claim-limits';
+import { isIntegrationActivelyClaimed } from '@/lib/integration-phases';
 
 export type { ClaimBlockReason } from '@/lib/integration-claim-limits';
 
@@ -29,7 +26,6 @@ export const PR_DEADLINE_MS = 3 * 60 * 60 * 1000;
 export type UserClaimEligibility = {
 	canClaim: boolean;
 	blockReason: ClaimBlockReason | null;
-	wipIntegrationName: string | null;
 	builtCount: number;
 };
 
@@ -166,6 +162,12 @@ export type ActiveDeadlineClaim = {
 	deadlineAt: Date;
 };
 
+type PendingDeadline = {
+	integrationId: string;
+	phase: ActiveDeadlineClaim['phase'];
+	deadlineAt: Date;
+};
+
 export async function getUserActiveDeadlineClaim(db: DB, userId: string) {
 	const rows = await db
 		.selectDistinctOn([integrationStatus.integrationId], {
@@ -181,23 +183,36 @@ export async function getUserActiveDeadlineClaim(db: DB, userId: string) {
 			desc(integrationStatus.occurredAt),
 		);
 
-	const wipRow = rows.find((row) => isWipPhase(row.phase));
-	if (!wipRow) {
-		return null;
-	}
+	// A user can hold two claims at once, so surface whichever deadline runs out
+	// first — otherwise the expiry cron could release a claim whose countdown was
+	// never shown.
+	const [next] = rows
+		.flatMap((row): PendingDeadline[] => {
+			if (row.phase === 'awaiting_issue' && row.issueDeadlineAt) {
+				return [
+					{
+						integrationId: row.integrationId,
+						phase: 'awaiting_issue',
+						deadlineAt: row.issueDeadlineAt,
+					},
+				];
+			}
 
-	let deadlineAt: Date | null = null;
-	let phase: ActiveDeadlineClaim['phase'] | null = null;
+			if (row.phase === 'awaiting_pr' && row.prDeadlineAt) {
+				return [
+					{
+						integrationId: row.integrationId,
+						phase: 'awaiting_pr',
+						deadlineAt: row.prDeadlineAt,
+					},
+				];
+			}
 
-	if (wipRow.phase === 'awaiting_issue' && wipRow.issueDeadlineAt) {
-		deadlineAt = wipRow.issueDeadlineAt;
-		phase = 'awaiting_issue';
-	} else if (wipRow.phase === 'awaiting_pr' && wipRow.prDeadlineAt) {
-		deadlineAt = wipRow.prDeadlineAt;
-		phase = 'awaiting_pr';
-	}
+			return [];
+		})
+		.sort((a, b) => a.deadlineAt.getTime() - b.deadlineAt.getTime());
 
-	if (!deadlineAt || !phase) {
+	if (!next) {
 		return null;
 	}
 
@@ -208,7 +223,7 @@ export async function getUserActiveDeadlineClaim(db: DB, userId: string) {
 			slug: integrations.slug,
 		})
 		.from(integrations)
-		.where(eq(integrations.id, wipRow.integrationId))
+		.where(eq(integrations.id, next.integrationId))
 		.limit(1);
 
 	if (!integration) {
@@ -217,79 +232,25 @@ export async function getUserActiveDeadlineClaim(db: DB, userId: string) {
 
 	return {
 		...integration,
-		phase,
-		deadlineAt,
+		phase: next.phase,
+		deadlineAt: next.deadlineAt,
 	} satisfies ActiveDeadlineClaim;
-}
-
-export async function getUserWipClaim(db: DB, userId: string) {
-	const rows = await db
-		.selectDistinctOn([integrationStatus.integrationId], {
-			integrationId: integrationStatus.integrationId,
-			phase: integrationStatus.phase,
-		})
-		.from(integrationStatus)
-		.where(eq(integrationStatus.userId, userId))
-		.orderBy(
-			integrationStatus.integrationId,
-			desc(integrationStatus.occurredAt),
-		);
-
-	const wipIntegrationId = rows.find((row) =>
-		isWipPhase(row.phase),
-	)?.integrationId;
-
-	if (!wipIntegrationId) {
-		return null;
-	}
-
-	const [integration] = await db
-		.select({
-			id: integrations.id,
-			name: integrations.name,
-			slug: integrations.slug,
-		})
-		.from(integrations)
-		.where(eq(integrations.id, wipIntegrationId))
-		.limit(1);
-
-	return integration ?? null;
-}
-
-export async function userHasWipClaim(
-	db: DB,
-	userId: string,
-): Promise<boolean> {
-	return (await getUserWipClaim(db, userId)) != null;
 }
 
 export async function getUserClaimEligibility(
 	db: DB,
 	userId: string,
 ): Promise<UserClaimEligibility> {
-	const [activeClaims, wipClaim] = await Promise.all([
-		getActiveClaimsForUser(db, userId),
-		getUserWipClaim(db, userId),
-	]);
+	// Every claim the user still holds counts against the cap — in progress,
+	// ready to review, and finished alike. A slot frees up only when a claim is
+	// released, by unclaiming or by a deadline timeout.
+	const activeClaims = await getActiveClaimsForUser(db, userId);
+	const builtCount = activeClaims.length;
 
-	const builtCount = activeClaims.filter(
-		(claim) => claim.phase === 'finished',
-	).length;
-
-	if (wipClaim != null) {
-		return {
-			canClaim: false,
-			blockReason: 'wip',
-			wipIntegrationName: wipClaim.name,
-			builtCount,
-		};
-	}
-
-	if (builtCount >= MAX_USER_BUILT_INTEGRATIONS) {
+	if (!canClaimMore(builtCount)) {
 		return {
 			canClaim: false,
 			blockReason: 'limit_reached',
-			wipIntegrationName: null,
 			builtCount,
 		};
 	}
@@ -297,7 +258,6 @@ export async function getUserClaimEligibility(
 	return {
 		canClaim: true,
 		blockReason: null,
-		wipIntegrationName: null,
 		builtCount,
 	};
 }

--- a/www/src/lib/integration-claim-limits.test.ts
+++ b/www/src/lib/integration-claim-limits.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+	canClaimMore,
+	MAX_USER_BUILT_INTEGRATIONS,
+} from './integration-claim-limits';
+
+describe('canClaimMore', () => {
+	it('caps a contributor at two held claims', () => {
+		assert.equal(MAX_USER_BUILT_INTEGRATIONS, 2);
+		assert.equal(canClaimMore(0), true);
+		assert.equal(canClaimMore(1), true);
+		assert.equal(canClaimMore(2), false);
+	});
+
+	it('stays closed if the count somehow exceeds the cap', () => {
+		assert.equal(canClaimMore(3), false);
+		assert.equal(canClaimMore(10), false);
+	});
+});

--- a/www/src/lib/integration-claim-limits.ts
+++ b/www/src/lib/integration-claim-limits.ts
@@ -1,3 +1,11 @@
 export const MAX_USER_BUILT_INTEGRATIONS = 2;
 
-export type ClaimBlockReason = 'wip' | 'limit_reached';
+export type ClaimBlockReason = 'limit_reached';
+
+/**
+ * Every claim a user still holds counts against the cap — in progress, ready to
+ * review, and finished alike.
+ */
+export function canClaimMore(activeClaimCount: number): boolean {
+	return activeClaimCount < MAX_USER_BUILT_INTEGRATIONS;
+}

--- a/www/src/server/api/routers/integrations.ts
+++ b/www/src/server/api/routers/integrations.ts
@@ -575,7 +575,6 @@ export const integrationsRouter = createTRPCRouter({
 				totalPages: Math.max(1, Math.ceil(total / PAGE_SIZE)),
 				q: input.q?.trim() ?? '',
 				tags: input.tags ?? [],
-				wipIntegrationName: claimEligibility?.wipIntegrationName ?? null,
 				claimBlockReason: claimEligibility?.blockReason ?? null,
 			};
 		}),
@@ -923,7 +922,6 @@ export const integrationsRouter = createTRPCRouter({
 				authSchemes: authSchemeRows,
 				...claimFields,
 				canClaimAnother: claimEligibility?.canClaim ?? true,
-				wipIntegrationName: claimEligibility?.wipIntegrationName ?? null,
 				claimBlockReason: claimEligibility?.blockReason ?? null,
 				claimExpiredForCurrentUser,
 				timeline: statusHistory.map((event) => ({

--- a/www/src/server/integration-cache.ts
+++ b/www/src/server/integration-cache.ts
@@ -51,7 +51,6 @@ async function withCurrentUserFields(summary: CachedSummary, userId?: string) {
 			claimedByCurrentUser: false,
 			claimExpiredForCurrentUser: null,
 			canClaimAnother: true,
-			wipIntegrationName: null,
 			claimBlockReason: null,
 		};
 	}
@@ -76,7 +75,6 @@ async function withCurrentUserFields(summary: CachedSummary, userId?: string) {
 		claimedByCurrentUser,
 		claimExpiredForCurrentUser,
 		canClaimAnother: claimEligibility.canClaim,
-		wipIntegrationName: claimEligibility.wipIntegrationName,
 		claimBlockReason: claimEligibility.blockReason,
 	};
 }

--- a/www/src/server/integrations/claim-integration.test.ts
+++ b/www/src/server/integrations/claim-integration.test.ts
@@ -135,15 +135,18 @@ describe('resolveClaimOutcome', () => {
 		assert.equal(queried, false);
 	});
 
-	it('blocks a genuinely new claim when the user is ineligible', async () => {
+	it('blocks a genuinely new claim when the user is at the claim cap', async () => {
 		const outcome = await resolveClaimOutcome(
 			{ action: 'insert' },
 			async () => ({
 				canClaim: false,
-				blockReason: 'wip',
+				blockReason: 'limit_reached',
 			}),
 		);
-		assert.deepEqual(outcome, { action: 'blocked', blockReason: 'wip' });
+		assert.deepEqual(outcome, {
+			action: 'blocked',
+			blockReason: 'limit_reached',
+		});
 	});
 
 	it('allows a new claim when the user is eligible', async () => {

--- a/www/src/server/integrations/claim-integration.ts
+++ b/www/src/server/integrations/claim-integration.ts
@@ -71,8 +71,8 @@ type ClaimEligibility = Pick<UserClaimEligibility, 'canClaim' | 'blockReason'>;
 /**
  * Claim precedence: an existing same-user claim or a conflict on this
  * integration is resolved before the per-user eligibility gate, so re-claiming
- * an in-progress integration returns already_owned instead of a 'wip' rejection.
- * Eligibility is passed as a thunk and only queried for a genuinely new insert.
+ * an integration you already hold returns already_owned instead of failing the
+ * claim cap. Eligibility is a thunk, only queried for a genuinely new insert.
  */
 export async function resolveClaimOutcome(
 	decision: ClaimDecision,
@@ -176,10 +176,7 @@ export async function claimIntegrationAtomically(
 		if (outcome.action === 'blocked') {
 			throw new TRPCError({
 				code: 'PRECONDITION_FAILED',
-				message:
-					outcome.blockReason === 'limit_reached'
-						? `You've built the maximum of ${MAX_USER_BUILT_INTEGRATIONS} integrations and can't claim another`
-						: 'Finish your current integration or mark it ready to review before claiming another',
+				message: `You've claimed the maximum of ${MAX_USER_BUILT_INTEGRATIONS} integrations and can't claim another`,
 			});
 		}
 

--- a/www/src/server/oss-public-cache.ts
+++ b/www/src/server/oss-public-cache.ts
@@ -96,7 +96,6 @@ export async function getIntegrationListForPage(
 
 		return {
 			...list,
-			wipIntegrationName: claimEligibility.wipIntegrationName,
 			claimBlockReason: claimEligibility.blockReason,
 			items: list.items.map((item) => ({
 				...item,
@@ -109,7 +108,6 @@ export async function getIntegrationListForPage(
 		// Fail safe: disable claim buttons rather than showing stale public-cache state.
 		return {
 			...list,
-			wipIntegrationName: null,
 			claimBlockReason: null,
 			items: list.items.map((item) => ({
 				...item,


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

Cap each contributor at 2 claimed integrations at a time.

The old limit only counted **finished** integrations, so someone could keep claiming after marking work ready to review. This counts every active claim (in progress, ready to review, or finished). A slot frees only when a claim is **released** (unclaim or deadline timeout).

## Checklist

Before submitting your PR, please verify the following:

- [ ] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [ ] I have run `pnpm build` and all packages build successfully
- [ ] I have run `pnpm test` and all tests pass
- [ ] I have added or updated tests where applicable
- [ ] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

N/A — claim button disables at 2 active claims; tooltip: "You've claimed the maximum of 2 integrations".

## Additional Notes

No new dependencies. Merged/finished work still occupies a slot until released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Claiming an integration now reliably recognizes existing claims and prevents duplicate claim creation.
  - Eligibility checks consistently account for all active integration claims.

- **Bug Fixes**
  - Improved handling of unavailable, conflicting, and limit-reached claim requests.
  - Updated messaging to accurately describe the maximum number of integrations claimed.

- **Changes**
  - Reduced the maximum number of integrations that can be claimed from 10 to 2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->