### PR TITLE
fix(resend): return error when webhook secret is missing

### DIFF
--- a/packages/resend/webhooks/types.test.ts
+++ b/packages/resend/webhooks/types.test.ts
@@ -1,0 +1,106 @@
+import type { WebhookRequest } from 'corsair/core';
+import crypto from 'crypto';
+
+import type { ResendWebhookPayload } from './types';
+import { verifyResendWebhookSignature } from './types';
+
+describe('verifyResendWebhookSignature', () => {
+	const secret = 'whsec_testsecret123';
+	const payload: ResendWebhookPayload = {
+		type: 'email.sent',
+		created_at: '2026-01-01T00:00:00.000Z',
+		data: {
+			email_id: 'email_123',
+			created_at: '2026-01-01T00:00:00.000Z',
+		},
+	};
+	const rawBody = JSON.stringify(payload);
+
+	const sign = (key: string, body: string = rawBody) =>
+		`sha256=${crypto.createHmac('sha256', key).update(body).digest('hex')}`;
+
+	const requestWith = (
+		headers: Record<string, string | string[] | undefined>,
+		body: string | null = rawBody,
+	): WebhookRequest<ResendWebhookPayload> => ({
+		payload,
+		headers,
+		rawBody: body === null ? undefined : body,
+	});
+
+	it('returns error when webhookSecret is empty string', () => {
+		const result = verifyResendWebhookSignature(
+			requestWith({ 'svix-signature': sign(secret) }),
+			'',
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('returns error when webhookSecret is undefined', () => {
+		const result = verifyResendWebhookSignature(
+			requestWith({ 'svix-signature': sign(secret) }),
+			undefined,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('returns error when rawBody is missing', () => {
+		const result = verifyResendWebhookSignature(
+			requestWith({ 'svix-signature': sign(secret) }, null),
+			secret,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing raw body for signature verification',
+		});
+	});
+
+	it('returns error when signature header is missing', () => {
+		const result = verifyResendWebhookSignature(requestWith({}), secret);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing svix-signature or x-resend-signature header',
+		});
+	});
+
+	it('returns valid for a correctly signed request using svix-signature', () => {
+		const result = verifyResendWebhookSignature(
+			requestWith({ 'svix-signature': sign(secret) }),
+			secret,
+		);
+		expect(result).toEqual({ valid: true });
+	});
+
+	it('returns valid for a correctly signed request using x-resend-signature', () => {
+		const result = verifyResendWebhookSignature(
+			requestWith({ 'x-resend-signature': sign(secret) }),
+			secret,
+		);
+		expect(result).toEqual({ valid: true });
+	});
+
+	it('accepts signature header when provided as an array', () => {
+		const result = verifyResendWebhookSignature(
+			requestWith({ 'svix-signature': [sign(secret)] }),
+			secret,
+		);
+		expect(result).toEqual({ valid: true });
+	});
+
+	it('returns invalid for a signature that does not match', () => {
+		const result = verifyResendWebhookSignature(
+			requestWith({ 'svix-signature': sign('a-different-secret') }),
+			secret,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid signature',
+		});
+	});
+});

--- a/packages/resend/webhooks/types.ts
+++ b/packages/resend/webhooks/types.ts
@@ -267,7 +267,7 @@ export function verifyResendWebhookSignature(
 	webhookSecret?: string,
 ): { valid: boolean; error?: string } {
 	if (!webhookSecret) {
-		return { valid: false };
+		return { valid: false, error: 'Missing webhook secret' };
 	}
 
 	const rawBody = request.rawBody;


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

Fixes https://github.com/corsairdev/corsair/issues/691

When `webhookSecret` is missing, `verifyResendWebhookSignature` in `packages/resend/webhooks/types.ts` previously returned `{ valid: false }` without an `error` property. Upstream handlers checking `verification.error` fell back to a generic failure message, hiding the root configuration issue.

This PR updates `verifyResendWebhookSignature` to return `{ valid: false, error: 'Missing webhook secret' }` when `webhookSecret` is missing, matching the behavior of all other signature verification error paths in the function.

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)
<img width="905" height="92" alt="Screenshot 2026-08-18 102001" src="https://github.com/user-attachments/assets/4343f6b2-9948-4c96-b38f-540474e2bbf4" />

## Additional Notes

Non-breaking change. Only provides an explicit error message when the secret is missing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook signature verification errors by clearly reporting when the webhook secret is missing.
  * Expanded signature verification coverage for valid, invalid, and incomplete webhook requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->