### PR TITLE
Fix/fireflies remove example files

### DIFF
--- a/packages/fireflies/endpoints/example.ts
+++ b/packages/fireflies/endpoints/example.ts
@@ -1,3 +1,0 @@
-// This file is intentionally left empty.
-// The example template has been replaced by the full Fireflies endpoint implementations.
-export {};

--- a/packages/fireflies/webhooks/example.ts
+++ b/packages/fireflies/webhooks/example.ts
@@ -1,3 +1,0 @@
-// This file is intentionally left empty.
-// The example template has been replaced by the full Fireflies webhook implementations.
-export {};


### PR DESCRIPTION
## Description

Fixes #713. Remove two empty generator leftover files from the Fireflies package:

* `packages/fireflies/webhooks/example.ts`
* `packages/fireflies/endpoints/example.ts`

These files contain no implementation and are not imported anywhere. Removing them cleans up unused generator artifacts without affecting the actual Fireflies functionality.

The real meeting/transcription handlers and `packages/fireflies/webhooks/index.ts` are unchanged.

## Checklist

* [X] I have run `pnpm lint` and all checks pass
* [X] I have run `pnpm typecheck` and there are no TypeScript errors
* [X] I have run `pnpm build` and all packages build successfully
* [X] I have run `pnpm test` and all tests pass
* [x] I have added or updated tests where applicable
* [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

N/A — no UI or CLI output changes. https://github.com/corsairdev/corsair/issues/713

## Additional Notes

* `pnpm --filter @corsair-dev/fireflies typecheck` was run.
* No Fireflies handlers, exports, or runtime logic were modified.
* No tests are required because this is a deletion of unused files.