### PR TITLE
fix(outlook): use constant-time comparison for clientState

### DIFF
--- a/packages/outlook/webhooks/types.ts
+++ b/packages/outlook/webhooks/types.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import type {
 	CorsairWebhookMatcher,
 	RawWebhookRequest,
@@ -127,10 +128,16 @@ export function verifyOutlookWebhookSignature(
 		return { valid: false, error: 'Missing client state' };
 	}
 
+	const expected = Buffer.from(clientState);
 	const notifications = request.payload?.value ?? [];
-	const allMatch = notifications.every(
-		(n) => typeof n.clientState === 'string' && n.clientState === clientState,
-	);
+	const allMatch = notifications.every((n) => {
+		if (typeof n.clientState !== 'string') return false;
+		const actual = Buffer.from(n.clientState);
+		return (
+			actual.length === expected.length &&
+			crypto.timingSafeEqual(actual, expected)
+		);
+	});
 
 	if (!allMatch) {
 		return { valid: false, error: 'Client state mismatch' };

--- a/packages/outlook/webhooks/verify-client-state.test.ts
+++ b/packages/outlook/webhooks/verify-client-state.test.ts
@@ -1,0 +1,71 @@
+import type { WebhookRequest } from 'corsair/core';
+import type { OutlookWebhookPayload } from './types';
+import { verifyOutlookWebhookSignature } from './types';
+
+// Regression for #683: verifyOutlookWebhookSignature compared clientState with
+// `===`, which is not constant-time. The comparison now uses timingSafeEqual
+// after a length check, while preserving the valid/invalid outcomes.
+
+function requestWith(
+	...clientStates: (string | undefined)[]
+): WebhookRequest<OutlookWebhookPayload> {
+	return {
+		payload: { value: clientStates.map((clientState) => ({ clientState })) },
+		headers: {},
+	};
+}
+
+describe('verifyOutlookWebhookSignature', () => {
+	it('accepts a matching clientState', () => {
+		const result = verifyOutlookWebhookSignature(
+			requestWith('secret-state'),
+			'secret-state',
+		);
+		expect(result).toEqual({ valid: true });
+	});
+
+	it('accepts when every notification matches', () => {
+		const result = verifyOutlookWebhookSignature(
+			requestWith('secret-state', 'secret-state'),
+			'secret-state',
+		);
+		expect(result).toEqual({ valid: true });
+	});
+
+	it('rejects a mismatched clientState of equal length', () => {
+		const result = verifyOutlookWebhookSignature(
+			requestWith('wrong-secret1'),
+			'secret-state1',
+		);
+		expect(result).toEqual({ valid: false, error: 'Client state mismatch' });
+	});
+
+	it('rejects a clientState of a different length', () => {
+		const result = verifyOutlookWebhookSignature(
+			requestWith('short'),
+			'secret-state',
+		);
+		expect(result).toEqual({ valid: false, error: 'Client state mismatch' });
+	});
+
+	it('rejects when any notification does not match', () => {
+		const result = verifyOutlookWebhookSignature(
+			requestWith('secret-state', 'other-state1'),
+			'secret-state',
+		);
+		expect(result).toEqual({ valid: false, error: 'Client state mismatch' });
+	});
+
+	it('rejects a missing clientState', () => {
+		const result = verifyOutlookWebhookSignature(
+			requestWith(undefined),
+			'secret-state',
+		);
+		expect(result).toEqual({ valid: false, error: 'Client state mismatch' });
+	});
+
+	it('errors when the expected clientState is empty', () => {
+		const result = verifyOutlookWebhookSignature(requestWith('anything'), '');
+		expect(result).toEqual({ valid: false, error: 'Missing client state' });
+	});
+});


### PR DESCRIPTION
## Description

Fixes #683.

`verifyOutlookWebhookSignature` in `packages/outlook/webhooks/types.ts` compared each notification's `clientState` with `===`, which is not constant-time and can leak timing information about the configured value.

This PR replaces the `===` comparison with `crypto.timingSafeEqual` after an equal-length check on `Buffer.from(...)` values, matching the pattern merged for Teams in #828:

```ts
const expected = Buffer.from(clientState);
const allMatch = notifications.every((n) => {
	if (typeof n.clientState !== 'string') return false;
	const actual = Buffer.from(n.clientState);
	return (
		actual.length === expected.length &&
		crypto.timingSafeEqual(actual, expected)
	);
});
```

The rest of the verifier is untouched: the existing `Missing client state` guard stays, the `typeof n.clientState === 'string'` check stays, and the empty `value[]` behaviour is unchanged (that is #625 / PR #626, out of scope here). All valid/invalid outcomes are preserved. Scope is a single plugin package (`packages/outlook/`).

Unit tests in `packages/outlook/webhooks/verify-client-state.test.ts` cover:
- matching clientState (single and multiple notifications) -> `{ valid: true }`
- equal-length mismatch -> `Client state mismatch`
- different-length mismatch -> `Client state mismatch`
- one mismatching notification among matching ones -> `Client state mismatch`
- missing clientState on a notification -> `Client state mismatch`
- empty expected clientState -> `Missing client state`

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation (no docs change needed; verifier behaviour is unchanged)

## Screenshots / Demos (if applicable)

There is no UI or CLI output to record for this change; the working proof is the unit test run on this PR in CI ("CI Checks" job): https://github.com/corsairdev/corsair/pull/855/checks , which executes `packages/outlook/webhooks/verify-client-state.test.ts`.

No UI or CLI output. This is a security hardening change to an internal webhook verification helper, covered by the 7 unit tests in `packages/outlook/webhooks/verify-client-state.test.ts`:

```
Tests:       7 passed, 7 total
```

Because this is a timing fix rather than a behavioural one, the outcome-level tests pass against both the old `===` and the new `timingSafeEqual` implementation; they lock in that the rewrite preserves every valid/invalid result, while the security property comes from `timingSafeEqual` with a length guard.

## Additional Notes

No new dependencies (`node:crypto` is built in). No breaking changes. Distinct from #625 / #626 (empty `value[]` handling); this PR does not change that behaviour, though both touch the same `every` block so whichever lands second will need a trivial rebase. The test file is named `verify-client-state.test.ts` to avoid an add/add conflict with #626's `types.test.ts`.

Checks were run at the package level for `packages/outlook` (biome check on the changed files, `tsc --noEmit`, `tsc --build && tsup`, `jest`), because `better-sqlite3` does not build under Node 26 on my machine so the full root install needed `--ignore-scripts`. `packages/outlook/api.test.ts` makes live Graph calls and fails identically on `main`.

This change was made with AI assistance (Claude Code) and reviewed by the author.
