### PR TITLE
feat: merge instead of overwrite on webhooks

### DIFF
--- a/packages/github/endpoints/comments.ts
+++ b/packages/github/endpoints/comments.ts
@@ -1,6 +1,7 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeGithubRequest } from '../client';
 import type { GithubEndpoints } from '../index';
+import { commentRecordFromApi } from '../persistence';
 import type {
 	CommentGetResponse,
 	CommentsListResponse,
@@ -10,19 +11,13 @@ import type {
 async function upsertComment(
 	db: Parameters<GithubEndpoints['commentsGet']>[0]['db'],
 	comment: CommentGetResponse,
+	extras?: { deletedAt?: Date | null },
 ) {
 	if (!db.comments) return;
-	await db.comments.upsertByEntityId(comment.id.toString(), {
-		id: comment.id,
-		nodeId: comment.nodeId,
-		url: comment.url,
-		htmlUrl: comment.htmlUrl,
-		issueUrl: comment.issueUrl,
-		body: comment.body,
-		authorAssociation: comment.authorAssociation,
-		createdAt: comment.createdAt ? new Date(comment.createdAt) : null,
-		updatedAt: comment.updatedAt ? new Date(comment.updatedAt) : null,
-	});
+	await db.comments.upsertByEntityId(
+		comment.id.toString(),
+		commentRecordFromApi(comment, extras),
+	);
 }
 
 export const list: GithubEndpoints['commentsList'] = async (ctx, input) => {
@@ -149,20 +144,12 @@ export const deleteComment: GithubEndpoints['commentsDelete'] = async (
 
 	if (ctx.db.comments) {
 		try {
-			await ctx.db.comments.upsertByEntityId(commentId.toString(), {
-				id: commentId,
-				...(existing && {
-					nodeId: existing.nodeId,
-					url: existing.url,
-					htmlUrl: existing.htmlUrl,
-					issueUrl: existing.issueUrl,
-					body: existing.body,
-					authorAssociation: existing.authorAssociation,
-					createdAt: existing.createdAt ? new Date(existing.createdAt) : null,
-					updatedAt: existing.updatedAt ? new Date(existing.updatedAt) : null,
-				}),
-				deletedAt: new Date(),
-			});
+			await ctx.db.comments.upsertByEntityId(
+				commentId.toString(),
+				existing
+					? commentRecordFromApi(existing, { deletedAt: new Date() })
+					: { id: commentId, deletedAt: new Date() },
+			);
 		} catch (error) {
 			console.warn('Failed to mark comment as deleted in database:', error);
 		}

--- a/packages/github/endpoints/issues.ts
+++ b/packages/github/endpoints/issues.ts
@@ -1,6 +1,7 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeGithubRequest } from '../client';
 import type { GithubBoundEndpoints, GithubEndpoints } from '../index';
+import { commentRecordFromApi } from '../persistence';
 import type {
 	CommentCreateResponse,
 	IssueCreateResponse,
@@ -124,16 +125,10 @@ export const createComment: GithubEndpoints['issuesCreateComment'] = async (
 		try {
 			// Save the comment itself
 			if (ctx.db.comments) {
-				await ctx.db.comments.upsertByEntityId(result.id.toString(), {
-					id: result.id,
-					nodeId: result.nodeId,
-					url: result.url,
-					htmlUrl: result.htmlUrl,
-					issueUrl: result.issueUrl,
-					body: result.body,
-					createdAt: result.createdAt ? new Date(result.createdAt) : null,
-					updatedAt: result.updatedAt ? new Date(result.updatedAt) : null,
-				});
+				await ctx.db.comments.upsertByEntityId(
+					result.id.toString(),
+					commentRecordFromApi(result),
+				);
 			}
 
 			// Refresh the parent issue comment count

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/github",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Github plugin for Corsair",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/github/persistence.test.ts
+++ b/packages/github/persistence.test.ts
@@ -1,0 +1,180 @@
+import {
+	commentRecordFromApi,
+	commentRecordFromWebhook,
+	issueRecordFromWebhook,
+	pullRequestRecordFromWebhook,
+} from './persistence';
+import type { Comment, Issue, PullRequest } from './webhooks/types';
+
+describe('github persistence', () => {
+	it('commentRecordFromApi keeps user login', () => {
+		const record = commentRecordFromApi({
+			id: 1,
+			body: 'hello',
+			user: {
+				id: 42,
+				login: 'octocat',
+				avatar_url: 'https://example.com/a.png',
+			},
+		});
+
+		expect(record.user).toEqual({
+			id: 42,
+			login: 'octocat',
+			avatarUrl: 'https://example.com/a.png',
+		});
+	});
+
+	it('commentRecordFromWebhook keeps user login', () => {
+		const record = commentRecordFromWebhook({
+			id: 1,
+			node_id: 'IC_1',
+			url: 'https://api.github.com/comments/1',
+			html_url: 'https://github.com/o/r/issues/2#issuecomment-1',
+			issue_url: 'https://api.github.com/repos/o/r/issues/2',
+			body: 'hello',
+			author_association: 'MEMBER',
+			created_at: '2024-01-01T00:00:00Z',
+			updated_at: '2024-01-01T00:00:00Z',
+			user: {
+				login: 'octocat',
+				id: 42,
+				node_id: 'U_1',
+				avatar_url: 'https://example.com/a.png',
+				gravatar_id: '',
+				url: 'https://api.github.com/users/octocat',
+				html_url: 'https://github.com/octocat',
+				followers_url: '',
+				following_url: '',
+				gists_url: '',
+				starred_url: '',
+				subscriptions_url: '',
+				organizations_url: '',
+				repos_url: '',
+				events_url: '',
+				received_events_url: '',
+				type: 'User',
+				site_admin: false,
+			},
+		} satisfies Comment);
+
+		expect(record.user).toMatchObject({
+			id: 42,
+			login: 'octocat',
+			avatarUrl: 'https://example.com/a.png',
+		});
+	});
+
+	it('issueRecordFromWebhook keeps user and labels', () => {
+		const record = issueRecordFromWebhook({
+			id: 10,
+			node_id: 'I_10',
+			url: 'https://api.github.com/repos/o/r/issues/10',
+			repository_url: 'https://api.github.com/repos/o/r',
+			html_url: 'https://github.com/o/r/issues/10',
+			number: 10,
+			title: 'Bug',
+			body: 'details',
+			state: 'open',
+			locked: false,
+			comments: 0,
+			created_at: '2024-01-01T00:00:00Z',
+			updated_at: '2024-01-01T00:00:00Z',
+			closed_at: null,
+			user: {
+				login: 'dev',
+				id: 7,
+				node_id: 'U_7',
+				avatar_url: 'https://example.com/dev.png',
+				gravatar_id: '',
+				url: 'https://api.github.com/users/dev',
+				html_url: 'https://github.com/dev',
+				followers_url: '',
+				following_url: '',
+				gists_url: '',
+				starred_url: '',
+				subscriptions_url: '',
+				organizations_url: '',
+				repos_url: '',
+				events_url: '',
+				received_events_url: '',
+				type: 'User',
+				site_admin: false,
+			},
+			labels: [
+				{
+					id: 1,
+					node_id: 'L_1',
+					url: 'https://api.github.com/repos/o/r/labels/bug',
+					name: 'bug',
+					color: 'd73a4a',
+					default: false,
+					description: 'Bug',
+				},
+			],
+			assignee: null,
+			assignees: [],
+			milestone: null,
+		} satisfies Issue);
+
+		expect(record.user).toMatchObject({ login: 'dev' });
+		expect(record.labels).toEqual([
+			expect.objectContaining({ name: 'bug', color: 'd73a4a' }),
+		]);
+	});
+
+	it('pullRequestRecordFromWebhook keeps user login', () => {
+		const record = pullRequestRecordFromWebhook({
+			id: 99,
+			node_id: 'PR_99',
+			url: 'https://api.github.com/repos/o/r/pulls/99',
+			html_url: 'https://github.com/o/r/pull/99',
+			diff_url: 'https://github.com/o/r/pull/99.diff',
+			patch_url: 'https://github.com/o/r/pull/99.patch',
+			issue_url: 'https://api.github.com/repos/o/r/issues/99',
+			number: 99,
+			state: 'open',
+			locked: false,
+			title: 'feat',
+			body: 'body',
+			created_at: '2024-01-01T00:00:00Z',
+			updated_at: '2024-01-02T00:00:00Z',
+			closed_at: null,
+			merged_at: null,
+			merge_commit_sha: null,
+			assignee: null,
+			assignees: [],
+			draft: false,
+			merged: false,
+			mergeable: true,
+			comments: 1,
+			review_comments: 0,
+			commits: 1,
+			additions: 1,
+			deletions: 0,
+			changed_files: 1,
+			user: {
+				login: 'dev',
+				id: 7,
+				node_id: 'U_7',
+				avatar_url: 'https://example.com/dev.png',
+				gravatar_id: '',
+				url: 'https://api.github.com/users/dev',
+				html_url: 'https://github.com/dev',
+				followers_url: '',
+				following_url: '',
+				gists_url: '',
+				starred_url: '',
+				subscriptions_url: '',
+				organizations_url: '',
+				repos_url: '',
+				events_url: '',
+				received_events_url: '',
+				type: 'User',
+				site_admin: false,
+			},
+		} satisfies PullRequest);
+
+		expect(record.user).toMatchObject({ login: 'dev' });
+	});
+});

--- a/packages/github/persistence.ts
+++ b/packages/github/persistence.ts
@@ -1,0 +1,123 @@
+import type { CommentGetResponse } from './endpoints/types';
+import { convertKeysToCamelCase } from './utils';
+import type { Comment, Issue, PullRequest } from './webhooks/types';
+
+type ApiComment = CommentGetResponse & {
+	user?: unknown;
+};
+
+function persistUser(user: unknown) {
+	if (user == null) return user;
+	return convertKeysToCamelCase(user);
+}
+
+function persistUsers(users: unknown) {
+	if (users == null) return users;
+	if (!Array.isArray(users)) return undefined;
+	return users.map((entry) => convertKeysToCamelCase(entry));
+}
+
+function persistLabels(labels: unknown) {
+	if (labels == null) return undefined;
+	if (!Array.isArray(labels)) return undefined;
+	return labels.map((entry) => convertKeysToCamelCase(entry));
+}
+
+export function commentRecordFromApi(
+	comment: ApiComment,
+	extras?: { deletedAt?: Date | null },
+) {
+	return {
+		id: comment.id,
+		nodeId: comment.nodeId,
+		url: comment.url,
+		htmlUrl: comment.htmlUrl,
+		issueUrl: comment.issueUrl,
+		body: comment.body,
+		authorAssociation: comment.authorAssociation,
+		user: persistUser(comment.user),
+		createdAt: comment.createdAt ? new Date(comment.createdAt) : null,
+		updatedAt: comment.updatedAt ? new Date(comment.updatedAt) : null,
+		...(extras?.deletedAt !== undefined ? { deletedAt: extras.deletedAt } : {}),
+	};
+}
+
+export function commentRecordFromWebhook(
+	comment: Comment,
+	extras?: { deletedAt?: Date | null },
+) {
+	return {
+		id: comment.id,
+		nodeId: comment.node_id,
+		url: comment.url,
+		htmlUrl: comment.html_url,
+		issueUrl: comment.issue_url,
+		body: comment.body,
+		authorAssociation: comment.author_association,
+		user: persistUser(comment.user),
+		createdAt: comment.created_at ? new Date(comment.created_at) : null,
+		updatedAt: comment.updated_at ? new Date(comment.updated_at) : null,
+		...(extras?.deletedAt !== undefined ? { deletedAt: extras.deletedAt } : {}),
+	};
+}
+
+export function issueRecordFromWebhook(
+	issue: Issue,
+	extras?: { deletedAt?: Date | null },
+) {
+	return {
+		id: issue.id,
+		nodeId: issue.node_id,
+		url: issue.url,
+		repositoryUrl: issue.repository_url,
+		htmlUrl: issue.html_url,
+		number: issue.number,
+		state: issue.state,
+		title: issue.title,
+		body: issue.body,
+		locked: issue.locked,
+		comments: issue.comments,
+		user: persistUser(issue.user),
+		labels: persistLabels(issue.labels),
+		assignee: persistUser(issue.assignee),
+		assignees: persistUsers(issue.assignees),
+		createdAt: issue.created_at ? new Date(issue.created_at) : null,
+		updatedAt: issue.updated_at ? new Date(issue.updated_at) : null,
+		closedAt: issue.closed_at ? new Date(issue.closed_at) : null,
+		...(extras?.deletedAt !== undefined ? { deletedAt: extras.deletedAt } : {}),
+	};
+}
+
+export function pullRequestRecordFromWebhook(pr: PullRequest) {
+	return {
+		id: pr.id,
+		nodeId: pr.node_id,
+		url: pr.url,
+		htmlUrl: pr.html_url,
+		diffUrl: pr.diff_url,
+		patchUrl: pr.patch_url,
+		issueUrl: pr.issue_url,
+		number: pr.number,
+		state: pr.state,
+		locked: pr.locked,
+		title: pr.title,
+		body: pr.body,
+		user: persistUser(pr.user),
+		assignee: persistUser(pr.assignee),
+		assignees: persistUsers(pr.assignees),
+		createdAt: new Date(pr.created_at),
+		updatedAt: new Date(pr.updated_at),
+		closedAt: pr.closed_at ? new Date(pr.closed_at) : null,
+		mergedAt: pr.merged_at ? new Date(pr.merged_at) : null,
+		mergeCommitSha: pr.merge_commit_sha,
+		draft: pr.draft,
+		merged: pr.merged ?? false,
+		mergeable: pr.mergeable,
+		comments: pr.comments,
+		reviewComments: pr.review_comments,
+		commits: pr.commits,
+		additions: pr.additions,
+		deletions: pr.deletions,
+		changedFiles: pr.changed_files,
+	};
+}

--- a/packages/github/webhooks/comments.ts
+++ b/packages/github/webhooks/comments.ts
@@ -1,4 +1,5 @@
 import type { GithubWebhooks } from '../index';
+import { commentRecordFromWebhook } from '../persistence';
 import type { Comment } from './types';
 import { createGithubEventMatch, verifyGithubWebhookSignature } from './types';
 
@@ -8,18 +9,10 @@ async function upsertComment(
 	deletedAt?: Date | null,
 ) {
 	if (!ctx.db.comments) return;
-	await ctx.db.comments.upsertByEntityId(comment.id.toString(), {
-		id: comment.id,
-		nodeId: comment.node_id,
-		url: comment.url,
-		htmlUrl: comment.html_url,
-		issueUrl: comment.issue_url,
-		body: comment.body,
-		authorAssociation: comment.author_association,
-		createdAt: comment.created_at ? new Date(comment.created_at) : null,
-		updatedAt: comment.updated_at ? new Date(comment.updated_at) : null,
-		deletedAt: deletedAt ?? null,
-	});
+	await ctx.db.comments.upsertByEntityId(
+		comment.id.toString(),
+		commentRecordFromWebhook(comment, { deletedAt }),
+	);
 }
 
 export const commentCreated: GithubWebhooks['commentCreated'] = {

--- a/packages/github/webhooks/issues.ts
+++ b/packages/github/webhooks/issues.ts
@@ -1,4 +1,5 @@
 import type { GithubWebhooks } from '../index';
+import { issueRecordFromWebhook } from '../persistence';
 import type { Issue } from './types';
 import { createGithubEventMatch, verifyGithubWebhookSignature } from './types';
 
@@ -8,23 +9,10 @@ async function upsertIssue(
 	deletedAt?: Date | null,
 ) {
 	if (!ctx.db.issues) return;
-	await ctx.db.issues.upsertByEntityId(issue.id.toString(), {
-		id: issue.id,
-		nodeId: issue.node_id,
-		url: issue.url,
-		repositoryUrl: issue.repository_url,
-		htmlUrl: issue.html_url,
-		number: issue.number,
-		state: issue.state,
-		title: issue.title,
-		body: issue.body,
-		locked: issue.locked,
-		comments: issue.comments,
-		createdAt: issue.created_at ? new Date(issue.created_at) : null,
-		updatedAt: issue.updated_at ? new Date(issue.updated_at) : null,
-		closedAt: issue.closed_at ? new Date(issue.closed_at) : null,
-		deletedAt: deletedAt ?? null,
-	});
+	await ctx.db.issues.upsertByEntityId(
+		issue.id.toString(),
+		issueRecordFromWebhook(issue, { deletedAt }),
+	);
 }
 
 export const issueOpened: GithubWebhooks['issueOpened'] = {

--- a/packages/github/webhooks/pull-requests.ts
+++ b/packages/github/webhooks/pull-requests.ts
@@ -1,4 +1,5 @@
 import type { GithubWebhooks } from '../index';
+import { pullRequestRecordFromWebhook } from '../persistence';
 import type { PullRequest } from './types';
 import { createGithubEventMatch, verifyGithubWebhookSignature } from './types';
 
@@ -7,34 +8,10 @@ async function upsertPR(
 	pr: PullRequest,
 ) {
 	if (!ctx.db.pullRequests) return;
-	await ctx.db.pullRequests.upsertByEntityId(pr.id.toString(), {
-		id: pr.id,
-		nodeId: pr.node_id,
-		url: pr.url,
-		htmlUrl: pr.html_url,
-		diffUrl: pr.diff_url,
-		patchUrl: pr.patch_url,
-		issueUrl: pr.issue_url,
-		number: pr.number,
-		state: pr.state,
-		locked: pr.locked,
-		title: pr.title,
-		body: pr.body,
-		createdAt: new Date(pr.created_at),
-		updatedAt: new Date(pr.updated_at),
-		closedAt: pr.closed_at ? new Date(pr.closed_at) : null,
-		mergedAt: pr.merged_at ? new Date(pr.merged_at) : null,
-		mergeCommitSha: pr.merge_commit_sha,
-		draft: pr.draft,
-		merged: pr.merged ?? false,
-		mergeable: pr.mergeable,
-		comments: pr.comments,
-		reviewComments: pr.review_comments,
-		commits: pr.commits,
-		additions: pr.additions,
-		deletions: pr.deletions,
-		changedFiles: pr.changed_files,
-	});
+	await ctx.db.pullRequests.upsertByEntityId(
+		pr.id.toString(),
+		pullRequestRecordFromWebhook(pr),
+	);
 }
 
 export const pullRequestOpened: GithubWebhooks['pullRequestOpened'] = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Entity updates now preserve existing fields when only partial data is provided.
  * Explicit values, including `null`, are applied correctly while `undefined` values are ignored.
  * GitHub comments, issues, and pull requests now use consistent data mapping across API and webhook events.
  * GitHub records better preserve user details, labels, timestamps, and deletion status.

* **Bug Fixes**
  * Prevented partial entity updates from unintentionally removing stored nested data.

* **Tests**
  * Added coverage for entity merging and GitHub persistence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->