### PR TITLE
fix(vercel): fail closed when webhook secret is empty

### DIFF
--- a/packages/vercel/webhooks/types.test.ts
+++ b/packages/vercel/webhooks/types.test.ts
@@ -42,4 +42,37 @@ describe('verifyVercelWebhookSignature', () => {
 		);
 		expect(result).toBe(false);
 	});
+
+	it('returns false when the signature header is missing', () => {
+		const result = verifyVercelWebhookSignature(
+			{
+				rawBody: '{"type":"deployment.created"}',
+				headers: {},
+			},
+			's3cret',
+		);
+		expect(result).toBe(false);
+	});
+
+	it('returns false when the signature header is not a string', () => {
+		const result = verifyVercelWebhookSignature(
+			{
+				rawBody: '{"type":"deployment.created"}',
+				headers: { 'x-vercel-signature': ['abc'] },
+			},
+			's3cret',
+		);
+		expect(result).toBe(false);
+	});
+
+	it('returns false when the signature length differs from the digest', () => {
+		const result = verifyVercelWebhookSignature(
+			{
+				rawBody: '{"type":"deployment.created"}',
+				headers: { 'x-vercel-signature': 'deadbeef' },
+			},
+			's3cret',
+		);
+		expect(result).toBe(false);
+	});
 });

--- a/packages/vercel/webhooks/types.test.ts
+++ b/packages/vercel/webhooks/types.test.ts
@@ -75,4 +75,30 @@ describe('verifyVercelWebhookSignature', () => {
 		);
 		expect(result).toBe(false);
 	});
+
+	it('returns false when secret is whitespace only', () => {
+		const body = '{"type":"deployment.created"}';
+		const secret = '   ';
+		const result = verifyVercelWebhookSignature(
+			{
+				rawBody: body,
+				headers: { 'x-vercel-signature': hmacSha1(secret, body) },
+			},
+			secret,
+		);
+		expect(result).toBe(false);
+	});
+
+	it('returns true for a matching signature when rawBody is a Buffer', () => {
+		const body = '{"type":"deployment.created"}';
+		const secret = 's3cret';
+		const result = verifyVercelWebhookSignature(
+			{
+				rawBody: Buffer.from(body),
+				headers: { 'x-vercel-signature': hmacSha1(secret, body) },
+			},
+			secret,
+		);
+		expect(result).toBe(true);
+	});
 });

--- a/packages/vercel/webhooks/types.test.ts
+++ b/packages/vercel/webhooks/types.test.ts
@@ -1,0 +1,45 @@
+import crypto from 'crypto';
+import { verifyVercelWebhookSignature } from './types';
+
+function hmacSha1(secret: string, body: string) {
+	return crypto.createHmac('sha1', secret).update(body).digest('hex');
+}
+
+describe('verifyVercelWebhookSignature', () => {
+	it('returns false when secret is empty', () => {
+		const result = verifyVercelWebhookSignature(
+			{
+				rawBody: '{"a":1}',
+				headers: { 'x-vercel-signature': hmacSha1('', '{"a":1}') },
+			},
+			'',
+		);
+		expect(result).toBe(false);
+	});
+
+	it('returns true for a matching signature with a real secret', () => {
+		const body = '{"type":"deployment.created"}';
+		const secret = 's3cret';
+		const result = verifyVercelWebhookSignature(
+			{
+				rawBody: body,
+				headers: { 'x-vercel-signature': hmacSha1(secret, body) },
+			},
+			secret,
+		);
+		expect(result).toBe(true);
+	});
+
+	it('returns false for a mismatched signature with a real secret', () => {
+		const body = '{"type":"deployment.created"}';
+		const secret = 's3cret';
+		const result = verifyVercelWebhookSignature(
+			{
+				rawBody: body,
+				headers: { 'x-vercel-signature': hmacSha1(secret, 'tampered') },
+			},
+			secret,
+		);
+		expect(result).toBe(false);
+	});
+});

--- a/packages/vercel/webhooks/types.ts
+++ b/packages/vercel/webhooks/types.ts
@@ -108,6 +108,7 @@ export function verifyVercelWebhookSignature(
 ): boolean {
 	const signature = request.headers['x-vercel-signature'];
 	if (!signature || typeof signature !== 'string') return false;
+	if (!secret) return false;
 
 	try {
 		const hmac = crypto.createHmac('sha1', secret);

--- a/packages/vercel/webhooks/types.ts
+++ b/packages/vercel/webhooks/types.ts
@@ -108,7 +108,7 @@ export function verifyVercelWebhookSignature(
 ): boolean {
 	const signature = request.headers['x-vercel-signature'];
 	if (!signature || typeof signature !== 'string') return false;
-	if (!secret) return false;
+	if (!secret?.trim()) return false;
 
 	try {
 		const hmac = crypto.createHmac('sha1', secret);


### PR DESCRIPTION
## Description

Fixes #712

`verifyVercelWebhookSignature` in `packages/vercel/webhooks/types.ts` computed `crypto.createHmac('sha1', secret)` even when `secret` was an empty string. Node accepts an empty HMAC key, so a request signed with `HMAC-SHA1('', body)` could verify as valid.

The verifier now returns `false` before HMAC computation when no webhook secret is configured. Existing signature-header checks and `timingSafeEqual` are unchanged.

Unit tests cover:
- Empty secret → `false`
- Matching signature with a real secret → `true`
- Mismatched signature with a real secret → `false`
- Missing `x-vercel-signature` header → `false`
- Non-string signature header → `false`
- Signature length that does not match the digest → `false`

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

No UI or CLI output. This is a fail-closed unit-test fix; CI Checks on this PR is the working proof:

https://github.com/corsairdev/corsair/actions/runs/32100181474

Tests: https://github.com/corsairdev/corsair/blob/fix/vercel-webhook-empty-secret/packages/vercel/webhooks/types.test.ts

## Additional Notes

No documentation changes. Issue #712 specified a one-line guard plus unit tests on an existing helper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook signature verification now rejects empty or whitespace-only secrets.
  * Improved handling of invalid, missing, mismatched, and incorrectly sized signatures.
  * Supports verification when the raw webhook payload is provided as a buffer.

* **Tests**
  * Added coverage for valid signatures and invalid input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->