### PR TITLE
fix(teams): use constant-time comparison for clientState (#684)

### DIFF
--- a/packages/teams/webhooks/types.ts
+++ b/packages/teams/webhooks/types.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto';
 import type { CorsairWebhookMatcher, RawWebhookRequest } from 'corsair/core';
 import { z } from 'zod';
 
@@ -195,9 +196,13 @@ export function verifyTeamsClientState(
 	if (!expectedClientState) {
 		return { valid: false, error: 'clientState is required' };
 	}
-	const allMatch = payload.value.every(
-		(n) => n.clientState === expectedClientState,
-	);
+	const expected = Buffer.from(expectedClientState);
+	const allMatch = payload.value.every((n) => {
+		const actual = Buffer.from(n.clientState ?? '');
+		return (
+			actual.length === expected.length && timingSafeEqual(actual, expected)
+		);
+	});
 	if (!allMatch) {
 		return { valid: false, error: 'clientState mismatch' };
 	}

--- a/packages/teams/webhooks/verify-client-state.test.ts
+++ b/packages/teams/webhooks/verify-client-state.test.ts
@@ -1,0 +1,68 @@
+import type { TeamsNotification, TeamsWebhookPayload } from './types';
+import { verifyTeamsClientState } from './types';
+
+// Regression for #684: verifyTeamsClientState compared clientState with `===`,
+// which is not constant-time. The comparison now uses timingSafeEqual after a
+// length check, while preserving the valid/invalid outcomes.
+
+function payloadWith(
+	...clientStates: (string | undefined)[]
+): TeamsWebhookPayload<TeamsNotification> {
+	return {
+		value: clientStates.map(
+			(clientState) => ({ clientState }) as TeamsNotification,
+		),
+	};
+}
+
+describe('verifyTeamsClientState', () => {
+	it('accepts a matching clientState', () => {
+		const result = verifyTeamsClientState(
+			payloadWith('secret-state'),
+			'secret-state',
+		);
+		expect(result).toEqual({ valid: true });
+	});
+
+	it('accepts when every notification matches', () => {
+		const result = verifyTeamsClientState(
+			payloadWith('secret-state', 'secret-state'),
+			'secret-state',
+		);
+		expect(result).toEqual({ valid: true });
+	});
+
+	it('rejects a mismatched clientState of equal length', () => {
+		const result = verifyTeamsClientState(
+			payloadWith('wrong-secret1'),
+			'secret-state1',
+		);
+		expect(result).toEqual({ valid: false, error: 'clientState mismatch' });
+	});
+
+	it('rejects a clientState of a different length', () => {
+		const result = verifyTeamsClientState(payloadWith('short'), 'secret-state');
+		expect(result).toEqual({ valid: false, error: 'clientState mismatch' });
+	});
+
+	it('rejects when any notification does not match', () => {
+		const result = verifyTeamsClientState(
+			payloadWith('secret-state', 'other-state1'),
+			'secret-state',
+		);
+		expect(result).toEqual({ valid: false, error: 'clientState mismatch' });
+	});
+
+	it('rejects a missing clientState', () => {
+		const result = verifyTeamsClientState(
+			payloadWith(undefined),
+			'secret-state',
+		);
+		expect(result).toEqual({ valid: false, error: 'clientState mismatch' });
+	});
+
+	it('errors when the expected clientState is empty', () => {
+		const result = verifyTeamsClientState(payloadWith('anything'), '');
+		expect(result).toEqual({ valid: false, error: 'clientState is required' });
+	});
+});


### PR DESCRIPTION
## Description

Closes #684.

`verifyTeamsClientState` in `packages/teams/webhooks/types.ts` compared each notification's `clientState` with `===`, which is not constant-time and can leak timing information about the expected secret value.

This PR replaces the `===` comparison with `crypto.timingSafeEqual` after a length check, matching the pattern already used in `packages/vapi/webhooks/types.ts`:

```ts
const expected = Buffer.from(expectedClientState);
const allMatch = payload.value.every((n) => {
    const actual = Buffer.from(n.clientState ?? '');
    return actual.length === expected.length && timingSafeEqual(actual, expected);
});
```

The rest of the verifier is untouched — the existing `expectedClientState is required` guard stays, empty `value[]` behaviour is unchanged (that is #625, out of scope here), and all valid/invalid outcomes are preserved. Scope is a single plugin package (`packages/teams/`).

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation (no docs change needed — internal verifier behaviour is unchanged)

## Screenshots / Demos (if applicable)

This is a security hardening change to an internal signature-verification helper, not a UI/CLI change, so there is no visual output to record. The behaviour is verified by unit tests in `packages/teams/webhooks/verify-client-state.test.ts` (7 assertions), which pass:

```
Tests:       7 passed, 7 total
```

Because this is a **timing** fix rather than a behavioural one, the outcome-level tests pass against both the old `===` and the new `timingSafeEqual` implementation (verified by reverting locally) — they lock in that the constant-time rewrite preserves every valid/invalid result, while the security property itself comes from using `timingSafeEqual` with a length guard, mirroring the repo's own `vapi` verifier.

## Additional Notes

No new dependencies (`node:crypto` is built in). No breaking changes. Distinct from #625 (empty `value[]` handling).
