### PR TITLE
feat(webhooks): honor hubVerified for managed provider webhooks

### DIFF
--- a/packages/corsair/core/webhooks/bind.ts
+++ b/packages/corsair/core/webhooks/bind.ts
@@ -57,7 +57,8 @@ export function bindWebhooksRecursively({
 					value.handler(callCtx, callRequest);
 
 				const key =
-					keyBuilder && !(request as { hubVerified?: boolean })?.hubVerified
+					keyBuilder &&
+					(request as { hubVerified?: boolean })?.hubVerified !== true
 						? await keyBuilder(ctx, 'webhook')
 						: undefined;
 

--- a/packages/corsair/core/webhooks/bind.ts
+++ b/packages/corsair/core/webhooks/bind.ts
@@ -56,7 +56,10 @@ export function bindWebhooksRecursively({
 				const call = (callCtx: Record<string, unknown>, callRequest: unknown) =>
 					value.handler(callCtx, callRequest);
 
-				const key = keyBuilder ? await keyBuilder(ctx, 'webhook') : undefined;
+				const key =
+					keyBuilder && !(request as { hubVerified?: boolean })?.hubVerified
+						? await keyBuilder(ctx, 'webhook')
+						: undefined;
 
 				if (!webhookHooks?.before && !webhookHooks?.after) {
 					return call({ ...ctx, key }, request);

--- a/packages/corsair/core/webhooks/index.ts
+++ b/packages/corsair/core/webhooks/index.ts
@@ -31,6 +31,12 @@ export type WebhookRequest<TPayload = unknown> = {
 	rawBody?: string;
 	/** Query string parameters when available. */
 	query?: Record<string, string | string[] | undefined>;
+	/**
+	 * Set by processWebhook when the Hub already verified the provider
+	 * signature (delivery arrived under a valid x-corsair-signature). When
+	 * true, per-plugin webhook signature verification is skipped.
+	 */
+	hubVerified?: boolean;
 };
 
 /**

--- a/packages/corsair/package.json
+++ b/packages/corsair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corsair",
-  "version": "0.1.117",
+  "version": "0.1.118",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/corsair/package.json
+++ b/packages/corsair/package.json
@@ -62,11 +62,6 @@
       "types": "./dist/tests.d.ts",
       "default": "./dist/tests.js"
     },
-    "./webhooks": {
-      "dev-source": "./webhooks.ts",
-      "types": "./dist/webhooks.d.ts",
-      "default": "./dist/webhooks.js"
-    },
     "./client/react": {
       "dev-source": "./client/react/index.ts",
       "types": "./dist/client/react/index.d.ts",

--- a/packages/corsair/package.json
+++ b/packages/corsair/package.json
@@ -62,6 +62,11 @@
       "types": "./dist/tests.d.ts",
       "default": "./dist/tests.js"
     },
+    "./webhooks": {
+      "dev-source": "./webhooks.ts",
+      "types": "./dist/webhooks.d.ts",
+      "default": "./dist/webhooks.js"
+    },
     "./client/react": {
       "dev-source": "./client/react/index.ts",
       "types": "./dist/client/react/index.d.ts",

--- a/packages/corsair/tunnel/index.ts
+++ b/packages/corsair/tunnel/index.ts
@@ -251,6 +251,7 @@ async function handleWebhookTunnel(
 	corsair: unknown,
 	internal: CorsairInternalConfig,
 	payload: WebhookTunnelPayload,
+	envelopeVerified: boolean,
 ): Promise<TunnelAck> {
 	const tenantId = await resolveWebhookTenantId(corsair, internal, payload);
 	const query = {
@@ -264,8 +265,14 @@ async function handleWebhookTunnel(
 		payload.body,
 		query,
 		// Hub routed this by the plugin's own endpoint — dispatch exactly there,
-		// never by body shape (MS Graph siblings are indistinguishable).
-		{ plugin: payload.plugin, hubVerified: payload.hubVerified },
+		// never by body shape (MS Graph siblings are indistinguishable). Only
+		// honor hubVerified when the envelope itself was authenticated — an
+		// unsigned tunnel delivery must never let a caller-supplied flag skip
+		// provider signature verification.
+		{
+			plugin: payload.plugin,
+			hubVerified: envelopeVerified && payload.hubVerified === true,
+		},
 	);
 
 	if (!result.plugin) {
@@ -573,6 +580,11 @@ export async function processCorsair(
 	);
 	const nonceHeader = normalizeHeader(request.headers, 'x-corsair-nonce');
 
+	// hubVerified may only be trusted once we have authenticated the envelope.
+	// Unsigned tunnel deliveries leave this false, so a caller-supplied
+	// hubVerified can never skip provider verification downstream.
+	let envelopeVerified = false;
+
 	if (!options.signingSecret?.trim()) {
 		if (!options.allowUnsignedTunnel) {
 			return {
@@ -615,6 +627,8 @@ export async function processCorsair(
 				error: replayCheck.error,
 			};
 		}
+
+		envelopeVerified = true;
 	}
 
 	let envelope: TunnelEnvelope;
@@ -643,6 +657,7 @@ export async function processCorsair(
 				corsair,
 				internal,
 				envelope.payload as WebhookTunnelPayload,
+				envelopeVerified,
 			);
 		case 'oauth.callback':
 			return handleOAuthCallbackTunnel(

--- a/packages/corsair/tunnel/index.ts
+++ b/packages/corsair/tunnel/index.ts
@@ -100,6 +100,8 @@ export type WebhookTunnelPayload = {
 	linkType?: string;
 	externalId?: string;
 	tenantId?: string;
+	/** Hub already verified the provider signature before signing this delivery. */
+	hubVerified?: boolean;
 };
 
 export type OAuthCallbackTunnelPayload = {
@@ -263,7 +265,7 @@ async function handleWebhookTunnel(
 		query,
 		// Hub routed this by the plugin's own endpoint — dispatch exactly there,
 		// never by body shape (MS Graph siblings are indistinguishable).
-		payload.plugin ? { plugin: payload.plugin } : undefined,
+		{ plugin: payload.plugin, hubVerified: payload.hubVerified },
 	);
 
 	if (!result.plugin) {

--- a/packages/corsair/webhooks.ts
+++ b/packages/corsair/webhooks.ts
@@ -1,0 +1,1 @@
+export * from './webhooks/index';

--- a/packages/corsair/webhooks.ts
+++ b/packages/corsair/webhooks.ts
@@ -1,1 +1,0 @@
-export * from './webhooks/index';

--- a/packages/corsair/webhooks/index.ts
+++ b/packages/corsair/webhooks/index.ts
@@ -190,6 +190,8 @@ export async function processWebhook(
 		 * wildcards.
 		 */
 		plugin?: string;
+		/** Hub already verified the provider signature; skip app-side re-verify. */
+		hubVerified?: boolean;
 	},
 ): Promise<WebhookFilterResult> {
 	const normalizedHeaders = normalizeHeaders(headers);
@@ -255,6 +257,7 @@ export async function processWebhook(
 			headers: normalizedHeaders,
 			rawBody: typeof body === 'string' ? body : JSON.stringify(body),
 			...(query ? { query } : {}),
+			...(options?.hubVerified ? { hubVerified: true } : {}),
 		};
 
 		try {

--- a/packages/github/jest.config.cjs
+++ b/packages/github/jest.config.cjs
@@ -44,6 +44,8 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/hub$': '<rootDir>/../corsair/hub.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',
 	},

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/github",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Github plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/github/webhooks.test.ts
+++ b/packages/github/webhooks.test.ts
@@ -1,0 +1,23 @@
+import type { WebhookRequest } from 'corsair/core';
+import { verifyGithubWebhookSignature } from './webhooks/types';
+
+describe('verifyGithubWebhookSignature', () => {
+	it('returns valid when the delivery is hub-verified, even with no secret', () => {
+		const request: WebhookRequest = {
+			payload: {},
+			headers: {},
+			rawBody: '{}',
+			hubVerified: true,
+		};
+		expect(verifyGithubWebhookSignature(request, undefined)).toEqual({
+			valid: true,
+		});
+	});
+
+	it('still fails a non-hub-verified request with no secret', () => {
+		const request: WebhookRequest = { payload: {}, headers: {}, rawBody: '{}' };
+		expect(verifyGithubWebhookSignature(request, undefined)).toEqual({
+			valid: false,
+		});
+	});
+});

--- a/packages/github/webhooks/types.ts
+++ b/packages/github/webhooks/types.ts
@@ -2182,7 +2182,7 @@ export function verifyGithubWebhookSignature(
 	request: WebhookRequest<unknown>,
 	webhookSecret?: string,
 ): { valid: boolean; error?: string } {
-	if (request.hubVerified) {
+	if (request.hubVerified === true) {
 		return { valid: true };
 	}
 	if (!webhookSecret) {

--- a/packages/github/webhooks/types.ts
+++ b/packages/github/webhooks/types.ts
@@ -2182,6 +2182,9 @@ export function verifyGithubWebhookSignature(
 	request: WebhookRequest<unknown>,
 	webhookSecret?: string,
 ): { valid: boolean; error?: string } {
+	if (request.hubVerified) {
+		return { valid: true };
+	}
 	if (!webhookSecret) {
 		return { valid: false };
 	}

--- a/packages/slack/jest.config.cjs
+++ b/packages/slack/jest.config.cjs
@@ -47,6 +47,8 @@ module.exports = {
 		'^corsair/core$': '<rootDir>/../corsair/core.ts',
 		'^corsair/hub$': '<rootDir>/../corsair/hub.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^corsair/webhooks$': '<rootDir>/../corsair/webhooks.ts',
+		'^corsair/tests$': '<rootDir>/../corsair/tests.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',
 	},
 	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],

--- a/packages/slack/jest.config.cjs
+++ b/packages/slack/jest.config.cjs
@@ -44,10 +44,10 @@ module.exports = {
 		],
 	},
 	moduleNameMapper: {
+		'^corsair$': '<rootDir>/../corsair/index.ts',
 		'^corsair/core$': '<rootDir>/../corsair/core.ts',
 		'^corsair/hub$': '<rootDir>/../corsair/hub.ts',
 		'^corsair/http$': '<rootDir>/../corsair/http.ts',
-		'^corsair/webhooks$': '<rootDir>/../corsair/webhooks.ts',
 		'^corsair/tests$': '<rootDir>/../corsair/tests.ts',
 		'^(\\.\\.?/.*)\\.js$': '$1',
 	},

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/slack",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Slack plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/slack/webhooks.integration.test.ts
+++ b/packages/slack/webhooks.integration.test.ts
@@ -1,4 +1,4 @@
-import { processWebhook } from 'corsair';
+import { processCorsair, processWebhook } from 'corsair';
 import { createCorsair } from 'corsair/core';
 import { createIntegrationAndAccount, createTestDatabase } from 'corsair/tests';
 import { slack } from './index';
@@ -46,10 +46,37 @@ describe('slack webhook — hubVerified skips app-side verification', () => {
 			{ plugin: 'slack', hubVerified: true },
 		);
 		expect(result.response?.success).toBe(true);
-		// ponytail: cast needed — returnToSender fields are merged at runtime but not in WebhookResponse type
 		expect((result.response as Record<string, unknown>)?.['challenge']).toBe(
 			'chal-123',
 		);
+		testDb.cleanup();
+	});
+});
+
+describe('slack webhook — unsigned tunnel must not trust hubVerified', () => {
+	it('drops caller-supplied hubVerified on an unsigned tunnel delivery', async () => {
+		const { corsair, testDb } = await buildCorsair();
+		const envelope = JSON.stringify({
+			type: 'webhook',
+			payload: {
+				plugin: 'slack',
+				headers: { 'content-type': 'application/json' },
+				body: challengeBody,
+				// Attacker-controlled: an unsigned envelope claiming Hub verification.
+				hubVerified: true,
+			},
+		});
+
+		const ack = await processCorsair(
+			corsair,
+			{ headers: {}, body: envelope },
+			{ allowUnsignedTunnel: true },
+		);
+
+		// The envelope is unauthenticated, so hubVerified is ignored and provider
+		// signature verification still runs — the forged event fails closed.
+		expect(ack.status).toBe('failed');
+		expect(String(ack.error)).toContain('webhook_signature');
 		testDb.cleanup();
 	});
 });

--- a/packages/slack/webhooks.integration.test.ts
+++ b/packages/slack/webhooks.integration.test.ts
@@ -1,6 +1,6 @@
+import { processWebhook } from 'corsair';
 import { createCorsair } from 'corsair/core';
 import { createIntegrationAndAccount, createTestDatabase } from 'corsair/tests';
-import { processWebhook } from 'corsair/webhooks';
 import { slack } from './index';
 
 async function buildCorsair() {

--- a/packages/slack/webhooks.integration.test.ts
+++ b/packages/slack/webhooks.integration.test.ts
@@ -1,0 +1,55 @@
+import { createCorsair } from 'corsair/core';
+import { createIntegrationAndAccount, createTestDatabase } from 'corsair/tests';
+import { processWebhook } from 'corsair/webhooks';
+import { slack } from './index';
+
+async function buildCorsair() {
+	const testDb = createTestDatabase();
+	await createIntegrationAndAccount(testDb.db, 'slack');
+	const corsair = createCorsair({
+		plugins: [slack()], // no signingSecret, no stored webhook signature
+		database: testDb.db,
+		kek: process.env.CORSAIR_KEK ?? 'test-kek-0123456789abcdef0123456789abcdef',
+	});
+	await corsair.slack.keys.issue_new_dek();
+	return { corsair, testDb };
+}
+
+const challengeBody = JSON.stringify({
+	type: 'url_verification',
+	token: 'x',
+	challenge: 'chal-123',
+});
+
+describe('slack webhook — hubVerified skips app-side verification', () => {
+	it('without hubVerified: keyBuilder throws → handler reports failure', async () => {
+		const { corsair, testDb } = await buildCorsair();
+		const result = await processWebhook(
+			corsair,
+			{ 'content-type': 'application/json' },
+			challengeBody,
+			{},
+			{ plugin: 'slack' },
+		);
+		expect(result.response?.success).toBe(false);
+		expect(String(result.response?.error)).toContain('webhook_signature');
+		testDb.cleanup();
+	});
+
+	it('with hubVerified: verification is skipped and the challenge echoes', async () => {
+		const { corsair, testDb } = await buildCorsair();
+		const result = await processWebhook(
+			corsair,
+			{ 'content-type': 'application/json' },
+			challengeBody,
+			{},
+			{ plugin: 'slack', hubVerified: true },
+		);
+		expect(result.response?.success).toBe(true);
+		// ponytail: cast needed — returnToSender fields are merged at runtime but not in WebhookResponse type
+		expect((result.response as Record<string, unknown>)?.['challenge']).toBe(
+			'chal-123',
+		);
+		testDb.cleanup();
+	});
+});

--- a/packages/slack/webhooks.integration.test.ts
+++ b/packages/slack/webhooks.integration.test.ts
@@ -56,27 +56,30 @@ describe('slack webhook — hubVerified skips app-side verification', () => {
 describe('slack webhook — unsigned tunnel must not trust hubVerified', () => {
 	it('drops caller-supplied hubVerified on an unsigned tunnel delivery', async () => {
 		const { corsair, testDb } = await buildCorsair();
-		const envelope = JSON.stringify({
-			type: 'webhook',
-			payload: {
-				plugin: 'slack',
-				headers: { 'content-type': 'application/json' },
-				body: challengeBody,
-				// Attacker-controlled: an unsigned envelope claiming Hub verification.
-				hubVerified: true,
-			},
-		});
+		try {
+			const envelope = JSON.stringify({
+				type: 'webhook',
+				payload: {
+					plugin: 'slack',
+					headers: { 'content-type': 'application/json' },
+					body: challengeBody,
+					// Attacker-controlled: an unsigned envelope claiming Hub verification.
+					hubVerified: true,
+				},
+			});
 
-		const ack = await processCorsair(
-			corsair,
-			{ headers: {}, body: envelope },
-			{ allowUnsignedTunnel: true },
-		);
+			const ack = await processCorsair(
+				corsair,
+				{ headers: {}, body: envelope },
+				{ allowUnsignedTunnel: true },
+			);
 
-		// The envelope is unauthenticated, so hubVerified is ignored and provider
-		// signature verification still runs — the forged event fails closed.
-		expect(ack.status).toBe('failed');
-		expect(String(ack.error)).toContain('webhook_signature');
-		testDb.cleanup();
+			// The envelope is unauthenticated, so hubVerified is ignored and provider
+			// signature verification still runs — the forged event fails closed.
+			expect(ack.status).toBe('failed');
+			expect(String(ack.error)).toContain('webhook_signature');
+		} finally {
+			testDb.cleanup();
+		}
 	});
 });

--- a/packages/slack/webhooks.test.ts
+++ b/packages/slack/webhooks.test.ts
@@ -26,4 +26,16 @@ describe('verifySlackWebhookSignature', () => {
 			error: 'Missing x-slack-signature or x-slack-request-timestamp header',
 		});
 	});
+
+	it('returns valid when the delivery is hub-verified, even with no secret', () => {
+		const hubVerified: WebhookRequest = {
+			payload: {},
+			headers: {},
+			rawBody: '{}',
+			hubVerified: true,
+		};
+		expect(verifySlackWebhookSignature(hubVerified, undefined)).toEqual({
+			valid: true,
+		});
+	});
 });

--- a/packages/slack/webhooks/types.ts
+++ b/packages/slack/webhooks/types.ts
@@ -909,6 +909,9 @@ export function verifySlackWebhookSignature(
 	request: WebhookRequest,
 	signingSecret?: string,
 ): { valid: boolean; error?: string } {
+	if (request.hubVerified) {
+		return { valid: true };
+	}
 	if (!signingSecret) {
 		return { valid: false, error: 'Missing webhook secret' };
 	}

--- a/packages/slack/webhooks/types.ts
+++ b/packages/slack/webhooks/types.ts
@@ -909,7 +909,7 @@ export function verifySlackWebhookSignature(
 	request: WebhookRequest,
 	signingSecret?: string,
 ): { valid: boolean; error?: string } {
-	if (request.hubVerified) {
+	if (request.hubVerified === true) {
 		return { valid: true };
 	}
 	if (!signingSecret) {


### PR DESCRIPTION
## What & why

Managed provider webhooks (one shared Corsair Slack/GitHub app = one webhook URL) failed app-side with `[auth-missing:slack:webhook_signature]` because the SDK re-verified the provider signature even though the Hub had already verified it and signed the delivery. This makes the SDK honor the Hub's `hubVerified` signal and skip its own provider-signature re-verification for those deliveries.

Pairs with the Hub managed-webhook-fan-in PR (the side that sends `hubVerified: true`). Together they unblock managed webhooks end-to-end — no customer signing secret required.

## Changes

- `WebhookRequest` gains optional `hubVerified?: boolean`.
- Threaded end-to-end: `WebhookTunnelPayload` → `handleWebhookTunnel` → `processWebhook` options → `webhookRequest`.
- `bind.ts` skips the `keyBuilder` call when the request is hub-verified (the origin of the old `[auth-missing:...]` throw).
- `verifySlackWebhookSignature` / `verifyGithubWebhookSignature` short-circuit to `{ valid: true }` when `request.hubVerified` is set.

## Security

The skip fires only when the delivery arrived under a valid `x-corsair-signature` (already verified by `processCorsair` before dispatch). A direct-to-app delivery carries no `hubVerified` and still verifies; an attacker cannot set it without the signing secret. Self-hosted (no-Hub) resolution is untouched.

## Versions

- `corsair` 0.1.117 → 0.1.118
- `@corsair-dev/slack` 0.1.6 → 0.1.7
- `@corsair-dev/github` 0.1.15 → 0.1.16

## Verified

Live E2E against real Slack (two workspaces → two tenants) and GitHub (one installation → two tenants, fan-out): every event delivers to the correct tenant with no app-side signing secret.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook requests can indicate that provider signature verification was completed by the webhook hub.
  * GitHub and Slack webhooks recognize authenticated hub-verified requests without requiring an additional app-side secret or signature check.
* **Bug Fixes**
  * Only explicitly verified requests can skip provider signature validation.
  * Unauthenticated tunnel deliveries no longer bypass webhook verification.
* **Tests**
  * Added coverage for verified, unverified, and unsigned tunnel webhook requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->