### PR TITLE
feat(integrations): add anthropic administrator plugin scaffold

### DIFF
--- a/packages/anthropicadministrator/client.ts
+++ b/packages/anthropicadministrator/client.ts
@@ -1,0 +1,61 @@
+import type { ApiRequestOptions } from 'corsair/http';
+import type { OpenAPIConfig } from 'corsair/http';
+import { request } from 'corsair/http';
+
+export class AnthropicAdministratorAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly code?: string,
+	) {
+		super(message);
+		this.name = 'AnthropicAdministratorAPIError';
+	}
+}
+
+// TODO: Update with your API base URL
+const ANTHROPICADMINISTRATOR_API_BASE = 'https://api.example.com';
+
+export async function makeAnthropicAdministratorRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	options: {
+		method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+		body?: Record<string, unknown>;
+		query?: Record<string, string | number | boolean | undefined>;
+	} = {},
+): Promise<T> {
+	const { method = 'GET', body, query } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: ANTHROPICADMINISTRATOR_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: apiKey,
+		HEADERS: {
+			'Content-Type': 'application/json',
+			// TODO: Add authentication headers
+			// 'Authorization': \`Bearer \${apiKey}\`
+		},
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint,
+		body:
+			method === 'POST' || method === 'PUT' || method === 'PATCH'
+				? body
+				: undefined,
+		mediaType: 'application/json; charset=utf-8',
+		query: method === 'GET' ? query : undefined,
+	};
+
+	try {
+		return await request<T>(config, requestOptions);
+	} catch (error) {
+		if (error instanceof Error) {
+			throw new AnthropicAdministratorAPIError(error.message);
+		}
+		throw new AnthropicAdministratorAPIError('Unknown error');
+	}
+}

--- a/packages/anthropicadministrator/endpoints/example.ts
+++ b/packages/anthropicadministrator/endpoints/example.ts
@@ -1,0 +1,15 @@
+import { logEventFromContext } from 'corsair/core';
+import type { AnthropicAdministratorEndpoints } from '..';
+import type { AnthropicAdministratorEndpointOutputs } from './types';
+import { makeAnthropicAdministratorRequest } from '../client';
+
+export const get: AnthropicAdministratorEndpoints['exampleGet'] = async (ctx, input) => {
+	const response = await makeAnthropicAdministratorRequest<AnthropicAdministratorEndpointOutputs['exampleGet']>(
+		`example/${input.id}`,
+		ctx.key,
+		{ method: 'GET' },
+	);
+
+	await logEventFromContext(ctx, 'anthropicadministrator.example.get', { ...input }, 'completed');
+	return response;
+};

--- a/packages/anthropicadministrator/endpoints/index.ts
+++ b/packages/anthropicadministrator/endpoints/index.ts
@@ -1,0 +1,7 @@
+import { get as exampleGet } from './example';
+
+export const Example = {
+	get: exampleGet,
+};
+
+export * from './types';

--- a/packages/anthropicadministrator/endpoints/types.ts
+++ b/packages/anthropicadministrator/endpoints/types.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+const ExampleGetInputSchema = z.object({
+	id: z.string(),
+});
+
+export type ExampleGetInput = z.infer<typeof ExampleGetInputSchema>;
+
+const ExampleGetResponseSchema = z.object({
+	id: z.string(),
+});
+
+export type ExampleGetResponse = z.infer<typeof ExampleGetResponseSchema>;
+
+export type AnthropicAdministratorEndpointInputs = {
+	exampleGet: ExampleGetInput;
+};
+
+export type AnthropicAdministratorEndpointOutputs = {
+	exampleGet: ExampleGetResponse;
+};
+
+export const AnthropicAdministratorEndpointInputSchemas = {
+	exampleGet: ExampleGetInputSchema,
+} as const;
+
+export const AnthropicAdministratorEndpointOutputSchemas = {
+	exampleGet: ExampleGetResponseSchema,
+} as const;

--- a/packages/anthropicadministrator/error-handlers.ts
+++ b/packages/anthropicadministrator/error-handlers.ts
@@ -1,0 +1,31 @@
+import { ApiError } from 'corsair/http';
+import type { CorsairErrorHandler } from 'corsair/core';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('429');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('unauthorized') || msg.includes('invalid_auth');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/anthropicadministrator/index.ts
+++ b/packages/anthropicadministrator/index.ts
@@ -1,0 +1,202 @@
+import type {
+	BindEndpoints,
+	BindWebhooks,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	CorsairWebhook,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+	RequiredPluginWebhookSchemas,
+} from 'corsair/core';
+import type { AuthTypes } from 'corsair/core';
+import type { AnthropicAdministratorEndpointInputs, AnthropicAdministratorEndpointOutputs } from './endpoints/types';
+import { AnthropicAdministratorEndpointInputSchemas, AnthropicAdministratorEndpointOutputSchemas } from './endpoints/types';
+import type {
+	AnthropicAdministratorWebhookOutputs,
+	ExampleEvent,
+} from './webhooks/types';
+import { ExampleEventSchema } from './webhooks/types';
+import { Example } from './endpoints';
+import { AnthropicAdministratorSchema } from './schema';
+import { ExampleWebhooks } from './webhooks';
+import { errorHandlers } from './error-handlers';
+import { matchAnthropicAdministratorTenantWebhook } from './webhooks/tenant-matcher';
+import { resolveAnthropicAdministratorOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
+
+export type AnthropicAdministratorPluginOptions = {
+	authType?: PickAuth<'api_key' | 'oauth_2'>;
+	key?: string;
+	webhookSecret?: string;
+	hooks?: InternalAnthropicAdministratorPlugin['hooks'];
+	webhookHooks?: InternalAnthropicAdministratorPlugin['webhookHooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof anthropicAdministratorEndpointsNested>;
+};
+
+export type AnthropicAdministratorContext = CorsairPluginContext<
+	typeof AnthropicAdministratorSchema,
+	AnthropicAdministratorPluginOptions
+>;
+
+export type AnthropicAdministratorKeyBuilderContext = KeyBuilderContext<AnthropicAdministratorPluginOptions>;
+
+export type AnthropicAdministratorBoundEndpoints = BindEndpoints<typeof anthropicAdministratorEndpointsNested>;
+
+type AnthropicAdministratorEndpoint<
+	K extends keyof AnthropicAdministratorEndpointOutputs,
+> = CorsairEndpoint<
+	AnthropicAdministratorContext,
+	AnthropicAdministratorEndpointInputs[K],
+	AnthropicAdministratorEndpointOutputs[K]
+>;
+
+export type AnthropicAdministratorEndpoints = {
+	exampleGet: AnthropicAdministratorEndpoint<'exampleGet'>;
+};
+
+type AnthropicAdministratorWebhook<
+	K extends keyof AnthropicAdministratorWebhookOutputs,
+	TEvent,
+> = CorsairWebhook<AnthropicAdministratorContext, TEvent, AnthropicAdministratorWebhookOutputs[K]>;
+
+export type AnthropicAdministratorWebhooks = {
+	example: AnthropicAdministratorWebhook<'example', ExampleEvent>;
+};
+
+export type AnthropicAdministratorBoundWebhooks = BindWebhooks<AnthropicAdministratorWebhooks>;
+
+const anthropicAdministratorEndpointsNested = {
+	example: {
+		get: Example.get,
+	},
+} as const;
+
+const anthropicAdministratorWebhooksNested = {
+	example: {
+		example: ExampleWebhooks.example,
+	},
+} as const;
+
+export const anthropicAdministratorEndpointSchemas = {
+	'example.get': {
+		input: AnthropicAdministratorEndpointInputSchemas.exampleGet,
+		output: AnthropicAdministratorEndpointOutputSchemas.exampleGet,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<typeof anthropicAdministratorEndpointsNested>;
+
+const anthropicAdministratorWebhookSchemas = {
+	'example.example': {
+		description: 'An example webhook event',
+		payload: ExampleEventSchema,
+		response: ExampleEventSchema,
+	},
+} as const satisfies RequiredPluginWebhookSchemas<typeof anthropicAdministratorWebhooksNested>;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const anthropicAdministratorEndpointMeta = {
+	'example.get': {
+		riskLevel: 'read',
+		description: 'Get an example resource by ID',
+	},
+} as const satisfies RequiredPluginEndpointMeta<typeof anthropicAdministratorEndpointsNested>;
+
+export const anthropicAdministratorAuthConfig = {
+	api_key: {
+		account: ['tenant_external_id'] as const,
+	},
+	oauth_2: {
+		account: ['tenant_external_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type BaseAnthropicAdministratorPlugin<T extends AnthropicAdministratorPluginOptions> = CorsairPlugin<
+	'anthropicadministrator',
+	typeof AnthropicAdministratorSchema,
+	typeof anthropicAdministratorEndpointsNested,
+	typeof anthropicAdministratorWebhooksNested,
+	T,
+	typeof defaultAuthType
+>;
+
+export type InternalAnthropicAdministratorPlugin = BaseAnthropicAdministratorPlugin<AnthropicAdministratorPluginOptions>;
+
+export type ExternalAnthropicAdministratorPlugin<T extends AnthropicAdministratorPluginOptions> =
+	BaseAnthropicAdministratorPlugin<T>;
+
+export function anthropicadministrator<const T extends AnthropicAdministratorPluginOptions>(
+	incomingOptions: AnthropicAdministratorPluginOptions & T = {} as AnthropicAdministratorPluginOptions & T,
+): ExternalAnthropicAdministratorPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'anthropicadministrator',
+		authConfig: anthropicAdministratorAuthConfig,
+		schema: AnthropicAdministratorSchema,
+		options: options,
+		hooks: options.hooks,
+		webhookHooks: options.webhookHooks,
+		endpoints: anthropicAdministratorEndpointsNested,
+		webhooks: anthropicAdministratorWebhooksNested,
+		endpointMeta: anthropicAdministratorEndpointMeta,
+		endpointSchemas: anthropicAdministratorEndpointSchemas,
+		webhookSchemas: anthropicAdministratorWebhookSchemas,
+		pluginWebhookMatcher: (request) => {
+			const headers = request.headers;
+			// TODO: Update to match your webhook signature headers
+			return 'x-anthropicadministrator-signature' in headers;
+		},
+		pluginTenantWebhookMatcher: matchAnthropicAdministratorTenantWebhook,
+		oauthWebhookTenantLinkResolver: resolveAnthropicAdministratorOAuthWebhookTenantLink,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: AnthropicAdministratorKeyBuilderContext, source) => {
+			if (source === 'webhook' && options.webhookSecret) {
+				return options.webhookSecret;
+			}
+
+			if (source === 'webhook') {
+				const res = await ctx.keys.get_webhook_signature();
+				return res ?? '';
+			}
+
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys.get_api_key();
+				return res ?? '';
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'oauth_2') {
+				const res = await ctx.keys.get_access_token();
+				return res ?? '';
+			}
+
+			return '';
+		},
+	} satisfies InternalAnthropicAdministratorPlugin;
+}
+
+export type {
+	ExampleEvent,
+	AnthropicAdministratorWebhookOutputs,
+} from './webhooks/types';
+
+export type {
+	AnthropicAdministratorEndpointInputs,
+	AnthropicAdministratorEndpointOutputs,
+	ExampleGetInput,
+	ExampleGetResponse,
+} from './endpoints/types';

--- a/packages/anthropicadministrator/jest.config.cjs
+++ b/packages/anthropicadministrator/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/anthropicadministrator/package.json
+++ b/packages/anthropicadministrator/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/anthropicadministrator",
+  "version": "0.1.0",
+  "description": "AnthropicAdministrator plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "anthropicadministrator",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/anthropicadministrator/schema.test.ts
+++ b/packages/anthropicadministrator/schema.test.ts
@@ -1,0 +1,20 @@
+import { AnthropicAdministratorSchema } from './schema';
+
+describe('AnthropicAdministrator schema', () => {
+	it('declares a semver version', () => {
+		expect(AnthropicAdministratorSchema.version).toBeDefined();
+		expect(AnthropicAdministratorSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof AnthropicAdministratorSchema.entities).toBe('object');
+		expect(AnthropicAdministratorSchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(AnthropicAdministratorSchema.entities))).toBe(true);
+		for (const entity of Object.values(AnthropicAdministratorSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/anthropicadministrator/schema/database.ts
+++ b/packages/anthropicadministrator/schema/database.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+// TODO: Define your database entities here
+// export const AnthropicAdministratorExample = z.object({
+// 	id: z.string(),
+// 	name: z.string(),
+// 	created_at: z.coerce.date().nullable().optional(),
+// });
+// export type AnthropicAdministratorExample = z.infer<typeof AnthropicAdministratorExample>;

--- a/packages/anthropicadministrator/schema/index.ts
+++ b/packages/anthropicadministrator/schema/index.ts
@@ -1,0 +1,4 @@
+export const AnthropicAdministratorSchema = {
+	version: '1.0.0',
+	entities: {},
+} as const;

--- a/packages/anthropicadministrator/tsconfig.json
+++ b/packages/anthropicadministrator/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": [
+      "esnext"
+    ],
+    "types": [
+      "node",
+      "jest"
+    ],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "./**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ],
+  "references": []
+}

--- a/packages/anthropicadministrator/tsup.config.ts
+++ b/packages/anthropicadministrator/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/anthropicadministrator/webhooks/example.ts
+++ b/packages/anthropicadministrator/webhooks/example.ts
@@ -1,0 +1,27 @@
+import { logEventFromContext } from 'corsair/core';
+import type { AnthropicAdministratorWebhooks } from '..';
+import { createAnthropicAdministratorMatch, verifyAnthropicAdministratorWebhookSignature } from './types';
+
+export const example: AnthropicAdministratorWebhooks['example'] = {
+	match: createAnthropicAdministratorMatch('example'),
+
+	handler: async (ctx, request) => {
+		const verification = verifyAnthropicAdministratorWebhookSignature(request, ctx.key);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
+
+		const event = request.payload;
+		if (event.type !== 'example') {
+			return { success: true, data: undefined };
+		}
+
+		await logEventFromContext(ctx, 'anthropicadministrator.webhook.example', { ...event }, 'completed');
+
+		return { success: true, data: event };
+	},
+};

--- a/packages/anthropicadministrator/webhooks/index.ts
+++ b/packages/anthropicadministrator/webhooks/index.ts
@@ -1,0 +1,9 @@
+import { example } from './example';
+
+export const ExampleWebhooks = {
+	example: example,
+};
+
+export * from './types';
+export * from './tenant-matcher';
+export * from './oauth-tenant-link';

--- a/packages/anthropicadministrator/webhooks/oauth-tenant-link.ts
+++ b/packages/anthropicadministrator/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,31 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, toExternalId } from 'corsair/core';
+
+// TODO: Rename linkType 'tenant_external_id' to match pluginTenantWebhookMatcher.
+// Called after OAuth to store the routing id on corsair_accounts.config.
+export async function resolveAnthropicAdministratorOAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): Promise<WebhookTenantMatch | null> {
+	// TODO: Read from token response when the provider includes a stable id.
+	// const externalId = toExternalId(asRecord(tokens.team)?.id);
+	const externalId = toExternalId(tokens.tenant_external_id);
+	if (externalId) {
+		return { linkType: 'tenant_external_id', externalId };
+	}
+
+	const accessToken = tokens.access_token;
+	if (!accessToken) return null;
+
+	// TODO: Fetch from provider API when the token response omits the id.
+	// const response = await fetch('https://api.example.com/me', {
+	// 	headers: { Authorization: `Bearer ${accessToken}` },
+	// });
+	// if (!response.ok) return null;
+	// const payload = (await response.json()) as { id?: string };
+	// const fetchedId = toExternalId(payload.id);
+	// return fetchedId
+	// 	? { linkType: 'tenant_external_id', externalId: fetchedId }
+	// 	: null;
+
+	return null;
+}

--- a/packages/anthropicadministrator/webhooks/tenant-matcher.ts
+++ b/packages/anthropicadministrator/webhooks/tenant-matcher.ts
@@ -1,0 +1,25 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// TODO: Rename linkType 'tenant_external_id' to match the provider field
+// (e.g. team_id, installation_id, organization_id). Must match authConfig.account
+// and oauthWebhookTenantLinkResolver.
+// Return null for URL verification / handshake payloads that have no tenant id.
+export function matchAnthropicAdministratorTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	// TODO: Extract the stable external id from the webhook payload.
+	// Example:
+	// const externalId = firstString([body.tenant_external_id, asRecord(body.data)?.id]);
+	const externalId = firstString([
+		body.tenant_external_id,
+		asRecord(body.data)?.tenant_external_id,
+	]);
+
+	if (!externalId) return null;
+
+	return { linkType: 'tenant_external_id', externalId };
+}

--- a/packages/anthropicadministrator/webhooks/types.ts
+++ b/packages/anthropicadministrator/webhooks/types.ts
@@ -1,0 +1,58 @@
+import type { CorsairWebhookMatcher, RawWebhookRequest, WebhookRequest } from 'corsair/core';
+import { z } from 'zod';
+
+export const AnthropicAdministratorWebhookPayloadSchema = z.object({
+	type: z.string(),
+	created_at: z.string(),
+	data: z.record(z.string(), z.unknown()),
+});
+
+export type AnthropicAdministratorWebhookPayload = z.infer<
+	typeof AnthropicAdministratorWebhookPayloadSchema
+>;
+
+export const ExampleEventSchema = AnthropicAdministratorWebhookPayloadSchema.extend({
+	type: z.literal('example'),
+	data: z
+		.object({
+			id: z.string(),
+		})
+		.loose(),
+});
+
+export type ExampleEvent = z.infer<typeof ExampleEventSchema>;
+
+export type AnthropicAdministratorWebhookOutputs = {
+	example: ExampleEvent;
+};
+
+function parseBody(body: unknown): Record<string, unknown> | null {
+	if (typeof body === 'string') {
+		try {
+			const parsed = JSON.parse(body);
+			return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+				? (parsed as Record<string, unknown>)
+				: null;
+		} catch {
+			return null;
+		}
+	}
+	return body !== null && typeof body === 'object' && !Array.isArray(body)
+		? (body as Record<string, unknown>)
+		: null;
+}
+
+export function createAnthropicAdministratorMatch(eventType: string): CorsairWebhookMatcher {
+	return (request: RawWebhookRequest) => {
+		const parsedBody = parseBody(request.body);
+		return parsedBody !== null && parsedBody.type === eventType;
+	};
+}
+
+export function verifyAnthropicAdministratorWebhookSignature(
+	request: WebhookRequest<AnthropicAdministratorWebhookPayload>,
+	secret: string,
+): { valid: boolean; error?: string } {
+	// TODO: Implement webhook signature verification
+	return { valid: true };
+}

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -35,6 +35,7 @@ export const BaseProviders = [
 	'ambientweather',
 	'amcards',
 	'amplitude',
+	'anthropicadministrator',
 	'apaleo',
 	'apibible',
 	'apify',
@@ -59,8 +60,8 @@ export const BaseProviders = [
 	'bugsnag',
 	'cal',
 	'calendly',
-	'canvas',
 	'canva',
+	'canvas',
 	'circleci',
 	'cloudflare',
 	'cloudinary',
@@ -187,6 +188,7 @@ export const ProviderDisplayNames = {
 	ambientweather: 'Ambient Weather',
 	amcards: 'AMcards',
 	amplitude: 'Amplitude',
+	anthropicadministrator: 'AnthropicAdministrator',
 	apaleo: 'Apaleo',
 	apibible: 'API.Bible',
 	apify: 'Apify',
@@ -211,8 +213,8 @@ export const ProviderDisplayNames = {
 	bugsnag: 'BugSnag',
 	cal: 'Cal',
 	calendly: 'Calendly',
-	canvas: 'Canvas LMS',
 	canva: 'Canva',
+	canvas: 'Canvas LMS',
 	circleci: 'CircleCI',
 	cloudflare: 'Cloudflare',
 	cloudinary: 'Cloudinary',
@@ -346,6 +348,7 @@ export type AllProviders =
 	| 'ambientweather'
 	| 'amcards'
 	| 'amplitude'
+	| 'anthropicadministrator'
 	| 'apaleo'
 	| 'apibible'
 	| 'apify'


### PR DESCRIPTION
### Summary
Adds the Anthropic Administrator integration plugin.

Closes #880

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Anthropic Administrator as a supported integration.
  * Added API access with authentication, request handling, and typed endpoint support.
  * Added webhook processing, signature validation responses, tenant matching, and OAuth tenant linking.
  * Added rate-limit retry handling and authentication error handling.
* **Documentation**
  * Added initial schema definitions and example endpoint/webhook contracts.
* **Tests**
  * Added schema validation tests and package test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->