### PR TITLE
test(twilio): add unit tests for verifyTwilioWebhookSignature

### DIFF
--- a/packages/twilio/webhooks/types.test.ts
+++ b/packages/twilio/webhooks/types.test.ts
@@ -1,0 +1,75 @@
+import crypto from 'crypto';
+import { verifyTwilioWebhookSignature } from './types';
+
+describe('verifyTwilioWebhookSignature', () => {
+	const url = 'https://example.com/api/twilio/webhook';
+	const authToken = 'auth_token_secret_123';
+	const params = {
+		AccountSid: 'AC123456789',
+		From: '+15005550006',
+		Body: 'Test Message',
+	};
+
+	function generateSignature(
+		endpointUrl: string,
+		payloadParams: Record<string, string>,
+		token: string,
+	): string {
+		const sortedKeys = Object.keys(payloadParams).sort();
+		let data = endpointUrl;
+		for (const key of sortedKeys) {
+			data += key + payloadParams[key];
+		}
+		return crypto.createHmac('sha1', token).update(data).digest('base64');
+	}
+
+	it('should return error when X-Twilio-Signature header is missing', () => {
+		const result = verifyTwilioWebhookSignature(url, params, '', authToken);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing X-Twilio-Signature header',
+		});
+	});
+
+	it('should return error when auth token is missing but signature header is provided', () => {
+		// Must supply signature so header check passes and reaches the auth token check
+		const signature = generateSignature(url, params, authToken);
+
+		const result = verifyTwilioWebhookSignature(url, params, signature, '');
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing auth token for verification',
+		});
+	});
+
+	it('should return failure when signature is incorrect', () => {
+		const invalidSignature = 'invalidBase64Signature=';
+
+		const result = verifyTwilioWebhookSignature(
+			url,
+			params,
+			invalidSignature,
+			authToken,
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Signature verification failed',
+		});
+	});
+
+	it('should return valid when signature matches HMAC-SHA1 over url and sorted params', () => {
+		const validSignature = generateSignature(url, params, authToken);
+
+		const result = verifyTwilioWebhookSignature(
+			url,
+			params,
+			validSignature,
+			authToken,
+		);
+
+		expect(result).toEqual({ valid: true });
+	});
+});


### PR DESCRIPTION
### Description

Adds unit tests for `verifyTwilioWebhookSignature` in `packages/twilio/webhooks/types.test.ts`.

Covers the following test cases in line with the signature verification logic:

* Missing `X-Twilio-Signature` header returns `'Missing X-Twilio-Signature header'` (validated first)
* Missing auth token returns `'Missing auth token for verification'` (when signature header is present)
* Incorrect/wrong HMAC-SHA1 signature returns invalid signature status
* Valid HMAC-SHA1 signature over `url + sorted(params)` (Base64) returns valid status

Follows the testing pattern of existing webhook tests (such as `packages/gitlab/webhooks/types.test.ts`).

Fixes #700 

---

### Checklist

* [x] Missing X-Twilio-Signature header returns error: `'Missing X-Twilio-Signature header'`
* [x] Missing auth token (with signature present) returns error: `'Missing auth token for verification'`
* [x] Wrong signature returns invalid status
* [x] Correct HMAC-SHA1 signature returns valid status
* [x] All test cases pass under package `jest` (`pnpm --filter twilio test -- webhooks/types.test.ts`)


---

### Screenshots / Demos (if applicable)

<img width="1272" height="500" alt="Screenshot 2026-08-19 at 11 33 55 AM" src="https://github.com/user-attachments/assets/c835a988-33d5-4006-b62f-58efa5a23122" />

---

#### Tests

* Added comprehensive unit test suite in `packages/twilio/webhooks/types.test.ts` covering missing headers, missing auth tokens, invalid HMAC-SHA1 signatures, and valid signature verification logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for Twilio webhook signature verification, including missing headers, missing authentication tokens, invalid signatures, and valid signatures.
  * Confirmed validation of HMAC-SHA1 signatures generated from webhook URLs and sorted parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->