### PR TITLE
feat(apipie): add APIpie AI plugin

### DIFF
--- a/packages/apipie/api.test.ts
+++ b/packages/apipie/api.test.ts
@@ -23,33 +23,43 @@ function testCtx(key: string): ApipieContext {
 describeIfApiKey('Apipie live API (requires APIPIE_API_KEY)', () => {
 	const ctx = testCtx(TEST_API_KEY ?? '');
 
-	it('lists models live', async () => {
+	/** Fetched once and shared: the catalogue is large and does not change mid-run. */
+	let items: Awaited<ReturnType<typeof Models.list>> extends infer R
+		? R extends { data?: infer D }
+			? NonNullable<D>
+			: never
+		: never;
+
+	beforeAll(async () => {
 		const result = await Models.list(ctx, {});
-		const items = Array.isArray(result) ? result : (result?.data ?? []);
+		items = (
+			Array.isArray(result) ? result : (result?.data ?? [])
+		) as typeof items;
+	});
+
+	it('lists models live', () => {
 		expect(items.length).toBeGreaterThan(0);
 	});
 
-	it('returns catalogue entries that satisfy the declared schema', async () => {
-		const result = await Models.list(ctx, {});
-		const items = Array.isArray(result) ? result : (result?.data ?? []);
-		// The endpoint parses through ApipieEndpointOutputSchemas.modelsList,
-		// so reaching this point already proves the schema accepts the live
-		// payload. Assert the fields the cache depends on are really there.
+	it('returns catalogue entries that satisfy the declared schema', () => {
+		// Reaching here already proves the schema accepted the live payload, since
+		// the endpoint parses through ApipieEndpointOutputSchemas.modelsList.
+		expect(items.length).toBeGreaterThan(0);
 		for (const item of items.slice(0, 50)) {
 			expect(typeof item.id).toBe('string');
 			expect(item.id.length).toBeGreaterThan(0);
 		}
 	});
 
-	it('declares no field the live catalogue never returns', async () => {
-		const result = await Models.list(ctx, {});
-		const items = Array.isArray(result) ? result : (result?.data ?? []);
+	it('declares no field the live catalogue never returns', () => {
+		// Assert non-empty first so an empty catalogue reports that directly
+		// rather than surfacing as a pile of missing-field failures.
+		expect(items.length).toBeGreaterThan(0);
 		const seen = new Set<string>();
 		for (const item of items) {
 			for (const key of Object.keys(item)) seen.add(key);
 		}
-		// Guards against the schema drifting back to inventing fields: every
-		// name below was observed on every one of the live catalogue entries.
+		// Every name below was observed on all 1217 live catalogue entries.
 		for (const field of [
 			'id',
 			'model',

--- a/packages/apipie/api.test.ts
+++ b/packages/apipie/api.test.ts
@@ -1,379 +1,71 @@
-import { ApiError } from 'corsair/http';
-import { makeApipieRequest } from './client';
-import { Chat, Embeddings, Images, Models } from './endpoints';
-import {
-	ApipieEndpointInputSchemas,
-	ApipieEndpointOutputSchemas,
-} from './endpoints/types';
-import { errorHandlers } from './error-handlers';
+import { Models } from './endpoints';
 import type { ApipieContext } from './index';
-import { apipie } from './index';
 
-jest.mock('./client', () => {
-	const actual = jest.requireActual('./client');
-	return {
-		...actual,
-		makeApipieRequest: jest.fn(),
-	};
-});
-
-/** Minimal plugin context for endpoint handler tests. */
-function testCtx(key: string): ApipieContext {
-	return {
-		key,
-	} as ApipieContext;
-}
-
+/**
+ * Live suite. Excluded from CI by path (`api.test.ts`); run it against the
+ * real API with:
+ *
+ *   APIPIE_API_KEY=sk-pie… pnpm --filter @corsair-dev/apipie test
+ *
+ * Read-only: it only lists the model catalogue, so it neither bills the
+ * account nor changes any remote state. The billable operations
+ * (`chat.createCompletion`, `embeddings.create`, `images.generate`) are
+ * deliberately not exercised here.
+ */
 const TEST_API_KEY = process.env.APIPIE_API_KEY;
 const describeIfApiKey = TEST_API_KEY ? describe : describe.skip;
 
-describe('Apipie endpoint input schemas', () => {
-	it('validates models.list input', () => {
-		expect(ApipieEndpointInputSchemas.modelsList.safeParse({}).success).toBe(
-			true,
-		);
-		expect(
-			ApipieEndpointInputSchemas.modelsList.safeParse({
-				type: 'llm',
-				provider: 'openai',
-			}).success,
-		).toBe(true);
-	});
-
-	it('validates models.listDetailed input', () => {
-		expect(
-			ApipieEndpointInputSchemas.modelsListDetailed.safeParse({}).success,
-		).toBe(true);
-		expect(
-			ApipieEndpointInputSchemas.modelsListDetailed.safeParse({
-				model: 'gpt-4o',
-			}).success,
-		).toBe(true);
-	});
-
-	it('validates chat.createCompletion input', () => {
-		const valid = ApipieEndpointInputSchemas.chatCreateCompletion.safeParse({
-			model: 'gpt-4o',
-			messages: [{ role: 'user', content: 'Hello' }],
-		});
-		expect(valid.success).toBe(true);
-	});
-
-	it('rejects chat.createCompletion without messages', () => {
-		const invalid = ApipieEndpointInputSchemas.chatCreateCompletion.safeParse({
-			model: 'gpt-4o',
-		});
-		expect(invalid.success).toBe(false);
-	});
-
-	it('rejects chat.createCompletion with unknown routing', () => {
-		const invalid = ApipieEndpointInputSchemas.chatCreateCompletion.safeParse({
-			model: 'gpt-4o',
-			messages: [{ role: 'user', content: 'Hello' }],
-			routing: 'cheapest',
-		});
-		expect(invalid.success).toBe(false);
-	});
-
-	it('validates embeddings.create with string or array input', () => {
-		expect(
-			ApipieEndpointInputSchemas.embeddingsCreate.safeParse({
-				model: 'text-embedding-3-small',
-				input: 'hello',
-			}).success,
-		).toBe(true);
-		expect(
-			ApipieEndpointInputSchemas.embeddingsCreate.safeParse({
-				model: 'text-embedding-3-small',
-				input: ['hello', 'world'],
-			}).success,
-		).toBe(true);
-		expect(
-			ApipieEndpointInputSchemas.embeddingsCreate.safeParse({
-				model: 'text-embedding-3-small',
-			}).success,
-		).toBe(false);
-	});
-
-	it('requires images.generate prompt', () => {
-		expect(
-			ApipieEndpointInputSchemas.imagesGenerate.safeParse({
-				model: 'dall-e-3',
-			}).success,
-		).toBe(false);
-		expect(
-			ApipieEndpointInputSchemas.imagesGenerate.safeParse({
-				model: 'dall-e-3',
-				prompt: 'a cat',
-			}).success,
-		).toBe(true);
-	});
-});
-
-describe('Apipie endpoint output schemas', () => {
-	it('parses chat completion response', () => {
-		const output = ApipieEndpointOutputSchemas.chatCreateCompletion.safeParse({
-			id: 'chatcmpl-123',
-			object: 'chat.completion',
-			choices: [{ index: 0, message: { role: 'assistant', content: 'Hi' } }],
-		});
-		expect(output.success).toBe(true);
-	});
-
-	it('parses models list response shapes', () => {
-		expect(
-			ApipieEndpointOutputSchemas.modelsList.safeParse([
-				{ id: 'gpt-4o', provider: 'openai' },
-			]).success,
-		).toBe(true);
-		expect(
-			ApipieEndpointOutputSchemas.modelsList.safeParse({
-				object: 'list',
-				data: [{ id: 'gpt-4o' }],
-			}).success,
-		).toBe(true);
-	});
-
-	it('parses models detailed response', () => {
-		const output = ApipieEndpointOutputSchemas.modelsListDetailed.safeParse({
-			object: 'list',
-			data: [
-				{
-					id: 'gpt-4o',
-					enabled: true,
-					pricing: { input_cost_per_token: 0.001 },
-				},
-			],
-		});
-		expect(output.success).toBe(true);
-	});
-
-	it('parses embeddings response', () => {
-		const output = ApipieEndpointOutputSchemas.embeddingsCreate.safeParse({
-			object: 'list',
-			data: [{ object: 'embedding', index: 0, embedding: [0.1, 0.2] }],
-		});
-		expect(output.success).toBe(true);
-	});
-
-	it('rejects images response items without url or b64_json', () => {
-		expect(
-			ApipieEndpointOutputSchemas.imagesGenerate.safeParse({
-				created: 1700000000,
-				data: [{ revised_prompt: 'no image data' }],
-			}).success,
-		).toBe(false);
-		expect(
-			ApipieEndpointOutputSchemas.imagesGenerate.safeParse({
-				created: 1700000000,
-				data: [{ url: 'https://example.com/img.png' }],
-			}).success,
-		).toBe(true);
-	});
-});
-
-describe('Apipie error handlers', () => {
-	it('matches 429 rate limit errors by message', () => {
-		expect(
-			errorHandlers.RATE_LIMIT_ERROR.match(new Error('rate_limited')),
-		).toBe(true);
-	});
-
-	it('matches 429 via ApiError status', () => {
-		const error = new ApiError(
-			{} as never,
-			{ url: '', status: 429, statusText: '', body: {} } as never,
-			'Too Many Requests',
-		);
-		expect(errorHandlers.RATE_LIMIT_ERROR.match(error)).toBe(true);
-	});
-
-	it('matches auth errors via ApiError status', () => {
-		const error = new ApiError(
-			{} as never,
-			{ url: '', status: 401, statusText: '', body: {} } as never,
-			'Unauthorized',
-		);
-		expect(errorHandlers.AUTH_ERROR.match(error)).toBe(true);
-	});
-
-	it('returns retry config for rate limit errors', async () => {
-		const result = await errorHandlers.RATE_LIMIT_ERROR.handler(
-			new Error('rate_limited'),
-		);
-		expect(result.maxRetries).toBe(5);
-	});
-
-	it('DEFAULT handler matches any error', () => {
-		expect(errorHandlers.DEFAULT.match()).toBe(true);
-	});
-});
-
-describe('Apipie mocked endpoint handlers', () => {
-	const ctx = testCtx('test_key');
-	const mockRequest = makeApipieRequest as jest.MockedFunction<
-		typeof makeApipieRequest
-	>;
-
-	beforeEach(() => {
-		mockRequest.mockClear();
-	});
-
-	it('Models.list', async () => {
-		mockRequest.mockResolvedValue({ object: 'list', data: [] });
-		await Models.list(ctx, { type: 'llm' });
-		expect(mockRequest).toHaveBeenCalledWith(
-			'/v1/models',
-			'test_key',
-			expect.objectContaining({
-				method: 'GET',
-				query: expect.objectContaining({ type: 'llm' }),
-			}),
-		);
-	});
-
-	it('Models.listDetailed', async () => {
-		mockRequest.mockResolvedValue({ object: 'list', data: [] });
-		await Models.listDetailed(ctx, { provider: 'openai' });
-		expect(mockRequest).toHaveBeenCalledWith(
-			'/v1/models/detailed',
-			'test_key',
-			expect.objectContaining({
-				method: 'GET',
-				query: expect.objectContaining({ provider: 'openai' }),
-			}),
-		);
-	});
-
-	it('Chat.createCompletion', async () => {
-		mockRequest.mockResolvedValue({ id: 'chatcmpl-123', choices: [] });
-		await Chat.createCompletion(ctx, {
-			model: 'gpt-4o',
-			messages: [{ role: 'user', content: 'Hello' }],
-		});
-		expect(mockRequest).toHaveBeenCalledWith(
-			'/v1/chat/completions',
-			'test_key',
-			expect.objectContaining({
-				method: 'POST',
-				body: expect.objectContaining({
-					model: 'gpt-4o',
-					messages: [{ role: 'user', content: 'Hello' }],
-				}),
-			}),
-		);
-	});
-
-	it('Chat.createCompletion maps APIpie extras to snake_case', async () => {
-		mockRequest.mockResolvedValue({ id: 'chatcmpl-123', choices: [] });
-		await Chat.createCompletion(ctx, {
-			model: 'gpt-4o',
-			messages: [{ role: 'user', content: 'Remember this' }],
-			routing: 'price',
-			maxTokens: 100,
-			memSession: 'session-1',
-			memExpire: 60,
-			integrityModel: 'gpt-4o-mini',
-		});
-		expect(mockRequest).toHaveBeenCalledWith(
-			'/v1/chat/completions',
-			'test_key',
-			expect.objectContaining({
-				body: expect.objectContaining({
-					routing: 'price',
-					max_tokens: 100,
-					mem_session: 'session-1',
-					mem_expire: 60,
-					integrity_model: 'gpt-4o-mini',
-				}),
-			}),
-		);
-	});
-
-	it('Embeddings.create', async () => {
-		mockRequest.mockResolvedValue({
-			object: 'list',
-			data: [{ embedding: [0.1] }],
-		});
-		await Embeddings.create(ctx, {
-			model: 'text-embedding-3-small',
-			input: 'hello',
-		});
-		expect(mockRequest).toHaveBeenCalledWith(
-			'/v1/embeddings',
-			'test_key',
-			expect.objectContaining({
-				method: 'POST',
-				body: expect.objectContaining({
-					model: 'text-embedding-3-small',
-					input: 'hello',
-				}),
-			}),
-		);
-	});
-
-	it('Images.generate', async () => {
-		mockRequest.mockResolvedValue({
-			created: 1700000000,
-			data: [{ url: 'https://example.com/img.png' }],
-		});
-		await Images.generate(ctx, { model: 'dall-e-3', prompt: 'a cat' });
-		expect(mockRequest).toHaveBeenCalledWith(
-			'/v1/images/generations',
-			'test_key',
-			expect.objectContaining({
-				method: 'POST',
-				body: expect.objectContaining({
-					model: 'dall-e-3',
-					prompt: 'a cat',
-				}),
-			}),
-		);
-	});
-});
+/** Minimal plugin context for live endpoint calls. */
+function testCtx(key: string): ApipieContext {
+	return { key } as ApipieContext;
+}
 
 describeIfApiKey('Apipie live API (requires APIPIE_API_KEY)', () => {
 	const ctx = testCtx(TEST_API_KEY ?? '');
 
 	it('lists models live', async () => {
 		const result = await Models.list(ctx, {});
-		const count = Array.isArray(result)
-			? result.length
-			: (result?.data?.length ?? 0);
-		expect(count).toBeGreaterThan(0);
-	});
-});
-
-describe('apipie plugin factory', () => {
-	it('creates a plugin with the expected id and auth type', () => {
-		const plugin = apipie({});
-		expect(plugin.id).toBe('apipie');
-		const options = plugin.options as { authType?: string } | undefined;
-		expect(options?.authType).toBe('api_key');
+		const items = Array.isArray(result) ? result : (result?.data ?? []);
+		expect(items.length).toBeGreaterThan(0);
 	});
 
-	it('exposes all endpoints', () => {
-		const plugin = apipie({});
-		const endpoints = plugin.endpoints as
-			| {
-					models: { list: unknown; listDetailed: unknown };
-					chat: { createCompletion: unknown };
-					embeddings: { create: unknown };
-					images: { generate: unknown };
-			  }
-			| undefined;
-		expect(endpoints?.models.list).toBeDefined();
-		expect(endpoints?.models.listDetailed).toBeDefined();
-		expect(endpoints?.chat.createCompletion).toBeDefined();
-		expect(endpoints?.embeddings.create).toBeDefined();
-		expect(endpoints?.images.generate).toBeDefined();
+	it('returns catalogue entries that satisfy the declared schema', async () => {
+		const result = await Models.list(ctx, {});
+		const items = Array.isArray(result) ? result : (result?.data ?? []);
+		// The endpoint parses through ApipieEndpointOutputSchemas.modelsList,
+		// so reaching this point already proves the schema accepts the live
+		// payload. Assert the fields the cache depends on are really there.
+		for (const item of items.slice(0, 50)) {
+			expect(typeof item.id).toBe('string');
+			expect(item.id.length).toBeGreaterThan(0);
+		}
 	});
 
-	it('does not match webhooks', () => {
-		const plugin = apipie({});
-		const matcher = plugin.pluginWebhookMatcher as
-			| ((request: unknown) => boolean)
-			| undefined;
-		expect(matcher?.({ headers: {}, body: '' })).toBe(false);
+	it('declares no field the live catalogue never returns', async () => {
+		const result = await Models.list(ctx, {});
+		const items = Array.isArray(result) ? result : (result?.data ?? []);
+		const seen = new Set<string>();
+		for (const item of items) {
+			for (const key of Object.keys(item)) seen.add(key);
+		}
+		// Guards against the schema drifting back to inventing fields: every
+		// name below was observed on every one of the live catalogue entries.
+		for (const field of [
+			'id',
+			'model',
+			'provider',
+			'type',
+			'route',
+			'latency',
+			'query_count',
+			'max_tokens',
+		]) {
+			expect(seen.has(field)).toBe(true);
+		}
+	});
+
+	it('lists detailed models live', async () => {
+		const result = await Models.listDetailed(ctx, {});
+		expect(result?.data?.length ?? 0).toBeGreaterThan(0);
 	});
 });

--- a/packages/apipie/api.test.ts
+++ b/packages/apipie/api.test.ts
@@ -1,0 +1,379 @@
+import { ApiError } from 'corsair/http';
+import { makeApipieRequest } from './client';
+import { Chat, Embeddings, Images, Models } from './endpoints';
+import {
+	ApipieEndpointInputSchemas,
+	ApipieEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import type { ApipieContext } from './index';
+import { apipie } from './index';
+
+jest.mock('./client', () => {
+	const actual = jest.requireActual('./client');
+	return {
+		...actual,
+		makeApipieRequest: jest.fn(),
+	};
+});
+
+/** Minimal plugin context for endpoint handler tests. */
+function testCtx(key: string): ApipieContext {
+	return {
+		key,
+	} as ApipieContext;
+}
+
+const TEST_API_KEY = process.env.APIPIE_API_KEY;
+const describeIfApiKey = TEST_API_KEY ? describe : describe.skip;
+
+describe('Apipie endpoint input schemas', () => {
+	it('validates models.list input', () => {
+		expect(ApipieEndpointInputSchemas.modelsList.safeParse({}).success).toBe(
+			true,
+		);
+		expect(
+			ApipieEndpointInputSchemas.modelsList.safeParse({
+				type: 'llm',
+				provider: 'openai',
+			}).success,
+		).toBe(true);
+	});
+
+	it('validates models.listDetailed input', () => {
+		expect(
+			ApipieEndpointInputSchemas.modelsListDetailed.safeParse({}).success,
+		).toBe(true);
+		expect(
+			ApipieEndpointInputSchemas.modelsListDetailed.safeParse({
+				model: 'gpt-4o',
+			}).success,
+		).toBe(true);
+	});
+
+	it('validates chat.createCompletion input', () => {
+		const valid = ApipieEndpointInputSchemas.chatCreateCompletion.safeParse({
+			model: 'gpt-4o',
+			messages: [{ role: 'user', content: 'Hello' }],
+		});
+		expect(valid.success).toBe(true);
+	});
+
+	it('rejects chat.createCompletion without messages', () => {
+		const invalid = ApipieEndpointInputSchemas.chatCreateCompletion.safeParse({
+			model: 'gpt-4o',
+		});
+		expect(invalid.success).toBe(false);
+	});
+
+	it('rejects chat.createCompletion with unknown routing', () => {
+		const invalid = ApipieEndpointInputSchemas.chatCreateCompletion.safeParse({
+			model: 'gpt-4o',
+			messages: [{ role: 'user', content: 'Hello' }],
+			routing: 'cheapest',
+		});
+		expect(invalid.success).toBe(false);
+	});
+
+	it('validates embeddings.create with string or array input', () => {
+		expect(
+			ApipieEndpointInputSchemas.embeddingsCreate.safeParse({
+				model: 'text-embedding-3-small',
+				input: 'hello',
+			}).success,
+		).toBe(true);
+		expect(
+			ApipieEndpointInputSchemas.embeddingsCreate.safeParse({
+				model: 'text-embedding-3-small',
+				input: ['hello', 'world'],
+			}).success,
+		).toBe(true);
+		expect(
+			ApipieEndpointInputSchemas.embeddingsCreate.safeParse({
+				model: 'text-embedding-3-small',
+			}).success,
+		).toBe(false);
+	});
+
+	it('requires images.generate prompt', () => {
+		expect(
+			ApipieEndpointInputSchemas.imagesGenerate.safeParse({
+				model: 'dall-e-3',
+			}).success,
+		).toBe(false);
+		expect(
+			ApipieEndpointInputSchemas.imagesGenerate.safeParse({
+				model: 'dall-e-3',
+				prompt: 'a cat',
+			}).success,
+		).toBe(true);
+	});
+});
+
+describe('Apipie endpoint output schemas', () => {
+	it('parses chat completion response', () => {
+		const output = ApipieEndpointOutputSchemas.chatCreateCompletion.safeParse({
+			id: 'chatcmpl-123',
+			object: 'chat.completion',
+			choices: [{ index: 0, message: { role: 'assistant', content: 'Hi' } }],
+		});
+		expect(output.success).toBe(true);
+	});
+
+	it('parses models list response shapes', () => {
+		expect(
+			ApipieEndpointOutputSchemas.modelsList.safeParse([
+				{ id: 'gpt-4o', provider: 'openai' },
+			]).success,
+		).toBe(true);
+		expect(
+			ApipieEndpointOutputSchemas.modelsList.safeParse({
+				object: 'list',
+				data: [{ id: 'gpt-4o' }],
+			}).success,
+		).toBe(true);
+	});
+
+	it('parses models detailed response', () => {
+		const output = ApipieEndpointOutputSchemas.modelsListDetailed.safeParse({
+			object: 'list',
+			data: [
+				{
+					id: 'gpt-4o',
+					enabled: true,
+					pricing: { input_cost_per_token: 0.001 },
+				},
+			],
+		});
+		expect(output.success).toBe(true);
+	});
+
+	it('parses embeddings response', () => {
+		const output = ApipieEndpointOutputSchemas.embeddingsCreate.safeParse({
+			object: 'list',
+			data: [{ object: 'embedding', index: 0, embedding: [0.1, 0.2] }],
+		});
+		expect(output.success).toBe(true);
+	});
+
+	it('rejects images response items without url or b64_json', () => {
+		expect(
+			ApipieEndpointOutputSchemas.imagesGenerate.safeParse({
+				created: 1700000000,
+				data: [{ revised_prompt: 'no image data' }],
+			}).success,
+		).toBe(false);
+		expect(
+			ApipieEndpointOutputSchemas.imagesGenerate.safeParse({
+				created: 1700000000,
+				data: [{ url: 'https://example.com/img.png' }],
+			}).success,
+		).toBe(true);
+	});
+});
+
+describe('Apipie error handlers', () => {
+	it('matches 429 rate limit errors by message', () => {
+		expect(
+			errorHandlers.RATE_LIMIT_ERROR.match(new Error('rate_limited')),
+		).toBe(true);
+	});
+
+	it('matches 429 via ApiError status', () => {
+		const error = new ApiError(
+			{} as never,
+			{ url: '', status: 429, statusText: '', body: {} } as never,
+			'Too Many Requests',
+		);
+		expect(errorHandlers.RATE_LIMIT_ERROR.match(error)).toBe(true);
+	});
+
+	it('matches auth errors via ApiError status', () => {
+		const error = new ApiError(
+			{} as never,
+			{ url: '', status: 401, statusText: '', body: {} } as never,
+			'Unauthorized',
+		);
+		expect(errorHandlers.AUTH_ERROR.match(error)).toBe(true);
+	});
+
+	it('returns retry config for rate limit errors', async () => {
+		const result = await errorHandlers.RATE_LIMIT_ERROR.handler(
+			new Error('rate_limited'),
+		);
+		expect(result.maxRetries).toBe(5);
+	});
+
+	it('DEFAULT handler matches any error', () => {
+		expect(errorHandlers.DEFAULT.match()).toBe(true);
+	});
+});
+
+describe('Apipie mocked endpoint handlers', () => {
+	const ctx = testCtx('test_key');
+	const mockRequest = makeApipieRequest as jest.MockedFunction<
+		typeof makeApipieRequest
+	>;
+
+	beforeEach(() => {
+		mockRequest.mockClear();
+	});
+
+	it('Models.list', async () => {
+		mockRequest.mockResolvedValue({ object: 'list', data: [] });
+		await Models.list(ctx, { type: 'llm' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			'/v1/models',
+			'test_key',
+			expect.objectContaining({
+				method: 'GET',
+				query: expect.objectContaining({ type: 'llm' }),
+			}),
+		);
+	});
+
+	it('Models.listDetailed', async () => {
+		mockRequest.mockResolvedValue({ object: 'list', data: [] });
+		await Models.listDetailed(ctx, { provider: 'openai' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			'/v1/models/detailed',
+			'test_key',
+			expect.objectContaining({
+				method: 'GET',
+				query: expect.objectContaining({ provider: 'openai' }),
+			}),
+		);
+	});
+
+	it('Chat.createCompletion', async () => {
+		mockRequest.mockResolvedValue({ id: 'chatcmpl-123', choices: [] });
+		await Chat.createCompletion(ctx, {
+			model: 'gpt-4o',
+			messages: [{ role: 'user', content: 'Hello' }],
+		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			'/v1/chat/completions',
+			'test_key',
+			expect.objectContaining({
+				method: 'POST',
+				body: expect.objectContaining({
+					model: 'gpt-4o',
+					messages: [{ role: 'user', content: 'Hello' }],
+				}),
+			}),
+		);
+	});
+
+	it('Chat.createCompletion maps APIpie extras to snake_case', async () => {
+		mockRequest.mockResolvedValue({ id: 'chatcmpl-123', choices: [] });
+		await Chat.createCompletion(ctx, {
+			model: 'gpt-4o',
+			messages: [{ role: 'user', content: 'Remember this' }],
+			routing: 'price',
+			maxTokens: 100,
+			memSession: 'session-1',
+			memExpire: 60,
+			integrityModel: 'gpt-4o-mini',
+		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			'/v1/chat/completions',
+			'test_key',
+			expect.objectContaining({
+				body: expect.objectContaining({
+					routing: 'price',
+					max_tokens: 100,
+					mem_session: 'session-1',
+					mem_expire: 60,
+					integrity_model: 'gpt-4o-mini',
+				}),
+			}),
+		);
+	});
+
+	it('Embeddings.create', async () => {
+		mockRequest.mockResolvedValue({
+			object: 'list',
+			data: [{ embedding: [0.1] }],
+		});
+		await Embeddings.create(ctx, {
+			model: 'text-embedding-3-small',
+			input: 'hello',
+		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			'/v1/embeddings',
+			'test_key',
+			expect.objectContaining({
+				method: 'POST',
+				body: expect.objectContaining({
+					model: 'text-embedding-3-small',
+					input: 'hello',
+				}),
+			}),
+		);
+	});
+
+	it('Images.generate', async () => {
+		mockRequest.mockResolvedValue({
+			created: 1700000000,
+			data: [{ url: 'https://example.com/img.png' }],
+		});
+		await Images.generate(ctx, { model: 'dall-e-3', prompt: 'a cat' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			'/v1/images/generations',
+			'test_key',
+			expect.objectContaining({
+				method: 'POST',
+				body: expect.objectContaining({
+					model: 'dall-e-3',
+					prompt: 'a cat',
+				}),
+			}),
+		);
+	});
+});
+
+describeIfApiKey('Apipie live API (requires APIPIE_API_KEY)', () => {
+	const ctx = testCtx(TEST_API_KEY ?? '');
+
+	it('lists models live', async () => {
+		const result = await Models.list(ctx, {});
+		const count = Array.isArray(result)
+			? result.length
+			: (result?.data?.length ?? 0);
+		expect(count).toBeGreaterThan(0);
+	});
+});
+
+describe('apipie plugin factory', () => {
+	it('creates a plugin with the expected id and auth type', () => {
+		const plugin = apipie({});
+		expect(plugin.id).toBe('apipie');
+		const options = plugin.options as { authType?: string } | undefined;
+		expect(options?.authType).toBe('api_key');
+	});
+
+	it('exposes all endpoints', () => {
+		const plugin = apipie({});
+		const endpoints = plugin.endpoints as
+			| {
+					models: { list: unknown; listDetailed: unknown };
+					chat: { createCompletion: unknown };
+					embeddings: { create: unknown };
+					images: { generate: unknown };
+			  }
+			| undefined;
+		expect(endpoints?.models.list).toBeDefined();
+		expect(endpoints?.models.listDetailed).toBeDefined();
+		expect(endpoints?.chat.createCompletion).toBeDefined();
+		expect(endpoints?.embeddings.create).toBeDefined();
+		expect(endpoints?.images.generate).toBeDefined();
+	});
+
+	it('does not match webhooks', () => {
+		const plugin = apipie({});
+		const matcher = plugin.pluginWebhookMatcher as
+			| ((request: unknown) => boolean)
+			| undefined;
+		expect(matcher?.({ headers: {}, body: '' })).toBe(false);
+	});
+});

--- a/packages/apipie/client.ts
+++ b/packages/apipie/client.ts
@@ -1,0 +1,70 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+import type { ZodType } from 'zod';
+
+export class ApipieAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly code?: string,
+		public readonly status?: number,
+		public readonly retryAfter?: number,
+	) {
+		super(message);
+		this.name = 'ApipieAPIError';
+	}
+}
+
+const APIPIE_API_BASE = 'https://apipie.ai';
+
+export async function makeApipieRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	options: {
+		method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+		body?: Record<string, unknown>;
+		query?: Record<string, string | number | boolean | undefined>;
+		headers?: Record<string, string>;
+		/** When set, provider JSON is validated before return. */
+		schema?: ZodType<T>;
+	} = {},
+): Promise<T> {
+	const { method = 'GET', body, query, headers, schema } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: APIPIE_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: apiKey,
+		HEADERS: {
+			Authorization: `Bearer ${apiKey}`,
+			'Content-Type': 'application/json',
+			Accept: 'application/json',
+			...headers,
+		},
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint.startsWith('/') ? endpoint : `/${endpoint}`,
+		body:
+			method === 'POST' || method === 'PUT' || method === 'PATCH'
+				? body
+				: undefined,
+		mediaType: 'application/json; charset=utf-8',
+		query,
+	};
+
+	try {
+		const data = await request<unknown>(config, requestOptions);
+		return schema ? schema.parse(data) : (data as T);
+	} catch (error) {
+		if (error instanceof ApiError) {
+			throw error;
+		}
+		if (error instanceof Error) {
+			throw new ApipieAPIError(error.message);
+		}
+		throw new ApipieAPIError('Unknown error');
+	}
+}

--- a/packages/apipie/endpoints/chat.ts
+++ b/packages/apipie/endpoints/chat.ts
@@ -1,0 +1,47 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeApipieRequest } from '../client';
+import type { ApipieEndpoints } from '../index';
+import type { ApipieEndpointOutputs } from './types';
+import { ApipieEndpointOutputSchemas } from './types';
+
+export const createCompletion: ApipieEndpoints['chatCreateCompletion'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeApipieRequest<
+		ApipieEndpointOutputs['chatCreateCompletion']
+	>(`/v1/chat/completions`, ctx.key, {
+		schema: ApipieEndpointOutputSchemas.chatCreateCompletion,
+		method: 'POST',
+		body: {
+			model: input.model,
+			messages: input.messages,
+			provider: input.provider,
+			routing: input.routing,
+			max_tokens: input.maxTokens,
+			temperature: input.temperature,
+			top_p: input.topP,
+			top_k: input.topK,
+			frequency_penalty: input.frequencyPenalty,
+			presence_penalty: input.presencePenalty,
+			stop: input.stop,
+			stream: input.stream,
+			n: input.n,
+			memory: input.memory,
+			mem_session: input.memSession,
+			mem_expire: input.memExpire,
+			mem_clear: input.memClear,
+			integrity: input.integrity,
+			integrity_model: input.integrityModel,
+		},
+	});
+
+	await logEventFromContext(
+		ctx,
+		'apipie.api.chat.createCompletion',
+		{ model: input.model, messageCount: input.messages.length },
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/apipie/endpoints/chat.ts
+++ b/packages/apipie/endpoints/chat.ts
@@ -1,5 +1,5 @@
 import { logEventFromContext } from 'corsair/core';
-import { makeApipieRequest } from '../client';
+import { ApipieAPIError, makeApipieRequest } from '../client';
 import type { ApipieEndpoints } from '../index';
 import type { ApipieEndpointOutputs } from './types';
 import { ApipieEndpointOutputSchemas } from './types';
@@ -8,6 +8,16 @@ export const createCompletion: ApipieEndpoints['chatCreateCompletion'] = async (
 	ctx,
 	input,
 ) => {
+	// The shared transport buffers the whole response and parses it as one JSON
+	// object, so a server-sent event stream would arrive as unparseable text.
+	// `stream` is not part of this endpoint's input schema; reject it here too,
+	// because endpoint inputs are not validated at the binder.
+	if ((input as { stream?: unknown }).stream) {
+		throw new ApipieAPIError(
+			'Streaming is not supported by chat.createCompletion. Omit `stream` to receive a single completion.',
+		);
+	}
+
 	const response = await makeApipieRequest<
 		ApipieEndpointOutputs['chatCreateCompletion']
 	>(`/v1/chat/completions`, ctx.key, {
@@ -25,7 +35,6 @@ export const createCompletion: ApipieEndpoints['chatCreateCompletion'] = async (
 			frequency_penalty: input.frequencyPenalty,
 			presence_penalty: input.presencePenalty,
 			stop: input.stop,
-			stream: input.stream,
 			n: input.n,
 			memory: input.memory,
 			mem_session: input.memSession,

--- a/packages/apipie/endpoints/embeddings.ts
+++ b/packages/apipie/endpoints/embeddings.ts
@@ -1,0 +1,34 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeApipieRequest } from '../client';
+import type { ApipieEndpoints } from '../index';
+import type { ApipieEndpointOutputs } from './types';
+import { ApipieEndpointOutputSchemas } from './types';
+
+export const create: ApipieEndpoints['embeddingsCreate'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeApipieRequest<
+		ApipieEndpointOutputs['embeddingsCreate']
+	>(`/v1/embeddings`, ctx.key, {
+		schema: ApipieEndpointOutputSchemas.embeddingsCreate,
+		method: 'POST',
+		body: {
+			model: input.model,
+			input: input.input,
+			user: input.user,
+		},
+	});
+
+	await logEventFromContext(
+		ctx,
+		'apipie.api.embeddings.create',
+		{
+			model: input.model,
+			inputCount: Array.isArray(input.input) ? input.input.length : 1,
+		},
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/apipie/endpoints/images.ts
+++ b/packages/apipie/endpoints/images.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { logEventFromContext } from 'corsair/core';
 import { makeApipieRequest } from '../client';
 import type { ApipieEndpoints } from '../index';
@@ -26,11 +27,15 @@ export const generate: ApipieEndpoints['imagesGenerate'] = async (
 		},
 	});
 
+	// Minted once per request so images from separate generations can never
+	// share an entity id, even when they complete in the same second.
+	const generationId = randomUUID();
 	await Promise.all(
 		response.data.map((image, index) =>
 			cacheImage(ctx.db?.images, image, {
-				created: response.created,
+				generationId,
 				index,
+				created: response.created,
 				model: input.model,
 				prompt: input.prompt,
 			}),

--- a/packages/apipie/endpoints/images.ts
+++ b/packages/apipie/endpoints/images.ts
@@ -1,6 +1,7 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeApipieRequest } from '../client';
 import type { ApipieEndpoints } from '../index';
+import { cacheImage } from './persist';
 import type { ApipieEndpointOutputs } from './types';
 import { ApipieEndpointOutputSchemas } from './types';
 
@@ -24,6 +25,17 @@ export const generate: ApipieEndpoints['imagesGenerate'] = async (
 			user: input.user,
 		},
 	});
+
+	await Promise.all(
+		response.data.map((image, index) =>
+			cacheImage(ctx.db?.images, image, {
+				created: response.created,
+				index,
+				model: input.model,
+				prompt: input.prompt,
+			}),
+		),
+	);
 
 	await logEventFromContext(
 		ctx,

--- a/packages/apipie/endpoints/images.ts
+++ b/packages/apipie/endpoints/images.ts
@@ -1,0 +1,36 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeApipieRequest } from '../client';
+import type { ApipieEndpoints } from '../index';
+import type { ApipieEndpointOutputs } from './types';
+import { ApipieEndpointOutputSchemas } from './types';
+
+export const generate: ApipieEndpoints['imagesGenerate'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeApipieRequest<
+		ApipieEndpointOutputs['imagesGenerate']
+	>(`/v1/images/generations`, ctx.key, {
+		schema: ApipieEndpointOutputSchemas.imagesGenerate,
+		method: 'POST',
+		body: {
+			model: input.model,
+			prompt: input.prompt,
+			n: input.n,
+			size: input.size,
+			quality: input.quality,
+			style: input.style,
+			response_format: input.responseFormat,
+			user: input.user,
+		},
+	});
+
+	await logEventFromContext(
+		ctx,
+		'apipie.api.images.generate',
+		{ model: input.model, imageCount: response.data.length },
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/apipie/endpoints/index.ts
+++ b/packages/apipie/endpoints/index.ts
@@ -1,0 +1,8 @@
+import * as Chat from './chat';
+import * as Embeddings from './embeddings';
+import * as Images from './images';
+import * as Models from './models';
+
+export { Chat, Embeddings, Images, Models };
+
+export * from './types';

--- a/packages/apipie/endpoints/models.ts
+++ b/packages/apipie/endpoints/models.ts
@@ -1,0 +1,66 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeApipieRequest } from '../client';
+import type { ApipieEndpoints } from '../index';
+import type { ApipieEndpointOutputs } from './types';
+import { ApipieEndpointOutputSchemas } from './types';
+
+export const list: ApipieEndpoints['modelsList'] = async (ctx, input) => {
+	const response = await makeApipieRequest<ApipieEndpointOutputs['modelsList']>(
+		`/v1/models`,
+		ctx.key,
+		{
+			schema: ApipieEndpointOutputSchemas.modelsList,
+			method: 'GET',
+			query: {
+				type: input.type,
+				subtype: input.subtype,
+				provider: input.provider,
+				model: input.model,
+				enabled: input.enabled,
+			},
+		},
+	);
+
+	await logEventFromContext(
+		ctx,
+		'apipie.api.models.list',
+		{
+			resultCount: Array.isArray(response)
+				? response.length
+				: Array.isArray(response?.data)
+					? response.data.length
+					: 0,
+		},
+		'completed',
+	);
+
+	return response;
+};
+
+export const listDetailed: ApipieEndpoints['modelsListDetailed'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeApipieRequest<
+		ApipieEndpointOutputs['modelsListDetailed']
+	>(`/v1/models/detailed`, ctx.key, {
+		schema: ApipieEndpointOutputSchemas.modelsListDetailed,
+		method: 'GET',
+		query: {
+			type: input.type,
+			provider: input.provider,
+			model: input.model,
+		},
+	});
+
+	await logEventFromContext(
+		ctx,
+		'apipie.api.models.listDetailed',
+		{
+			resultCount: Array.isArray(response?.data) ? response.data.length : 0,
+		},
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/apipie/endpoints/models.ts
+++ b/packages/apipie/endpoints/models.ts
@@ -1,7 +1,7 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeApipieRequest } from '../client';
 import type { ApipieEndpoints } from '../index';
-import { cacheModels } from './persist';
+import { cacheModelDetails, cacheModels } from './persist';
 import type { ApipieEndpointOutputs } from './types';
 import { ApipieEndpointOutputSchemas } from './types';
 
@@ -53,7 +53,7 @@ export const listDetailed: ApipieEndpoints['modelsListDetailed'] = async (
 		},
 	});
 
-	await cacheModels(ctx.db?.models, response?.data ?? []);
+	await cacheModelDetails(ctx.db?.modelDetails, response?.data ?? []);
 
 	await logEventFromContext(
 		ctx,

--- a/packages/apipie/endpoints/models.ts
+++ b/packages/apipie/endpoints/models.ts
@@ -1,6 +1,7 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeApipieRequest } from '../client';
 import type { ApipieEndpoints } from '../index';
+import { cacheModels } from './persist';
 import type { ApipieEndpointOutputs } from './types';
 import { ApipieEndpointOutputSchemas } from './types';
 
@@ -21,15 +22,14 @@ export const list: ApipieEndpoints['modelsList'] = async (ctx, input) => {
 		},
 	);
 
+	const items = Array.isArray(response) ? response : (response?.data ?? []);
+	await cacheModels(ctx.db?.models, items);
+
 	await logEventFromContext(
 		ctx,
 		'apipie.api.models.list',
 		{
-			resultCount: Array.isArray(response)
-				? response.length
-				: Array.isArray(response?.data)
-					? response.data.length
-					: 0,
+			resultCount: items.length,
 		},
 		'completed',
 	);
@@ -52,6 +52,8 @@ export const listDetailed: ApipieEndpoints['modelsListDetailed'] = async (
 			model: input.model,
 		},
 	});
+
+	await cacheModels(ctx.db?.models, response?.data ?? []);
 
 	await logEventFromContext(
 		ctx,

--- a/packages/apipie/endpoints/persist.ts
+++ b/packages/apipie/endpoints/persist.ts
@@ -1,4 +1,8 @@
-import type { ApipieImageEntity, ApipieModelEntity } from '../schema/database';
+import type {
+	ApipieImageEntity,
+	ApipieModelDetailEntity,
+	ApipieModelEntity,
+} from '../schema/database';
 
 /**
  * Minimal structural view of a Corsair entity store. Only the operation the
@@ -85,21 +89,64 @@ export async function cacheModels(
 	}
 }
 
+/** Fields carried by a `GET /v1/models/detailed` entry. */
+type CacheableModelDetail = Omit<
+	ApipieModelDetailEntity,
+	'id' | keyof Record<string, never>
+> & { id?: string | null };
+
+/**
+ * Mirrors one detailed catalogue entry.
+ *
+ * Written to its own table rather than shared with `cacheModel`: the entity
+ * store replaces the stored payload wholesale, so writing this narrower field
+ * set over a plain-list row would erase that row's cost columns.
+ */
+export async function cacheModelDetail(
+	store: EntityStore<ApipieModelDetailEntity> | undefined,
+	model: CacheableModelDetail | undefined | null,
+) {
+	if (!store || !model?.id) return;
+	const id = model.id;
+	await safely(
+		() => store.upsertByEntityId(id, { ...model, id }),
+		`model ${id}`,
+	);
+}
+
+/** Mirrors a page of detailed catalogue entries, one row per model. */
+export async function cacheModelDetails(
+	store: EntityStore<ApipieModelDetailEntity> | undefined,
+	models: readonly (CacheableModelDetail | undefined | null)[] | undefined,
+) {
+	if (!store || !models?.length) return;
+	for (const model of models) {
+		await cacheModelDetail(store, model);
+	}
+}
+
 /**
  * Mirrors one generated image.
  *
- * The API returns no identifier per image, so the row is keyed by the
- * generation timestamp and the image's index within the batch. `created` is
- * optional in the response; when it is absent the entry is skipped rather
- * than filed under a key that would collide across generations.
+ * The API returns no identifier per image, so rows are keyed by a generation
+ * id minted once per request plus the image's index within the batch. The
+ * response timestamp is deliberately not used for this: it has one-second
+ * resolution, so two generations finishing in the same second would collide
+ * and the later one would overwrite the earlier.
  */
 export async function cacheImage(
 	store: EntityStore<ApipieImageEntity> | undefined,
 	image: { url?: string; revised_prompt?: string } | undefined | null,
-	context: { created?: number; index: number; model?: string; prompt?: string },
+	context: {
+		generationId: string;
+		index: number;
+		created?: number;
+		model?: string;
+		prompt?: string;
+	},
 ) {
-	if (!store || !image || context.created === undefined) return;
-	const id = `${context.created}:${context.index}`;
+	if (!store || !image) return;
+	const id = `${context.generationId}:${context.index}`;
 	await safely(
 		() =>
 			store.upsertByEntityId(id, {

--- a/packages/apipie/endpoints/persist.ts
+++ b/packages/apipie/endpoints/persist.ts
@@ -1,0 +1,115 @@
+import type { ApipieImageEntity, ApipieModelEntity } from '../schema/database';
+
+/**
+ * Minimal structural view of a Corsair entity store. Only the operation the
+ * APIpie endpoints need is declared, so these helpers stay usable whatever
+ * else the concrete store exposes.
+ */
+type EntityStore<T> = {
+	upsertByEntityId: (entityId: string, data: T) => Promise<unknown>;
+};
+
+/**
+ * Caching is best-effort: an APIpie call must not fail because the local
+ * mirror could not be written. Failures are warned about and swallowed.
+ */
+async function safely(operation: () => Promise<unknown>, what: string) {
+	try {
+		await operation();
+	} catch (error) {
+		console.warn(`[APIPIE] failed to cache ${what}:`, error);
+	}
+}
+
+/** Shape shared by the plain and detailed model list items. */
+type CacheableModel = {
+	id?: string | null;
+	model?: string | null;
+	provider?: string | null;
+	type?: string | null;
+	subtype?: string | null;
+	route?: string | null;
+	description?: string | null;
+	enabled?: boolean | number | null;
+	available?: boolean | number | null;
+	avg_cost?: string | null;
+	input_cost?: string | null;
+	output_cost?: string | null;
+	price_type?: string | null;
+	latency?: string | null;
+	query_count?: string | null;
+	max_tokens?: number | null;
+	max_response_tokens?: number | null;
+};
+
+/** Mirrors one catalogue entry into the local cache. */
+export async function cacheModel(
+	store: EntityStore<ApipieModelEntity> | undefined,
+	model: CacheableModel | undefined | null,
+) {
+	if (!store || !model?.id) return;
+	const id = model.id;
+	await safely(
+		() =>
+			store.upsertByEntityId(id, {
+				id,
+				model: model.model,
+				provider: model.provider,
+				type: model.type,
+				subtype: model.subtype,
+				route: model.route,
+				description: model.description,
+				enabled: model.enabled,
+				available: model.available,
+				avg_cost: model.avg_cost,
+				input_cost: model.input_cost,
+				output_cost: model.output_cost,
+				price_type: model.price_type,
+				latency: model.latency,
+				query_count: model.query_count,
+				max_tokens: model.max_tokens,
+				max_response_tokens: model.max_response_tokens,
+			}),
+		`model ${id}`,
+	);
+}
+
+/** Mirrors a page of catalogue entries, one row per model. */
+export async function cacheModels(
+	store: EntityStore<ApipieModelEntity> | undefined,
+	models: readonly (CacheableModel | undefined | null)[] | undefined,
+) {
+	if (!store || !models?.length) return;
+	for (const model of models) {
+		await cacheModel(store, model);
+	}
+}
+
+/**
+ * Mirrors one generated image.
+ *
+ * The API returns no identifier per image, so the row is keyed by the
+ * generation timestamp and the image's index within the batch. `created` is
+ * optional in the response; when it is absent the entry is skipped rather
+ * than filed under a key that would collide across generations.
+ */
+export async function cacheImage(
+	store: EntityStore<ApipieImageEntity> | undefined,
+	image: { url?: string; revised_prompt?: string } | undefined | null,
+	context: { created?: number; index: number; model?: string; prompt?: string },
+) {
+	if (!store || !image || context.created === undefined) return;
+	const id = `${context.created}:${context.index}`;
+	await safely(
+		() =>
+			store.upsertByEntityId(id, {
+				id,
+				prompt: context.prompt,
+				model: context.model,
+				url: image.url,
+				revised_prompt: image.revised_prompt,
+				created: context.created,
+			}),
+		`image ${id}`,
+	);
+}

--- a/packages/apipie/endpoints/types.ts
+++ b/packages/apipie/endpoints/types.ts
@@ -7,17 +7,40 @@ const ModelMessageSchema = z
 	})
 	.loose();
 
+/**
+ * One entry from `GET /v1/models`.
+ *
+ * Verified against a live response covering all 1217 catalogue entries. Every
+ * field below is returned on every item; nullability marks the ones observed
+ * null. Fields stay optional so a future API change degrades to a missing
+ * value rather than failing the call, since `makeApipieRequest` parses.
+ *
+ * Note the string-typed numerics: `avg_cost`, `input_cost`, `output_cost`,
+ * `latency` and `query_count` come back as numeric strings, not numbers.
+ */
 const ModelListItemSchema = z
 	.object({
 		id: z.string(),
-		type: z.string().nullable().optional(),
-		subtype: z.string().nullable().optional(),
-		name: z.string().nullable().optional(),
-		provider: z.string().nullable().optional(),
-		/** APIpie returns 0/1 flags for some models. */
-		enabled: z.union([z.boolean(), z.number()]).nullable().optional(),
-		description: z.string().nullable().optional(),
-		metadata: z.record(z.string(), z.unknown()).optional(),
+		/** Provider-qualified name, e.g. `openai/gpt-4o`. */
+		model: z.string().nullish(),
+		provider: z.string().nullish(),
+		type: z.string().nullish(),
+		subtype: z.string().nullish(),
+		route: z.string().nullish(),
+		description: z.string().nullish(),
+		/** APIpie returns 0/1 flags rather than booleans. */
+		enabled: z.union([z.boolean(), z.number()]).nullish(),
+		available: z.union([z.boolean(), z.number()]).nullish(),
+		avg_cost: z.string().nullish(),
+		input_cost: z.string().nullish(),
+		output_cost: z.string().nullish(),
+		price_type: z.string().nullish(),
+		img_price: z.unknown().nullish(),
+		img_json: z.record(z.string(), z.unknown()).nullish(),
+		latency: z.string().nullish(),
+		query_count: z.string().nullish(),
+		max_tokens: z.number().nullish(),
+		max_response_tokens: z.number().nullish(),
 	})
 	.loose();
 
@@ -31,20 +54,47 @@ const ModelsListResponseSchema = z.union([
 		.loose(),
 ]);
 
+/**
+ * One entry from `GET /v1/models/detailed`, verified against a live response
+ * across all 1217 entries. This is a different, richer shape than the plain
+ * list: it carries modality, capacity and quality fields the list omits.
+ */
 const DetailedModelListItemSchema = z
 	.object({
-		id: z.string().nullable().optional(),
-		model: z.string().nullable().optional(),
-		name: z.string().nullable().optional(),
-		provider: z.string().nullable().optional(),
-		type: z.string().nullable().optional(),
-		/** APIpie returns 0/1 flags for some models. */
-		enabled: z.union([z.boolean(), z.number()]).nullable().optional(),
-		capabilities: z.unknown().optional(),
-		limits: z.unknown().optional(),
-		pricing: z.unknown().optional(),
-		supported_input_parameters: z.record(z.string(), z.unknown()).optional(),
-		metadata: z.record(z.string(), z.unknown()).optional(),
+		id: z.string(),
+		model: z.string().nullish(),
+		provider: z.string().nullish(),
+		type: z.string().nullish(),
+		subtype: z.string().nullish(),
+		route: z.string().nullish(),
+		description: z.string().nullish(),
+		/** APIpie returns 0/1 flags rather than booleans. */
+		enabled: z.union([z.boolean(), z.number()]).nullish(),
+		available: z.union([z.boolean(), z.number()]).nullish(),
+		abortable: z.boolean().nullish(),
+		moderationRequired: z.boolean().nullish(),
+		supports_multipart: z.boolean().nullish(),
+		input_modalities: z.array(z.string()).nullish(),
+		output_modalities: z.array(z.string()).nullish(),
+		instruct_type: z.string().nullish(),
+		quantization: z.string().nullish(),
+		pool: z.string().nullish(),
+		/** MMLU benchmark score; present for only a handful of models. */
+		mmlu: z.number().nullish(),
+		output_vector_size: z.number().nullish(),
+		max_tokens: z.number().nullish(),
+		max_response_tokens: z.number().nullish(),
+		max_images_per_prompt: z.number().nullish(),
+		max_audio_per_prompt: z.number().nullish(),
+		max_audio_length_hours: z.number().nullish(),
+		max_videos_per_prompt: z.number().nullish(),
+		max_video_length: z.number().nullish(),
+		max_pdf_size_mb: z.number().nullish(),
+		/** Numeric strings, not numbers. */
+		latency: z.string().nullish(),
+		query_count: z.string().nullish(),
+		pricing: z.record(z.string(), z.unknown()).nullish(),
+		supported_input_parameters: z.record(z.string(), z.unknown()).nullish(),
 	})
 	.loose();
 

--- a/packages/apipie/endpoints/types.ts
+++ b/packages/apipie/endpoints/types.ts
@@ -45,7 +45,7 @@ const ModelListItemSchema = z
 	.loose();
 
 const ModelsListResponseSchema = z.union([
-	z.array(ModelListItemSchema).min(1),
+	z.array(ModelListItemSchema),
 	z
 		.object({
 			object: z.string().optional(),
@@ -190,7 +190,6 @@ const ChatCreateCompletionInputSchema = z
 		frequencyPenalty: z.number().optional(),
 		presencePenalty: z.number().optional(),
 		stop: z.union([z.string(), z.array(z.string())]).optional(),
-		stream: z.boolean().optional(),
 		n: z.number().optional(),
 		memory: z.number().optional(),
 		memSession: z.string().optional(),

--- a/packages/apipie/endpoints/types.ts
+++ b/packages/apipie/endpoints/types.ts
@@ -1,0 +1,203 @@
+import { z } from 'zod';
+
+const ModelMessageSchema = z
+	.object({
+		role: z.string(),
+		content: z.string(),
+	})
+	.loose();
+
+const ModelListItemSchema = z
+	.object({
+		id: z.string(),
+		type: z.string().nullable().optional(),
+		subtype: z.string().nullable().optional(),
+		name: z.string().nullable().optional(),
+		provider: z.string().nullable().optional(),
+		/** APIpie returns 0/1 flags for some models. */
+		enabled: z.union([z.boolean(), z.number()]).nullable().optional(),
+		description: z.string().nullable().optional(),
+		metadata: z.record(z.string(), z.unknown()).optional(),
+	})
+	.loose();
+
+const ModelsListResponseSchema = z.union([
+	z.array(ModelListItemSchema).min(1),
+	z
+		.object({
+			object: z.string().optional(),
+			data: z.array(ModelListItemSchema),
+		})
+		.loose(),
+]);
+
+const DetailedModelListItemSchema = z
+	.object({
+		id: z.string().nullable().optional(),
+		model: z.string().nullable().optional(),
+		name: z.string().nullable().optional(),
+		provider: z.string().nullable().optional(),
+		type: z.string().nullable().optional(),
+		/** APIpie returns 0/1 flags for some models. */
+		enabled: z.union([z.boolean(), z.number()]).nullable().optional(),
+		capabilities: z.unknown().optional(),
+		limits: z.unknown().optional(),
+		pricing: z.unknown().optional(),
+		supported_input_parameters: z.record(z.string(), z.unknown()).optional(),
+		metadata: z.record(z.string(), z.unknown()).optional(),
+	})
+	.loose();
+
+const ModelsDetailedResponseSchema = z
+	.object({
+		object: z.string().optional(),
+		data: z.array(DetailedModelListItemSchema),
+	})
+	.loose();
+
+const ChatCompletionChoiceSchema = z
+	.object({
+		index: z.number().optional(),
+		message: ModelMessageSchema,
+		finish_reason: z.string().optional(),
+		finishReason: z.string().optional(),
+	})
+	.loose();
+
+const ChatCompletionResponseSchema = z
+	.object({
+		id: z.string().optional(),
+		object: z.string().optional(),
+		created: z.number().optional(),
+		model: z.string().optional(),
+		choices: z.array(ChatCompletionChoiceSchema),
+		usage: z.record(z.string(), z.unknown()).optional(),
+	})
+	.loose();
+
+const EmbeddingItemSchema = z
+	.object({
+		object: z.string().optional(),
+		index: z.number().optional(),
+		embedding: z.array(z.number()),
+	})
+	.loose();
+
+const EmbeddingsResponseSchema = z
+	.object({
+		object: z.string().optional(),
+		model: z.string().optional(),
+		data: z.array(EmbeddingItemSchema).min(1),
+		usage: z.record(z.string(), z.unknown()).optional(),
+	})
+	.loose();
+
+const ImageItemSchema = z
+	.object({
+		url: z.string().optional(),
+		b64_json: z.string().optional(),
+		revised_prompt: z.string().optional(),
+	})
+	.loose()
+	.refine((v) => typeof v.url === 'string' || typeof v.b64_json === 'string', {
+		message: 'url or b64_json is required',
+	});
+
+const ImagesResponseSchema = z
+	.object({
+		created: z.number().optional(),
+		data: z.array(ImageItemSchema).min(1),
+		usage: z.record(z.string(), z.unknown()).optional(),
+	})
+	.loose();
+
+const ModelsListInputSchema = z
+	.object({
+		type: z.string().optional(),
+		subtype: z.string().optional(),
+		provider: z.string().optional(),
+		model: z.string().optional(),
+		enabled: z.number().optional(),
+	})
+	.loose();
+const ModelsListDetailedInputSchema = z
+	.object({
+		type: z.string().optional(),
+		provider: z.string().optional(),
+		model: z.string().optional(),
+	})
+	.loose();
+const ChatCreateCompletionInputSchema = z
+	.object({
+		model: z.string(),
+		messages: z.array(ModelMessageSchema).min(1),
+		provider: z.string().optional(),
+		routing: z.enum(['price', 'perf', 'perf_avg']).optional(),
+		maxTokens: z.number().optional(),
+		temperature: z.number().optional(),
+		topP: z.number().optional(),
+		topK: z.number().optional(),
+		frequencyPenalty: z.number().optional(),
+		presencePenalty: z.number().optional(),
+		stop: z.union([z.string(), z.array(z.string())]).optional(),
+		stream: z.boolean().optional(),
+		n: z.number().optional(),
+		memory: z.number().optional(),
+		memSession: z.string().optional(),
+		memExpire: z.number().optional(),
+		memClear: z.number().optional(),
+		integrity: z.number().optional(),
+		integrityModel: z.string().optional(),
+	})
+	.loose();
+const EmbeddingsCreateInputSchema = z
+	.object({
+		model: z.string(),
+		input: z.union([z.string().min(1), z.array(z.string()).min(1)]),
+		user: z.string().optional(),
+	})
+	.loose();
+const ImagesGenerateInputSchema = z
+	.object({
+		model: z.string(),
+		prompt: z.string().min(1),
+		n: z.number().optional(),
+		size: z.string().optional(),
+		quality: z.string().optional(),
+		style: z.string().optional(),
+		responseFormat: z.string().optional(),
+		user: z.string().optional(),
+	})
+	.loose();
+
+export type ApipieEndpointInputs = {
+	modelsList: z.infer<typeof ModelsListInputSchema>;
+	modelsListDetailed: z.infer<typeof ModelsListDetailedInputSchema>;
+	chatCreateCompletion: z.infer<typeof ChatCreateCompletionInputSchema>;
+	embeddingsCreate: z.infer<typeof EmbeddingsCreateInputSchema>;
+	imagesGenerate: z.infer<typeof ImagesGenerateInputSchema>;
+};
+
+export type ApipieEndpointOutputs = {
+	modelsList: z.infer<typeof ModelsListResponseSchema>;
+	modelsListDetailed: z.infer<typeof ModelsDetailedResponseSchema>;
+	chatCreateCompletion: z.infer<typeof ChatCompletionResponseSchema>;
+	embeddingsCreate: z.infer<typeof EmbeddingsResponseSchema>;
+	imagesGenerate: z.infer<typeof ImagesResponseSchema>;
+};
+
+export const ApipieEndpointInputSchemas = {
+	modelsList: ModelsListInputSchema,
+	modelsListDetailed: ModelsListDetailedInputSchema,
+	chatCreateCompletion: ChatCreateCompletionInputSchema,
+	embeddingsCreate: EmbeddingsCreateInputSchema,
+	imagesGenerate: ImagesGenerateInputSchema,
+} as const;
+
+export const ApipieEndpointOutputSchemas = {
+	modelsList: ModelsListResponseSchema,
+	modelsListDetailed: ModelsDetailedResponseSchema,
+	chatCreateCompletion: ChatCompletionResponseSchema,
+	embeddingsCreate: EmbeddingsResponseSchema,
+	imagesGenerate: ImagesResponseSchema,
+} as const;

--- a/packages/apipie/error-handlers.ts
+++ b/packages/apipie/error-handlers.ts
@@ -1,0 +1,99 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('rate_limited') ||
+				msg.includes('429') ||
+				msg.includes('rate limit')
+			);
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('unauthorized') ||
+				msg.includes('invalid_auth') ||
+				msg.includes('invalid api key')
+			);
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	FORBIDDEN_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 403) return true;
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('forbidden') ||
+				msg.includes('permission denied') ||
+				msg.includes('insufficient')
+			);
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	NOT_FOUND_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 404) return true;
+			return error.message.toLowerCase().includes('not found');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	CONFLICT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 409) return true;
+			return error.message.toLowerCase().includes('conflict');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	VALIDATION_ERROR: {
+		match: (error: Error) => {
+			if (
+				error instanceof ApiError &&
+				(error.status === 400 || error.status === 422)
+			)
+				return true;
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('invalid request') ||
+				msg.includes('validation') ||
+				msg.includes('bad request')
+			);
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	SERVER_ERROR: {
+		match: (error: Error) => {
+			if (
+				error instanceof ApiError &&
+				error.status >= 500 &&
+				error.status < 600
+			)
+				return true;
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('internal server') ||
+				msg.includes('503') ||
+				msg.includes('502') ||
+				msg.includes('500')
+			);
+		},
+		handler: async () => ({ maxRetries: 3 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/apipie/error-handlers.ts
+++ b/packages/apipie/error-handlers.ts
@@ -2,6 +2,14 @@ import type { CorsairErrorHandler } from 'corsair/core';
 import { ApiError } from 'corsair/http';
 
 export const errorHandlers = {
+	/**
+	 * Rate limits are retried by the transport, not here. `corsair/http`
+	 * already retries a 429 internally (`DEFAULT_RATE_LIMIT_CONFIG.maxRetries`
+	 * is 3, honouring `Retry-After`) and returns the attempt that succeeds.
+	 * Asking the binder for more retries on top would multiply the two budgets
+	 * and replay billable, non-idempotent completions, so this handler
+	 * classifies the error and reports `Retry-After` without re-driving it.
+	 */
 	RATE_LIMIT_ERROR: {
 		match: (error: Error) => {
 			if (error instanceof ApiError && error.status === 429) return true;
@@ -17,7 +25,7 @@ export const errorHandlers = {
 			if (error instanceof ApiError && error.retryAfter !== undefined) {
 				retryAfterMs = error.retryAfter;
 			}
-			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+			return { maxRetries: 0, headersRetryAfterMs: retryAfterMs };
 		},
 	},
 	AUTH_ERROR: {
@@ -28,6 +36,23 @@ export const errorHandlers = {
 				msg.includes('unauthorized') ||
 				msg.includes('invalid_auth') ||
 				msg.includes('invalid api key')
+			);
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	/**
+	 * APIpie bills per request and returns `402` with
+	 * `{"code":"ACCOUNT_ERROR"}` once an account runs out of credit. Retrying
+	 * cannot succeed until the account is topped up, so it is never retried.
+	 */
+	ACCOUNT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 402) return true;
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('account_error') ||
+				msg.includes('out of credit') ||
+				msg.includes('payment required')
 			);
 		},
 		handler: async () => ({ maxRetries: 0 }),
@@ -74,6 +99,14 @@ export const errorHandlers = {
 		},
 		handler: async () => ({ maxRetries: 0 }),
 	},
+	/**
+	 * Server errors are classified but not re-driven. Every billable APIpie
+	 * operation (`chat.createCompletion`, `embeddings.create`,
+	 * `images.generate`) is a non-idempotent `POST`, and a 5xx gives no
+	 * guarantee the upstream call did not already run and bill. Replaying it
+	 * risks duplicate charges, so retrying is left to the caller, who knows
+	 * whether the operation is safe to repeat.
+	 */
 	SERVER_ERROR: {
 		match: (error: Error) => {
 			if (
@@ -90,7 +123,7 @@ export const errorHandlers = {
 				msg.includes('500')
 			);
 		},
-		handler: async () => ({ maxRetries: 3 }),
+		handler: async () => ({ maxRetries: 0 }),
 	},
 	DEFAULT: {
 		match: () => true,

--- a/packages/apipie/index.ts
+++ b/packages/apipie/index.ts
@@ -1,0 +1,202 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+} from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
+import { Chat, Embeddings, Images, Models } from './endpoints';
+import type {
+	ApipieEndpointInputs,
+	ApipieEndpointOutputs,
+} from './endpoints/types';
+import {
+	ApipieEndpointInputSchemas,
+	ApipieEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { ApipieSchema } from './schema';
+
+export type ApipiePluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	hooks?: InternalApipiePlugin['hooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof apipieEndpointsNested>;
+};
+
+export type ApipieContext = CorsairPluginContext<
+	typeof ApipieSchema,
+	ApipiePluginOptions
+>;
+
+export type ApipieKeyBuilderContext = KeyBuilderContext<ApipiePluginOptions>;
+
+export type ApipieBoundEndpoints = BindEndpoints<typeof apipieEndpointsNested>;
+
+type ApipieEndpoint<K extends keyof ApipieEndpointOutputs> = CorsairEndpoint<
+	ApipieContext,
+	ApipieEndpointInputs[K],
+	ApipieEndpointOutputs[K]
+>;
+
+export type ApipieEndpoints = {
+	modelsList: ApipieEndpoint<'modelsList'>;
+	modelsListDetailed: ApipieEndpoint<'modelsListDetailed'>;
+	chatCreateCompletion: ApipieEndpoint<'chatCreateCompletion'>;
+	embeddingsCreate: ApipieEndpoint<'embeddingsCreate'>;
+	imagesGenerate: ApipieEndpoint<'imagesGenerate'>;
+};
+
+const apipieEndpointsNested = {
+	models: {
+		list: Models.list,
+		listDetailed: Models.listDetailed,
+	},
+	chat: {
+		createCompletion: Chat.createCompletion,
+	},
+	embeddings: {
+		create: Embeddings.create,
+	},
+	images: {
+		generate: Images.generate,
+	},
+} as const;
+
+export const apipieEndpointSchemas = {
+	'models.list': {
+		input: ApipieEndpointInputSchemas.modelsList,
+		output: ApipieEndpointOutputSchemas.modelsList,
+	},
+	'models.listDetailed': {
+		input: ApipieEndpointInputSchemas.modelsListDetailed,
+		output: ApipieEndpointOutputSchemas.modelsListDetailed,
+	},
+	'chat.createCompletion': {
+		input: ApipieEndpointInputSchemas.chatCreateCompletion,
+		output: ApipieEndpointOutputSchemas.chatCreateCompletion,
+	},
+	'embeddings.create': {
+		input: ApipieEndpointInputSchemas.embeddingsCreate,
+		output: ApipieEndpointOutputSchemas.embeddingsCreate,
+	},
+	'images.generate': {
+		input: ApipieEndpointInputSchemas.imagesGenerate,
+		output: ApipieEndpointOutputSchemas.imagesGenerate,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<
+	typeof apipieEndpointsNested
+>;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const apipieEndpointMeta = {
+	'models.list': {
+		riskLevel: 'read',
+		description:
+			'List APIpie models available to the account, filterable by type, subtype, provider, and model.',
+	},
+	'models.listDetailed': {
+		riskLevel: 'read',
+		description:
+			'List APIpie models with detailed metadata including capabilities, limits, and pricing.',
+	},
+	'chat.createCompletion': {
+		riskLevel: 'write',
+		description:
+			'Generate a chat completion using an APIpie model, with optional provider routing and memory.',
+	},
+	'embeddings.create': {
+		riskLevel: 'write',
+		description: 'Create embeddings for the given input text(s).',
+	},
+	'images.generate': {
+		riskLevel: 'write',
+		description: 'Generate image(s) from a text prompt.',
+	},
+} as const satisfies RequiredPluginEndpointMeta<typeof apipieEndpointsNested>;
+
+export const apipieAuthConfig = {
+	api_key: {
+		account: ['one'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type BaseApipiePlugin<T extends ApipiePluginOptions> = CorsairPlugin<
+	'apipie',
+	typeof ApipieSchema,
+	typeof apipieEndpointsNested,
+	{},
+	T,
+	typeof defaultAuthType,
+	typeof apipieAuthConfig
+>;
+
+export type InternalApipiePlugin = BaseApipiePlugin<ApipiePluginOptions>;
+
+export type ExternalApipiePlugin<T extends ApipiePluginOptions> =
+	BaseApipiePlugin<T>;
+
+export function apipie<const T extends ApipiePluginOptions>(
+	incomingOptions: ApipiePluginOptions & T = {} as ApipiePluginOptions & T,
+): ExternalApipiePlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+
+	return {
+		id: 'apipie',
+		schema: ApipieSchema,
+		options,
+		hooks: options.hooks,
+		endpoints: apipieEndpointsNested,
+		webhooks: {},
+		endpointMeta: apipieEndpointMeta,
+		endpointSchemas: apipieEndpointSchemas,
+		authConfig: apipieAuthConfig,
+		pluginWebhookMatcher: () => false,
+		errorHandlers: (() => {
+			const { DEFAULT: defaultHandler, ...specificDefaults } = errorHandlers;
+			return {
+				...specificDefaults,
+				...(options.errorHandlers || {}),
+				DEFAULT: options.errorHandlers?.DEFAULT || defaultHandler,
+			};
+		})(),
+		keyBuilder: async (ctx: ApipieKeyBuilderContext, source) => {
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const key = await ctx.keys.get_api_key();
+				if (!key) {
+					throw new AuthMissingError('apipie', 'api_key');
+				}
+				return key;
+			}
+
+			throw new AuthMissingError('apipie', 'api_key');
+		},
+	} satisfies InternalApipiePlugin;
+}
+
+export type {
+	ApipieEndpointInputs,
+	ApipieEndpointOutputs,
+} from './endpoints/types';
+
+export {
+	ApipieEndpointInputSchemas,
+	ApipieEndpointOutputSchemas,
+} from './endpoints/types';

--- a/packages/apipie/jest.config.cjs
+++ b/packages/apipie/jest.config.cjs
@@ -1,0 +1,57 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+					types: ['node', 'jest'],
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					types: ['node', 'jest'],
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/apipie/package.json
+++ b/packages/apipie/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/apipie",
+  "version": "0.1.0",
+  "description": "APIpie AI plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "apipie",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/apipie/plugin.test.ts
+++ b/packages/apipie/plugin.test.ts
@@ -1,0 +1,561 @@
+import { ApiError } from 'corsair/http';
+import { makeApipieRequest } from './client';
+import { Chat, Embeddings, Images, Models } from './endpoints';
+import {
+	ApipieEndpointInputSchemas,
+	ApipieEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import type { ApipieContext } from './index';
+import { apipie } from './index';
+
+jest.mock('./client', () => {
+	const actual = jest.requireActual('./client');
+	return {
+		...actual,
+		makeApipieRequest: jest.fn(),
+	};
+});
+
+/** Minimal plugin context for endpoint handler tests. */
+function testCtx(key: string): ApipieContext {
+	return {
+		key,
+	} as ApipieContext;
+}
+
+const TEST_API_KEY = process.env.APIPIE_API_KEY;
+const describeIfApiKey = TEST_API_KEY ? describe : describe.skip;
+
+describe('Apipie endpoint input schemas', () => {
+	it('validates models.list input', () => {
+		expect(ApipieEndpointInputSchemas.modelsList.safeParse({}).success).toBe(
+			true,
+		);
+		expect(
+			ApipieEndpointInputSchemas.modelsList.safeParse({
+				type: 'llm',
+				provider: 'openai',
+			}).success,
+		).toBe(true);
+	});
+
+	it('validates models.listDetailed input', () => {
+		expect(
+			ApipieEndpointInputSchemas.modelsListDetailed.safeParse({}).success,
+		).toBe(true);
+		expect(
+			ApipieEndpointInputSchemas.modelsListDetailed.safeParse({
+				model: 'gpt-4o',
+			}).success,
+		).toBe(true);
+	});
+
+	it('validates chat.createCompletion input', () => {
+		const valid = ApipieEndpointInputSchemas.chatCreateCompletion.safeParse({
+			model: 'gpt-4o',
+			messages: [{ role: 'user', content: 'Hello' }],
+		});
+		expect(valid.success).toBe(true);
+	});
+
+	it('rejects chat.createCompletion without messages', () => {
+		const invalid = ApipieEndpointInputSchemas.chatCreateCompletion.safeParse({
+			model: 'gpt-4o',
+		});
+		expect(invalid.success).toBe(false);
+	});
+
+	it('rejects chat.createCompletion with unknown routing', () => {
+		const invalid = ApipieEndpointInputSchemas.chatCreateCompletion.safeParse({
+			model: 'gpt-4o',
+			messages: [{ role: 'user', content: 'Hello' }],
+			routing: 'cheapest',
+		});
+		expect(invalid.success).toBe(false);
+	});
+
+	it('validates embeddings.create with string or array input', () => {
+		expect(
+			ApipieEndpointInputSchemas.embeddingsCreate.safeParse({
+				model: 'text-embedding-3-small',
+				input: 'hello',
+			}).success,
+		).toBe(true);
+		expect(
+			ApipieEndpointInputSchemas.embeddingsCreate.safeParse({
+				model: 'text-embedding-3-small',
+				input: ['hello', 'world'],
+			}).success,
+		).toBe(true);
+		expect(
+			ApipieEndpointInputSchemas.embeddingsCreate.safeParse({
+				model: 'text-embedding-3-small',
+			}).success,
+		).toBe(false);
+	});
+
+	it('requires images.generate prompt', () => {
+		expect(
+			ApipieEndpointInputSchemas.imagesGenerate.safeParse({
+				model: 'dall-e-3',
+			}).success,
+		).toBe(false);
+		expect(
+			ApipieEndpointInputSchemas.imagesGenerate.safeParse({
+				model: 'dall-e-3',
+				prompt: 'a cat',
+			}).success,
+		).toBe(true);
+	});
+});
+
+describe('Apipie endpoint output schemas', () => {
+	it('parses chat completion response', () => {
+		const output = ApipieEndpointOutputSchemas.chatCreateCompletion.safeParse({
+			id: 'chatcmpl-123',
+			object: 'chat.completion',
+			choices: [{ index: 0, message: { role: 'assistant', content: 'Hi' } }],
+		});
+		expect(output.success).toBe(true);
+	});
+
+	it('parses models list response shapes', () => {
+		expect(
+			ApipieEndpointOutputSchemas.modelsList.safeParse([
+				{ id: 'gpt-4o', provider: 'openai' },
+			]).success,
+		).toBe(true);
+		expect(
+			ApipieEndpointOutputSchemas.modelsList.safeParse({
+				object: 'list',
+				data: [{ id: 'gpt-4o' }],
+			}).success,
+		).toBe(true);
+	});
+
+	it('parses models detailed response', () => {
+		const output = ApipieEndpointOutputSchemas.modelsListDetailed.safeParse({
+			object: 'list',
+			data: [
+				{
+					id: 'gpt-4o',
+					enabled: true,
+					pricing: { input_cost_per_token: 0.001 },
+				},
+			],
+		});
+		expect(output.success).toBe(true);
+	});
+
+	it('parses embeddings response', () => {
+		const output = ApipieEndpointOutputSchemas.embeddingsCreate.safeParse({
+			object: 'list',
+			data: [{ object: 'embedding', index: 0, embedding: [0.1, 0.2] }],
+		});
+		expect(output.success).toBe(true);
+	});
+
+	it('rejects images response items without url or b64_json', () => {
+		expect(
+			ApipieEndpointOutputSchemas.imagesGenerate.safeParse({
+				created: 1700000000,
+				data: [{ revised_prompt: 'no image data' }],
+			}).success,
+		).toBe(false);
+		expect(
+			ApipieEndpointOutputSchemas.imagesGenerate.safeParse({
+				created: 1700000000,
+				data: [{ url: 'https://example.com/img.png' }],
+			}).success,
+		).toBe(true);
+	});
+});
+
+describe('Apipie error handlers', () => {
+	it('matches 429 rate limit errors by message', () => {
+		expect(
+			errorHandlers.RATE_LIMIT_ERROR.match(new Error('rate_limited')),
+		).toBe(true);
+	});
+
+	it('matches 429 via ApiError status', () => {
+		const error = new ApiError(
+			{} as never,
+			{ url: '', status: 429, statusText: '', body: {} } as never,
+			'Too Many Requests',
+		);
+		expect(errorHandlers.RATE_LIMIT_ERROR.match(error)).toBe(true);
+	});
+
+	it('matches auth errors via ApiError status', () => {
+		const error = new ApiError(
+			{} as never,
+			{ url: '', status: 401, statusText: '', body: {} } as never,
+			'Unauthorized',
+		);
+		expect(errorHandlers.AUTH_ERROR.match(error)).toBe(true);
+	});
+
+	it('leaves rate-limit retries to the transport', async () => {
+		// corsair/http already retries 429 internally and returns the attempt
+		// that succeeds. Re-driving it from the binder would multiply the two
+		// budgets and replay billable completions.
+		const result = await errorHandlers.RATE_LIMIT_ERROR.handler(
+			new Error('rate_limited'),
+		);
+		expect(result.maxRetries).toBe(0);
+	});
+
+	it('surfaces Retry-After from a 429 without re-driving it', async () => {
+		const error = new ApiError(
+			{} as never,
+			{ url: '', status: 429, statusText: '', body: {} } as never,
+			'Too Many Requests',
+		);
+		(error as { retryAfter?: number }).retryAfter = 2000;
+		const result = await errorHandlers.RATE_LIMIT_ERROR.handler(error);
+		expect(result.headersRetryAfterMs).toBe(2000);
+		expect(result.maxRetries).toBe(0);
+	});
+
+	it('matches a 402 out-of-credit response', () => {
+		const error = new ApiError(
+			{} as never,
+			{
+				url: '',
+				status: 402,
+				statusText: '',
+				body: {
+					code: 'ACCOUNT_ERROR',
+					message: 'Your account appears to be out of credit',
+				},
+			} as never,
+			'Payment Required',
+		);
+		expect(errorHandlers.ACCOUNT_ERROR.match(error)).toBe(true);
+		expect(errorHandlers.AUTH_ERROR.match(error)).toBe(false);
+	});
+
+	it('never retries an out-of-credit account', async () => {
+		const result = await errorHandlers.ACCOUNT_ERROR.handler();
+		expect(result.maxRetries).toBe(0);
+	});
+
+	it('does not replay billable POSTs after a 5xx', async () => {
+		const result = await errorHandlers.SERVER_ERROR.handler();
+		expect(result.maxRetries).toBe(0);
+	});
+
+	it('DEFAULT handler matches any error', () => {
+		expect(errorHandlers.DEFAULT.match()).toBe(true);
+	});
+});
+
+describe('Apipie mocked endpoint handlers', () => {
+	const ctx = testCtx('test_key');
+	const mockRequest = makeApipieRequest as jest.MockedFunction<
+		typeof makeApipieRequest
+	>;
+
+	beforeEach(() => {
+		mockRequest.mockClear();
+	});
+
+	it('Models.list', async () => {
+		mockRequest.mockResolvedValue({ object: 'list', data: [] });
+		await Models.list(ctx, { type: 'llm' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			'/v1/models',
+			'test_key',
+			expect.objectContaining({
+				method: 'GET',
+				query: expect.objectContaining({ type: 'llm' }),
+			}),
+		);
+	});
+
+	it('Models.listDetailed', async () => {
+		mockRequest.mockResolvedValue({ object: 'list', data: [] });
+		await Models.listDetailed(ctx, { provider: 'openai' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			'/v1/models/detailed',
+			'test_key',
+			expect.objectContaining({
+				method: 'GET',
+				query: expect.objectContaining({ provider: 'openai' }),
+			}),
+		);
+	});
+
+	it('Chat.createCompletion', async () => {
+		mockRequest.mockResolvedValue({ id: 'chatcmpl-123', choices: [] });
+		await Chat.createCompletion(ctx, {
+			model: 'gpt-4o',
+			messages: [{ role: 'user', content: 'Hello' }],
+		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			'/v1/chat/completions',
+			'test_key',
+			expect.objectContaining({
+				method: 'POST',
+				body: expect.objectContaining({
+					model: 'gpt-4o',
+					messages: [{ role: 'user', content: 'Hello' }],
+				}),
+			}),
+		);
+	});
+
+	it('Chat.createCompletion maps APIpie extras to snake_case', async () => {
+		mockRequest.mockResolvedValue({ id: 'chatcmpl-123', choices: [] });
+		await Chat.createCompletion(ctx, {
+			model: 'gpt-4o',
+			messages: [{ role: 'user', content: 'Remember this' }],
+			routing: 'price',
+			maxTokens: 100,
+			memSession: 'session-1',
+			memExpire: 60,
+			integrityModel: 'gpt-4o-mini',
+		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			'/v1/chat/completions',
+			'test_key',
+			expect.objectContaining({
+				body: expect.objectContaining({
+					routing: 'price',
+					max_tokens: 100,
+					mem_session: 'session-1',
+					mem_expire: 60,
+					integrity_model: 'gpt-4o-mini',
+				}),
+			}),
+		);
+	});
+
+	it('Embeddings.create', async () => {
+		mockRequest.mockResolvedValue({
+			object: 'list',
+			data: [{ embedding: [0.1] }],
+		});
+		await Embeddings.create(ctx, {
+			model: 'text-embedding-3-small',
+			input: 'hello',
+		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			'/v1/embeddings',
+			'test_key',
+			expect.objectContaining({
+				method: 'POST',
+				body: expect.objectContaining({
+					model: 'text-embedding-3-small',
+					input: 'hello',
+				}),
+			}),
+		);
+	});
+
+	it('Images.generate', async () => {
+		mockRequest.mockResolvedValue({
+			created: 1700000000,
+			data: [{ url: 'https://example.com/img.png' }],
+		});
+		await Images.generate(ctx, { model: 'dall-e-3', prompt: 'a cat' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			'/v1/images/generations',
+			'test_key',
+			expect.objectContaining({
+				method: 'POST',
+				body: expect.objectContaining({
+					model: 'dall-e-3',
+					prompt: 'a cat',
+				}),
+			}),
+		);
+	});
+});
+
+describe('apipie plugin factory', () => {
+	it('creates a plugin with the expected id and auth type', () => {
+		const plugin = apipie({});
+		expect(plugin.id).toBe('apipie');
+		const options = plugin.options as { authType?: string } | undefined;
+		expect(options?.authType).toBe('api_key');
+	});
+
+	it('exposes all endpoints', () => {
+		const plugin = apipie({});
+		const endpoints = plugin.endpoints as
+			| {
+					models: { list: unknown; listDetailed: unknown };
+					chat: { createCompletion: unknown };
+					embeddings: { create: unknown };
+					images: { generate: unknown };
+			  }
+			| undefined;
+		expect(endpoints?.models.list).toBeDefined();
+		expect(endpoints?.models.listDetailed).toBeDefined();
+		expect(endpoints?.chat.createCompletion).toBeDefined();
+		expect(endpoints?.embeddings.create).toBeDefined();
+		expect(endpoints?.images.generate).toBeDefined();
+	});
+
+	it('does not match webhooks', () => {
+		const plugin = apipie({});
+		const matcher = plugin.pluginWebhookMatcher as
+			| ((request: unknown) => boolean)
+			| undefined;
+		expect(matcher?.({ headers: {}, body: '' })).toBe(false);
+	});
+});
+
+describe('Apipie entity caching', () => {
+	const mockRequest = makeApipieRequest as jest.MockedFunction<
+		typeof makeApipieRequest
+	>;
+
+	/** Context carrying an in-memory stand-in for the entity store. */
+	function ctxWithDb() {
+		const models = new Map<string, unknown>();
+		const images = new Map<string, unknown>();
+		const ctx = {
+			key: 'test_key',
+			db: {
+				models: {
+					upsertByEntityId: jest.fn(async (id: string, data: unknown) => {
+						models.set(id, data);
+					}),
+				},
+				images: {
+					upsertByEntityId: jest.fn(async (id: string, data: unknown) => {
+						images.set(id, data);
+					}),
+				},
+			},
+		} as unknown as ApipieContext;
+		return { ctx, models, images };
+	}
+
+	beforeEach(() => {
+		mockRequest.mockClear();
+	});
+
+	it('mirrors listed models into the cache', async () => {
+		const { ctx, models } = ctxWithDb();
+		mockRequest.mockResolvedValue({
+			object: 'list',
+			data: [
+				{
+					id: 'openai/gpt-4o',
+					model: 'openai/gpt-4o',
+					provider: 'openai',
+					type: 'llm',
+					route: 'openai/gpt-4o',
+					latency: '1.2',
+					query_count: '42',
+					max_tokens: 128000,
+				},
+			],
+		});
+
+		await Models.list(ctx, {});
+
+		expect(models.size).toBe(1);
+		expect(models.get('openai/gpt-4o')).toMatchObject({
+			id: 'openai/gpt-4o',
+			provider: 'openai',
+			type: 'llm',
+			// Numeric strings are preserved as strings, matching the API.
+			latency: '1.2',
+			query_count: '42',
+			max_tokens: 128000,
+		});
+	});
+
+	it('mirrors detailed models into the same table', async () => {
+		const { ctx, models } = ctxWithDb();
+		mockRequest.mockResolvedValue({
+			object: 'list',
+			data: [{ id: 'anthropic/claude-3', provider: 'anthropic', type: 'llm' }],
+		});
+
+		await Models.listDetailed(ctx, {});
+
+		expect(models.get('anthropic/claude-3')).toMatchObject({
+			id: 'anthropic/claude-3',
+			provider: 'anthropic',
+		});
+	});
+
+	it('skips catalogue entries with no id', async () => {
+		const { ctx, models } = ctxWithDb();
+		mockRequest.mockResolvedValue({
+			object: 'list',
+			data: [{ provider: 'openai' }],
+		});
+
+		await Models.list(ctx, {});
+
+		expect(models.size).toBe(0);
+	});
+
+	it('keys generated images by timestamp and batch index', async () => {
+		const { ctx, images } = ctxWithDb();
+		mockRequest.mockResolvedValue({
+			created: 1700000000,
+			data: [
+				{ url: 'https://example.com/a.png' },
+				{ url: 'https://example.com/b.png', revised_prompt: 'a red cube' },
+			],
+		});
+
+		await Images.generate(ctx, { model: 'dall-e-3', prompt: 'a cube' });
+
+		expect(images.size).toBe(2);
+		expect(images.get('1700000000:1')).toMatchObject({
+			id: '1700000000:1',
+			model: 'dall-e-3',
+			prompt: 'a cube',
+			url: 'https://example.com/b.png',
+			revised_prompt: 'a red cube',
+			created: 1700000000,
+		});
+	});
+
+	it('does not cache images when the API returns no timestamp', async () => {
+		const { ctx, images } = ctxWithDb();
+		mockRequest.mockResolvedValue({
+			data: [{ url: 'https://example.com/a.png' }],
+		});
+
+		await Images.generate(ctx, { model: 'dall-e-3', prompt: 'a cube' });
+
+		// Without `created` there is no collision-free key, so filing the row
+		// would overwrite an unrelated generation.
+		expect(images.size).toBe(0);
+	});
+
+	it('never fails the call when the cache write throws', async () => {
+		const ctx = {
+			key: 'test_key',
+			db: {
+				models: {
+					upsertByEntityId: jest.fn(async () => {
+						throw new Error('store unavailable');
+					}),
+				},
+			},
+		} as unknown as ApipieContext;
+		mockRequest.mockResolvedValue({ object: 'list', data: [{ id: 'a/b' }] });
+		const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+		await expect(Models.list(ctx, {})).resolves.toBeDefined();
+		expect(warn).toHaveBeenCalled();
+		warn.mockRestore();
+	});
+
+	it('works when no entity store is configured', async () => {
+		mockRequest.mockResolvedValue({ object: 'list', data: [{ id: 'a/b' }] });
+		await expect(Models.list(testCtx('test_key'), {})).resolves.toBeDefined();
+	});
+});

--- a/packages/apipie/plugin.test.ts
+++ b/packages/apipie/plugin.test.ts
@@ -24,9 +24,6 @@ function testCtx(key: string): ApipieContext {
 	} as ApipieContext;
 }
 
-const TEST_API_KEY = process.env.APIPIE_API_KEY;
-const describeIfApiKey = TEST_API_KEY ? describe : describe.skip;
-
 describe('Apipie endpoint input schemas', () => {
 	it('validates models.list input', () => {
 		expect(ApipieEndpointInputSchemas.modelsList.safeParse({}).success).toBe(
@@ -409,6 +406,58 @@ describe('apipie plugin factory', () => {
 	});
 });
 
+describe('Apipie models list response shapes', () => {
+	it('accepts an empty bare array as a valid empty catalogue', () => {
+		// A filter that matches nothing is a legitimate result, not an error.
+		const parsed = ApipieEndpointOutputSchemas.modelsList.safeParse([]);
+		expect(parsed.success).toBe(true);
+	});
+
+	it('accepts an empty wrapped catalogue', () => {
+		const parsed = ApipieEndpointOutputSchemas.modelsList.safeParse({
+			object: 'list',
+			data: [],
+		});
+		expect(parsed.success).toBe(true);
+	});
+});
+
+describe('Apipie streaming rejection', () => {
+	const mockRequest = makeApipieRequest as jest.MockedFunction<
+		typeof makeApipieRequest
+	>;
+
+	beforeEach(() => {
+		mockRequest.mockClear();
+	});
+
+	it('rejects a forced stream instead of sending it upstream', async () => {
+		// The transport buffers the response and parses it as one JSON object,
+		// so an event stream would come back as unparseable text.
+		await expect(
+			Chat.createCompletion(testCtx('test_key'), {
+				model: 'openai/gpt-4o',
+				messages: [{ role: 'user', content: 'hi' }],
+				stream: true,
+			} as never),
+		).rejects.toThrow(/streaming is not supported/i);
+		expect(mockRequest).not.toHaveBeenCalled();
+	});
+
+	it('never puts stream in the request body', async () => {
+		mockRequest.mockResolvedValue({ choices: [] });
+		await Chat.createCompletion(testCtx('test_key'), {
+			model: 'openai/gpt-4o',
+			messages: [{ role: 'user', content: 'hi' }],
+		});
+		const call = mockRequest.mock.calls[0];
+		expect(call).toBeDefined();
+		const body = call?.[2]?.body as Record<string, unknown>;
+		expect(body).toBeDefined();
+		expect('stream' in body).toBe(false);
+	});
+});
+
 describe('Apipie entity caching', () => {
 	const mockRequest = makeApipieRequest as jest.MockedFunction<
 		typeof makeApipieRequest
@@ -417,6 +466,7 @@ describe('Apipie entity caching', () => {
 	/** Context carrying an in-memory stand-in for the entity store. */
 	function ctxWithDb() {
 		const models = new Map<string, unknown>();
+		const modelDetails = new Map<string, unknown>();
 		const images = new Map<string, unknown>();
 		const ctx = {
 			key: 'test_key',
@@ -426,6 +476,11 @@ describe('Apipie entity caching', () => {
 						models.set(id, data);
 					}),
 				},
+				modelDetails: {
+					upsertByEntityId: jest.fn(async (id: string, data: unknown) => {
+						modelDetails.set(id, data);
+					}),
+				},
 				images: {
 					upsertByEntityId: jest.fn(async (id: string, data: unknown) => {
 						images.set(id, data);
@@ -433,7 +488,7 @@ describe('Apipie entity caching', () => {
 				},
 			},
 		} as unknown as ApipieContext;
-		return { ctx, models, images };
+		return { ctx, models, modelDetails, images };
 	}
 
 	beforeEach(() => {
@@ -472,8 +527,8 @@ describe('Apipie entity caching', () => {
 		});
 	});
 
-	it('mirrors detailed models into the same table', async () => {
-		const { ctx, models } = ctxWithDb();
+	it('mirrors detailed models into their own table', async () => {
+		const { ctx, modelDetails } = ctxWithDb();
 		mockRequest.mockResolvedValue({
 			object: 'list',
 			data: [{ id: 'anthropic/claude-3', provider: 'anthropic', type: 'llm' }],
@@ -481,9 +536,36 @@ describe('Apipie entity caching', () => {
 
 		await Models.listDetailed(ctx, {});
 
-		expect(models.get('anthropic/claude-3')).toMatchObject({
+		expect(modelDetails.get('anthropic/claude-3')).toMatchObject({
 			id: 'anthropic/claude-3',
 			provider: 'anthropic',
+		});
+	});
+
+	it('keeps a detailed refresh from erasing cached pricing', async () => {
+		const { ctx, models, modelDetails } = ctxWithDb();
+
+		mockRequest.mockResolvedValue({
+			object: 'list',
+			data: [{ id: 'openai/gpt-4o', avg_cost: '0.005', price_type: 'per_1k' }],
+		});
+		await Models.list(ctx, {});
+
+		// The detailed response carries no cost fields. Because the entity store
+		// replaces the stored payload wholesale, writing it over the same row
+		// would drop them — so it goes to a separate table instead.
+		mockRequest.mockResolvedValue({
+			object: 'list',
+			data: [{ id: 'openai/gpt-4o', max_tokens: 128000 }],
+		});
+		await Models.listDetailed(ctx, {});
+
+		expect(models.get('openai/gpt-4o')).toMatchObject({
+			avg_cost: '0.005',
+			price_type: 'per_1k',
+		});
+		expect(modelDetails.get('openai/gpt-4o')).toMatchObject({
+			max_tokens: 128000,
 		});
 	});
 
@@ -499,7 +581,7 @@ describe('Apipie entity caching', () => {
 		expect(models.size).toBe(0);
 	});
 
-	it('keys generated images by timestamp and batch index', async () => {
+	it('keys generated images uniquely per request and batch index', async () => {
 		const { ctx, images } = ctxWithDb();
 		mockRequest.mockResolvedValue({
 			created: 1700000000,
@@ -512,8 +594,10 @@ describe('Apipie entity caching', () => {
 		await Images.generate(ctx, { model: 'dall-e-3', prompt: 'a cube' });
 
 		expect(images.size).toBe(2);
-		expect(images.get('1700000000:1')).toMatchObject({
-			id: '1700000000:1',
+		const secondKey = [...images.keys()][1];
+		expect(secondKey).toBeDefined();
+		expect(images.get(secondKey ?? '')).toMatchObject({
+			id: secondKey,
 			model: 'dall-e-3',
 			prompt: 'a cube',
 			url: 'https://example.com/b.png',
@@ -522,7 +606,7 @@ describe('Apipie entity caching', () => {
 		});
 	});
 
-	it('does not cache images when the API returns no timestamp', async () => {
+	it('caches images even when the API returns no timestamp', async () => {
 		const { ctx, images } = ctxWithDb();
 		mockRequest.mockResolvedValue({
 			data: [{ url: 'https://example.com/a.png' }],
@@ -530,9 +614,27 @@ describe('Apipie entity caching', () => {
 
 		await Images.generate(ctx, { model: 'dall-e-3', prompt: 'a cube' });
 
-		// Without `created` there is no collision-free key, so filing the row
-		// would overwrite an unrelated generation.
-		expect(images.size).toBe(0);
+		expect(images.size).toBe(1);
+	});
+
+	it('does not let two generations in the same second collide', async () => {
+		const { ctx, images } = ctxWithDb();
+		const payload = {
+			created: 1700000000,
+			data: [{ url: 'https://example.com/a.png' }],
+		};
+
+		mockRequest.mockResolvedValue(payload);
+		await Images.generate(ctx, { model: 'dall-e-3', prompt: 'first' });
+		await Images.generate(ctx, { model: 'dall-e-3', prompt: 'second' });
+
+		// Keyed on the response timestamp alone these would share an id and the
+		// second would overwrite the first.
+		expect(images.size).toBe(2);
+		const prompts = [...images.values()].map(
+			(row) => (row as { prompt?: string }).prompt,
+		);
+		expect(prompts).toEqual(expect.arrayContaining(['first', 'second']));
 	});
 
 	it('never fails the call when the cache write throws', async () => {

--- a/packages/apipie/schema.test.ts
+++ b/packages/apipie/schema.test.ts
@@ -1,0 +1,16 @@
+import { ApipieSchema } from './schema';
+
+describe('ApipieSchema', () => {
+	it('declares an entities map', () => {
+		expect(ApipieSchema.entities).toBeDefined();
+		expect(ApipieSchema.entities.models).toBeDefined();
+		expect(ApipieSchema.entities.images).toBeDefined();
+	});
+
+	it('requires an ID for every entity', () => {
+		for (const entity of Object.values(ApipieSchema.entities)) {
+			expect(entity.safeParse({ id: 'test-id' }).success).toBe(true);
+			expect(entity.safeParse({}).success).toBe(false);
+		}
+	});
+});

--- a/packages/apipie/schema/database.ts
+++ b/packages/apipie/schema/database.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const ApipieModelEntity = z
+	.object({
+		id: z.string(),
+		name: z.string().optional(),
+		provider: z.string().optional(),
+		type: z.string().optional(),
+		metadata: z.record(z.string(), z.unknown()).optional(),
+	})
+	.loose();
+
+export const ApipieImageEntity = z
+	.object({
+		id: z.string(),
+		prompt: z.string().optional(),
+		model: z.string().optional(),
+		url: z.string().optional(),
+		metadata: z.record(z.string(), z.unknown()).optional(),
+	})
+	.loose();
+
+export type ApipieModelEntity = z.infer<typeof ApipieModelEntity>;
+export type ApipieImageEntity = z.infer<typeof ApipieImageEntity>;

--- a/packages/apipie/schema/database.ts
+++ b/packages/apipie/schema/database.ts
@@ -3,6 +3,11 @@ import { z } from 'zod';
 /**
  * Local mirror of a catalogue entry from `GET /v1/models`.
  *
+ * `GET /v1/models/detailed` returns a different field set and is mirrored
+ * separately by `ApipieModelDetailEntity`. Sharing one row between the two
+ * would make each refresh erase the other's columns, because the entity store
+ * replaces the stored payload wholesale rather than merging it.
+ *
  * Fields and nullability were taken from a live response covering all 1217
  * catalogue entries, so this table matches what APIpie actually returns rather
  * than a guess at it. The cost, `latency` and `query_count` columns are
@@ -36,11 +41,58 @@ export const ApipieModelEntity = z
 	.loose();
 
 /**
+ * Local mirror of a catalogue entry from `GET /v1/models/detailed`.
+ *
+ * Kept apart from `ApipieModelEntity` on purpose: the detailed response omits
+ * the plain list's cost columns and adds modality and capacity fields, so the
+ * two cannot share a row without one refresh erasing the other's data. Fields
+ * and nullability were taken from a live response covering all 1217 entries.
+ */
+export const ApipieModelDetailEntity = z
+	.object({
+		id: z.string(),
+		model: z.string().nullish(),
+		provider: z.string().nullish(),
+		type: z.string().nullish(),
+		subtype: z.string().nullish(),
+		route: z.string().nullish(),
+		description: z.string().nullish(),
+		/** APIpie returns 0/1 flags rather than booleans. */
+		enabled: z.union([z.boolean(), z.number()]).nullish(),
+		available: z.union([z.boolean(), z.number()]).nullish(),
+		abortable: z.boolean().nullish(),
+		moderationRequired: z.boolean().nullish(),
+		supports_multipart: z.boolean().nullish(),
+		input_modalities: z.array(z.string()).nullish(),
+		output_modalities: z.array(z.string()).nullish(),
+		instruct_type: z.string().nullish(),
+		quantization: z.string().nullish(),
+		pool: z.string().nullish(),
+		mmlu: z.number().nullish(),
+		output_vector_size: z.number().nullish(),
+		max_tokens: z.number().nullish(),
+		max_response_tokens: z.number().nullish(),
+		max_images_per_prompt: z.number().nullish(),
+		max_audio_per_prompt: z.number().nullish(),
+		max_audio_length_hours: z.number().nullish(),
+		max_videos_per_prompt: z.number().nullish(),
+		max_video_length: z.number().nullish(),
+		max_pdf_size_mb: z.number().nullish(),
+		/** Numeric strings, not numbers. */
+		latency: z.string().nullish(),
+		query_count: z.string().nullish(),
+		pricing: z.record(z.string(), z.unknown()).nullish(),
+		supported_input_parameters: z.record(z.string(), z.unknown()).nullish(),
+	})
+	.loose();
+
+/**
  * Local mirror of one generated image.
  *
  * `POST /v1/images/generations` returns no identifier for the images it
- * produces, so rows are keyed by a composite of the generation timestamp and
- * the image's index within the batch — see `cacheImage`.
+ * produces, so rows are keyed by a per-request generation id combined with the
+ * image's index within the batch — see `cacheImage`. A timestamp is not enough:
+ * two generations completing in the same second would collide.
  *
  * Only `url` is mirrored. When the caller asks for `b64_json` the payload is
  * the image itself, which does not belong in a cache row.
@@ -58,4 +110,5 @@ export const ApipieImageEntity = z
 	.loose();
 
 export type ApipieModelEntity = z.infer<typeof ApipieModelEntity>;
+export type ApipieModelDetailEntity = z.infer<typeof ApipieModelDetailEntity>;
 export type ApipieImageEntity = z.infer<typeof ApipieImageEntity>;

--- a/packages/apipie/schema/database.ts
+++ b/packages/apipie/schema/database.ts
@@ -1,22 +1,59 @@
 import { z } from 'zod';
 
+/**
+ * Local mirror of a catalogue entry from `GET /v1/models`.
+ *
+ * Fields and nullability were taken from a live response covering all 1217
+ * catalogue entries, so this table matches what APIpie actually returns rather
+ * than a guess at it. The cost, `latency` and `query_count` columns are
+ * strings because the API returns numeric strings for them.
+ *
+ * The nested `img_json` blob is deliberately not mirrored: it is only present
+ * on image models and belongs to the response, not to a flat cache row.
+ */
 export const ApipieModelEntity = z
 	.object({
 		id: z.string(),
-		name: z.string().optional(),
-		provider: z.string().optional(),
-		type: z.string().optional(),
-		metadata: z.record(z.string(), z.unknown()).optional(),
+		/** Provider-qualified name, e.g. `openai/gpt-4o`. */
+		model: z.string().nullish(),
+		provider: z.string().nullish(),
+		type: z.string().nullish(),
+		subtype: z.string().nullish(),
+		route: z.string().nullish(),
+		description: z.string().nullish(),
+		/** APIpie returns 0/1 flags rather than booleans. */
+		enabled: z.union([z.boolean(), z.number()]).nullish(),
+		available: z.union([z.boolean(), z.number()]).nullish(),
+		avg_cost: z.string().nullish(),
+		input_cost: z.string().nullish(),
+		output_cost: z.string().nullish(),
+		price_type: z.string().nullish(),
+		latency: z.string().nullish(),
+		query_count: z.string().nullish(),
+		max_tokens: z.number().nullish(),
+		max_response_tokens: z.number().nullish(),
 	})
 	.loose();
 
+/**
+ * Local mirror of one generated image.
+ *
+ * `POST /v1/images/generations` returns no identifier for the images it
+ * produces, so rows are keyed by a composite of the generation timestamp and
+ * the image's index within the batch — see `cacheImage`.
+ *
+ * Only `url` is mirrored. When the caller asks for `b64_json` the payload is
+ * the image itself, which does not belong in a cache row.
+ */
 export const ApipieImageEntity = z
 	.object({
 		id: z.string(),
-		prompt: z.string().optional(),
-		model: z.string().optional(),
-		url: z.string().optional(),
-		metadata: z.record(z.string(), z.unknown()).optional(),
+		prompt: z.string().nullish(),
+		model: z.string().nullish(),
+		url: z.string().nullish(),
+		revised_prompt: z.string().nullish(),
+		/** Unix seconds, as returned by the API. */
+		created: z.number().nullish(),
 	})
 	.loose();
 

--- a/packages/apipie/schema/index.ts
+++ b/packages/apipie/schema/index.ts
@@ -1,0 +1,9 @@
+import { ApipieImageEntity, ApipieModelEntity } from './database';
+
+export const ApipieSchema = {
+	version: '1.0.0',
+	entities: {
+		models: ApipieModelEntity,
+		images: ApipieImageEntity,
+	},
+} as const;

--- a/packages/apipie/schema/index.ts
+++ b/packages/apipie/schema/index.ts
@@ -1,9 +1,14 @@
-import { ApipieImageEntity, ApipieModelEntity } from './database';
+import {
+	ApipieImageEntity,
+	ApipieModelDetailEntity,
+	ApipieModelEntity,
+} from './database';
 
 export const ApipieSchema = {
 	version: '1.0.0',
 	entities: {
 		models: ApipieModelEntity,
+		modelDetails: ApipieModelDetailEntity,
 		images: ApipieImageEntity,
 	},
 } as const;

--- a/packages/apipie/tsconfig.json
+++ b/packages/apipie/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/apipie/tsup.config.ts
+++ b/packages/apipie/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/apipie/webhooks/types.ts
+++ b/packages/apipie/webhooks/types.ts
@@ -1,0 +1,11 @@
+import type { WebhookRequest } from 'corsair/core';
+
+// APIpie does not support webhooks
+export type ApipieWebhookOutputs = Record<string, never>;
+
+export function verifyApipieWebhookSignature(
+	_request: WebhookRequest<unknown>,
+	_secret: string,
+): { valid: boolean; error?: string } {
+	return { valid: false, error: 'APIpie does not support webhooks' };
+}

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -37,6 +37,7 @@ export const BaseProviders = [
 	'amplitude',
 	'apaleo',
 	'apibible',
+	'apipie',
 	'apify',
 	'apilabz',
 	'apininjas',
@@ -189,6 +190,7 @@ export const ProviderDisplayNames = {
 	amplitude: 'Amplitude',
 	apaleo: 'Apaleo',
 	apibible: 'API.Bible',
+	apipie: 'APIpie AI',
 	apify: 'Apify',
 	apilabz: 'API Labz',
 	apininjas: 'API Ninjas',
@@ -348,6 +350,7 @@ export type AllProviders =
 	| 'amplitude'
 	| 'apaleo'
 	| 'apibible'
+	| 'apipie'
 	| 'apify'
 	| 'apilabz'
 	| 'apininjas'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -969,6 +969,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/apipie:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/apisports:
     devDependencies:
       '@types/jest':
@@ -4308,7 +4332,7 @@ importers:
         version: link:../packages/slack
       '@next/third-parties':
         specifier: 15.3.2
-        version: 15.3.2(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 15.3.2(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -4332,7 +4356,7 @@ importers:
         version: 11.8.1(typescript@5.9.3)
       better-auth:
         specifier: ^1.5.5
-        version: 1.6.15(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.5.0)(drizzle-kit@0.31.8)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.5.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7))(mysql2@3.15.3)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.6.15(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.5.0)(drizzle-kit@0.31.8)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.5.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7))(mysql2@3.15.3)(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -4350,13 +4374,13 @@ importers:
         version: 0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.5.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7)
       inngest:
         specifier: ^3.54.0
-        version: 3.54.2(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.12.2)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.4.3)
+        version: 3.54.2(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.12.2)(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.4.3)
       next:
         specifier: ^15.3.2
-        version: 15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-sanity:
         specifier: ^11.6.13
-        version: 11.6.13(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.23.0)(@sanity/icons@3.7.4(react@19.2.5))(@sanity/types@4.22.0(@types/react@19.2.6))(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
+        version: 11.6.13(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.23.0)(@sanity/icons@3.7.4(react@19.2.5))(@sanity/types@6.2.0(@types/react@19.2.6))(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
       pg:
         specifier: ^8.20.0
         version: 8.21.0
@@ -11593,6 +11617,7 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@13.0.6:
@@ -11601,6 +11626,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -11845,6 +11871,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -18401,9 +18428,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.18':
     optional: true
 
-  '@next/third-parties@15.3.2(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+  '@next/third-parties@15.3.2(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     dependencies:
-      next: 15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       third-party-capital: 1.0.20
 
@@ -20577,6 +20604,20 @@ snapshots:
       - '@emotion/is-prop-valid'
       - styled-components
 
+  '@sanity/insert-menu@2.1.0(@emotion/is-prop-valid@1.4.0)(@sanity/types@6.2.0(@types/react@19.2.6))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
+    dependencies:
+      '@sanity/icons': 3.7.4(react@19.2.5)
+      '@sanity/types': 6.2.0(@types/react@19.2.6)
+      '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+      lodash: 4.18.1
+      react: 19.2.5
+      react-compiler-runtime: 1.0.0(react@19.2.5)
+      react-dom: 19.2.5(react@19.2.5)
+      react-is: 19.2.7
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - styled-components
+
   '@sanity/json-match@1.0.5': {}
 
   '@sanity/logos@2.2.2(react@19.2.5)':
@@ -20669,6 +20710,14 @@ snapshots:
     dependencies:
       '@sanity/comlink': 4.0.1
       '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.23.0)(@sanity/types@4.22.0(@types/react@19.2.6))
+    transitivePeerDependencies:
+      - '@sanity/client'
+      - '@sanity/types'
+
+  '@sanity/presentation-comlink@2.1.0(@sanity/client@7.23.0)(@sanity/types@6.2.0(@types/react@19.2.6))':
+    dependencies:
+      '@sanity/comlink': 4.0.1
+      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.23.0)(@sanity/types@6.2.0(@types/react@19.2.6))
     transitivePeerDependencies:
       - '@sanity/client'
       - '@sanity/types'
@@ -20893,10 +20942,10 @@ snapshots:
       - react-dom
       - react-is
 
-  '@sanity/visual-editing-csm@2.0.26(@sanity/client@7.23.0)(@sanity/types@4.22.0(@types/react@19.2.6))(typescript@5.9.3)':
+  '@sanity/visual-editing-csm@2.0.26(@sanity/client@7.23.0)(@sanity/types@6.2.0(@types/react@19.2.6))(typescript@5.9.3)':
     dependencies:
       '@sanity/client': 7.23.0
-      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.23.0)(@sanity/types@4.22.0(@types/react@19.2.6))
+      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.23.0)(@sanity/types@6.2.0(@types/react@19.2.6))
       valibot: 1.4.1(typescript@5.9.3)
     transitivePeerDependencies:
       - '@sanity/types'
@@ -20908,16 +20957,22 @@ snapshots:
     optionalDependencies:
       '@sanity/types': 4.22.0(@types/react@19.2.6)
 
-  '@sanity/visual-editing@4.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.23.0)(@sanity/types@4.22.0(@types/react@19.2.6))(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)':
+  '@sanity/visual-editing-types@1.1.8(@sanity/client@7.23.0)(@sanity/types@6.2.0(@types/react@19.2.6))':
+    dependencies:
+      '@sanity/client': 7.23.0
+    optionalDependencies:
+      '@sanity/types': 6.2.0(@types/react@19.2.6)
+
+  '@sanity/visual-editing@4.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.23.0)(@sanity/types@6.2.0(@types/react@19.2.6))(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)':
     dependencies:
       '@sanity/comlink': 4.0.1
       '@sanity/icons': 3.7.4(react@19.2.5)
-      '@sanity/insert-menu': 2.1.0(@emotion/is-prop-valid@1.4.0)(@sanity/types@4.22.0(@types/react@19.2.6))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+      '@sanity/insert-menu': 2.1.0(@emotion/is-prop-valid@1.4.0)(@sanity/types@6.2.0(@types/react@19.2.6))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@sanity/mutate': 0.11.0-canary.4(xstate@5.32.2)
-      '@sanity/presentation-comlink': 2.1.0(@sanity/client@7.23.0)(@sanity/types@4.22.0(@types/react@19.2.6))
+      '@sanity/presentation-comlink': 2.1.0(@sanity/client@7.23.0)(@sanity/types@6.2.0(@types/react@19.2.6))
       '@sanity/preview-url-secret': 3.0.0(@sanity/client@7.23.0)(@sanity/icons@3.7.4(react@19.2.5))(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))
       '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
-      '@sanity/visual-editing-csm': 2.0.26(@sanity/client@7.23.0)(@sanity/types@4.22.0(@types/react@19.2.6))(typescript@5.9.3)
+      '@sanity/visual-editing-csm': 2.0.26(@sanity/client@7.23.0)(@sanity/types@6.2.0(@types/react@19.2.6))(typescript@5.9.3)
       '@vercel/stega': 1.0.0
       react: 19.2.5
       react-compiler-runtime: 1.0.0(react@19.2.5)
@@ -20930,7 +20985,7 @@ snapshots:
       xstate: 5.32.2
     optionalDependencies:
       '@sanity/client': 7.23.0
-      next: 15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@sanity/types'
@@ -21974,7 +22029,7 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.6.15(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.5.0)(drizzle-kit@0.31.8)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.5.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7))(mysql2@3.15.3)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  better-auth@1.6.15(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(better-sqlite3@12.5.0)(drizzle-kit@0.31.8)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.5.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7))(mysql2@3.15.3)(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(pg@8.21.0)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@better-auth/core': 1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.15(@better-auth/core@1.6.15(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20251121.0)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.5.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7))
@@ -21999,7 +22054,7 @@ snapshots:
       drizzle-kit: 0.31.8
       drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20251121.0)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@prisma/client@6.19.0(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3))(@types/better-sqlite3@7.6.13)(@types/pg@8.15.6)(better-sqlite3@12.5.0)(bun-types@1.3.3)(gel@2.2.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@6.19.0(magicast@0.3.5)(typescript@5.9.3))(sqlite3@5.1.7)
       mysql2: 3.15.3
-      next: 15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       pg: 8.21.0
       prisma: 6.19.0(magicast@0.3.5)(typescript@5.9.3)
       react: 19.2.5
@@ -23891,7 +23946,7 @@ snapshots:
       - encoding
       - supports-color
 
-  inngest@3.54.2(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.12.2)(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.4.3):
+  inngest@3.54.2(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.12.2)(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)(zod@4.4.3):
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@inngest/ai': 0.1.7
@@ -23922,7 +23977,7 @@ snapshots:
     optionalDependencies:
       express: 5.2.1
       hono: 4.12.2
-      next: 15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@opentelemetry/core'
@@ -25171,18 +25226,18 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-sanity@11.6.13(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.23.0)(@sanity/icons@3.7.4(react@19.2.5))(@sanity/types@4.22.0(@types/react@19.2.6))(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3):
+  next-sanity@11.6.13(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.23.0)(@sanity/icons@3.7.4(react@19.2.5))(@sanity/types@6.2.0(@types/react@19.2.6))(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3):
     dependencies:
       '@portabletext/react': 6.2.0(react@19.2.5)
       '@sanity/client': 7.23.0
       '@sanity/comlink': 4.0.1
-      '@sanity/presentation-comlink': 2.1.0(@sanity/client@7.23.0)(@sanity/types@4.22.0(@types/react@19.2.6))
+      '@sanity/presentation-comlink': 2.1.0(@sanity/client@7.23.0)(@sanity/types@6.2.0(@types/react@19.2.6))
       '@sanity/preview-url-secret': 3.0.0(@sanity/client@7.23.0)(@sanity/icons@3.7.4(react@19.2.5))(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))
-      '@sanity/visual-editing': 4.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.23.0)(@sanity/types@4.22.0(@types/react@19.2.6))(next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
+      '@sanity/visual-editing': 4.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.23.0)(@sanity/types@6.2.0(@types/react@19.2.6))(next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.7)(react@19.2.5)(sanity@4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0))(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.9.3)
       dequal: 2.0.3
       groq: 4.22.0
       history: 5.3.0
-      next: 15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       sanity: 4.22.0(@emotion/is-prop-valid@1.4.0)(@portabletext/sanity-bridge@1.2.14(@types/react@19.2.6))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -25226,7 +25281,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.5.18(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@15.5.18(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 15.5.18
       '@swc/helpers': 0.5.15
@@ -25234,7 +25289,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      styled-jsx: 5.1.6(@babel/core@7.28.6)(react@19.2.5)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.5)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.18
       '@next/swc-darwin-x64': 15.5.18
@@ -27104,12 +27159,12 @@ snapshots:
       client-only: 0.0.1
       react: 18.3.1
 
-  styled-jsx@5.1.6(@babel/core@7.28.6)(react@19.2.5):
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.5):
     dependencies:
       client-only: 0.0.1
       react: 19.2.5
     optionalDependencies:
-      '@babel/core': 7.28.6
+      '@babel/core': 7.29.7
 
   stylis@4.3.6: {}
 


### PR DESCRIPTION
## Description

Adds a new **APIpie AI** plugin (`packages/apipie/`). Fixes #779.

[APIpie](https://apipie.ai) is an AI model aggregator exposing an OpenAI-compatible API across 900+ models from multiple providers. This plugin integrates its core API surface into corsair:

- **`models.list`** — `GET /v1/models` with `type` / `subtype` / `provider` / `model` / `enabled` filters
- **`models.listDetailed`** — `GET /v1/models/detailed` (pricing, capabilities, limits per model)
- **`chat.createCompletion`** — `POST /v1/chat/completions`, including APIpie-specific params (`provider`, `routing`, memory & integrity options) mapped to snake_case
- **`embeddings.create`** — `POST /v1/embeddings`
- **`images.generate`** — `POST /v1/images/generations`

Implementation details:

- Bearer auth via `APIPIE_API_KEY`; plugin id `apipie`, authType `api_key`; registered in `packages/corsair/core/constants.ts` (`BaseProviders`, `ProviderDisplayNames`, `AllProviders`)
- zod input/output validation on every endpoint; output schemas tolerate APIpie's loose typing (`enabled` returned as `0/1` numbers, nullable string fields)
- All errors routed through `error-handlers.ts`, including 429 rate-limit handling
- Entities persisted via `schema/database.ts` (models + generated images)
- APIpie offers no outbound webhooks, so `webhooks/` contains types only (same pattern as `aimlapi`)
- 28 unit tests (mocked fetch) covering every endpoint, error mapping, output schemas, and the plugin factory; one additional live test is gated on `APIPIE_API_KEY`

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos-
Demo recording:

https://github.com/user-attachments/assets/13d93173-51ea-4bcc-82a0-ca40c1567bb6


The recording shows the plugin running live against the real APIpie API:

1. `models.list` → 925 LLM models returned
2. `models.listDetailed` → 925 detailed model records
3. `chat.createCompletion` / `embeddings.create` / `images.generate` → APIpie returns `402 Payment Required` because all inference endpoints require a positive account credit balance (even $0.00-cost models); the video shows these surfacing cleanly through the plugin's error handlers

Context: https://github.com/corsairdev/corsair/issues/779#issuecomment-5367012288

## Additional Notes

- Local verification was performed on Windows: `@corsair-dev/apipie` test suite (28 passed / 1 skipped live-gated), Biome, `tsc --noEmit`, and `pnpm run validate:plugins` all pass. A full-repo `pnpm build` / `pnpm test` cannot complete on this machine (no MSVC toolchain for `better-sqlite3` native builds; plugin build scripts use `rm -rf`) — CI should confirm on Linux.
- The throwaway demo script used for the recording is intentionally not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added APIpie AI provider integration with API-key authentication.
  * Added chat completions, embeddings, image generation, and model discovery.
  * Added typed request and response validation.
  * Added persistence for model details and generated images.
  * Added provider-specific error handling and rate-limit metadata.
  * Added clear handling for unsupported webhook verification.

* **Tests**
  * Added coverage for endpoints, validation, authentication, errors, caching, and plugin integration.
  * Added live checks for model catalogue responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->