### PR TITLE
fix(figma): fail closed when webhook passcode is missing

### DIFF
--- a/packages/figma/webhooks/types.test.ts
+++ b/packages/figma/webhooks/types.test.ts
@@ -1,0 +1,73 @@
+import { verifyFigmaWebhookPasscode } from './types';
+
+// Regression for #685: verifyFigmaWebhookPasscode never checked the configured
+// passcode before timingSafeEqual, so an empty passcode fell into the
+// length-mismatch catch and surfaced as a vague 'Invalid passcode'. The verifier
+// now fails closed with a clear configuration error.
+
+function requestWith(payload: unknown) {
+	return { payload, headers: {} };
+}
+
+describe('verifyFigmaWebhookPasscode', () => {
+	const passcode = 'figma-webhook-passcode';
+
+	it('fails closed when the configured passcode is empty', () => {
+		const result = verifyFigmaWebhookPasscode(
+			requestWith({ event_type: 'PING', passcode }),
+			'',
+		);
+		expect(result).toEqual({ valid: false, error: 'Missing webhook passcode' });
+	});
+
+	it('fails closed when the configured passcode is missing', () => {
+		const result = verifyFigmaWebhookPasscode(
+			requestWith({ event_type: 'PING', passcode }),
+			undefined as unknown as string,
+		);
+		expect(result).toEqual({ valid: false, error: 'Missing webhook passcode' });
+	});
+
+	it('accepts a matching payload passcode', () => {
+		const result = verifyFigmaWebhookPasscode(
+			requestWith({ event_type: 'PING', passcode }),
+			passcode,
+		);
+		expect(result).toEqual({ valid: true, error: undefined });
+	});
+
+	it('accepts a matching payload passcode when the payload is a JSON string', () => {
+		const result = verifyFigmaWebhookPasscode(
+			requestWith(JSON.stringify({ event_type: 'PING', passcode })),
+			passcode,
+		);
+		expect(result).toEqual({ valid: true, error: undefined });
+	});
+
+	it('rejects a mismatched payload passcode of equal length', () => {
+		const result = verifyFigmaWebhookPasscode(
+			requestWith({ event_type: 'PING', passcode: 'figma-webhook-passcodX' }),
+			passcode,
+		);
+		expect(result).toEqual({ valid: false, error: 'Invalid passcode' });
+	});
+
+	it('rejects a mismatched payload passcode of a different length', () => {
+		const result = verifyFigmaWebhookPasscode(
+			requestWith({ event_type: 'PING', passcode: 'short' }),
+			passcode,
+		);
+		expect(result).toEqual({ valid: false, error: 'Invalid passcode' });
+	});
+
+	it('rejects a payload without a passcode', () => {
+		const result = verifyFigmaWebhookPasscode(
+			requestWith({ event_type: 'PING' }),
+			passcode,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing passcode in payload',
+		});
+	});
+});

--- a/packages/figma/webhooks/types.test.ts
+++ b/packages/figma/webhooks/types.test.ts
@@ -5,6 +5,7 @@ import { verifyFigmaWebhookPasscode } from './types';
 // length-mismatch catch and surfaced as a vague 'Invalid passcode'. The verifier
 // now fails closed with a clear configuration error.
 
+// type: unknown is used to simulate arbitrary payload shapes for testing
 function requestWith(payload: unknown) {
 	return { payload, headers: {} };
 }
@@ -23,6 +24,7 @@ describe('verifyFigmaWebhookPasscode', () => {
 	it('fails closed when the configured passcode is missing', () => {
 		const result = verifyFigmaWebhookPasscode(
 			requestWith({ event_type: 'PING', passcode }),
+			// type assertion: passing undefined to test runtime missing passcode guard
 			undefined as unknown as string,
 		);
 		expect(result).toEqual({ valid: false, error: 'Missing webhook passcode' });

--- a/packages/figma/webhooks/types.ts
+++ b/packages/figma/webhooks/types.ts
@@ -93,6 +93,10 @@ export function verifyFigmaWebhookPasscode(
 	request: WebhookRequest<unknown>,
 	passcode: string,
 ): { valid: boolean; error?: string } {
+	if (!passcode) {
+		return { valid: false, error: 'Missing webhook passcode' };
+	}
+
 	// type assertion: parsed payload shape is unknown at runtime; narrowed to Record to access passcode field
 	const parsedBody = parseBody(request.payload) as Record<string, unknown>;
 	const payloadPasscode = parsedBody.passcode;


### PR DESCRIPTION
## Description

Fixes #685.

`verifyFigmaWebhookPasscode` in `packages/figma/webhooks/types.ts` never checked the configured `passcode` before calling `crypto.timingSafeEqual`. With an empty or missing passcode, `Buffer.from('')` has length 0, `timingSafeEqual` throws on the length mismatch, and the `catch` returned a vague `Invalid passcode` instead of a clear configuration error.

This PR adds a guard at the top of the verifier so it fails closed with an explicit error:

```ts
if (!passcode) {
	return { valid: false, error: 'Missing webhook passcode' };
}
```

The rest of the verifier is untouched: the `Missing passcode in payload` check, the `timingSafeEqual` comparison and the `Invalid passcode` outcomes are all preserved. Scope is a single plugin package (`packages/figma/`).

Unit tests in `packages/figma/webhooks/types.test.ts` cover:
- empty configured passcode -> `{ valid: false, error: 'Missing webhook passcode' }`
- missing (undefined) configured passcode -> `{ valid: false, error: 'Missing webhook passcode' }`
- matching payload passcode (object payload and JSON-string payload) -> `{ valid: true }`
- mismatched payload passcode, equal length and different length -> `Invalid passcode`
- payload without a passcode -> `Missing passcode in payload`

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation (no docs change needed; internal verifier behaviour only)

## Screenshots / Demos (if applicable)

There is no UI or CLI output to record for this change; the working proof is the unit test run on this PR in CI ("CI Checks" job): https://github.com/corsairdev/corsair/pull/854/checks , which executes `packages/figma/webhooks/types.test.ts`.

No UI or CLI output. This is a fail-closed fix to an internal webhook verification helper. The behaviour is covered by the 7 unit tests in `packages/figma/webhooks/types.test.ts`:

```
Tests:       7 passed, 7 total
```

The two fail-closed tests fail against the previous implementation (they got `Invalid passcode`) and pass with this change.

## Additional Notes

No new dependencies. No breaking changes: callers that pass a real passcode see identical results; only callers with an empty passcode see a different (clearer) error string.

Checks were run at the package level for `packages/figma` (biome check on the changed files, `tsc --noEmit`, `tsc --build && tsup`, `jest`), because `better-sqlite3` does not build under Node 26 on my machine so the full root install needed `--ignore-scripts`. `packages/figma/api.test.ts` needs `FIGMA_API_KEY` and fails identically on `main`.

This change was made with AI assistance (Claude Code) and reviewed by the author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook passcode validation when no passcode is configured or supplied.
  * Missing passcodes now produce a clear validation error without attempting further payload processing.

* **Tests**
  * Added coverage for valid payloads, JSON payload strings, mismatched passcodes, missing passcodes, and empty configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->