### PR TITLE
fix(asana): return error when webhook secret is missing

### DIFF
--- a/packages/asana/webhooks/types.test.ts
+++ b/packages/asana/webhooks/types.test.ts
@@ -1,0 +1,81 @@
+import crypto from 'crypto';
+import { verifyAsanaWebhookSignature } from './types';
+
+describe('verifyAsanaWebhookSignature', () => {
+	const secret = 'asana-test-secret';
+	const payload = {
+		events: [
+			{
+				action: 'changed',
+				resource: { gid: '12345', resource_type: 'task' },
+			},
+		],
+	};
+	const rawBody = JSON.stringify(payload);
+
+	const sign = (key: string, body: string = rawBody) =>
+		crypto.createHmac('sha256', key).update(body).digest('hex');
+
+	it('returns error when secret is an empty string', () => {
+		const result = verifyAsanaWebhookSignature(
+			{ payload, headers: { 'x-hook-signature': sign(secret) } },
+			'',
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('returns error when secret is undefined', () => {
+		const result = verifyAsanaWebhookSignature(
+			{ payload, headers: { 'x-hook-signature': sign(secret) } },
+			undefined as unknown as string,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('returns error when x-hook-signature header is missing', () => {
+		const result = verifyAsanaWebhookSignature(
+			{ payload, headers: {} },
+			secret,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing x-hook-signature header',
+		});
+	});
+
+	it('returns valid for a correctly signed request', () => {
+		const result = verifyAsanaWebhookSignature(
+			{ payload, headers: { 'x-hook-signature': sign(secret) } },
+			secret,
+		);
+		expect(result).toEqual({ valid: true });
+	});
+
+	it('returns invalid for a signature that does not match', () => {
+		const result = verifyAsanaWebhookSignature(
+			{ payload, headers: { 'x-hook-signature': sign('wrong-secret') } },
+			secret,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid signature',
+		});
+	});
+
+	it('returns error when signature comparison fails due to length mismatch', () => {
+		const result = verifyAsanaWebhookSignature(
+			{ payload, headers: { 'x-hook-signature': 'too-short' } },
+			secret,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Signature comparison failed',
+		});
+	});
+});

--- a/packages/asana/webhooks/types.test.ts
+++ b/packages/asana/webhooks/types.test.ts
@@ -30,7 +30,7 @@ describe('verifyAsanaWebhookSignature', () => {
 	it('returns error when secret is undefined', () => {
 		const result = verifyAsanaWebhookSignature(
 			{ payload, headers: { 'x-hook-signature': sign(secret) } },
-			undefined as unknown as string,
+			undefined,
 		);
 		expect(result).toEqual({
 			valid: false,

--- a/packages/asana/webhooks/types.test.ts
+++ b/packages/asana/webhooks/types.test.ts
@@ -38,6 +38,17 @@ describe('verifyAsanaWebhookSignature', () => {
 		});
 	});
 
+	it('returns error when secret is whitespace-only', () => {
+		const result = verifyAsanaWebhookSignature(
+			{ payload, headers: { 'x-hook-signature': sign(secret) } },
+			'   ',
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
 	it('returns error when x-hook-signature header is missing', () => {
 		const result = verifyAsanaWebhookSignature(
 			{ payload, headers: {} },

--- a/packages/asana/webhooks/types.ts
+++ b/packages/asana/webhooks/types.ts
@@ -134,7 +134,10 @@ export function createAsanaEventMatch(
 export function verifyAsanaWebhookSignature(
 	// any/unknown for payload and headers since they come from raw webhook request before parsing
 	request: { payload: unknown; headers: unknown },
-	secret: string,
+	// The secret comes from the webhook signing key, which is optional: an
+	// unset key is resolved as undefined. Allow the missing-value case in the
+	// type so callers and tests can pass it without a cast.
+	secret: string | undefined,
 ): { valid: boolean; error?: string } {
 	if (!secret) {
 		return { valid: false, error: 'Missing webhook secret' };

--- a/packages/asana/webhooks/types.ts
+++ b/packages/asana/webhooks/types.ts
@@ -136,6 +136,10 @@ export function verifyAsanaWebhookSignature(
 	request: { payload: unknown; headers: unknown },
 	secret: string,
 ): { valid: boolean; error?: string } {
+	if (!secret) {
+		return { valid: false, error: 'Missing webhook secret' };
+	}
+
 	const rawBody =
 		typeof request.payload === 'string'
 			? request.payload

--- a/packages/asana/webhooks/types.ts
+++ b/packages/asana/webhooks/types.ts
@@ -134,12 +134,9 @@ export function createAsanaEventMatch(
 export function verifyAsanaWebhookSignature(
 	// any/unknown for payload and headers since they come from raw webhook request before parsing
 	request: { payload: unknown; headers: unknown },
-	// The secret comes from the webhook signing key, which is optional: an
-	// unset key is resolved as undefined. Allow the missing-value case in the
-	// type so callers and tests can pass it without a cast.
 	secret: string | undefined,
 ): { valid: boolean; error?: string } {
-	if (!secret) {
+	if (!secret?.trim()) {
 		return { valid: false, error: 'Missing webhook secret' };
 	}
 


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

Fixes https://github.com/corsairdev/corsair/issues/709

`verifyAsanaWebhookSignature` in `packages/asana/webhooks/types.ts` previously did not verify whether `secret` was present before running the HMAC calculation. An unconfigured or empty secret caused it to calculate signatures using an empty key without returning an explicit error message explaining the misconfiguration.

This PR adds a guard check at the top of `verifyAsanaWebhookSignature` to return `{ valid: false, error: 'Missing webhook secret' }` when `secret` is missing or empty.

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

<img width="751" height="90" alt="Screenshot 2026-08-19 122641" src="https://github.com/user-attachments/assets/8aa501fe-9432-4dab-9f40-83c40e1e6c9f" />


## Additional Notes

Includes comprehensive unit tests covering all signature verification error paths in `packages/asana/webhooks/types.test.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook signature validation by clearly reporting when the webhook secret is missing or empty.
  * Preserved validation for missing, invalid, and mismatched signatures.

* **Tests**
  * Added coverage for valid signatures, invalid signatures, missing headers, missing secrets, and signature-length mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->