### PR TITLE
fix(posthog): return error when webhook secret is missing

### DIFF
--- a/packages/posthog/webhooks/types.test.ts
+++ b/packages/posthog/webhooks/types.test.ts
@@ -1,0 +1,60 @@
+import * as crypto from 'node:crypto';
+import type { WebhookRequest } from 'corsair/core';
+import { verifyPostHogWebhookSignature } from './types';
+
+describe('verifyPostHogWebhookSignature', () => {
+	const secret = 'my-super-secret-token';
+
+	const requestWith = (
+		headers: Record<string, string | string[]>,
+		rawBody = JSON.stringify({ event: 'event.captured', distinct_id: 'x' }),
+	): WebhookRequest<unknown> => ({
+		payload: {},
+		headers,
+		rawBody,
+	});
+
+	it('should fail closed when webhook secret is missing', () => {
+		const result = verifyPostHogWebhookSignature(requestWith({}), '');
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('should return invalid when the signature header is missing', () => {
+		const result = verifyPostHogWebhookSignature(requestWith({}), secret);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing x-posthog-signature or x-signature header',
+		});
+	});
+
+	it('should return valid for a matching signature', () => {
+		const rawBody = JSON.stringify({
+			event: 'event.captured',
+			distinct_id: 'x',
+		});
+		const signature = `sha256=${createHmac(secret, rawBody)}`;
+		const result = verifyPostHogWebhookSignature(
+			requestWith({ 'x-posthog-signature': signature }, rawBody),
+			secret,
+		);
+		expect(result).toEqual({ valid: true });
+	});
+
+	it('should return invalid for a wrong signature', () => {
+		const result = verifyPostHogWebhookSignature(
+			requestWith({ 'x-posthog-signature': 'sha256=deadbeef' }),
+			secret,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid signature',
+		});
+	});
+});
+
+function createHmac(secret: string, body: string): string {
+	return crypto.createHmac('sha256', secret).update(body).digest('hex');
+}

--- a/packages/posthog/webhooks/types.test.ts
+++ b/packages/posthog/webhooks/types.test.ts
@@ -5,6 +5,11 @@ import { verifyPostHogWebhookSignature } from './types';
 describe('verifyPostHogWebhookSignature', () => {
 	const secret = 'my-super-secret-token';
 
+	/**
+	 * Helper to create a minimal webhook request for signature verification testing.
+	 * We use `unknown` as the generic parameter for `WebhookRequest` because the actual
+	 * payload content type is irrelevant to the signature validation logic.
+	 */
 	const requestWith = (
 		headers: Record<string, string | string[]>,
 		rawBody = JSON.stringify({ event: 'event.captured', distinct_id: 'x' }),
@@ -14,8 +19,16 @@ describe('verifyPostHogWebhookSignature', () => {
 		rawBody,
 	});
 
-	it('should fail closed when webhook secret is missing', () => {
+	it('should fail closed when webhook secret is missing (empty string)', () => {
 		const result = verifyPostHogWebhookSignature(requestWith({}), '');
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('should fail closed when webhook secret is missing (undefined)', () => {
+		const result = verifyPostHogWebhookSignature(requestWith({}));
 		expect(result).toEqual({
 			valid: false,
 			error: 'Missing webhook secret',

--- a/packages/posthog/webhooks/types.ts
+++ b/packages/posthog/webhooks/types.ts
@@ -60,7 +60,7 @@ export function verifyPostHogWebhookSignature(
 	webhookSecret?: string,
 ): { valid: boolean; error?: string } {
 	if (!webhookSecret) {
-		return { valid: false };
+		return { valid: false, error: 'Missing webhook secret' };
 	}
 
 	const rawBody = request.rawBody;


### PR DESCRIPTION
## Description

`verifyPostHogWebhookSignature` returned a bare `{ valid: false }` when the webhook secret wasn't configured, which made handlers fall back to a generic failure message and hid the real misconfiguration.

Now it fails closed with an explicit error, matching the pattern used across the other webhook verifiers (gitlab, resend, linear, etc.):

```ts
if (!webhookSecret) {
  return { valid: false, error: 'Missing webhook secret' };
}
```

## Tests

Added `packages/posthog/webhooks/types.test.ts` covering:
- missing secret → `Missing webhook secret`
- missing signature header → header error
- matching SHA-256 signature → valid
- wrong signature → `Invalid signature`

## Verification

- `pnpm --filter @corsair-dev/posthog exec jest webhooks/types.test.ts` — 4/4 pass
- `biome check` on both files — clean (formatted)
- `tsc --noEmit` — clean

Closes #689

## Screenshots / Demos
<img width="941" height="219" alt="Screenshot 2026-08-19 at 9 46 16 PM" src="https://github.com/user-attachments/assets/b27344fe-1c6a-41b0-bb65-5947f69b92e9" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook signature validation feedback when a webhook secret is missing.
  * Continued to reject requests with missing or invalid signatures while accepting valid signatures.
  * Webhook verification now clearly reports when required security configuration is absent.

* **Tests**
  * Added coverage for missing secrets, missing signature headers, valid signatures, and invalid signatures.
  * Expanded verification scenarios to ensure expected handling of HMAC-signed webhook requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->