### PR TITLE
fix(tunnel): ensure the frpc binary is executable before spawn

### DIFF
--- a/packages/corsair/hub/tunnel/frpc-binary.ts
+++ b/packages/corsair/hub/tunnel/frpc-binary.ts
@@ -79,9 +79,11 @@ export function frpcCacheBinary(): string {
 function ensureExecutable(bin: string): string {
 	if (process.platform === 'win32') return bin;
 	try {
-		const { mode } = statSync(bin);
-		const executable = mode | 0o111;
-		if (executable !== mode) chmodSync(bin, executable);
+		// Mask to the permission bits — fs.Stats.mode also carries file-type bits
+		// that must not be handed to chmod.
+		const perms = statSync(bin).mode & 0o777;
+		const executable = perms | 0o111;
+		if (executable !== perms) chmodSync(bin, executable);
 	} catch {
 		// A chmod failure on an already-executable binary is harmless; a
 		// genuinely missing bit surfaces as the existing spawn EACCES.

--- a/packages/corsair/hub/tunnel/frpc-binary.ts
+++ b/packages/corsair/hub/tunnel/frpc-binary.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { chmodSync, existsSync, statSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -69,15 +69,35 @@ export function frpcCacheBinary(): string {
  * then the postinstall download cache as a fallback. Throws with an install hint
  * if none resolves.
  */
+/**
+ * Ensure the resolved frpc binary carries the executable bit. Published npm
+ * tarballs and some package stores drop it, which makes spawn() fail with
+ * EACCES. Only touches the mode when a bit is missing; a no-op on Windows
+ * (frpc.exe needs none) and best-effort elsewhere — a read-only store that
+ * already has the bit still runs.
+ */
+function ensureExecutable(bin: string): string {
+	if (process.platform === 'win32') return bin;
+	try {
+		const { mode } = statSync(bin);
+		const executable = mode | 0o111;
+		if (executable !== mode) chmodSync(bin, executable);
+	} catch {
+		// A chmod failure on an already-executable binary is harmless; a
+		// genuinely missing bit surfaces as the existing spawn EACCES.
+	}
+	return bin;
+}
+
 export function resolveFrpcBinary(): string {
 	const override = process.env.CORSAIR_FRP_BIN;
-	if (override && existsSync(override)) return override;
+	if (override && existsSync(override)) return ensureExecutable(override);
 
 	const fromPackage = platformPackageBinary();
-	if (fromPackage) return fromPackage;
+	if (fromPackage) return ensureExecutable(fromPackage);
 
 	const cached = frpcCacheBinary();
-	if (existsSync(cached)) return cached;
+	if (existsSync(cached)) return ensureExecutable(cached);
 
 	// pnpm 10 skips a dependency's postinstall until the consumer approves its
 	// build, which leaves this cache empty — name that remedy explicitly.

--- a/packages/corsair/package.json
+++ b/packages/corsair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corsair",
-  "version": "0.1.117",
+  "version": "0.1.118",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/corsair/package.json
+++ b/packages/corsair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corsair",
-  "version": "0.1.118",
+  "version": "0.1.119",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/corsair/tests/frpc-binary.test.ts
+++ b/packages/corsair/tests/frpc-binary.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { frpcPlatformKey, resolveFrpcBinary } from '../hub/tunnel/frpc-binary';
@@ -19,6 +19,19 @@ describe('resolveFrpcBinary', () => {
 		writeFileSync(fake, '#!/bin/sh\n');
 		process.env.CORSAIR_FRP_BIN = fake;
 		expect(resolveFrpcBinary()).toBe(fake);
+	});
+
+	it('adds the executable bit to a resolved binary that lacks it', () => {
+		// Windows frpc.exe needs no execute bit.
+		if (process.platform === 'win32') return;
+
+		const bin = join(mkdtempSync(join(tmpdir(), 'frpc-')), 'frpc');
+		writeFileSync(bin, '#!/bin/sh\nexit 0\n');
+		chmodSync(bin, 0o644); // no execute bits
+		process.env.CORSAIR_FRP_BIN = bin;
+
+		expect(resolveFrpcBinary()).toBe(bin);
+		expect(statSync(bin).mode & 0o111).not.toBe(0);
 	});
 
 	it('ignores a CORSAIR_FRP_BIN that does not exist', () => {


### PR DESCRIPTION
## What

The per-platform `frpc` binary can lose its executable bit (npm tarball
extraction and some package stores don't preserve it), so `spawn(frpc)` fails
with `EACCES` and the dev tunnel won't start until the user runs `chmod +x`
manually.

## Fix

`resolveFrpcBinary()` now ensures the resolved binary is executable — it adds
any missing execute bits (best-effort, no-op on Windows) for the
`CORSAIR_FRP_BIN` override, the platform optional-dependency package, and the
download cache. One runtime guard covers all six platform packages without
republishing them.

## Test

Added a case to `tests/frpc-binary.test.ts`: a resolved binary with mode `0o644`
comes back with the execute bit set. Suite green.

## Version

`corsair` 0.1.117 -> 0.1.118.

> Heads up: corsairdev/corsair#848 also targets 0.1.118. Whichever lands second should rebase to 0.1.119.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved tunnel binaries are now made executable automatically on supported non-Windows platforms.
  - This applies to configured overrides, optional packages, and cached binaries, improving startup reliability when permissions are missing.

- **Tests**
  - Added coverage verifying that configured binaries receive the required execute permissions.

- **Chores**
  - Updated the Corsair package version to 0.1.119.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->