### PR TITLE
feat(chatbotkit): add ChatBotKit plugin (bots list/get)

### DIFF
--- a/packages/chatbotkit/api.test.ts
+++ b/packages/chatbotkit/api.test.ts
@@ -2,11 +2,14 @@ import { logEventFromContext } from 'corsair/core';
 import { ApiError, request } from 'corsair/http';
 import { makeChatbotkitRequest } from './client';
 import {
+	BlueprintSchema,
 	BotSchema,
-	BotsGetInputSchema,
-	BotsGetResponseSchema,
-	BotsListInputSchema,
-	BotsListResponseSchema,
+	ConversationSchema,
+	DatasetSchema,
+	FileSchema,
+	SecretSchema,
+	SkillsetSchema,
+	TaskSchema,
 } from './endpoints/types';
 import { errorHandlers } from './error-handlers';
 import type { ChatbotkitContext } from './index';
@@ -72,27 +75,76 @@ const botFixture = {
 	description: 'A test bot',
 	model: 'gpt-4o',
 	backstory: 'Helpful support agent',
+	privacy: true,
+	moderation: false,
 	visibility: 'private',
 	createdAt: 1787397742217,
 	updatedAt: 1787397742217,
 };
 
-type BotsList = (
-	ctx: ChatbotkitContext,
-	input: { cursor?: string; limit?: number; order?: 'asc' | 'desc' },
-) => Promise<unknown>;
-type BotsGet = (
-	ctx: ChatbotkitContext,
-	input: { id: string },
-) => Promise<unknown>;
+const datasetFixture = {
+	id: 'dataset_1',
+	name: 'FAQ Dataset',
+	description: 'Knowledge dataset',
+	visibility: 'private',
+	createdAt: 1787397740293,
+	updatedAt: 1787397740293,
+};
 
-function getEndpoints(): { list: BotsList; get: BotsGet } {
-	const plugin = chatbotkit({ key: 'sk-test-api-key' });
-	const endpoints = plugin.endpoints as NonNullable<typeof plugin.endpoints> & {
-		bots: { list: BotsList; get: BotsGet };
-	};
-	return endpoints.bots;
-}
+const skillsetFixture = {
+	id: 'skillset_1',
+	name: 'Support Tools',
+	description: 'Skillset with tools',
+	state: 'enabled',
+	visibility: 'private',
+	createdAt: 1787397739735,
+	updatedAt: 1787397739735,
+};
+
+const blueprintFixture = {
+	id: 'blueprint_1',
+	name: 'Template',
+	description: 'Blueprint template',
+	visibility: 'private',
+	createdAt: 1787397739259,
+	updatedAt: 1787397739259,
+};
+
+const secretFixture = {
+	id: 'secret_1',
+	name: 'Gmail API Key',
+	kind: 'personal',
+	type: 'template',
+	visibility: 'private',
+	createdAt: 1787397890820,
+	updatedAt: 1787397890820,
+};
+
+const conversationFixture = {
+	id: 'conv_1',
+	name: 'Test Conversation',
+	visibility: 'private',
+	createdAt: 1787397890820,
+	updatedAt: 1787397890820,
+};
+
+const fileFixture = {
+	id: 'file_1',
+	name: 'document.pdf',
+	mimeType: 'application/pdf',
+	size: 1024,
+	createdAt: 1787397890820,
+	updatedAt: 1787397890820,
+};
+
+const taskFixture = {
+	id: 'task_1',
+	name: 'Nightly Sync',
+	schedule: '0 0 * * *',
+	status: 'active',
+	createdAt: 1787397890820,
+	updatedAt: 1787397890820,
+};
 
 function classify(error: Error): string {
 	const name = (
@@ -121,63 +173,51 @@ function httpError(status: number, message: string): ApiError {
 
 describe('ChatBotKit Zod Schemas', () => {
 	it('validates a complete Bot object', () => {
-		const parsed = BotSchema.safeParse(botFixture);
-		expect(parsed.success).toBe(true);
+		expect(BotSchema.safeParse(botFixture).success).toBe(true);
 	});
 
-	it('validates minimal Bot object with only required fields', () => {
-		const parsed = BotSchema.safeParse({ id: 'b_123', name: 'Bot' });
-		expect(parsed.success).toBe(true);
+	it('validates a complete Dataset object', () => {
+		expect(DatasetSchema.safeParse(datasetFixture).success).toBe(true);
 	});
 
-	it('rejects Bot missing required id or name', () => {
-		expect(BotSchema.safeParse({ name: 'Bot' }).success).toBe(false);
-		expect(BotSchema.safeParse({ id: 'b_123' }).success).toBe(false);
+	it('validates a complete Skillset object', () => {
+		expect(SkillsetSchema.safeParse(skillsetFixture).success).toBe(true);
 	});
 
-	it('validates BotsListInputSchema options', () => {
-		expect(BotsListInputSchema.safeParse({}).success).toBe(true);
-		expect(
-			BotsListInputSchema.safeParse({
-				cursor: 'c_1',
-				limit: 50,
-				order: 'asc',
-			}).success,
-		).toBe(true);
-		expect(BotsListInputSchema.safeParse({ limit: 0 }).success).toBe(false);
-		expect(BotsListInputSchema.safeParse({ limit: 101 }).success).toBe(false);
+	it('validates a complete Blueprint object', () => {
+		expect(BlueprintSchema.safeParse(blueprintFixture).success).toBe(true);
 	});
 
-	it('validates BotsListResponseSchema with items and cursor', () => {
-		const parsed = BotsListResponseSchema.safeParse({
-			items: [botFixture],
-			cursor: 'c_next',
-		});
-		expect(parsed.success).toBe(true);
-		if (parsed.success) {
-			expect(parsed.data.items).toHaveLength(1);
-			expect(parsed.data.cursor).toBe('c_next');
-		}
+	it('validates a complete Secret object', () => {
+		expect(SecretSchema.safeParse(secretFixture).success).toBe(true);
 	});
 
-	it('validates BotsGetInputSchema and BotsGetResponseSchema', () => {
-		expect(BotsGetInputSchema.safeParse({ id: 'bot_1' }).success).toBe(true);
-		expect(BotsGetInputSchema.safeParse({}).success).toBe(false);
-		expect(BotsGetResponseSchema.safeParse(botFixture).success).toBe(true);
+	it('validates a complete Conversation object', () => {
+		expect(ConversationSchema.safeParse(conversationFixture).success).toBe(
+			true,
+		);
+	});
+
+	it('validates a complete File object', () => {
+		expect(FileSchema.safeParse(fileFixture).success).toBe(true);
+	});
+
+	it('validates a complete Task object', () => {
+		expect(TaskSchema.safeParse(taskFixture).success).toBe(true);
 	});
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Plugin Structure Tests
+// Plugin Structure & Namespace Verification
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('Chatbotkit plugin shape', () => {
-	it('exposes the implemented operations with schemas and no webhooks', () => {
+	it('exposes all 43 implemented operations with schemas and no webhooks', () => {
 		const plugin = chatbotkit();
 		const endpoints = plugin.endpoints as Record<string, unknown>;
 		const paths = endpointPaths(endpoints).sort();
 
-		expect(countLeaves(endpoints)).toBe(2);
+		expect(countLeaves(endpoints)).toBe(43);
 		expect(Object.keys(plugin.endpointMeta ?? {}).sort()).toEqual(paths);
 		expect(Object.keys(chatbotkitEndpointSchemas).sort()).toEqual(paths);
 		expect(plugin.webhooks).toEqual({});
@@ -230,82 +270,242 @@ describe('Chatbotkit request client', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Endpoint Mock Tests
+// Endpoint Mock Handlers Tests
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('Chatbotkit bots endpoints', () => {
+describe('Chatbotkit resource endpoints', () => {
+	const plugin = chatbotkit({ key: 'sk-test-api-key' });
+	const endpoints = plugin.endpoints as any;
+
 	beforeEach(() => {
 		mockRequest.mockReset();
 		mockLog.mockReset();
 	});
 
-	it('lists bots with cursor pagination query params', async () => {
-		mockRequest.mockResolvedValue({
+	// Bots
+	it('executes bots.list and bots.get', async () => {
+		mockRequest.mockResolvedValueOnce({
 			items: [botFixture],
-			cursor: 'next-page',
+			cursor: 'c_1',
+		});
+		const listRes = await endpoints.bots.list(mockCtx, { limit: 10 });
+		expect(listRes).toEqual({ items: [botFixture], cursor: 'c_1' });
+		expect(listRes.items[0].privacy).toBe(true);
+		expect(listRes.items[0].moderation).toBe(false);
+
+		mockRequest.mockResolvedValueOnce(botFixture);
+		const getRes = await endpoints.bots.get(mockCtx, { id: 'bot_1' });
+		expect(getRes).toEqual(botFixture);
+		expect(getRes.privacy).toBe(true);
+		expect(getRes.moderation).toBe(false);
+	});
+
+	it('executes bots.create, update, delete, upvote, downvote', async () => {
+		mockRequest.mockResolvedValue({ id: 'bot_1' });
+		expect(await endpoints.bots.create(mockCtx, { name: 'Bot' })).toEqual({
+			id: 'bot_1',
+		});
+		expect(
+			await endpoints.bots.update(mockCtx, { id: 'bot_1', name: 'Bot2' }),
+		).toEqual({ id: 'bot_1' });
+		expect(await endpoints.bots.delete(mockCtx, { id: 'bot_1' })).toEqual({
+			id: 'bot_1',
+		});
+		expect(await endpoints.bots.upvote(mockCtx, { id: 'bot_1' })).toEqual({
+			id: 'bot_1',
+		});
+		expect(await endpoints.bots.downvote(mockCtx, { id: 'bot_1' })).toEqual({
+			id: 'bot_1',
+		});
+	});
+
+	// Datasets
+	it('executes datasets.list, get, create, update, delete, search', async () => {
+		mockRequest.mockResolvedValueOnce({ items: [datasetFixture] });
+		expect(await endpoints.datasets.list(mockCtx, {})).toEqual({
+			items: [datasetFixture],
 		});
 
-		const result = await getEndpoints().list(mockCtx, {
-			cursor: 'abc',
-			limit: 10,
-			order: 'desc',
-		});
+		mockRequest.mockResolvedValueOnce(datasetFixture);
+		expect(await endpoints.datasets.get(mockCtx, { id: 'dataset_1' })).toEqual(
+			datasetFixture,
+		);
 
-		expect(mockRequest).toHaveBeenCalledWith(
-			expect.anything(),
-			expect.objectContaining({
-				method: 'GET',
-				url: 'bot/list',
-				query: { cursor: 'abc', limit: 10, order: 'desc' },
+		mockRequest.mockResolvedValueOnce({ id: 'dataset_1' });
+		expect(
+			await endpoints.datasets.create(mockCtx, { name: 'Dataset' }),
+		).toEqual({ id: 'dataset_1' });
+
+		mockRequest.mockResolvedValueOnce({ id: 'dataset_1' });
+		expect(
+			await endpoints.datasets.update(mockCtx, { id: 'dataset_1' }),
+		).toEqual({ id: 'dataset_1' });
+
+		mockRequest.mockResolvedValueOnce({ id: 'dataset_1' });
+		expect(
+			await endpoints.datasets.delete(mockCtx, { id: 'dataset_1' }),
+		).toEqual({ id: 'dataset_1' });
+
+		mockRequest.mockResolvedValueOnce({
+			items: [{ id: 'r_1', text: 'match' }],
+		});
+		expect(
+			await endpoints.datasets.search(mockCtx, {
+				id: 'dataset_1',
+				query: 'test',
 			}),
+		).toEqual({ items: [{ id: 'r_1', text: 'match' }] });
+	});
+
+	// Skillsets
+	it('executes skillsets.list, get, create, update, delete', async () => {
+		mockRequest.mockResolvedValueOnce({ items: [skillsetFixture] });
+		expect(await endpoints.skillsets.list(mockCtx, {})).toEqual({
+			items: [skillsetFixture],
+		});
+
+		mockRequest.mockResolvedValueOnce(skillsetFixture);
+		expect(
+			await endpoints.skillsets.get(mockCtx, { id: 'skillset_1' }),
+		).toEqual(skillsetFixture);
+
+		mockRequest.mockResolvedValueOnce({ id: 'skillset_1' });
+		expect(
+			await endpoints.skillsets.create(mockCtx, { name: 'Skillset' }),
+		).toEqual({ id: 'skillset_1' });
+
+		mockRequest.mockResolvedValueOnce({ id: 'skillset_1' });
+		expect(
+			await endpoints.skillsets.delete(mockCtx, { id: 'skillset_1' }),
+		).toEqual({ id: 'skillset_1' });
+	});
+
+	// Blueprints
+	it('executes blueprints.list, get, create, update, delete', async () => {
+		mockRequest.mockResolvedValueOnce({ items: [blueprintFixture] });
+		expect(await endpoints.blueprints.list(mockCtx, {})).toEqual({
+			items: [blueprintFixture],
+		});
+
+		mockRequest.mockResolvedValueOnce(blueprintFixture);
+		expect(
+			await endpoints.blueprints.get(mockCtx, { id: 'blueprint_1' }),
+		).toEqual(blueprintFixture);
+
+		mockRequest.mockResolvedValueOnce({ id: 'blueprint_1' });
+		expect(
+			await endpoints.blueprints.create(mockCtx, { name: 'Blueprint' }),
+		).toEqual({ id: 'blueprint_1' });
+
+		mockRequest.mockResolvedValueOnce({ id: 'blueprint_1' });
+		expect(
+			await endpoints.blueprints.delete(mockCtx, { id: 'blueprint_1' }),
+		).toEqual({ id: 'blueprint_1' });
+	});
+
+	// Secrets
+	it('executes secrets.list, get, create, update, delete', async () => {
+		mockRequest.mockResolvedValueOnce({ items: [secretFixture] });
+		expect(await endpoints.secrets.list(mockCtx, {})).toEqual({
+			items: [secretFixture],
+		});
+
+		mockRequest.mockResolvedValueOnce(secretFixture);
+		expect(await endpoints.secrets.get(mockCtx, { id: 'secret_1' })).toEqual(
+			secretFixture,
 		);
-		expect(result).toEqual({ items: [botFixture], cursor: 'next-page' });
-		expect(mockLog).toHaveBeenCalledWith(
-			mockCtx,
-			'chatbotkit.bots.list',
-			{ cursor: 'abc', limit: 10, order: 'desc' },
-			'completed',
+
+		mockRequest.mockResolvedValueOnce({ id: 'secret_1' });
+		expect(await endpoints.secrets.create(mockCtx, { name: 'Secret' })).toEqual(
+			{ id: 'secret_1' },
+		);
+
+		mockRequest.mockResolvedValueOnce({ id: 'secret_1' });
+		expect(await endpoints.secrets.delete(mockCtx, { id: 'secret_1' })).toEqual(
+			{ id: 'secret_1' },
 		);
 	});
 
-	it('omits undefined query params when listing without filters', async () => {
-		mockRequest.mockResolvedValue({ items: [] });
+	// Conversations
+	it('executes conversations.list, get, create, update, delete, complete', async () => {
+		mockRequest.mockResolvedValueOnce({ items: [conversationFixture] });
+		expect(await endpoints.conversations.list(mockCtx, {})).toEqual({
+			items: [conversationFixture],
+		});
 
-		await getEndpoints().list(mockCtx, {});
+		mockRequest.mockResolvedValueOnce(conversationFixture);
+		expect(
+			await endpoints.conversations.get(mockCtx, { id: 'conv_1' }),
+		).toEqual(conversationFixture);
 
-		expect(mockRequest).toHaveBeenCalledWith(
-			expect.anything(),
-			expect.objectContaining({ query: {} }),
-		);
+		mockRequest.mockResolvedValueOnce({ id: 'conv_1' });
+		expect(await endpoints.conversations.create(mockCtx, {})).toEqual({
+			id: 'conv_1',
+		});
+
+		mockRequest.mockResolvedValueOnce({ id: 'conv_1' });
+		expect(
+			await endpoints.conversations.update(mockCtx, { id: 'conv_1' }),
+		).toEqual({ id: 'conv_1' });
+
+		mockRequest.mockResolvedValueOnce({ id: 'conv_1' });
+		expect(
+			await endpoints.conversations.delete(mockCtx, { id: 'conv_1' }),
+		).toEqual({ id: 'conv_1' });
+
+		mockRequest.mockResolvedValueOnce({ text: 'Hello!' });
+		expect(
+			await endpoints.conversations.complete(mockCtx, {
+				id: 'conv_1',
+				text: 'Hi',
+			}),
+		).toEqual({ text: 'Hello!' });
 	});
 
-	it('fetches a single bot by id', async () => {
-		mockRequest.mockResolvedValue(botFixture);
+	// Files
+	it('executes files.list, get, create, delete', async () => {
+		mockRequest.mockResolvedValueOnce({ items: [fileFixture] });
+		expect(await endpoints.files.list(mockCtx, {})).toEqual({
+			items: [fileFixture],
+		});
 
-		const result = await getEndpoints().get(mockCtx, { id: 'bot_1' });
+		mockRequest.mockResolvedValueOnce(fileFixture);
+		expect(await endpoints.files.get(mockCtx, { id: 'file_1' })).toEqual(
+			fileFixture,
+		);
 
-		expect(mockRequest).toHaveBeenCalledWith(
-			expect.anything(),
-			expect.objectContaining({ method: 'GET', url: 'bot/bot_1/fetch' }),
-		);
-		expect(result).toMatchObject(botFixture);
-		expect(mockLog).toHaveBeenCalledWith(
-			mockCtx,
-			'chatbotkit.bots.get',
-			{ id: 'bot_1' },
-			'completed',
-		);
+		mockRequest.mockResolvedValueOnce({ id: 'file_1' });
+		expect(await endpoints.files.create(mockCtx, { name: 'f.pdf' })).toEqual({
+			id: 'file_1',
+		});
+
+		mockRequest.mockResolvedValueOnce({ id: 'file_1' });
+		expect(await endpoints.files.delete(mockCtx, { id: 'file_1' })).toEqual({
+			id: 'file_1',
+		});
 	});
 
-	it('URL-encodes the bot id path segment', async () => {
-		mockRequest.mockResolvedValue(botFixture);
+	// Tasks
+	it('executes tasks.list, get, create, update, delete', async () => {
+		mockRequest.mockResolvedValueOnce({ items: [taskFixture] });
+		expect(await endpoints.tasks.list(mockCtx, {})).toEqual({
+			items: [taskFixture],
+		});
 
-		await getEndpoints().get(mockCtx, { id: 'bot/weird id' });
-
-		expect(mockRequest).toHaveBeenCalledWith(
-			expect.anything(),
-			expect.objectContaining({ url: 'bot/bot%2Fweird%20id/fetch' }),
+		mockRequest.mockResolvedValueOnce(taskFixture);
+		expect(await endpoints.tasks.get(mockCtx, { id: 'task_1' })).toEqual(
+			taskFixture,
 		);
+
+		mockRequest.mockResolvedValueOnce({ id: 'task_1' });
+		expect(await endpoints.tasks.create(mockCtx, { name: 'Task' })).toEqual({
+			id: 'task_1',
+		});
+
+		mockRequest.mockResolvedValueOnce({ id: 'task_1' });
+		expect(await endpoints.tasks.delete(mockCtx, { id: 'task_1' })).toEqual({
+			id: 'task_1',
+		});
 	});
 });
 
@@ -353,40 +553,70 @@ describeIfKey('ChatBotKit Live API integration', () => {
 		mockRequest.mockImplementation(unmockedHttp.request);
 	});
 
-	it('fetches bots list from real ChatBotKit API', async () => {
+	it('fetches bots, datasets, skillsets, blueprints, secrets from live API', async () => {
 		const plugin = chatbotkit({ key: TEST_API_KEY });
-		const endpoints = plugin.endpoints as NonNullable<
-			typeof plugin.endpoints
-		> & {
-			bots: { list: BotsList; get: BotsGet };
-		};
+		const endpoints = plugin.endpoints as any;
 
-		const result = (await endpoints.bots.list(liveCtx, {
-			limit: 10,
-		})) as { items: unknown[] };
-
-		expect(result).toBeDefined();
-		expect(Array.isArray(result.items)).toBe(true);
-		expect(BotsListResponseSchema.safeParse(result).success).toBe(true);
-	}, 20000);
-
-	it('fetches single bot by ID from real ChatBotKit API', async () => {
-		const plugin = chatbotkit({ key: TEST_API_KEY });
-		const endpoints = plugin.endpoints as NonNullable<
-			typeof plugin.endpoints
-		> & {
-			bots: { list: BotsList; get: BotsGet };
-		};
-
-		const listRes = (await endpoints.bots.list(liveCtx, { limit: 1 })) as {
-			items: Array<{ id: string }>;
-		};
-
-		const firstBot = listRes.items?.[0];
-		if (firstBot) {
-			const botRes = await endpoints.bots.get(liveCtx, { id: firstBot.id });
-			expect(botRes).toBeDefined();
-			expect(BotsGetResponseSchema.safeParse(botRes).success).toBe(true);
+		// 1. Bots list & get
+		const botsRes = await endpoints.bots.list(liveCtx, { limit: 5 });
+		expect(botsRes).toBeDefined();
+		expect(Array.isArray(botsRes.items)).toBe(true);
+		if (botsRes.items.length > 0) {
+			const bot = await endpoints.bots.get(liveCtx, {
+				id: botsRes.items[0].id,
+			});
+			expect(bot).toBeDefined();
+			expect(bot.id).toBe(botsRes.items[0].id);
 		}
-	}, 20000);
+
+		// 2. Datasets list & get
+		const datasetsRes = await endpoints.datasets.list(liveCtx, { limit: 5 });
+		expect(datasetsRes).toBeDefined();
+		expect(Array.isArray(datasetsRes.items)).toBe(true);
+		if (datasetsRes.items.length > 0) {
+			const dataset = await endpoints.datasets.get(liveCtx, {
+				id: datasetsRes.items[0].id,
+			});
+			expect(dataset).toBeDefined();
+			expect(dataset.id).toBe(datasetsRes.items[0].id);
+		}
+
+		// 3. Skillsets list & get
+		const skillsetsRes = await endpoints.skillsets.list(liveCtx, { limit: 5 });
+		expect(skillsetsRes).toBeDefined();
+		expect(Array.isArray(skillsetsRes.items)).toBe(true);
+		if (skillsetsRes.items.length > 0) {
+			const skillset = await endpoints.skillsets.get(liveCtx, {
+				id: skillsetsRes.items[0].id,
+			});
+			expect(skillset).toBeDefined();
+			expect(skillset.id).toBe(skillsetsRes.items[0].id);
+		}
+
+		// 4. Blueprints list & get
+		const blueprintsRes = await endpoints.blueprints.list(liveCtx, {
+			limit: 5,
+		});
+		expect(blueprintsRes).toBeDefined();
+		expect(Array.isArray(blueprintsRes.items)).toBe(true);
+		if (blueprintsRes.items.length > 0) {
+			const blueprint = await endpoints.blueprints.get(liveCtx, {
+				id: blueprintsRes.items[0].id,
+			});
+			expect(blueprint).toBeDefined();
+			expect(blueprint.id).toBe(blueprintsRes.items[0].id);
+		}
+
+		// 5. Secrets list & get
+		const secretsRes = await endpoints.secrets.list(liveCtx, { limit: 5 });
+		expect(secretsRes).toBeDefined();
+		expect(Array.isArray(secretsRes.items)).toBe(true);
+		if (secretsRes.items.length > 0) {
+			const secret = await endpoints.secrets.get(liveCtx, {
+				id: secretsRes.items[0].id,
+			});
+			expect(secret).toBeDefined();
+			expect(secret.id).toBe(secretsRes.items[0].id);
+		}
+	}, 30000);
 });

--- a/packages/chatbotkit/api.test.ts
+++ b/packages/chatbotkit/api.test.ts
@@ -1,0 +1,260 @@
+import { logEventFromContext } from 'corsair/core';
+import { ApiError, request } from 'corsair/http';
+import { ChatbotkitAPIError, makeChatbotkitRequest } from './client';
+import { errorHandlers } from './error-handlers';
+import type { ChatbotkitContext } from './index';
+import { chatbotkit, chatbotkitEndpointSchemas } from './index';
+
+jest.mock('corsair/core', () => ({
+	...jest.requireActual('corsair/core'),
+	logEventFromContext: jest.fn(),
+}));
+
+jest.mock('corsair/http', () => {
+	const original = jest.requireActual('corsair/http');
+	return {
+		...original,
+		request: jest.fn(),
+	};
+});
+
+const mockRequest = request as jest.Mock;
+const mockLog = jest.mocked(logEventFromContext);
+
+function countLeaves(tree: Record<string, unknown>): number {
+	return Object.values(tree).reduce<number>((count, value) => {
+		if (typeof value === 'function') return count + 1;
+		if (value && typeof value === 'object') {
+			return count + countLeaves(value as Record<string, unknown>);
+		}
+		return count;
+	}, 0);
+}
+
+function endpointPaths(tree: Record<string, unknown>, prefix = ''): string[] {
+	return Object.entries(tree).flatMap(([key, value]) => {
+		const path = prefix ? `${prefix}.${key}` : key;
+		if (typeof value === 'function') return [path];
+		if (value && typeof value === 'object') {
+			return endpointPaths(value as Record<string, unknown>, path);
+		}
+		return [];
+	});
+}
+
+const mockCtx = {
+	key: 'sk-test-api-key',
+	$getAccountId: () => 'test-account-id',
+	options: {},
+	logEvent: jest.fn(),
+	db: {},
+	keyBuilder: async () => 'sk-test-api-key',
+} as unknown as ChatbotkitContext;
+
+const bot = { id: 'bot_1', name: 'Support Bot', description: 'A test bot' };
+
+type BotsList = (
+	ctx: ChatbotkitContext,
+	input: { cursor?: string; limit?: number; order?: 'asc' | 'desc' },
+) => Promise<unknown>;
+type BotsGet = (
+	ctx: ChatbotkitContext,
+	input: { id: string },
+) => Promise<unknown>;
+
+function getEndpoints(): { list: BotsList; get: BotsGet } {
+	const plugin = chatbotkit({ key: 'sk-test-api-key' });
+	const endpoints = plugin.endpoints as NonNullable<typeof plugin.endpoints> & {
+		bots: { list: BotsList; get: BotsGet };
+	};
+	return endpoints.bots;
+}
+
+function classify(error: Error): string {
+	const name = (
+		Object.keys(errorHandlers) as Array<keyof typeof errorHandlers>
+	).find((key) => errorHandlers[key].match(error));
+	return name ?? 'none';
+}
+
+function httpError(status: number, message: string): ApiError {
+	return new ApiError(
+		{ method: 'GET', url: 'https://api.chatbotkit.com/api/v1/bot/list' },
+		{
+			url: 'https://api.chatbotkit.com/api/v1/bot/list',
+			ok: false,
+			status,
+			statusText: 'Error',
+			body: { message },
+		},
+		message,
+	);
+}
+
+describe('Chatbotkit plugin shape', () => {
+	it('exposes the implemented operations with schemas and no webhooks', () => {
+		const plugin = chatbotkit();
+		const endpoints = plugin.endpoints as Record<string, unknown>;
+		const paths = endpointPaths(endpoints).sort();
+
+		expect(countLeaves(endpoints)).toBe(2);
+		expect(Object.keys(plugin.endpointMeta ?? {}).sort()).toEqual(paths);
+		expect(Object.keys(chatbotkitEndpointSchemas).sort()).toEqual(paths);
+		expect(plugin.webhooks).toEqual({});
+		expect(typeof plugin.pluginWebhookMatcher).toBe('function');
+	});
+
+	it('supports api key auth configuration', () => {
+		const plugin = chatbotkit();
+		expect(plugin.options?.authType).toBe('api_key');
+		expect(plugin.authConfig).toEqual({
+			api_key: { account: ['tenant_external_id'] },
+		});
+	});
+});
+
+describe('Chatbotkit request client', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockRequest.mockResolvedValue({ success: true, data: bot });
+	});
+
+	it('sends a bearer Authorization header and the v1 base URL', async () => {
+		await makeChatbotkitRequest('bot/bot_1/fetch', 'sk-test-api-key', {
+			method: 'GET',
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.objectContaining({
+				BASE: 'https://api.chatbotkit.com/api/v1',
+				TOKEN: 'sk-test-api-key',
+				HEADERS: expect.objectContaining({
+					Authorization: 'Bearer sk-test-api-key',
+				}),
+			}),
+			expect.objectContaining({ method: 'GET', url: 'bot/bot_1/fetch' }),
+		);
+	});
+
+	it('unwraps a successful envelope into { data, meta }', async () => {
+		await expect(
+			makeChatbotkitRequest('bot/bot_1/fetch', 'sk-test-api-key'),
+		).resolves.toEqual({ data: bot, meta: undefined });
+	});
+
+	it('throws on an unsuccessful envelope', async () => {
+		mockRequest.mockResolvedValue({ success: false, error: 'Bot not found' });
+
+		await expect(
+			makeChatbotkitRequest('bot/missing/fetch', 'sk-test-api-key'),
+		).rejects.toBeInstanceOf(ChatbotkitAPIError);
+	});
+});
+
+describe('Chatbotkit bots endpoints', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockLog.mockReset();
+	});
+
+	it('lists bots with cursor pagination query params', async () => {
+		mockRequest.mockResolvedValue({
+			success: true,
+			data: [bot],
+			meta: { cursor: 'next-page' },
+		});
+
+		const result = await getEndpoints().list(mockCtx, {
+			cursor: 'abc',
+			limit: 10,
+			order: 'desc',
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'bot/list',
+				query: { cursor: 'abc', limit: 10, order: 'desc' },
+			}),
+		);
+		expect(result).toEqual({ data: [bot], meta: { cursor: 'next-page' } });
+		expect(mockLog).toHaveBeenCalledWith(
+			mockCtx,
+			'chatbotkit.bots.list',
+			{ cursor: 'abc', limit: 10, order: 'desc' },
+			'completed',
+		);
+	});
+
+	it('omits undefined query params when listing without filters', async () => {
+		mockRequest.mockResolvedValue({ success: true, data: [] });
+
+		await getEndpoints().list(mockCtx, {});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ query: {} }),
+		);
+	});
+
+	it('fetches a single bot by id', async () => {
+		mockRequest.mockResolvedValue({ success: true, data: bot });
+
+		const result = await getEndpoints().get(mockCtx, { id: 'bot_1' });
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ method: 'GET', url: 'bot/bot_1/fetch' }),
+		);
+		expect(result).toMatchObject(bot);
+		expect(mockLog).toHaveBeenCalledWith(
+			mockCtx,
+			'chatbotkit.bots.get',
+			{ id: 'bot_1' },
+			'completed',
+		);
+	});
+
+	it('URL-encodes the bot id path segment', async () => {
+		mockRequest.mockResolvedValue({ success: true, data: bot });
+
+		await getEndpoints().get(mockCtx, { id: 'bot/weird id' });
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ url: 'bot/bot%2Fweird%20id/fetch' }),
+		);
+	});
+
+	it('propagates a not-found error without logging completion', async () => {
+		mockRequest.mockResolvedValue({ success: false, error: 'Bot not found' });
+
+		await expect(
+			getEndpoints().get(mockCtx, { id: 'missing' }),
+		).rejects.toBeInstanceOf(ChatbotkitAPIError);
+		expect(mockLog).not.toHaveBeenCalled();
+	});
+});
+
+describe('error handler classification', () => {
+	it('classifies auth, rate-limit, and not-found responses', () => {
+		expect(classify(httpError(401, 'Invalid secret key'))).toBe('AUTH_ERROR');
+		expect(classify(httpError(429, 'Too many requests'))).toBe(
+			'RATE_LIMIT_ERROR',
+		);
+		expect(classify(httpError(404, 'Bot not found'))).toBe('NOT_FOUND_ERROR');
+	});
+
+	it('does not retry auth or not-found failures, but retries rate limits', async () => {
+		expect((await errorHandlers.AUTH_ERROR.handler()).maxRetries).toBe(0);
+		expect((await errorHandlers.NOT_FOUND_ERROR.handler()).maxRetries).toBe(0);
+		expect(
+			(
+				await errorHandlers.RATE_LIMIT_ERROR.handler(
+					httpError(429, 'slow down'),
+				)
+			).maxRetries,
+		).toBeGreaterThan(0);
+	});
+});

--- a/packages/chatbotkit/api.test.ts
+++ b/packages/chatbotkit/api.test.ts
@@ -1,14 +1,29 @@
 import { logEventFromContext } from 'corsair/core';
 import { ApiError, request } from 'corsair/http';
-import { ChatbotkitAPIError, makeChatbotkitRequest } from './client';
+import { makeChatbotkitRequest } from './client';
+import {
+	BotSchema,
+	BotsGetInputSchema,
+	BotsGetResponseSchema,
+	BotsListInputSchema,
+	BotsListResponseSchema,
+} from './endpoints/types';
 import { errorHandlers } from './error-handlers';
 import type { ChatbotkitContext } from './index';
 import { chatbotkit, chatbotkitEndpointSchemas } from './index';
 
-jest.mock('corsair/core', () => ({
-	...jest.requireActual('corsair/core'),
-	logEventFromContext: jest.fn(),
-}));
+jest.mock('corsair/core', () => {
+	class AuthMissingError extends Error {
+		constructor(plugin: string, authType: string) {
+			super(`Missing ${authType} for ${plugin}`);
+			this.name = 'AuthMissingError';
+		}
+	}
+	return {
+		AuthMissingError,
+		logEventFromContext: jest.fn(),
+	};
+});
 
 jest.mock('corsair/http', () => {
 	const original = jest.requireActual('corsair/http');
@@ -51,7 +66,16 @@ const mockCtx = {
 	keyBuilder: async () => 'sk-test-api-key',
 } as unknown as ChatbotkitContext;
 
-const bot = { id: 'bot_1', name: 'Support Bot', description: 'A test bot' };
+const botFixture = {
+	id: 'bot_1',
+	name: 'Support Bot',
+	description: 'A test bot',
+	model: 'gpt-4o',
+	backstory: 'Helpful support agent',
+	visibility: 'private',
+	createdAt: 1787397742217,
+	updatedAt: 1787397742217,
+};
 
 type BotsList = (
 	ctx: ChatbotkitContext,
@@ -79,9 +103,9 @@ function classify(error: Error): string {
 
 function httpError(status: number, message: string): ApiError {
 	return new ApiError(
-		{ method: 'GET', url: 'https://api.chatbotkit.com/api/v1/bot/list' },
+		{ method: 'GET', url: 'https://api.chatbotkit.com/v1/bot/list' },
 		{
-			url: 'https://api.chatbotkit.com/api/v1/bot/list',
+			url: 'https://api.chatbotkit.com/v1/bot/list',
 			ok: false,
 			status,
 			statusText: 'Error',
@@ -90,6 +114,62 @@ function httpError(status: number, message: string): ApiError {
 		message,
 	);
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Schema Unit Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ChatBotKit Zod Schemas', () => {
+	it('validates a complete Bot object', () => {
+		const parsed = BotSchema.safeParse(botFixture);
+		expect(parsed.success).toBe(true);
+	});
+
+	it('validates minimal Bot object with only required fields', () => {
+		const parsed = BotSchema.safeParse({ id: 'b_123', name: 'Bot' });
+		expect(parsed.success).toBe(true);
+	});
+
+	it('rejects Bot missing required id or name', () => {
+		expect(BotSchema.safeParse({ name: 'Bot' }).success).toBe(false);
+		expect(BotSchema.safeParse({ id: 'b_123' }).success).toBe(false);
+	});
+
+	it('validates BotsListInputSchema options', () => {
+		expect(BotsListInputSchema.safeParse({}).success).toBe(true);
+		expect(
+			BotsListInputSchema.safeParse({
+				cursor: 'c_1',
+				limit: 50,
+				order: 'asc',
+			}).success,
+		).toBe(true);
+		expect(BotsListInputSchema.safeParse({ limit: 0 }).success).toBe(false);
+		expect(BotsListInputSchema.safeParse({ limit: 101 }).success).toBe(false);
+	});
+
+	it('validates BotsListResponseSchema with items and cursor', () => {
+		const parsed = BotsListResponseSchema.safeParse({
+			items: [botFixture],
+			cursor: 'c_next',
+		});
+		expect(parsed.success).toBe(true);
+		if (parsed.success) {
+			expect(parsed.data.items).toHaveLength(1);
+			expect(parsed.data.cursor).toBe('c_next');
+		}
+	});
+
+	it('validates BotsGetInputSchema and BotsGetResponseSchema', () => {
+		expect(BotsGetInputSchema.safeParse({ id: 'bot_1' }).success).toBe(true);
+		expect(BotsGetInputSchema.safeParse({}).success).toBe(false);
+		expect(BotsGetResponseSchema.safeParse(botFixture).success).toBe(true);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin Structure Tests
+// ─────────────────────────────────────────────────────────────────────────────
 
 describe('Chatbotkit plugin shape', () => {
 	it('exposes the implemented operations with schemas and no webhooks', () => {
@@ -113,10 +193,14 @@ describe('Chatbotkit plugin shape', () => {
 	});
 });
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Request Client Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
 describe('Chatbotkit request client', () => {
 	beforeEach(() => {
 		mockRequest.mockReset();
-		mockRequest.mockResolvedValue({ success: true, data: bot });
+		mockRequest.mockResolvedValue(botFixture);
 	});
 
 	it('sends a bearer Authorization header and the v1 base URL', async () => {
@@ -126,7 +210,7 @@ describe('Chatbotkit request client', () => {
 
 		expect(mockRequest).toHaveBeenCalledWith(
 			expect.objectContaining({
-				BASE: 'https://api.chatbotkit.com/api/v1',
+				BASE: 'https://api.chatbotkit.com/v1',
 				TOKEN: 'sk-test-api-key',
 				HEADERS: expect.objectContaining({
 					Authorization: 'Bearer sk-test-api-key',
@@ -136,20 +220,18 @@ describe('Chatbotkit request client', () => {
 		);
 	});
 
-	it('unwraps a successful envelope into { data, meta }', async () => {
-		await expect(
-			makeChatbotkitRequest('bot/bot_1/fetch', 'sk-test-api-key'),
-		).resolves.toEqual({ data: bot, meta: undefined });
-	});
-
-	it('throws on an unsuccessful envelope', async () => {
-		mockRequest.mockResolvedValue({ success: false, error: 'Bot not found' });
+	it('passes through ApiError directly for error classification', async () => {
+		mockRequest.mockRejectedValue(httpError(404, 'Bot not found'));
 
 		await expect(
 			makeChatbotkitRequest('bot/missing/fetch', 'sk-test-api-key'),
-		).rejects.toBeInstanceOf(ChatbotkitAPIError);
+		).rejects.toBeInstanceOf(ApiError);
 	});
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint Mock Tests
+// ─────────────────────────────────────────────────────────────────────────────
 
 describe('Chatbotkit bots endpoints', () => {
 	beforeEach(() => {
@@ -159,9 +241,8 @@ describe('Chatbotkit bots endpoints', () => {
 
 	it('lists bots with cursor pagination query params', async () => {
 		mockRequest.mockResolvedValue({
-			success: true,
-			data: [bot],
-			meta: { cursor: 'next-page' },
+			items: [botFixture],
+			cursor: 'next-page',
 		});
 
 		const result = await getEndpoints().list(mockCtx, {
@@ -178,7 +259,7 @@ describe('Chatbotkit bots endpoints', () => {
 				query: { cursor: 'abc', limit: 10, order: 'desc' },
 			}),
 		);
-		expect(result).toEqual({ data: [bot], meta: { cursor: 'next-page' } });
+		expect(result).toEqual({ items: [botFixture], cursor: 'next-page' });
 		expect(mockLog).toHaveBeenCalledWith(
 			mockCtx,
 			'chatbotkit.bots.list',
@@ -188,7 +269,7 @@ describe('Chatbotkit bots endpoints', () => {
 	});
 
 	it('omits undefined query params when listing without filters', async () => {
-		mockRequest.mockResolvedValue({ success: true, data: [] });
+		mockRequest.mockResolvedValue({ items: [] });
 
 		await getEndpoints().list(mockCtx, {});
 
@@ -199,7 +280,7 @@ describe('Chatbotkit bots endpoints', () => {
 	});
 
 	it('fetches a single bot by id', async () => {
-		mockRequest.mockResolvedValue({ success: true, data: bot });
+		mockRequest.mockResolvedValue(botFixture);
 
 		const result = await getEndpoints().get(mockCtx, { id: 'bot_1' });
 
@@ -207,7 +288,7 @@ describe('Chatbotkit bots endpoints', () => {
 			expect.anything(),
 			expect.objectContaining({ method: 'GET', url: 'bot/bot_1/fetch' }),
 		);
-		expect(result).toMatchObject(bot);
+		expect(result).toMatchObject(botFixture);
 		expect(mockLog).toHaveBeenCalledWith(
 			mockCtx,
 			'chatbotkit.bots.get',
@@ -217,7 +298,7 @@ describe('Chatbotkit bots endpoints', () => {
 	});
 
 	it('URL-encodes the bot id path segment', async () => {
-		mockRequest.mockResolvedValue({ success: true, data: bot });
+		mockRequest.mockResolvedValue(botFixture);
 
 		await getEndpoints().get(mockCtx, { id: 'bot/weird id' });
 
@@ -226,16 +307,11 @@ describe('Chatbotkit bots endpoints', () => {
 			expect.objectContaining({ url: 'bot/bot%2Fweird%20id/fetch' }),
 		);
 	});
-
-	it('propagates a not-found error without logging completion', async () => {
-		mockRequest.mockResolvedValue({ success: false, error: 'Bot not found' });
-
-		await expect(
-			getEndpoints().get(mockCtx, { id: 'missing' }),
-		).rejects.toBeInstanceOf(ChatbotkitAPIError);
-		expect(mockLog).not.toHaveBeenCalled();
-	});
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error Handler Tests
+// ─────────────────────────────────────────────────────────────────────────────
 
 describe('error handler classification', () => {
 	it('classifies auth, rate-limit, and not-found responses', () => {
@@ -257,4 +333,60 @@ describe('error handler classification', () => {
 			).maxRetries,
 		).toBeGreaterThan(0);
 	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration: Live API Tests (gated on CHATBOTKIT_API_KEY)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TEST_API_KEY = process.env.CHATBOTKIT_API_KEY ?? '';
+const describeIfKey = TEST_API_KEY ? describe : describe.skip;
+
+describeIfKey('ChatBotKit Live API integration', () => {
+	const unmockedHttp = jest.requireActual('corsair/http');
+	const liveCtx = {
+		...mockCtx,
+		key: TEST_API_KEY,
+	};
+
+	beforeEach(() => {
+		mockRequest.mockImplementation(unmockedHttp.request);
+	});
+
+	it('fetches bots list from real ChatBotKit API', async () => {
+		const plugin = chatbotkit({ key: TEST_API_KEY });
+		const endpoints = plugin.endpoints as NonNullable<
+			typeof plugin.endpoints
+		> & {
+			bots: { list: BotsList; get: BotsGet };
+		};
+
+		const result = (await endpoints.bots.list(liveCtx, {
+			limit: 10,
+		})) as { items: unknown[] };
+
+		expect(result).toBeDefined();
+		expect(Array.isArray(result.items)).toBe(true);
+		expect(BotsListResponseSchema.safeParse(result).success).toBe(true);
+	}, 20000);
+
+	it('fetches single bot by ID from real ChatBotKit API', async () => {
+		const plugin = chatbotkit({ key: TEST_API_KEY });
+		const endpoints = plugin.endpoints as NonNullable<
+			typeof plugin.endpoints
+		> & {
+			bots: { list: BotsList; get: BotsGet };
+		};
+
+		const listRes = (await endpoints.bots.list(liveCtx, { limit: 1 })) as {
+			items: Array<{ id: string }>;
+		};
+
+		const firstBot = listRes.items?.[0];
+		if (firstBot) {
+			const botRes = await endpoints.bots.get(liveCtx, { id: firstBot.id });
+			expect(botRes).toBeDefined();
+			expect(BotsGetResponseSchema.safeParse(botRes).success).toBe(true);
+		}
+	}, 20000);
 });

--- a/packages/chatbotkit/api.test.ts
+++ b/packages/chatbotkit/api.test.ts
@@ -172,38 +172,91 @@ function httpError(status: number, message: string): ApiError {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('ChatBotKit Zod Schemas', () => {
-	it('validates a complete Bot object', () => {
-		expect(BotSchema.safeParse(botFixture).success).toBe(true);
+	it('validates a complete Bot object and rejects invalid', () => {
+		const parsed = BotSchema.safeParse(botFixture);
+		expect(parsed.success).toBe(true);
+		if (parsed.success) {
+			expect(parsed.data.id).toBe('bot_1');
+			expect(parsed.data.name).toBe('Support Bot');
+			expect(parsed.data.privacy).toBe(true);
+			expect(parsed.data.moderation).toBe(false);
+		}
+		expect(BotSchema.safeParse({ id: 123 }).success).toBe(false);
 	});
 
-	it('validates a complete Dataset object', () => {
-		expect(DatasetSchema.safeParse(datasetFixture).success).toBe(true);
+	it('validates a complete Dataset object and rejects invalid', () => {
+		const parsed = DatasetSchema.safeParse(datasetFixture);
+		expect(parsed.success).toBe(true);
+		if (parsed.success) {
+			expect(parsed.data.id).toBe('dataset_1');
+			expect(parsed.data.name).toBe('FAQ Dataset');
+			expect(parsed.data.visibility).toBe('private');
+		}
+		expect(DatasetSchema.safeParse({ id: 123 }).success).toBe(false);
 	});
 
-	it('validates a complete Skillset object', () => {
-		expect(SkillsetSchema.safeParse(skillsetFixture).success).toBe(true);
+	it('validates a complete Skillset object and rejects invalid', () => {
+		const parsed = SkillsetSchema.safeParse(skillsetFixture);
+		expect(parsed.success).toBe(true);
+		if (parsed.success) {
+			expect(parsed.data.id).toBe('skillset_1');
+			expect(parsed.data.name).toBe('Support Tools');
+			expect(parsed.data.state).toBe('enabled');
+		}
+		expect(SkillsetSchema.safeParse({ id: 123 }).success).toBe(false);
 	});
 
-	it('validates a complete Blueprint object', () => {
-		expect(BlueprintSchema.safeParse(blueprintFixture).success).toBe(true);
+	it('validates a complete Blueprint object and rejects invalid', () => {
+		const parsed = BlueprintSchema.safeParse(blueprintFixture);
+		expect(parsed.success).toBe(true);
+		if (parsed.success) {
+			expect(parsed.data.id).toBe('blueprint_1');
+			expect(parsed.data.name).toBe('Template');
+		}
+		expect(BlueprintSchema.safeParse({ id: 123 }).success).toBe(false);
 	});
 
-	it('validates a complete Secret object', () => {
-		expect(SecretSchema.safeParse(secretFixture).success).toBe(true);
+	it('validates a complete Secret object and rejects invalid', () => {
+		const parsed = SecretSchema.safeParse(secretFixture);
+		expect(parsed.success).toBe(true);
+		if (parsed.success) {
+			expect(parsed.data.id).toBe('secret_1');
+			expect(parsed.data.name).toBe('Gmail API Key');
+			expect(parsed.data.kind).toBe('personal');
+		}
+		expect(SecretSchema.safeParse({ id: 123 }).success).toBe(false);
 	});
 
-	it('validates a complete Conversation object', () => {
-		expect(ConversationSchema.safeParse(conversationFixture).success).toBe(
-			true,
-		);
+	it('validates a complete Conversation object and rejects invalid', () => {
+		const parsed = ConversationSchema.safeParse(conversationFixture);
+		expect(parsed.success).toBe(true);
+		if (parsed.success) {
+			expect(parsed.data.id).toBe('conv_1');
+			expect(parsed.data.name).toBe('Test Conversation');
+		}
+		expect(ConversationSchema.safeParse({ id: 123 }).success).toBe(false);
 	});
 
-	it('validates a complete File object', () => {
-		expect(FileSchema.safeParse(fileFixture).success).toBe(true);
+	it('validates a complete File object and rejects invalid', () => {
+		const parsed = FileSchema.safeParse(fileFixture);
+		expect(parsed.success).toBe(true);
+		if (parsed.success) {
+			expect(parsed.data.id).toBe('file_1');
+			expect(parsed.data.name).toBe('document.pdf');
+			expect(parsed.data.size).toBe(1024);
+		}
+		expect(FileSchema.safeParse({ id: 123 }).success).toBe(false);
 	});
 
-	it('validates a complete Task object', () => {
-		expect(TaskSchema.safeParse(taskFixture).success).toBe(true);
+	it('validates a complete Task object and rejects invalid', () => {
+		const parsed = TaskSchema.safeParse(taskFixture);
+		expect(parsed.success).toBe(true);
+		if (parsed.success) {
+			expect(parsed.data.id).toBe('task_1');
+			expect(parsed.data.name).toBe('Nightly Sync');
+			expect(parsed.data.schedule).toBe('0 0 * * *');
+		}
+		expect(TaskSchema.safeParse({ id: 123 }).success).toBe(false);
 	});
 });
 
@@ -283,7 +336,7 @@ describe('Chatbotkit resource endpoints', () => {
 	});
 
 	// Bots
-	it('executes bots.list and bots.get', async () => {
+	it('executes bots.list and bots.get with correct request contract', async () => {
 		mockRequest.mockResolvedValueOnce({
 			items: [botFixture],
 			cursor: 'c_1',
@@ -292,59 +345,157 @@ describe('Chatbotkit resource endpoints', () => {
 		expect(listRes).toEqual({ items: [botFixture], cursor: 'c_1' });
 		expect(listRes.items[0].privacy).toBe(true);
 		expect(listRes.items[0].moderation).toBe(false);
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'bot/list',
+				query: { take: 10 },
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce(botFixture);
 		const getRes = await endpoints.bots.get(mockCtx, { id: 'bot_1' });
 		expect(getRes).toEqual(botFixture);
 		expect(getRes.privacy).toBe(true);
 		expect(getRes.moderation).toBe(false);
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'bot/bot_1/fetch',
+			}),
+		);
 	});
 
-	it('executes bots.create, update, delete, upvote, downvote', async () => {
+	it('executes bots.create, update, delete, upvote, downvote with request contract', async () => {
 		mockRequest.mockResolvedValue({ id: 'bot_1' });
+
 		expect(await endpoints.bots.create(mockCtx, { name: 'Bot' })).toEqual({
 			id: 'bot_1',
 		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'bot/create',
+				body: { name: 'Bot' },
+			}),
+		);
+
 		expect(
 			await endpoints.bots.update(mockCtx, { id: 'bot_1', name: 'Bot2' }),
 		).toEqual({ id: 'bot_1' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'bot/bot_1/update',
+				body: { name: 'Bot2' },
+			}),
+		);
+
 		expect(await endpoints.bots.delete(mockCtx, { id: 'bot_1' })).toEqual({
 			id: 'bot_1',
 		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'bot/bot_1/delete',
+			}),
+		);
+
 		expect(await endpoints.bots.upvote(mockCtx, { id: 'bot_1' })).toEqual({
 			id: 'bot_1',
 		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'bot/bot_1/upvote',
+			}),
+		);
+
 		expect(await endpoints.bots.downvote(mockCtx, { id: 'bot_1' })).toEqual({
 			id: 'bot_1',
 		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'bot/bot_1/downvote',
+			}),
+		);
 	});
 
 	// Datasets
-	it('executes datasets.list, get, create, update, delete, search', async () => {
+	it('executes datasets.list, get, create, update, delete, search with request contract', async () => {
 		mockRequest.mockResolvedValueOnce({ items: [datasetFixture] });
-		expect(await endpoints.datasets.list(mockCtx, {})).toEqual({
+		expect(await endpoints.datasets.list(mockCtx, { limit: 5 })).toEqual({
 			items: [datasetFixture],
 		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'dataset/list',
+				query: { take: 5 },
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce(datasetFixture);
 		expect(await endpoints.datasets.get(mockCtx, { id: 'dataset_1' })).toEqual(
 			datasetFixture,
+		);
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'dataset/dataset_1/fetch',
+			}),
 		);
 
 		mockRequest.mockResolvedValueOnce({ id: 'dataset_1' });
 		expect(
 			await endpoints.datasets.create(mockCtx, { name: 'Dataset' }),
 		).toEqual({ id: 'dataset_1' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'dataset/create',
+				body: { name: 'Dataset' },
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce({ id: 'dataset_1' });
 		expect(
-			await endpoints.datasets.update(mockCtx, { id: 'dataset_1' }),
+			await endpoints.datasets.update(mockCtx, {
+				id: 'dataset_1',
+				name: 'Dataset2',
+			}),
 		).toEqual({ id: 'dataset_1' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'dataset/dataset_1/update',
+				body: { name: 'Dataset2' },
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce({ id: 'dataset_1' });
 		expect(
 			await endpoints.datasets.delete(mockCtx, { id: 'dataset_1' }),
 		).toEqual({ id: 'dataset_1' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'dataset/dataset_1/delete',
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce({
 			items: [{ id: 'r_1', text: 'match' }],
@@ -355,103 +506,289 @@ describe('Chatbotkit resource endpoints', () => {
 				query: 'test',
 			}),
 		).toEqual({ items: [{ id: 'r_1', text: 'match' }] });
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'dataset/dataset_1/search',
+				body: { query: 'test' },
+			}),
+		);
 	});
 
 	// Skillsets
-	it('executes skillsets.list, get, create, update, delete', async () => {
+	it('executes skillsets.list, get, create, update, delete with request contract', async () => {
 		mockRequest.mockResolvedValueOnce({ items: [skillsetFixture] });
-		expect(await endpoints.skillsets.list(mockCtx, {})).toEqual({
+		expect(await endpoints.skillsets.list(mockCtx, { limit: 10 })).toEqual({
 			items: [skillsetFixture],
 		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'skillset/list',
+				query: { take: 10 },
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce(skillsetFixture);
 		expect(
 			await endpoints.skillsets.get(mockCtx, { id: 'skillset_1' }),
 		).toEqual(skillsetFixture);
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'skillset/skillset_1/fetch',
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce({ id: 'skillset_1' });
 		expect(
 			await endpoints.skillsets.create(mockCtx, { name: 'Skillset' }),
 		).toEqual({ id: 'skillset_1' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'skillset/create',
+				body: { name: 'Skillset' },
+			}),
+		);
+
+		mockRequest.mockResolvedValueOnce({ id: 'skillset_1' });
+		expect(
+			await endpoints.skillsets.update(mockCtx, {
+				id: 'skillset_1',
+				name: 'Skillset2',
+			}),
+		).toEqual({ id: 'skillset_1' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'skillset/skillset_1/update',
+				body: { name: 'Skillset2' },
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce({ id: 'skillset_1' });
 		expect(
 			await endpoints.skillsets.delete(mockCtx, { id: 'skillset_1' }),
 		).toEqual({ id: 'skillset_1' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'skillset/skillset_1/delete',
+			}),
+		);
 	});
 
 	// Blueprints
-	it('executes blueprints.list, get, create, update, delete', async () => {
+	it('executes blueprints.list, get, create, update, delete with request contract', async () => {
 		mockRequest.mockResolvedValueOnce({ items: [blueprintFixture] });
-		expect(await endpoints.blueprints.list(mockCtx, {})).toEqual({
+		expect(await endpoints.blueprints.list(mockCtx, { limit: 10 })).toEqual({
 			items: [blueprintFixture],
 		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'blueprint/list',
+				query: { take: 10 },
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce(blueprintFixture);
 		expect(
 			await endpoints.blueprints.get(mockCtx, { id: 'blueprint_1' }),
 		).toEqual(blueprintFixture);
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'blueprint/blueprint_1/fetch',
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce({ id: 'blueprint_1' });
 		expect(
 			await endpoints.blueprints.create(mockCtx, { name: 'Blueprint' }),
 		).toEqual({ id: 'blueprint_1' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'blueprint/create',
+				body: { name: 'Blueprint' },
+			}),
+		);
+
+		mockRequest.mockResolvedValueOnce({ id: 'blueprint_1' });
+		expect(
+			await endpoints.blueprints.update(mockCtx, {
+				id: 'blueprint_1',
+				name: 'Blueprint2',
+			}),
+		).toEqual({ id: 'blueprint_1' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'blueprint/blueprint_1/update',
+				body: { name: 'Blueprint2' },
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce({ id: 'blueprint_1' });
 		expect(
 			await endpoints.blueprints.delete(mockCtx, { id: 'blueprint_1' }),
 		).toEqual({ id: 'blueprint_1' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'blueprint/blueprint_1/delete',
+			}),
+		);
 	});
 
 	// Secrets
-	it('executes secrets.list, get, create, update, delete', async () => {
+	it('executes secrets.list, get, create, update, delete with request contract', async () => {
 		mockRequest.mockResolvedValueOnce({ items: [secretFixture] });
-		expect(await endpoints.secrets.list(mockCtx, {})).toEqual({
+		expect(await endpoints.secrets.list(mockCtx, { limit: 10 })).toEqual({
 			items: [secretFixture],
 		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'secret/list',
+				query: { take: 10 },
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce(secretFixture);
 		expect(await endpoints.secrets.get(mockCtx, { id: 'secret_1' })).toEqual(
 			secretFixture,
+		);
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'secret/secret_1/fetch',
+			}),
 		);
 
 		mockRequest.mockResolvedValueOnce({ id: 'secret_1' });
 		expect(await endpoints.secrets.create(mockCtx, { name: 'Secret' })).toEqual(
 			{ id: 'secret_1' },
 		);
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'secret/create',
+				body: { name: 'Secret' },
+			}),
+		);
+
+		mockRequest.mockResolvedValueOnce({ id: 'secret_1' });
+		expect(
+			await endpoints.secrets.update(mockCtx, {
+				id: 'secret_1',
+				name: 'Secret2',
+			}),
+		).toEqual({ id: 'secret_1' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'secret/secret_1/update',
+				body: { name: 'Secret2' },
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce({ id: 'secret_1' });
 		expect(await endpoints.secrets.delete(mockCtx, { id: 'secret_1' })).toEqual(
 			{ id: 'secret_1' },
 		);
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'secret/secret_1/delete',
+			}),
+		);
 	});
 
 	// Conversations
-	it('executes conversations.list, get, create, update, delete, complete', async () => {
+	it('executes conversations.list, get, create, update, delete, complete with request contract', async () => {
 		mockRequest.mockResolvedValueOnce({ items: [conversationFixture] });
-		expect(await endpoints.conversations.list(mockCtx, {})).toEqual({
+		expect(await endpoints.conversations.list(mockCtx, { limit: 10 })).toEqual({
 			items: [conversationFixture],
 		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'conversation/list',
+				query: { take: 10 },
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce(conversationFixture);
 		expect(
 			await endpoints.conversations.get(mockCtx, { id: 'conv_1' }),
 		).toEqual(conversationFixture);
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'conversation/conv_1/fetch',
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce({ id: 'conv_1' });
 		expect(await endpoints.conversations.create(mockCtx, {})).toEqual({
 			id: 'conv_1',
 		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'conversation/create',
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce({ id: 'conv_1' });
 		expect(
-			await endpoints.conversations.update(mockCtx, { id: 'conv_1' }),
+			await endpoints.conversations.update(mockCtx, {
+				id: 'conv_1',
+				name: 'Conv2',
+			}),
 		).toEqual({ id: 'conv_1' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'conversation/conv_1/update',
+				body: { name: 'Conv2' },
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce({ id: 'conv_1' });
 		expect(
 			await endpoints.conversations.delete(mockCtx, { id: 'conv_1' }),
 		).toEqual({ id: 'conv_1' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'conversation/conv_1/delete',
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce({ text: 'Hello!' });
 		expect(
@@ -460,52 +797,133 @@ describe('Chatbotkit resource endpoints', () => {
 				text: 'Hi',
 			}),
 		).toEqual({ text: 'Hello!' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'conversation/conv_1/complete',
+				body: { text: 'Hi' },
+			}),
+		);
 	});
 
 	// Files
-	it('executes files.list, get, create, delete', async () => {
+	it('executes files.list, get, create, delete with request contract', async () => {
 		mockRequest.mockResolvedValueOnce({ items: [fileFixture] });
-		expect(await endpoints.files.list(mockCtx, {})).toEqual({
+		expect(await endpoints.files.list(mockCtx, { limit: 10 })).toEqual({
 			items: [fileFixture],
 		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'file/list',
+				query: { take: 10 },
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce(fileFixture);
 		expect(await endpoints.files.get(mockCtx, { id: 'file_1' })).toEqual(
 			fileFixture,
+		);
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'file/file_1/fetch',
+			}),
 		);
 
 		mockRequest.mockResolvedValueOnce({ id: 'file_1' });
 		expect(await endpoints.files.create(mockCtx, { name: 'f.pdf' })).toEqual({
 			id: 'file_1',
 		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'file/create',
+				body: { name: 'f.pdf' },
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce({ id: 'file_1' });
 		expect(await endpoints.files.delete(mockCtx, { id: 'file_1' })).toEqual({
 			id: 'file_1',
 		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'file/file_1/delete',
+			}),
+		);
 	});
 
 	// Tasks
-	it('executes tasks.list, get, create, update, delete', async () => {
+	it('executes tasks.list, get, create, update, delete with request contract', async () => {
 		mockRequest.mockResolvedValueOnce({ items: [taskFixture] });
-		expect(await endpoints.tasks.list(mockCtx, {})).toEqual({
+		expect(await endpoints.tasks.list(mockCtx, { limit: 10 })).toEqual({
 			items: [taskFixture],
 		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'task/list',
+				query: { take: 10 },
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce(taskFixture);
 		expect(await endpoints.tasks.get(mockCtx, { id: 'task_1' })).toEqual(
 			taskFixture,
+		);
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'task/task_1/fetch',
+			}),
 		);
 
 		mockRequest.mockResolvedValueOnce({ id: 'task_1' });
 		expect(await endpoints.tasks.create(mockCtx, { name: 'Task' })).toEqual({
 			id: 'task_1',
 		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'task/create',
+				body: { name: 'Task' },
+			}),
+		);
+
+		mockRequest.mockResolvedValueOnce({ id: 'task_1' });
+		expect(
+			await endpoints.tasks.update(mockCtx, { id: 'task_1', name: 'Task2' }),
+		).toEqual({ id: 'task_1' });
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'task/task_1/update',
+				body: { name: 'Task2' },
+			}),
+		);
 
 		mockRequest.mockResolvedValueOnce({ id: 'task_1' });
 		expect(await endpoints.tasks.delete(mockCtx, { id: 'task_1' })).toEqual({
 			id: 'task_1',
 		});
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'task/task_1/delete',
+			}),
+		);
 	});
 });
 

--- a/packages/chatbotkit/client.ts
+++ b/packages/chatbotkit/client.ts
@@ -1,0 +1,87 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+
+export class ChatbotkitAPIError extends Error {
+	readonly status?: number;
+	readonly body?: unknown;
+
+	constructor(
+		message: string,
+		options: { status?: number; body?: unknown } = {},
+	) {
+		super(message);
+		this.name = 'ChatbotkitAPIError';
+		this.status = options.status;
+		this.body = options.body;
+	}
+}
+
+// https://chatbotkit.com/manuals/spec-introduction — v1 REST API, secret-key
+// bearer auth (`sk-...`), envelope response shape `{ success, data, meta }`.
+const CHATBOTKIT_API_BASE = 'https://api.chatbotkit.com/api/v1';
+
+export type ChatbotkitEnvelope<TData> = {
+	data: TData;
+	meta?: Record<string, unknown>;
+};
+
+export async function makeChatbotkitRequest<TData>(
+	endpoint: string,
+	apiKey: string,
+	options: {
+		method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+		body?: Record<string, unknown>;
+		query?: Record<string, string | number | boolean | undefined>;
+	} = {},
+): Promise<ChatbotkitEnvelope<TData>> {
+	const { method = 'GET', body, query } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: CHATBOTKIT_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: apiKey,
+		HEADERS: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${apiKey}`,
+		},
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint,
+		body:
+			method === 'POST' || method === 'PUT' || method === 'PATCH'
+				? body
+				: undefined,
+		mediaType: 'application/json; charset=utf-8',
+		query: method === 'GET' ? query : undefined,
+	};
+
+	try {
+		const envelope = await request<{
+			success: boolean;
+			data?: TData;
+			meta?: Record<string, unknown>;
+			error?: string;
+		}>(config, requestOptions);
+
+		if (!envelope.success) {
+			throw new ChatbotkitAPIError(
+				envelope.error ?? 'Chatbotkit request failed',
+				{ body: envelope },
+			);
+		}
+
+		return { data: envelope.data as TData, meta: envelope.meta };
+	} catch (error) {
+		if (error instanceof ApiError || error instanceof ChatbotkitAPIError) {
+			throw error;
+		}
+		if (error instanceof Error) {
+			throw new ChatbotkitAPIError(error.message);
+		}
+		throw new ChatbotkitAPIError('Unknown error');
+	}
+}

--- a/packages/chatbotkit/client.ts
+++ b/packages/chatbotkit/client.ts
@@ -16,14 +16,8 @@ export class ChatbotkitAPIError extends Error {
 	}
 }
 
-// https://chatbotkit.com/manuals/spec-introduction — v1 REST API, secret-key
-// bearer auth (`sk-...`), envelope response shape `{ success, data, meta }`.
-const CHATBOTKIT_API_BASE = 'https://api.chatbotkit.com/api/v1';
-
-export type ChatbotkitEnvelope<TData> = {
-	data: TData;
-	meta?: Record<string, unknown>;
-};
+// https://chatbotkit.com/docs/api — v1 REST API, secret-key bearer auth (`sk-...`).
+const CHATBOTKIT_API_BASE = 'https://api.chatbotkit.com/v1';
 
 export async function makeChatbotkitRequest<TData>(
 	endpoint: string,
@@ -33,7 +27,7 @@ export async function makeChatbotkitRequest<TData>(
 		body?: Record<string, unknown>;
 		query?: Record<string, string | number | boolean | undefined>;
 	} = {},
-): Promise<ChatbotkitEnvelope<TData>> {
+): Promise<TData> {
 	const { method = 'GET', body, query } = options;
 
 	const config: OpenAPIConfig = {
@@ -60,21 +54,7 @@ export async function makeChatbotkitRequest<TData>(
 	};
 
 	try {
-		const envelope = await request<{
-			success: boolean;
-			data?: TData;
-			meta?: Record<string, unknown>;
-			error?: string;
-		}>(config, requestOptions);
-
-		if (!envelope.success) {
-			throw new ChatbotkitAPIError(
-				envelope.error ?? 'Chatbotkit request failed',
-				{ body: envelope },
-			);
-		}
-
-		return { data: envelope.data as TData, meta: envelope.meta };
+		return await request<TData>(config, requestOptions);
 	} catch (error) {
 		if (error instanceof ApiError || error instanceof ChatbotkitAPIError) {
 			throw error;

--- a/packages/chatbotkit/endpoints/blueprints.ts
+++ b/packages/chatbotkit/endpoints/blueprints.ts
@@ -1,0 +1,152 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeChatbotkitRequest } from '../client';
+import type { ChatbotkitContext } from '../index';
+import type {
+	BlueprintsCreateInput,
+	BlueprintsCreateResponse,
+	BlueprintsDeleteInput,
+	BlueprintsDeleteResponse,
+	BlueprintsGetInput,
+	BlueprintsGetResponse,
+	BlueprintsListInput,
+	BlueprintsListResponse,
+	BlueprintsUpdateInput,
+	BlueprintsUpdateResponse,
+} from './types';
+import {
+	BlueprintsCreateResponseSchema,
+	BlueprintsDeleteResponseSchema,
+	BlueprintsGetResponseSchema,
+	BlueprintsListResponseSchema,
+	BlueprintsUpdateResponseSchema,
+} from './types';
+
+function compactQuery(
+	query: Record<string, string | number | boolean | undefined>,
+): Record<string, string | number | boolean> {
+	return Object.fromEntries(
+		Object.entries(query).filter(([, value]) => value !== undefined),
+	) as Record<string, string | number | boolean>;
+}
+
+export const list = async (
+	ctx: ChatbotkitContext,
+	input: BlueprintsListInput,
+): Promise<BlueprintsListResponse> => {
+	const response = await makeChatbotkitRequest<BlueprintsListResponse>(
+		'blueprint/list',
+		ctx.key,
+		{
+			method: 'GET',
+			query: compactQuery({
+				cursor: input.cursor,
+				limit: input.limit,
+				order: input.order,
+			}),
+		},
+	);
+
+	const parsed = BlueprintsListResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.blueprints.list',
+		{ cursor: input.cursor, limit: input.limit, order: input.order },
+		'completed',
+	);
+	return parsed;
+};
+
+export const get = async (
+	ctx: ChatbotkitContext,
+	input: BlueprintsGetInput,
+): Promise<BlueprintsGetResponse> => {
+	const response = await makeChatbotkitRequest<BlueprintsGetResponse>(
+		`blueprint/${encodeURIComponent(input.id)}/fetch`,
+		ctx.key,
+		{ method: 'GET' },
+	);
+
+	const parsed = BlueprintsGetResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.blueprints.get',
+		{ id: input.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const create = async (
+	ctx: ChatbotkitContext,
+	input: BlueprintsCreateInput,
+): Promise<BlueprintsCreateResponse> => {
+	const response = await makeChatbotkitRequest<BlueprintsCreateResponse>(
+		'blueprint/create',
+		ctx.key,
+		{
+			method: 'POST',
+			body: input as Record<string, unknown>,
+		},
+	);
+
+	const parsed = BlueprintsCreateResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.blueprints.create',
+		{ id: parsed.id, name: input.name },
+		'completed',
+	);
+	return parsed;
+};
+
+export const update = async (
+	ctx: ChatbotkitContext,
+	input: BlueprintsUpdateInput,
+): Promise<BlueprintsUpdateResponse> => {
+	const { id, ...body } = input;
+	const response = await makeChatbotkitRequest<BlueprintsUpdateResponse>(
+		`blueprint/${encodeURIComponent(id)}/update`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: body as Record<string, unknown>,
+		},
+	);
+
+	const parsed = BlueprintsUpdateResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.blueprints.update',
+		{ id: parsed.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const del = async (
+	ctx: ChatbotkitContext,
+	input: BlueprintsDeleteInput,
+): Promise<BlueprintsDeleteResponse> => {
+	const response = await makeChatbotkitRequest<BlueprintsDeleteResponse>(
+		`blueprint/${encodeURIComponent(input.id)}/delete`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: {},
+		},
+	);
+
+	const parsed = BlueprintsDeleteResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.blueprints.delete',
+		{ id: parsed.id },
+		'completed',
+	);
+	return parsed;
+};

--- a/packages/chatbotkit/endpoints/blueprints.ts
+++ b/packages/chatbotkit/endpoints/blueprints.ts
@@ -40,7 +40,7 @@ export const list = async (
 			method: 'GET',
 			query: compactQuery({
 				cursor: input.cursor,
-				limit: input.limit,
+				take: input.limit,
 				order: input.order,
 			}),
 		},

--- a/packages/chatbotkit/endpoints/bots.ts
+++ b/packages/chatbotkit/endpoints/bots.ts
@@ -2,6 +2,7 @@ import { logEventFromContext } from 'corsair/core';
 import type { ChatbotkitEndpoints } from '..';
 import { makeChatbotkitRequest } from '../client';
 import type { BotsGetResponse, BotsListResponse } from './types';
+import { BotsGetResponseSchema, BotsListResponseSchema } from './types';
 
 function compactQuery(
 	query: Record<string, string | number | boolean | undefined>,
@@ -25,13 +26,15 @@ export const list: ChatbotkitEndpoints['botsList'] = async (ctx, input) => {
 		},
 	);
 
+	const parsed = BotsListResponseSchema.parse(response);
+
 	await logEventFromContext(
 		ctx,
 		'chatbotkit.bots.list',
 		{ cursor: input.cursor, limit: input.limit, order: input.order },
 		'completed',
 	);
-	return { items: response.items ?? [], cursor: response.cursor };
+	return parsed;
 };
 
 export const get: ChatbotkitEndpoints['botsGet'] = async (ctx, input) => {
@@ -41,11 +44,13 @@ export const get: ChatbotkitEndpoints['botsGet'] = async (ctx, input) => {
 		{ method: 'GET' },
 	);
 
+	const parsed = BotsGetResponseSchema.parse(response);
+
 	await logEventFromContext(
 		ctx,
 		'chatbotkit.bots.get',
 		{ id: input.id },
 		'completed',
 	);
-	return response;
+	return parsed;
 };

--- a/packages/chatbotkit/endpoints/bots.ts
+++ b/packages/chatbotkit/endpoints/bots.ts
@@ -1,0 +1,47 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ChatbotkitEndpoints } from '..';
+import { makeChatbotkitRequest } from '../client';
+import type { Bot } from './types';
+
+function compactQuery(
+	query: Record<string, string | number | boolean | undefined>,
+): Record<string, string | number | boolean> {
+	return Object.fromEntries(
+		Object.entries(query).filter(([, value]) => value !== undefined),
+	) as Record<string, string | number | boolean>;
+}
+
+export const list: ChatbotkitEndpoints['botsList'] = async (ctx, input) => {
+	const envelope = await makeChatbotkitRequest<Bot[]>('bot/list', ctx.key, {
+		method: 'GET',
+		query: compactQuery({
+			cursor: input.cursor,
+			limit: input.limit,
+			order: input.order,
+		}),
+	});
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.bots.list',
+		{ cursor: input.cursor, limit: input.limit, order: input.order },
+		'completed',
+	);
+	return { data: envelope.data ?? [], meta: envelope.meta };
+};
+
+export const get: ChatbotkitEndpoints['botsGet'] = async (ctx, input) => {
+	const envelope = await makeChatbotkitRequest<Bot>(
+		`bot/${encodeURIComponent(input.id)}/fetch`,
+		ctx.key,
+		{ method: 'GET' },
+	);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.bots.get',
+		{ id: input.id },
+		'completed',
+	);
+	return envelope.data;
+};

--- a/packages/chatbotkit/endpoints/bots.ts
+++ b/packages/chatbotkit/endpoints/bots.ts
@@ -46,7 +46,7 @@ export const list = async (
 			method: 'GET',
 			query: compactQuery({
 				cursor: input.cursor,
-				limit: input.limit,
+				take: input.limit,
 				order: input.order,
 			}),
 		},

--- a/packages/chatbotkit/endpoints/bots.ts
+++ b/packages/chatbotkit/endpoints/bots.ts
@@ -1,7 +1,7 @@
 import { logEventFromContext } from 'corsair/core';
 import type { ChatbotkitEndpoints } from '..';
 import { makeChatbotkitRequest } from '../client';
-import type { Bot } from './types';
+import type { BotsGetResponse, BotsListResponse } from './types';
 
 function compactQuery(
 	query: Record<string, string | number | boolean | undefined>,
@@ -12,14 +12,18 @@ function compactQuery(
 }
 
 export const list: ChatbotkitEndpoints['botsList'] = async (ctx, input) => {
-	const envelope = await makeChatbotkitRequest<Bot[]>('bot/list', ctx.key, {
-		method: 'GET',
-		query: compactQuery({
-			cursor: input.cursor,
-			limit: input.limit,
-			order: input.order,
-		}),
-	});
+	const response = await makeChatbotkitRequest<BotsListResponse>(
+		'bot/list',
+		ctx.key,
+		{
+			method: 'GET',
+			query: compactQuery({
+				cursor: input.cursor,
+				limit: input.limit,
+				order: input.order,
+			}),
+		},
+	);
 
 	await logEventFromContext(
 		ctx,
@@ -27,11 +31,11 @@ export const list: ChatbotkitEndpoints['botsList'] = async (ctx, input) => {
 		{ cursor: input.cursor, limit: input.limit, order: input.order },
 		'completed',
 	);
-	return { data: envelope.data ?? [], meta: envelope.meta };
+	return { items: response.items ?? [], cursor: response.cursor };
 };
 
 export const get: ChatbotkitEndpoints['botsGet'] = async (ctx, input) => {
-	const envelope = await makeChatbotkitRequest<Bot>(
+	const response = await makeChatbotkitRequest<BotsGetResponse>(
 		`bot/${encodeURIComponent(input.id)}/fetch`,
 		ctx.key,
 		{ method: 'GET' },
@@ -43,5 +47,5 @@ export const get: ChatbotkitEndpoints['botsGet'] = async (ctx, input) => {
 		{ id: input.id },
 		'completed',
 	);
-	return envelope.data;
+	return response;
 };

--- a/packages/chatbotkit/endpoints/bots.ts
+++ b/packages/chatbotkit/endpoints/bots.ts
@@ -1,8 +1,31 @@
 import { logEventFromContext } from 'corsair/core';
-import type { ChatbotkitEndpoints } from '..';
 import { makeChatbotkitRequest } from '../client';
-import type { BotsGetResponse, BotsListResponse } from './types';
-import { BotsGetResponseSchema, BotsListResponseSchema } from './types';
+import type { ChatbotkitContext } from '../index';
+import type {
+	BotsCreateInput,
+	BotsCreateResponse,
+	BotsDeleteInput,
+	BotsDeleteResponse,
+	BotsDownvoteInput,
+	BotsDownvoteResponse,
+	BotsGetInput,
+	BotsGetResponse,
+	BotsListInput,
+	BotsListResponse,
+	BotsUpdateInput,
+	BotsUpdateResponse,
+	BotsUpvoteInput,
+	BotsUpvoteResponse,
+} from './types';
+import {
+	BotsCreateResponseSchema,
+	BotsDeleteResponseSchema,
+	BotsDownvoteResponseSchema,
+	BotsGetResponseSchema,
+	BotsListResponseSchema,
+	BotsUpdateResponseSchema,
+	BotsUpvoteResponseSchema,
+} from './types';
 
 function compactQuery(
 	query: Record<string, string | number | boolean | undefined>,
@@ -12,7 +35,10 @@ function compactQuery(
 	) as Record<string, string | number | boolean>;
 }
 
-export const list: ChatbotkitEndpoints['botsList'] = async (ctx, input) => {
+export const list = async (
+	ctx: ChatbotkitContext,
+	input: BotsListInput,
+): Promise<BotsListResponse> => {
 	const response = await makeChatbotkitRequest<BotsListResponse>(
 		'bot/list',
 		ctx.key,
@@ -37,7 +63,10 @@ export const list: ChatbotkitEndpoints['botsList'] = async (ctx, input) => {
 	return parsed;
 };
 
-export const get: ChatbotkitEndpoints['botsGet'] = async (ctx, input) => {
+export const get = async (
+	ctx: ChatbotkitContext,
+	input: BotsGetInput,
+): Promise<BotsGetResponse> => {
 	const response = await makeChatbotkitRequest<BotsGetResponse>(
 		`bot/${encodeURIComponent(input.id)}/fetch`,
 		ctx.key,
@@ -50,6 +79,127 @@ export const get: ChatbotkitEndpoints['botsGet'] = async (ctx, input) => {
 		ctx,
 		'chatbotkit.bots.get',
 		{ id: input.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const create = async (
+	ctx: ChatbotkitContext,
+	input: BotsCreateInput,
+): Promise<BotsCreateResponse> => {
+	const response = await makeChatbotkitRequest<BotsCreateResponse>(
+		'bot/create',
+		ctx.key,
+		{
+			method: 'POST',
+			body: input as Record<string, unknown>,
+		},
+	);
+
+	const parsed = BotsCreateResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.bots.create',
+		{ id: parsed.id, name: input.name },
+		'completed',
+	);
+	return parsed;
+};
+
+export const update = async (
+	ctx: ChatbotkitContext,
+	input: BotsUpdateInput,
+): Promise<BotsUpdateResponse> => {
+	const { id, ...body } = input;
+	const response = await makeChatbotkitRequest<BotsUpdateResponse>(
+		`bot/${encodeURIComponent(id)}/update`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: body as Record<string, unknown>,
+		},
+	);
+
+	const parsed = BotsUpdateResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.bots.update',
+		{ id: parsed.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const del = async (
+	ctx: ChatbotkitContext,
+	input: BotsDeleteInput,
+): Promise<BotsDeleteResponse> => {
+	const response = await makeChatbotkitRequest<BotsDeleteResponse>(
+		`bot/${encodeURIComponent(input.id)}/delete`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: {},
+		},
+	);
+
+	const parsed = BotsDeleteResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.bots.delete',
+		{ id: parsed.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const upvote = async (
+	ctx: ChatbotkitContext,
+	input: BotsUpvoteInput,
+): Promise<BotsUpvoteResponse> => {
+	const response = await makeChatbotkitRequest<BotsUpvoteResponse>(
+		`bot/${encodeURIComponent(input.id)}/upvote`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: {},
+		},
+	);
+
+	const parsed = BotsUpvoteResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.bots.upvote',
+		{ id: parsed.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const downvote = async (
+	ctx: ChatbotkitContext,
+	input: BotsDownvoteInput,
+): Promise<BotsDownvoteResponse> => {
+	const response = await makeChatbotkitRequest<BotsDownvoteResponse>(
+		`bot/${encodeURIComponent(input.id)}/downvote`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: {},
+		},
+	);
+
+	const parsed = BotsDownvoteResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.bots.downvote',
+		{ id: parsed.id },
 		'completed',
 	);
 	return parsed;

--- a/packages/chatbotkit/endpoints/conversations.ts
+++ b/packages/chatbotkit/endpoints/conversations.ts
@@ -1,0 +1,180 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeChatbotkitRequest } from '../client';
+import type { ChatbotkitContext } from '../index';
+import type {
+	ConversationsCompleteInput,
+	ConversationsCompleteResponse,
+	ConversationsCreateInput,
+	ConversationsCreateResponse,
+	ConversationsDeleteInput,
+	ConversationsDeleteResponse,
+	ConversationsGetInput,
+	ConversationsGetResponse,
+	ConversationsListInput,
+	ConversationsListResponse,
+	ConversationsUpdateInput,
+	ConversationsUpdateResponse,
+} from './types';
+import {
+	ConversationsCompleteResponseSchema,
+	ConversationsCreateResponseSchema,
+	ConversationsDeleteResponseSchema,
+	ConversationsGetResponseSchema,
+	ConversationsListResponseSchema,
+	ConversationsUpdateResponseSchema,
+} from './types';
+
+function compactQuery(
+	query: Record<string, string | number | boolean | undefined>,
+): Record<string, string | number | boolean> {
+	return Object.fromEntries(
+		Object.entries(query).filter(([, value]) => value !== undefined),
+	) as Record<string, string | number | boolean>;
+}
+
+export const list = async (
+	ctx: ChatbotkitContext,
+	input: ConversationsListInput,
+): Promise<ConversationsListResponse> => {
+	const response = await makeChatbotkitRequest<ConversationsListResponse>(
+		'conversation/list',
+		ctx.key,
+		{
+			method: 'GET',
+			query: compactQuery({
+				cursor: input.cursor,
+				limit: input.limit,
+				order: input.order,
+			}),
+		},
+	);
+
+	const parsed = ConversationsListResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.conversations.list',
+		{ cursor: input.cursor, limit: input.limit, order: input.order },
+		'completed',
+	);
+	return parsed;
+};
+
+export const get = async (
+	ctx: ChatbotkitContext,
+	input: ConversationsGetInput,
+): Promise<ConversationsGetResponse> => {
+	const response = await makeChatbotkitRequest<ConversationsGetResponse>(
+		`conversation/${encodeURIComponent(input.id)}/fetch`,
+		ctx.key,
+		{ method: 'GET' },
+	);
+
+	const parsed = ConversationsGetResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.conversations.get',
+		{ id: input.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const create = async (
+	ctx: ChatbotkitContext,
+	input: ConversationsCreateInput,
+): Promise<ConversationsCreateResponse> => {
+	const response = await makeChatbotkitRequest<ConversationsCreateResponse>(
+		'conversation/create',
+		ctx.key,
+		{
+			method: 'POST',
+			body: input as Record<string, unknown>,
+		},
+	);
+
+	const parsed = ConversationsCreateResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.conversations.create',
+		{ id: parsed.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const update = async (
+	ctx: ChatbotkitContext,
+	input: ConversationsUpdateInput,
+): Promise<ConversationsUpdateResponse> => {
+	const { id, ...body } = input;
+	const response = await makeChatbotkitRequest<ConversationsUpdateResponse>(
+		`conversation/${encodeURIComponent(id)}/update`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: body as Record<string, unknown>,
+		},
+	);
+
+	const parsed = ConversationsUpdateResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.conversations.update',
+		{ id: parsed.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const del = async (
+	ctx: ChatbotkitContext,
+	input: ConversationsDeleteInput,
+): Promise<ConversationsDeleteResponse> => {
+	const response = await makeChatbotkitRequest<ConversationsDeleteResponse>(
+		`conversation/${encodeURIComponent(input.id)}/delete`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: {},
+		},
+	);
+
+	const parsed = ConversationsDeleteResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.conversations.delete',
+		{ id: parsed.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const complete = async (
+	ctx: ChatbotkitContext,
+	input: ConversationsCompleteInput,
+): Promise<ConversationsCompleteResponse> => {
+	const { id, text } = input;
+	const response = await makeChatbotkitRequest<ConversationsCompleteResponse>(
+		`conversation/${encodeURIComponent(id)}/complete`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: { text },
+		},
+	);
+
+	const parsed = ConversationsCompleteResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.conversations.complete',
+		{ id },
+		'completed',
+	);
+	return parsed;
+};

--- a/packages/chatbotkit/endpoints/conversations.ts
+++ b/packages/chatbotkit/endpoints/conversations.ts
@@ -43,7 +43,7 @@ export const list = async (
 			method: 'GET',
 			query: compactQuery({
 				cursor: input.cursor,
-				limit: input.limit,
+				take: input.limit,
 				order: input.order,
 			}),
 		},

--- a/packages/chatbotkit/endpoints/datasets.ts
+++ b/packages/chatbotkit/endpoints/datasets.ts
@@ -1,0 +1,180 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeChatbotkitRequest } from '../client';
+import type { ChatbotkitContext } from '../index';
+import type {
+	DatasetsCreateInput,
+	DatasetsCreateResponse,
+	DatasetsDeleteInput,
+	DatasetsDeleteResponse,
+	DatasetsGetInput,
+	DatasetsGetResponse,
+	DatasetsListInput,
+	DatasetsListResponse,
+	DatasetsSearchInput,
+	DatasetsSearchResponse,
+	DatasetsUpdateInput,
+	DatasetsUpdateResponse,
+} from './types';
+import {
+	DatasetsCreateResponseSchema,
+	DatasetsDeleteResponseSchema,
+	DatasetsGetResponseSchema,
+	DatasetsListResponseSchema,
+	DatasetsSearchResponseSchema,
+	DatasetsUpdateResponseSchema,
+} from './types';
+
+function compactQuery(
+	query: Record<string, string | number | boolean | undefined>,
+): Record<string, string | number | boolean> {
+	return Object.fromEntries(
+		Object.entries(query).filter(([, value]) => value !== undefined),
+	) as Record<string, string | number | boolean>;
+}
+
+export const list = async (
+	ctx: ChatbotkitContext,
+	input: DatasetsListInput,
+): Promise<DatasetsListResponse> => {
+	const response = await makeChatbotkitRequest<DatasetsListResponse>(
+		'dataset/list',
+		ctx.key,
+		{
+			method: 'GET',
+			query: compactQuery({
+				cursor: input.cursor,
+				limit: input.limit,
+				order: input.order,
+			}),
+		},
+	);
+
+	const parsed = DatasetsListResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.datasets.list',
+		{ cursor: input.cursor, limit: input.limit, order: input.order },
+		'completed',
+	);
+	return parsed;
+};
+
+export const get = async (
+	ctx: ChatbotkitContext,
+	input: DatasetsGetInput,
+): Promise<DatasetsGetResponse> => {
+	const response = await makeChatbotkitRequest<DatasetsGetResponse>(
+		`dataset/${encodeURIComponent(input.id)}/fetch`,
+		ctx.key,
+		{ method: 'GET' },
+	);
+
+	const parsed = DatasetsGetResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.datasets.get',
+		{ id: input.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const create = async (
+	ctx: ChatbotkitContext,
+	input: DatasetsCreateInput,
+): Promise<DatasetsCreateResponse> => {
+	const response = await makeChatbotkitRequest<DatasetsCreateResponse>(
+		'dataset/create',
+		ctx.key,
+		{
+			method: 'POST',
+			body: input as Record<string, unknown>,
+		},
+	);
+
+	const parsed = DatasetsCreateResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.datasets.create',
+		{ id: parsed.id, name: input.name },
+		'completed',
+	);
+	return parsed;
+};
+
+export const update = async (
+	ctx: ChatbotkitContext,
+	input: DatasetsUpdateInput,
+): Promise<DatasetsUpdateResponse> => {
+	const { id, ...body } = input;
+	const response = await makeChatbotkitRequest<DatasetsUpdateResponse>(
+		`dataset/${encodeURIComponent(id)}/update`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: body as Record<string, unknown>,
+		},
+	);
+
+	const parsed = DatasetsUpdateResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.datasets.update',
+		{ id: parsed.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const del = async (
+	ctx: ChatbotkitContext,
+	input: DatasetsDeleteInput,
+): Promise<DatasetsDeleteResponse> => {
+	const response = await makeChatbotkitRequest<DatasetsDeleteResponse>(
+		`dataset/${encodeURIComponent(input.id)}/delete`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: {},
+		},
+	);
+
+	const parsed = DatasetsDeleteResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.datasets.delete',
+		{ id: parsed.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const search = async (
+	ctx: ChatbotkitContext,
+	input: DatasetsSearchInput,
+): Promise<DatasetsSearchResponse> => {
+	const { id, ...body } = input;
+	const response = await makeChatbotkitRequest<DatasetsSearchResponse>(
+		`dataset/${encodeURIComponent(id)}/search`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: body as Record<string, unknown>,
+		},
+	);
+
+	const parsed = DatasetsSearchResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.datasets.search',
+		{ id },
+		'completed',
+	);
+	return parsed;
+};

--- a/packages/chatbotkit/endpoints/datasets.ts
+++ b/packages/chatbotkit/endpoints/datasets.ts
@@ -43,7 +43,7 @@ export const list = async (
 			method: 'GET',
 			query: compactQuery({
 				cursor: input.cursor,
-				limit: input.limit,
+				take: input.limit,
 				order: input.order,
 			}),
 		},

--- a/packages/chatbotkit/endpoints/files.ts
+++ b/packages/chatbotkit/endpoints/files.ts
@@ -1,0 +1,124 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeChatbotkitRequest } from '../client';
+import type { ChatbotkitContext } from '../index';
+import type {
+	FilesCreateInput,
+	FilesCreateResponse,
+	FilesDeleteInput,
+	FilesDeleteResponse,
+	FilesGetInput,
+	FilesGetResponse,
+	FilesListInput,
+	FilesListResponse,
+} from './types';
+import {
+	FilesCreateResponseSchema,
+	FilesDeleteResponseSchema,
+	FilesGetResponseSchema,
+	FilesListResponseSchema,
+} from './types';
+
+function compactQuery(
+	query: Record<string, string | number | boolean | undefined>,
+): Record<string, string | number | boolean> {
+	return Object.fromEntries(
+		Object.entries(query).filter(([, value]) => value !== undefined),
+	) as Record<string, string | number | boolean>;
+}
+
+export const list = async (
+	ctx: ChatbotkitContext,
+	input: FilesListInput,
+): Promise<FilesListResponse> => {
+	const response = await makeChatbotkitRequest<FilesListResponse>(
+		'file/list',
+		ctx.key,
+		{
+			method: 'GET',
+			query: compactQuery({
+				cursor: input.cursor,
+				limit: input.limit,
+				order: input.order,
+			}),
+		},
+	);
+
+	const parsed = FilesListResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.files.list',
+		{ cursor: input.cursor, limit: input.limit, order: input.order },
+		'completed',
+	);
+	return parsed;
+};
+
+export const get = async (
+	ctx: ChatbotkitContext,
+	input: FilesGetInput,
+): Promise<FilesGetResponse> => {
+	const response = await makeChatbotkitRequest<FilesGetResponse>(
+		`file/${encodeURIComponent(input.id)}/fetch`,
+		ctx.key,
+		{ method: 'GET' },
+	);
+
+	const parsed = FilesGetResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.files.get',
+		{ id: input.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const create = async (
+	ctx: ChatbotkitContext,
+	input: FilesCreateInput,
+): Promise<FilesCreateResponse> => {
+	const response = await makeChatbotkitRequest<FilesCreateResponse>(
+		'file/create',
+		ctx.key,
+		{
+			method: 'POST',
+			body: input as Record<string, unknown>,
+		},
+	);
+
+	const parsed = FilesCreateResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.files.create',
+		{ id: parsed.id, name: input.name },
+		'completed',
+	);
+	return parsed;
+};
+
+export const del = async (
+	ctx: ChatbotkitContext,
+	input: FilesDeleteInput,
+): Promise<FilesDeleteResponse> => {
+	const response = await makeChatbotkitRequest<FilesDeleteResponse>(
+		`file/${encodeURIComponent(input.id)}/delete`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: {},
+		},
+	);
+
+	const parsed = FilesDeleteResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.files.delete',
+		{ id: parsed.id },
+		'completed',
+	);
+	return parsed;
+};

--- a/packages/chatbotkit/endpoints/files.ts
+++ b/packages/chatbotkit/endpoints/files.ts
@@ -37,7 +37,7 @@ export const list = async (
 			method: 'GET',
 			query: compactQuery({
 				cursor: input.cursor,
-				limit: input.limit,
+				take: input.limit,
 				order: input.order,
 			}),
 		},

--- a/packages/chatbotkit/endpoints/index.ts
+++ b/packages/chatbotkit/endpoints/index.ts
@@ -1,8 +1,8 @@
-import { get as botsGet, list as botsList } from './bots';
-
-export const Bots = {
-	list: botsList,
-	get: botsGet,
-};
-
-export * from './types';
+export * as Blueprints from './blueprints';
+export * as Bots from './bots';
+export * as Conversations from './conversations';
+export * as Datasets from './datasets';
+export * as Files from './files';
+export * as Secrets from './secrets';
+export * as Skillsets from './skillsets';
+export * as Tasks from './tasks';

--- a/packages/chatbotkit/endpoints/index.ts
+++ b/packages/chatbotkit/endpoints/index.ts
@@ -1,0 +1,8 @@
+import { get as botsGet, list as botsList } from './bots';
+
+export const Bots = {
+	list: botsList,
+	get: botsGet,
+};
+
+export * from './types';

--- a/packages/chatbotkit/endpoints/secrets.ts
+++ b/packages/chatbotkit/endpoints/secrets.ts
@@ -1,0 +1,152 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeChatbotkitRequest } from '../client';
+import type { ChatbotkitContext } from '../index';
+import type {
+	SecretsCreateInput,
+	SecretsCreateResponse,
+	SecretsDeleteInput,
+	SecretsDeleteResponse,
+	SecretsGetInput,
+	SecretsGetResponse,
+	SecretsListInput,
+	SecretsListResponse,
+	SecretsUpdateInput,
+	SecretsUpdateResponse,
+} from './types';
+import {
+	SecretsCreateResponseSchema,
+	SecretsDeleteResponseSchema,
+	SecretsGetResponseSchema,
+	SecretsListResponseSchema,
+	SecretsUpdateResponseSchema,
+} from './types';
+
+function compactQuery(
+	query: Record<string, string | number | boolean | undefined>,
+): Record<string, string | number | boolean> {
+	return Object.fromEntries(
+		Object.entries(query).filter(([, value]) => value !== undefined),
+	) as Record<string, string | number | boolean>;
+}
+
+export const list = async (
+	ctx: ChatbotkitContext,
+	input: SecretsListInput,
+): Promise<SecretsListResponse> => {
+	const response = await makeChatbotkitRequest<SecretsListResponse>(
+		'secret/list',
+		ctx.key,
+		{
+			method: 'GET',
+			query: compactQuery({
+				cursor: input.cursor,
+				limit: input.limit,
+				order: input.order,
+			}),
+		},
+	);
+
+	const parsed = SecretsListResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.secrets.list',
+		{ cursor: input.cursor, limit: input.limit, order: input.order },
+		'completed',
+	);
+	return parsed;
+};
+
+export const get = async (
+	ctx: ChatbotkitContext,
+	input: SecretsGetInput,
+): Promise<SecretsGetResponse> => {
+	const response = await makeChatbotkitRequest<SecretsGetResponse>(
+		`secret/${encodeURIComponent(input.id)}/fetch`,
+		ctx.key,
+		{ method: 'GET' },
+	);
+
+	const parsed = SecretsGetResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.secrets.get',
+		{ id: input.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const create = async (
+	ctx: ChatbotkitContext,
+	input: SecretsCreateInput,
+): Promise<SecretsCreateResponse> => {
+	const response = await makeChatbotkitRequest<SecretsCreateResponse>(
+		'secret/create',
+		ctx.key,
+		{
+			method: 'POST',
+			body: input as Record<string, unknown>,
+		},
+	);
+
+	const parsed = SecretsCreateResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.secrets.create',
+		{ id: parsed.id, name: input.name },
+		'completed',
+	);
+	return parsed;
+};
+
+export const update = async (
+	ctx: ChatbotkitContext,
+	input: SecretsUpdateInput,
+): Promise<SecretsUpdateResponse> => {
+	const { id, ...body } = input;
+	const response = await makeChatbotkitRequest<SecretsUpdateResponse>(
+		`secret/${encodeURIComponent(id)}/update`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: body as Record<string, unknown>,
+		},
+	);
+
+	const parsed = SecretsUpdateResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.secrets.update',
+		{ id: parsed.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const del = async (
+	ctx: ChatbotkitContext,
+	input: SecretsDeleteInput,
+): Promise<SecretsDeleteResponse> => {
+	const response = await makeChatbotkitRequest<SecretsDeleteResponse>(
+		`secret/${encodeURIComponent(input.id)}/delete`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: {},
+		},
+	);
+
+	const parsed = SecretsDeleteResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.secrets.delete',
+		{ id: parsed.id },
+		'completed',
+	);
+	return parsed;
+};

--- a/packages/chatbotkit/endpoints/secrets.ts
+++ b/packages/chatbotkit/endpoints/secrets.ts
@@ -40,7 +40,7 @@ export const list = async (
 			method: 'GET',
 			query: compactQuery({
 				cursor: input.cursor,
-				limit: input.limit,
+				take: input.limit,
 				order: input.order,
 			}),
 		},

--- a/packages/chatbotkit/endpoints/skillsets.ts
+++ b/packages/chatbotkit/endpoints/skillsets.ts
@@ -1,0 +1,152 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeChatbotkitRequest } from '../client';
+import type { ChatbotkitContext } from '../index';
+import type {
+	SkillsetsCreateInput,
+	SkillsetsCreateResponse,
+	SkillsetsDeleteInput,
+	SkillsetsDeleteResponse,
+	SkillsetsGetInput,
+	SkillsetsGetResponse,
+	SkillsetsListInput,
+	SkillsetsListResponse,
+	SkillsetsUpdateInput,
+	SkillsetsUpdateResponse,
+} from './types';
+import {
+	SkillsetsCreateResponseSchema,
+	SkillsetsDeleteResponseSchema,
+	SkillsetsGetResponseSchema,
+	SkillsetsListResponseSchema,
+	SkillsetsUpdateResponseSchema,
+} from './types';
+
+function compactQuery(
+	query: Record<string, string | number | boolean | undefined>,
+): Record<string, string | number | boolean> {
+	return Object.fromEntries(
+		Object.entries(query).filter(([, value]) => value !== undefined),
+	) as Record<string, string | number | boolean>;
+}
+
+export const list = async (
+	ctx: ChatbotkitContext,
+	input: SkillsetsListInput,
+): Promise<SkillsetsListResponse> => {
+	const response = await makeChatbotkitRequest<SkillsetsListResponse>(
+		'skillset/list',
+		ctx.key,
+		{
+			method: 'GET',
+			query: compactQuery({
+				cursor: input.cursor,
+				limit: input.limit,
+				order: input.order,
+			}),
+		},
+	);
+
+	const parsed = SkillsetsListResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.skillsets.list',
+		{ cursor: input.cursor, limit: input.limit, order: input.order },
+		'completed',
+	);
+	return parsed;
+};
+
+export const get = async (
+	ctx: ChatbotkitContext,
+	input: SkillsetsGetInput,
+): Promise<SkillsetsGetResponse> => {
+	const response = await makeChatbotkitRequest<SkillsetsGetResponse>(
+		`skillset/${encodeURIComponent(input.id)}/fetch`,
+		ctx.key,
+		{ method: 'GET' },
+	);
+
+	const parsed = SkillsetsGetResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.skillsets.get',
+		{ id: input.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const create = async (
+	ctx: ChatbotkitContext,
+	input: SkillsetsCreateInput,
+): Promise<SkillsetsCreateResponse> => {
+	const response = await makeChatbotkitRequest<SkillsetsCreateResponse>(
+		'skillset/create',
+		ctx.key,
+		{
+			method: 'POST',
+			body: input as Record<string, unknown>,
+		},
+	);
+
+	const parsed = SkillsetsCreateResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.skillsets.create',
+		{ id: parsed.id, name: input.name },
+		'completed',
+	);
+	return parsed;
+};
+
+export const update = async (
+	ctx: ChatbotkitContext,
+	input: SkillsetsUpdateInput,
+): Promise<SkillsetsUpdateResponse> => {
+	const { id, ...body } = input;
+	const response = await makeChatbotkitRequest<SkillsetsUpdateResponse>(
+		`skillset/${encodeURIComponent(id)}/update`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: body as Record<string, unknown>,
+		},
+	);
+
+	const parsed = SkillsetsUpdateResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.skillsets.update',
+		{ id: parsed.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const del = async (
+	ctx: ChatbotkitContext,
+	input: SkillsetsDeleteInput,
+): Promise<SkillsetsDeleteResponse> => {
+	const response = await makeChatbotkitRequest<SkillsetsDeleteResponse>(
+		`skillset/${encodeURIComponent(input.id)}/delete`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: {},
+		},
+	);
+
+	const parsed = SkillsetsDeleteResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.skillsets.delete',
+		{ id: parsed.id },
+		'completed',
+	);
+	return parsed;
+};

--- a/packages/chatbotkit/endpoints/skillsets.ts
+++ b/packages/chatbotkit/endpoints/skillsets.ts
@@ -40,7 +40,7 @@ export const list = async (
 			method: 'GET',
 			query: compactQuery({
 				cursor: input.cursor,
-				limit: input.limit,
+				take: input.limit,
 				order: input.order,
 			}),
 		},

--- a/packages/chatbotkit/endpoints/tasks.ts
+++ b/packages/chatbotkit/endpoints/tasks.ts
@@ -1,0 +1,152 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeChatbotkitRequest } from '../client';
+import type { ChatbotkitContext } from '../index';
+import type {
+	TasksCreateInput,
+	TasksCreateResponse,
+	TasksDeleteInput,
+	TasksDeleteResponse,
+	TasksGetInput,
+	TasksGetResponse,
+	TasksListInput,
+	TasksListResponse,
+	TasksUpdateInput,
+	TasksUpdateResponse,
+} from './types';
+import {
+	TasksCreateResponseSchema,
+	TasksDeleteResponseSchema,
+	TasksGetResponseSchema,
+	TasksListResponseSchema,
+	TasksUpdateResponseSchema,
+} from './types';
+
+function compactQuery(
+	query: Record<string, string | number | boolean | undefined>,
+): Record<string, string | number | boolean> {
+	return Object.fromEntries(
+		Object.entries(query).filter(([, value]) => value !== undefined),
+	) as Record<string, string | number | boolean>;
+}
+
+export const list = async (
+	ctx: ChatbotkitContext,
+	input: TasksListInput,
+): Promise<TasksListResponse> => {
+	const response = await makeChatbotkitRequest<TasksListResponse>(
+		'task/list',
+		ctx.key,
+		{
+			method: 'GET',
+			query: compactQuery({
+				cursor: input.cursor,
+				limit: input.limit,
+				order: input.order,
+			}),
+		},
+	);
+
+	const parsed = TasksListResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.tasks.list',
+		{ cursor: input.cursor, limit: input.limit, order: input.order },
+		'completed',
+	);
+	return parsed;
+};
+
+export const get = async (
+	ctx: ChatbotkitContext,
+	input: TasksGetInput,
+): Promise<TasksGetResponse> => {
+	const response = await makeChatbotkitRequest<TasksGetResponse>(
+		`task/${encodeURIComponent(input.id)}/fetch`,
+		ctx.key,
+		{ method: 'GET' },
+	);
+
+	const parsed = TasksGetResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.tasks.get',
+		{ id: input.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const create = async (
+	ctx: ChatbotkitContext,
+	input: TasksCreateInput,
+): Promise<TasksCreateResponse> => {
+	const response = await makeChatbotkitRequest<TasksCreateResponse>(
+		'task/create',
+		ctx.key,
+		{
+			method: 'POST',
+			body: input as Record<string, unknown>,
+		},
+	);
+
+	const parsed = TasksCreateResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.tasks.create',
+		{ id: parsed.id, name: input.name },
+		'completed',
+	);
+	return parsed;
+};
+
+export const update = async (
+	ctx: ChatbotkitContext,
+	input: TasksUpdateInput,
+): Promise<TasksUpdateResponse> => {
+	const { id, ...body } = input;
+	const response = await makeChatbotkitRequest<TasksUpdateResponse>(
+		`task/${encodeURIComponent(id)}/update`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: body as Record<string, unknown>,
+		},
+	);
+
+	const parsed = TasksUpdateResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.tasks.update',
+		{ id: parsed.id },
+		'completed',
+	);
+	return parsed;
+};
+
+export const del = async (
+	ctx: ChatbotkitContext,
+	input: TasksDeleteInput,
+): Promise<TasksDeleteResponse> => {
+	const response = await makeChatbotkitRequest<TasksDeleteResponse>(
+		`task/${encodeURIComponent(input.id)}/delete`,
+		ctx.key,
+		{
+			method: 'POST',
+			body: {},
+		},
+	);
+
+	const parsed = TasksDeleteResponseSchema.parse(response);
+
+	await logEventFromContext(
+		ctx,
+		'chatbotkit.tasks.delete',
+		{ id: parsed.id },
+		'completed',
+	);
+	return parsed;
+};

--- a/packages/chatbotkit/endpoints/tasks.ts
+++ b/packages/chatbotkit/endpoints/tasks.ts
@@ -40,7 +40,7 @@ export const list = async (
 			method: 'GET',
 			query: compactQuery({
 				cursor: input.cursor,
-				limit: input.limit,
+				take: input.limit,
 				order: input.order,
 			}),
 		},

--- a/packages/chatbotkit/endpoints/types.ts
+++ b/packages/chatbotkit/endpoints/types.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+const BotSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	description: z.string().nullable().optional(),
+	model: z.string().nullable().optional(),
+	backstory: z.string().nullable().optional(),
+	createdAt: z.coerce.date().nullable().optional(),
+	updatedAt: z.coerce.date().nullable().optional(),
+});
+export type Bot = z.infer<typeof BotSchema>;
+
+const BotsListInputSchema = z.object({
+	cursor: z.string().optional(),
+	limit: z.number().int().positive().max(100).optional(),
+	order: z.enum(['asc', 'desc']).optional(),
+});
+export type BotsListInput = z.infer<typeof BotsListInputSchema>;
+
+const BotsListResponseSchema = z.object({
+	data: z.array(BotSchema),
+	meta: z.object({ cursor: z.string().nullable().optional() }).optional(),
+});
+export type BotsListResponse = z.infer<typeof BotsListResponseSchema>;
+
+const BotsGetInputSchema = z.object({
+	id: z.string(),
+});
+export type BotsGetInput = z.infer<typeof BotsGetInputSchema>;
+
+const BotsGetResponseSchema = BotSchema;
+export type BotsGetResponse = z.infer<typeof BotsGetResponseSchema>;
+
+export type ChatbotkitEndpointInputs = {
+	botsList: BotsListInput;
+	botsGet: BotsGetInput;
+};
+
+export type ChatbotkitEndpointOutputs = {
+	botsList: BotsListResponse;
+	botsGet: BotsGetResponse;
+};
+
+export const ChatbotkitEndpointInputSchemas = {
+	botsList: BotsListInputSchema,
+	botsGet: BotsGetInputSchema,
+} as const;
+
+export const ChatbotkitEndpointOutputSchemas = {
+	botsList: BotsListResponseSchema,
+	botsGet: BotsGetResponseSchema,
+} as const;

--- a/packages/chatbotkit/endpoints/types.ts
+++ b/packages/chatbotkit/endpoints/types.ts
@@ -47,12 +47,12 @@ export const BotSchema = z.object({
 		.optional()
 		.describe('Custom metadata attached to the bot'),
 	createdAt: z
-		.union([z.number(), z.string(), z.coerce.date()])
+		.number()
 		.nullable()
 		.optional()
 		.describe('Creation timestamp in milliseconds'),
 	updatedAt: z
-		.union([z.number(), z.string(), z.coerce.date()])
+		.number()
 		.nullable()
 		.optional()
 		.describe('Last updated timestamp in milliseconds'),

--- a/packages/chatbotkit/endpoints/types.ts
+++ b/packages/chatbotkit/endpoints/types.ts
@@ -1,5 +1,34 @@
 import { z } from 'zod';
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Common Types & Schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const IdResponseSchema = z.object({
+	id: z.string().describe('Unique identifier of the resource'),
+});
+export type IdResponse = z.infer<typeof IdResponseSchema>;
+
+export const ListQueryInputSchema = z.object({
+	cursor: z.string().optional().describe('Cursor for pagination'),
+	limit: z
+		.number()
+		.int()
+		.positive()
+		.max(100)
+		.optional()
+		.describe('Maximum number of items to return'),
+	order: z
+		.enum(['asc', 'desc'])
+		.optional()
+		.describe('Sort order by creation time'),
+});
+export type ListQueryInput = z.infer<typeof ListQueryInputSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Bots
+// ─────────────────────────────────────────────────────────────────────────────
+
 export const BotSchema = z.object({
 	id: z.string().describe('Unique identifier of the bot'),
 	alias: z.string().nullable().optional().describe('Custom alias for the bot'),
@@ -36,6 +65,16 @@ export const BotSchema = z.object({
 		.nullable()
 		.optional()
 		.describe('AI model configured for the bot'),
+	privacy: z
+		.boolean()
+		.nullable()
+		.optional()
+		.describe('Whether PII protection and anonymization is enabled'),
+	moderation: z
+		.boolean()
+		.nullable()
+		.optional()
+		.describe('Whether content safety and filtering is active'),
 	visibility: z
 		.string()
 		.nullable()
@@ -59,20 +98,7 @@ export const BotSchema = z.object({
 });
 export type Bot = z.infer<typeof BotSchema>;
 
-export const BotsListInputSchema = z.object({
-	cursor: z.string().optional().describe('Cursor for pagination'),
-	limit: z
-		.number()
-		.int()
-		.positive()
-		.max(100)
-		.optional()
-		.describe('Maximum number of items to return'),
-	order: z
-		.enum(['asc', 'desc'])
-		.optional()
-		.describe('Sort order by creation time'),
-});
+export const BotsListInputSchema = ListQueryInputSchema;
 export type BotsListInput = z.infer<typeof BotsListInputSchema>;
 
 export const BotsListResponseSchema = z.object({
@@ -93,22 +119,1272 @@ export type BotsGetInput = z.infer<typeof BotsGetInputSchema>;
 export const BotsGetResponseSchema = BotSchema;
 export type BotsGetResponse = z.infer<typeof BotsGetResponseSchema>;
 
+export const BotsCreateInputSchema = z.object({
+	name: z.string().describe('Name of the bot'),
+	description: z.string().optional().describe('Description of the bot'),
+	backstory: z
+		.string()
+		.optional()
+		.describe('Instructions and persona for the bot'),
+	model: z.string().optional().describe('AI model to use for the bot'),
+	datasetId: z
+		.string()
+		.optional()
+		.describe('ID of the dataset to connect to the bot'),
+	skillsetId: z
+		.string()
+		.optional()
+		.describe('ID of the skillset to connect to the bot'),
+	blueprintId: z
+		.string()
+		.optional()
+		.describe('ID of the blueprint template to connect'),
+	privacy: z
+		.boolean()
+		.optional()
+		.describe('Enable PII protection and anonymization'),
+	moderation: z
+		.boolean()
+		.optional()
+		.describe('Enable content safety and filtering'),
+	visibility: z
+		.enum(['private', 'protected', 'public'])
+		.optional()
+		.describe('Visibility level of the bot'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Custom metadata'),
+});
+export type BotsCreateInput = z.infer<typeof BotsCreateInputSchema>;
+
+export const BotsCreateResponseSchema = IdResponseSchema;
+export type BotsCreateResponse = z.infer<typeof BotsCreateResponseSchema>;
+
+export const BotsUpdateInputSchema = z.object({
+	id: z.string().describe('ID of the bot to update'),
+	name: z.string().optional().describe('Updated name of the bot'),
+	description: z.string().optional().describe('Updated description of the bot'),
+	backstory: z.string().optional().describe('Updated persona instructions'),
+	model: z.string().optional().describe('Updated model'),
+	datasetId: z.string().nullable().optional().describe('Updated dataset ID'),
+	skillsetId: z.string().nullable().optional().describe('Updated skillset ID'),
+	blueprintId: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Updated blueprint ID'),
+	visibility: z
+		.enum(['private', 'protected', 'public'])
+		.optional()
+		.describe('Updated visibility'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Updated metadata'),
+});
+export type BotsUpdateInput = z.infer<typeof BotsUpdateInputSchema>;
+
+export const BotsUpdateResponseSchema = IdResponseSchema;
+export type BotsUpdateResponse = z.infer<typeof BotsUpdateResponseSchema>;
+
+export const BotsDeleteInputSchema = z.object({
+	id: z.string().describe('ID of the bot to delete'),
+});
+export type BotsDeleteInput = z.infer<typeof BotsDeleteInputSchema>;
+
+export const BotsDeleteResponseSchema = IdResponseSchema;
+export type BotsDeleteResponse = z.infer<typeof BotsDeleteResponseSchema>;
+
+export const BotsUpvoteInputSchema = z.object({
+	id: z.string().describe('ID of the bot to upvote'),
+});
+export type BotsUpvoteInput = z.infer<typeof BotsUpvoteInputSchema>;
+
+export const BotsUpvoteResponseSchema = IdResponseSchema;
+export type BotsUpvoteResponse = z.infer<typeof BotsUpvoteResponseSchema>;
+
+export const BotsDownvoteInputSchema = z.object({
+	id: z.string().describe('ID of the bot to downvote'),
+});
+export type BotsDownvoteInput = z.infer<typeof BotsDownvoteInputSchema>;
+
+export const BotsDownvoteResponseSchema = IdResponseSchema;
+export type BotsDownvoteResponse = z.infer<typeof BotsDownvoteResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Datasets
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const DatasetSchema = z.object({
+	id: z.string().describe('Unique identifier of the dataset'),
+	alias: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Custom alias for the dataset'),
+	name: z.string().describe('Descriptive name of the dataset'),
+	description: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Brief description of dataset contents'),
+	blueprintId: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Associated blueprint ID'),
+	reranker: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Configured reranker model'),
+	recordMaxTokens: z
+		.number()
+		.nullable()
+		.optional()
+		.describe('Maximum tokens per record'),
+	searchMinScore: z
+		.number()
+		.nullable()
+		.optional()
+		.describe('Minimum score for search retrieval'),
+	searchMaxRecords: z
+		.number()
+		.nullable()
+		.optional()
+		.describe('Maximum search records returned'),
+	searchMaxTokens: z
+		.number()
+		.nullable()
+		.optional()
+		.describe('Maximum search tokens returned'),
+	matchInstruction: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Prompt instruction on search match'),
+	mismatchInstruction: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Prompt instruction on search mismatch'),
+	separators: z
+		.array(z.string())
+		.nullable()
+		.optional()
+		.describe('Text chunk separators'),
+	visibility: z.string().nullable().optional().describe('Visibility setting'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.nullable()
+		.optional()
+		.describe('Custom metadata'),
+	createdAt: z
+		.number()
+		.nullable()
+		.optional()
+		.describe('Creation timestamp in milliseconds'),
+	updatedAt: z
+		.number()
+		.nullable()
+		.optional()
+		.describe('Last updated timestamp in milliseconds'),
+});
+export type Dataset = z.infer<typeof DatasetSchema>;
+
+export const DatasetsListInputSchema = ListQueryInputSchema;
+export type DatasetsListInput = z.infer<typeof DatasetsListInputSchema>;
+
+export const DatasetsListResponseSchema = z.object({
+	items: z.array(DatasetSchema).describe('List of datasets matching the query'),
+	cursor: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Pagination cursor for the next page of results'),
+});
+export type DatasetsListResponse = z.infer<typeof DatasetsListResponseSchema>;
+
+export const DatasetsGetInputSchema = z.object({
+	id: z.string().describe('ID of the dataset to fetch'),
+});
+export type DatasetsGetInput = z.infer<typeof DatasetsGetInputSchema>;
+
+export const DatasetsGetResponseSchema = DatasetSchema;
+export type DatasetsGetResponse = z.infer<typeof DatasetsGetResponseSchema>;
+
+export const DatasetsCreateInputSchema = z.object({
+	name: z.string().describe('Name of the dataset'),
+	description: z.string().optional().describe('Description of the dataset'),
+	blueprintId: z
+		.string()
+		.optional()
+		.describe('ID of blueprint template to connect'),
+	visibility: z
+		.enum(['private', 'protected', 'public'])
+		.optional()
+		.describe('Visibility level'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Custom metadata'),
+});
+export type DatasetsCreateInput = z.infer<typeof DatasetsCreateInputSchema>;
+
+export const DatasetsCreateResponseSchema = IdResponseSchema;
+export type DatasetsCreateResponse = z.infer<
+	typeof DatasetsCreateResponseSchema
+>;
+
+export const DatasetsUpdateInputSchema = z.object({
+	id: z.string().describe('ID of the dataset to update'),
+	name: z.string().optional().describe('Updated name of the dataset'),
+	description: z
+		.string()
+		.optional()
+		.describe('Updated description of the dataset'),
+	blueprintId: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Updated blueprint ID'),
+	visibility: z
+		.enum(['private', 'protected', 'public'])
+		.optional()
+		.describe('Updated visibility'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Updated metadata'),
+});
+export type DatasetsUpdateInput = z.infer<typeof DatasetsUpdateInputSchema>;
+
+export const DatasetsUpdateResponseSchema = IdResponseSchema;
+export type DatasetsUpdateResponse = z.infer<
+	typeof DatasetsUpdateResponseSchema
+>;
+
+export const DatasetsDeleteInputSchema = z.object({
+	id: z.string().describe('ID of the dataset to delete'),
+});
+export type DatasetsDeleteInput = z.infer<typeof DatasetsDeleteInputSchema>;
+
+export const DatasetsDeleteResponseSchema = IdResponseSchema;
+export type DatasetsDeleteResponse = z.infer<
+	typeof DatasetsDeleteResponseSchema
+>;
+
+export const DatasetSearchResultItemSchema = z.object({
+	id: z.string().describe('Record identifier'),
+	score: z.number().optional().describe('Relevance score'),
+	text: z.string().describe('Matched text content'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.nullable()
+		.optional()
+		.describe('Record metadata'),
+});
+
+export const DatasetsSearchInputSchema = z.object({
+	id: z.string().describe('ID of the dataset to search'),
+	query: z.string().describe('Search query string'),
+	limit: z
+		.number()
+		.int()
+		.positive()
+		.optional()
+		.describe('Max records to return'),
+});
+export type DatasetsSearchInput = z.infer<typeof DatasetsSearchInputSchema>;
+
+export const DatasetsSearchResponseSchema = z.object({
+	items: z
+		.array(DatasetSearchResultItemSchema)
+		.describe('Array of search matches from the dataset'),
+});
+export type DatasetsSearchResponse = z.infer<
+	typeof DatasetsSearchResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Skillsets
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const SkillsetSchema = z.object({
+	id: z.string().describe('Unique identifier of the skillset'),
+	alias: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Custom alias for the skillset'),
+	name: z.string().describe('Descriptive name of the skillset'),
+	description: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Brief description of skillset capabilities'),
+	blueprintId: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Associated blueprint ID'),
+	visibility: z.string().nullable().optional().describe('Visibility setting'),
+	state: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Operational state (e.g. enabled, disabled)'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.nullable()
+		.optional()
+		.describe('Custom metadata'),
+	createdAt: z
+		.number()
+		.nullable()
+		.optional()
+		.describe('Creation timestamp in milliseconds'),
+	updatedAt: z
+		.number()
+		.nullable()
+		.optional()
+		.describe('Last updated timestamp in milliseconds'),
+});
+export type Skillset = z.infer<typeof SkillsetSchema>;
+
+export const SkillsetsListInputSchema = ListQueryInputSchema;
+export type SkillsetsListInput = z.infer<typeof SkillsetsListInputSchema>;
+
+export const SkillsetsListResponseSchema = z.object({
+	items: z
+		.array(SkillsetSchema)
+		.describe('List of skillsets matching the query'),
+	cursor: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Pagination cursor for the next page of results'),
+});
+export type SkillsetsListResponse = z.infer<typeof SkillsetsListResponseSchema>;
+
+export const SkillsetsGetInputSchema = z.object({
+	id: z.string().describe('ID of the skillset to fetch'),
+});
+export type SkillsetsGetInput = z.infer<typeof SkillsetsGetInputSchema>;
+
+export const SkillsetsGetResponseSchema = SkillsetSchema;
+export type SkillsetsGetResponse = z.infer<typeof SkillsetsGetResponseSchema>;
+
+export const SkillsetsCreateInputSchema = z.object({
+	name: z.string().describe('Name of the skillset'),
+	description: z.string().optional().describe('Description of the skillset'),
+	blueprintId: z.string().optional().describe('Blueprint template ID'),
+	visibility: z
+		.enum(['private', 'protected', 'public'])
+		.optional()
+		.describe('Visibility level'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Custom metadata'),
+});
+export type SkillsetsCreateInput = z.infer<typeof SkillsetsCreateInputSchema>;
+
+export const SkillsetsCreateResponseSchema = IdResponseSchema;
+export type SkillsetsCreateResponse = z.infer<
+	typeof SkillsetsCreateResponseSchema
+>;
+
+export const SkillsetsUpdateInputSchema = z.object({
+	id: z.string().describe('ID of the skillset to update'),
+	name: z.string().optional().describe('Updated name of the skillset'),
+	description: z
+		.string()
+		.optional()
+		.describe('Updated description of the skillset'),
+	visibility: z
+		.enum(['private', 'protected', 'public'])
+		.optional()
+		.describe('Updated visibility'),
+	state: z.enum(['enabled', 'disabled']).optional().describe('Updated state'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Updated metadata'),
+});
+export type SkillsetsUpdateInput = z.infer<typeof SkillsetsUpdateInputSchema>;
+
+export const SkillsetsUpdateResponseSchema = IdResponseSchema;
+export type SkillsetsUpdateResponse = z.infer<
+	typeof SkillsetsUpdateResponseSchema
+>;
+
+export const SkillsetsDeleteInputSchema = z.object({
+	id: z.string().describe('ID of the skillset to delete'),
+});
+export type SkillsetsDeleteInput = z.infer<typeof SkillsetsDeleteInputSchema>;
+
+export const SkillsetsDeleteResponseSchema = IdResponseSchema;
+export type SkillsetsDeleteResponse = z.infer<
+	typeof SkillsetsDeleteResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Blueprints
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const BlueprintSchema = z.object({
+	id: z.string().describe('Unique identifier of the blueprint'),
+	alias: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Custom alias for the blueprint'),
+	name: z.string().describe('Descriptive name of the blueprint'),
+	description: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Brief description of blueprint configuration'),
+	config: z
+		.record(z.string(), z.unknown())
+		.nullable()
+		.optional()
+		.describe('Template configuration settings'),
+	visibility: z.string().nullable().optional().describe('Visibility setting'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.nullable()
+		.optional()
+		.describe('Custom metadata'),
+	createdAt: z
+		.number()
+		.nullable()
+		.optional()
+		.describe('Creation timestamp in milliseconds'),
+	updatedAt: z
+		.number()
+		.nullable()
+		.optional()
+		.describe('Last updated timestamp in milliseconds'),
+});
+export type Blueprint = z.infer<typeof BlueprintSchema>;
+
+export const BlueprintsListInputSchema = ListQueryInputSchema;
+export type BlueprintsListInput = z.infer<typeof BlueprintsListInputSchema>;
+
+export const BlueprintsListResponseSchema = z.object({
+	items: z
+		.array(BlueprintSchema)
+		.describe('List of blueprints matching the query'),
+	cursor: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Pagination cursor for the next page of results'),
+});
+export type BlueprintsListResponse = z.infer<
+	typeof BlueprintsListResponseSchema
+>;
+
+export const BlueprintsGetInputSchema = z.object({
+	id: z.string().describe('ID of the blueprint to fetch'),
+});
+export type BlueprintsGetInput = z.infer<typeof BlueprintsGetInputSchema>;
+
+export const BlueprintsGetResponseSchema = BlueprintSchema;
+export type BlueprintsGetResponse = z.infer<typeof BlueprintsGetResponseSchema>;
+
+export const BlueprintsCreateInputSchema = z.object({
+	name: z.string().describe('Name of the blueprint template'),
+	description: z
+		.string()
+		.optional()
+		.describe('Description of the blueprint template'),
+	config: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Configuration dictionary'),
+	visibility: z
+		.enum(['private', 'protected', 'public'])
+		.optional()
+		.describe('Visibility level'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Custom metadata'),
+});
+export type BlueprintsCreateInput = z.infer<typeof BlueprintsCreateInputSchema>;
+
+export const BlueprintsCreateResponseSchema = IdResponseSchema;
+export type BlueprintsCreateResponse = z.infer<
+	typeof BlueprintsCreateResponseSchema
+>;
+
+export const BlueprintsUpdateInputSchema = z.object({
+	id: z.string().describe('ID of the blueprint to update'),
+	name: z.string().optional().describe('Updated name'),
+	description: z.string().optional().describe('Updated description'),
+	config: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Updated configuration'),
+	visibility: z
+		.enum(['private', 'protected', 'public'])
+		.optional()
+		.describe('Updated visibility'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Updated metadata'),
+});
+export type BlueprintsUpdateInput = z.infer<typeof BlueprintsUpdateInputSchema>;
+
+export const BlueprintsUpdateResponseSchema = IdResponseSchema;
+export type BlueprintsUpdateResponse = z.infer<
+	typeof BlueprintsUpdateResponseSchema
+>;
+
+export const BlueprintsDeleteInputSchema = z.object({
+	id: z.string().describe('ID of the blueprint to delete'),
+});
+export type BlueprintsDeleteInput = z.infer<typeof BlueprintsDeleteInputSchema>;
+
+export const BlueprintsDeleteResponseSchema = IdResponseSchema;
+export type BlueprintsDeleteResponse = z.infer<
+	typeof BlueprintsDeleteResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Secrets
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const SecretSchema = z.object({
+	id: z.string().describe('Unique identifier of the secret credential'),
+	alias: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Custom alias for the secret'),
+	name: z.string().describe('Descriptive name of the secret'),
+	description: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Description of the secret or connected service'),
+	blueprintId: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Associated blueprint ID'),
+	kind: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Kind of secret (e.g. personal, shared)'),
+	type: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Type of credential template'),
+	config: z
+		.record(z.string(), z.unknown())
+		.nullable()
+		.optional()
+		.describe('Credential configuration'),
+	visibility: z.string().nullable().optional().describe('Visibility setting'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.nullable()
+		.optional()
+		.describe('Custom metadata'),
+	createdAt: z
+		.number()
+		.nullable()
+		.optional()
+		.describe('Creation timestamp in milliseconds'),
+	updatedAt: z
+		.number()
+		.nullable()
+		.optional()
+		.describe('Last updated timestamp in milliseconds'),
+});
+export type Secret = z.infer<typeof SecretSchema>;
+
+export const SecretsListInputSchema = ListQueryInputSchema;
+export type SecretsListInput = z.infer<typeof SecretsListInputSchema>;
+
+export const SecretsListResponseSchema = z.object({
+	items: z.array(SecretSchema).describe('List of secrets matching the query'),
+	cursor: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Pagination cursor for the next page of results'),
+});
+export type SecretsListResponse = z.infer<typeof SecretsListResponseSchema>;
+
+export const SecretsGetInputSchema = z.object({
+	id: z.string().describe('ID of the secret to fetch'),
+});
+export type SecretsGetInput = z.infer<typeof SecretsGetInputSchema>;
+
+export const SecretsGetResponseSchema = SecretSchema;
+export type SecretsGetResponse = z.infer<typeof SecretsGetResponseSchema>;
+
+export const SecretsCreateInputSchema = z.object({
+	name: z.string().describe('Name of the secret'),
+	description: z.string().optional().describe('Description of the secret'),
+	blueprintId: z.string().optional().describe('Blueprint template ID'),
+	type: z.string().optional().describe('Secret type or provider template'),
+	config: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Secret configuration credentials'),
+	visibility: z
+		.enum(['private', 'protected', 'public'])
+		.optional()
+		.describe('Visibility level'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Custom metadata'),
+});
+export type SecretsCreateInput = z.infer<typeof SecretsCreateInputSchema>;
+
+export const SecretsCreateResponseSchema = IdResponseSchema;
+export type SecretsCreateResponse = z.infer<typeof SecretsCreateResponseSchema>;
+
+export const SecretsUpdateInputSchema = z.object({
+	id: z.string().describe('ID of the secret to update'),
+	name: z.string().optional().describe('Updated name'),
+	description: z.string().optional().describe('Updated description'),
+	config: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Updated configuration credentials'),
+	visibility: z
+		.enum(['private', 'protected', 'public'])
+		.optional()
+		.describe('Updated visibility'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Updated metadata'),
+});
+export type SecretsUpdateInput = z.infer<typeof SecretsUpdateInputSchema>;
+
+export const SecretsUpdateResponseSchema = IdResponseSchema;
+export type SecretsUpdateResponse = z.infer<typeof SecretsUpdateResponseSchema>;
+
+export const SecretsDeleteInputSchema = z.object({
+	id: z.string().describe('ID of the secret to delete'),
+});
+export type SecretsDeleteInput = z.infer<typeof SecretsDeleteInputSchema>;
+
+export const SecretsDeleteResponseSchema = IdResponseSchema;
+export type SecretsDeleteResponse = z.infer<typeof SecretsDeleteResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. Conversations & Messages
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ConversationSchema = z.object({
+	id: z.string().describe('Unique identifier of the conversation'),
+	alias: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Custom alias for the conversation'),
+	name: z.string().nullable().optional().describe('Name of the conversation'),
+	description: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Description of the conversation'),
+	botId: z.string().nullable().optional().describe('Associated bot ID'),
+	backstory: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Instructions override for the conversation'),
+	model: z.string().nullable().optional().describe('Model override'),
+	datasetId: z.string().nullable().optional().describe('Dataset ID override'),
+	skillsetId: z.string().nullable().optional().describe('Skillset ID override'),
+	blueprintId: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Associated blueprint ID'),
+	visibility: z.string().nullable().optional().describe('Visibility setting'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.nullable()
+		.optional()
+		.describe('Custom metadata'),
+	createdAt: z
+		.number()
+		.nullable()
+		.optional()
+		.describe('Creation timestamp in milliseconds'),
+	updatedAt: z
+		.number()
+		.nullable()
+		.optional()
+		.describe('Last updated timestamp in milliseconds'),
+});
+export type Conversation = z.infer<typeof ConversationSchema>;
+
+export const ConversationsListInputSchema = ListQueryInputSchema;
+export type ConversationsListInput = z.infer<
+	typeof ConversationsListInputSchema
+>;
+
+export const ConversationsListResponseSchema = z.object({
+	items: z
+		.array(ConversationSchema)
+		.describe('List of conversations matching the query'),
+	cursor: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Pagination cursor for the next page of results'),
+});
+export type ConversationsListResponse = z.infer<
+	typeof ConversationsListResponseSchema
+>;
+
+export const ConversationsGetInputSchema = z.object({
+	id: z.string().describe('ID of the conversation to fetch'),
+});
+export type ConversationsGetInput = z.infer<typeof ConversationsGetInputSchema>;
+
+export const ConversationsGetResponseSchema = ConversationSchema;
+export type ConversationsGetResponse = z.infer<
+	typeof ConversationsGetResponseSchema
+>;
+
+export const ConversationsCreateInputSchema = z.object({
+	name: z.string().optional().describe('Name of the conversation'),
+	description: z
+		.string()
+		.optional()
+		.describe('Description of the conversation'),
+	botId: z.string().optional().describe('ID of bot to associate'),
+	datasetId: z.string().optional().describe('Dataset ID override'),
+	skillsetId: z.string().optional().describe('Skillset ID override'),
+	blueprintId: z.string().optional().describe('Blueprint template ID'),
+	visibility: z
+		.enum(['private', 'protected', 'public'])
+		.optional()
+		.describe('Visibility level'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Custom metadata'),
+});
+export type ConversationsCreateInput = z.infer<
+	typeof ConversationsCreateInputSchema
+>;
+
+export const ConversationsCreateResponseSchema = IdResponseSchema;
+export type ConversationsCreateResponse = z.infer<
+	typeof ConversationsCreateResponseSchema
+>;
+
+export const ConversationsUpdateInputSchema = z.object({
+	id: z.string().describe('ID of the conversation to update'),
+	name: z.string().optional().describe('Updated name'),
+	description: z.string().optional().describe('Updated description'),
+	botId: z.string().nullable().optional().describe('Updated bot ID'),
+	visibility: z
+		.enum(['private', 'protected', 'public'])
+		.optional()
+		.describe('Updated visibility'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Updated metadata'),
+});
+export type ConversationsUpdateInput = z.infer<
+	typeof ConversationsUpdateInputSchema
+>;
+
+export const ConversationsUpdateResponseSchema = IdResponseSchema;
+export type ConversationsUpdateResponse = z.infer<
+	typeof ConversationsUpdateResponseSchema
+>;
+
+export const ConversationsDeleteInputSchema = z.object({
+	id: z.string().describe('ID of the conversation to delete'),
+});
+export type ConversationsDeleteInput = z.infer<
+	typeof ConversationsDeleteInputSchema
+>;
+
+export const ConversationsDeleteResponseSchema = IdResponseSchema;
+export type ConversationsDeleteResponse = z.infer<
+	typeof ConversationsDeleteResponseSchema
+>;
+
+export const ConversationCompletionResponseSchema = z.object({
+	text: z.string().optional().describe('AI response message text'),
+	message: z
+		.string()
+		.optional()
+		.describe('Completion status or error message if limits reached'),
+	code: z.string().optional().describe('Error code if completion failed'),
+	usage: z
+		.object({
+			tokens: z.number().optional().describe('Total tokens used'),
+		})
+		.optional()
+		.describe('Token usage breakdown'),
+});
+export type ConversationCompletionResponse = z.infer<
+	typeof ConversationCompletionResponseSchema
+>;
+
+export const ConversationsCompleteInputSchema = z.object({
+	id: z.string().describe('ID of the conversation'),
+	text: z.string().describe('User message text sent to the chatbot'),
+});
+export type ConversationsCompleteInput = z.infer<
+	typeof ConversationsCompleteInputSchema
+>;
+
+export const ConversationsCompleteResponseSchema =
+	ConversationCompletionResponseSchema;
+export type ConversationsCompleteResponse = z.infer<
+	typeof ConversationsCompleteResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. Files
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const FileSchema = z.object({
+	id: z.string().describe('Unique identifier of the file resource'),
+	name: z.string().describe('File name'),
+	description: z.string().nullable().optional().describe('File description'),
+	mimeType: z.string().nullable().optional().describe('MIME type of the file'),
+	size: z.number().nullable().optional().describe('File size in bytes'),
+	visibility: z.string().nullable().optional().describe('Visibility setting'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.nullable()
+		.optional()
+		.describe('Custom metadata'),
+	createdAt: z
+		.number()
+		.nullable()
+		.optional()
+		.describe('Creation timestamp in milliseconds'),
+	updatedAt: z
+		.number()
+		.nullable()
+		.optional()
+		.describe('Last updated timestamp in milliseconds'),
+});
+export type File = z.infer<typeof FileSchema>;
+
+export const FilesListInputSchema = ListQueryInputSchema;
+export type FilesListInput = z.infer<typeof FilesListInputSchema>;
+
+export const FilesListResponseSchema = z.object({
+	items: z.array(FileSchema).describe('List of files matching query'),
+	cursor: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Pagination cursor for the next page of results'),
+});
+export type FilesListResponse = z.infer<typeof FilesListResponseSchema>;
+
+export const FilesGetInputSchema = z.object({
+	id: z.string().describe('ID of the file to fetch'),
+});
+export type FilesGetInput = z.infer<typeof FilesGetInputSchema>;
+
+export const FilesGetResponseSchema = FileSchema;
+export type FilesGetResponse = z.infer<typeof FilesGetResponseSchema>;
+
+export const FilesCreateInputSchema = z.object({
+	name: z.string().describe('Name of the file'),
+	description: z.string().optional().describe('Description of the file'),
+	mimeType: z.string().optional().describe('MIME type of the file'),
+	visibility: z
+		.enum(['private', 'protected', 'public'])
+		.optional()
+		.describe('Visibility level'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Custom metadata'),
+});
+export type FilesCreateInput = z.infer<typeof FilesCreateInputSchema>;
+
+export const FilesCreateResponseSchema = IdResponseSchema;
+export type FilesCreateResponse = z.infer<typeof FilesCreateResponseSchema>;
+
+export const FilesDeleteInputSchema = z.object({
+	id: z.string().describe('ID of the file to delete'),
+});
+export type FilesDeleteInput = z.infer<typeof FilesDeleteInputSchema>;
+
+export const FilesDeleteResponseSchema = IdResponseSchema;
+export type FilesDeleteResponse = z.infer<typeof FilesDeleteResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 8. Tasks
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const TaskSchema = z.object({
+	id: z.string().describe('Unique identifier of the task'),
+	name: z.string().describe('Descriptive name of the task'),
+	description: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Brief description of the task'),
+	botId: z.string().nullable().optional().describe('Associated bot ID'),
+	schedule: z.string().nullable().optional().describe('Cron schedule string'),
+	status: z.string().nullable().optional().describe('Task execution status'),
+	visibility: z.string().nullable().optional().describe('Visibility setting'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.nullable()
+		.optional()
+		.describe('Custom metadata'),
+	createdAt: z
+		.number()
+		.nullable()
+		.optional()
+		.describe('Creation timestamp in milliseconds'),
+	updatedAt: z
+		.number()
+		.nullable()
+		.optional()
+		.describe('Last updated timestamp in milliseconds'),
+});
+export type Task = z.infer<typeof TaskSchema>;
+
+export const TasksListInputSchema = ListQueryInputSchema;
+export type TasksListInput = z.infer<typeof TasksListInputSchema>;
+
+export const TasksListResponseSchema = z.object({
+	items: z.array(TaskSchema).describe('List of tasks matching query'),
+	cursor: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Pagination cursor for next page of results'),
+});
+export type TasksListResponse = z.infer<typeof TasksListResponseSchema>;
+
+export const TasksGetInputSchema = z.object({
+	id: z.string().describe('ID of the task to fetch'),
+});
+export type TasksGetInput = z.infer<typeof TasksGetInputSchema>;
+
+export const TasksGetResponseSchema = TaskSchema;
+export type TasksGetResponse = z.infer<typeof TasksGetResponseSchema>;
+
+export const TasksCreateInputSchema = z.object({
+	name: z.string().describe('Name of the background task'),
+	description: z.string().optional().describe('Description of the task'),
+	botId: z.string().optional().describe('ID of bot executing the task'),
+	schedule: z
+		.string()
+		.optional()
+		.describe('Cron schedule expression for recurring runs'),
+	visibility: z
+		.enum(['private', 'protected', 'public'])
+		.optional()
+		.describe('Visibility level'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Custom metadata'),
+});
+export type TasksCreateInput = z.infer<typeof TasksCreateInputSchema>;
+
+export const TasksCreateResponseSchema = IdResponseSchema;
+export type TasksCreateResponse = z.infer<typeof TasksCreateResponseSchema>;
+
+export const TasksUpdateInputSchema = z.object({
+	id: z.string().describe('ID of the task to update'),
+	name: z.string().optional().describe('Updated name'),
+	description: z.string().optional().describe('Updated description'),
+	botId: z.string().nullable().optional().describe('Updated bot ID'),
+	schedule: z.string().nullable().optional().describe('Updated cron schedule'),
+	visibility: z
+		.enum(['private', 'protected', 'public'])
+		.optional()
+		.describe('Updated visibility'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.optional()
+		.describe('Updated metadata'),
+});
+export type TasksUpdateInput = z.infer<typeof TasksUpdateInputSchema>;
+
+export const TasksUpdateResponseSchema = IdResponseSchema;
+export type TasksUpdateResponse = z.infer<typeof TasksUpdateResponseSchema>;
+
+export const TasksDeleteInputSchema = z.object({
+	id: z.string().describe('ID of the task to delete'),
+});
+export type TasksDeleteInput = z.infer<typeof TasksDeleteInputSchema>;
+
+export const TasksDeleteResponseSchema = IdResponseSchema;
+export type TasksDeleteResponse = z.infer<typeof TasksDeleteResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint Input/Output Maps
+// ─────────────────────────────────────────────────────────────────────────────
+
 export type ChatbotkitEndpointInputs = {
+	// Bots
 	botsList: BotsListInput;
 	botsGet: BotsGetInput;
+	botsCreate: BotsCreateInput;
+	botsUpdate: BotsUpdateInput;
+	botsDelete: BotsDeleteInput;
+	botsUpvote: BotsUpvoteInput;
+	botsDownvote: BotsDownvoteInput;
+
+	// Datasets
+	datasetsList: DatasetsListInput;
+	datasetsGet: DatasetsGetInput;
+	datasetsCreate: DatasetsCreateInput;
+	datasetsUpdate: DatasetsUpdateInput;
+	datasetsDelete: DatasetsDeleteInput;
+	datasetsSearch: DatasetsSearchInput;
+
+	// Skillsets
+	skillsetsList: SkillsetsListInput;
+	skillsetsGet: SkillsetsGetInput;
+	skillsetsCreate: SkillsetsCreateInput;
+	skillsetsUpdate: SkillsetsUpdateInput;
+	skillsetsDelete: SkillsetsDeleteInput;
+
+	// Blueprints
+	blueprintsList: BlueprintsListInput;
+	blueprintsGet: BlueprintsGetInput;
+	blueprintsCreate: BlueprintsCreateInput;
+	blueprintsUpdate: BlueprintsUpdateInput;
+	blueprintsDelete: BlueprintsDeleteInput;
+
+	// Secrets
+	secretsList: SecretsListInput;
+	secretsGet: SecretsGetInput;
+	secretsCreate: SecretsCreateInput;
+	secretsUpdate: SecretsUpdateInput;
+	secretsDelete: SecretsDeleteInput;
+
+	// Conversations
+	conversationsList: ConversationsListInput;
+	conversationsGet: ConversationsGetInput;
+	conversationsCreate: ConversationsCreateInput;
+	conversationsUpdate: ConversationsUpdateInput;
+	conversationsDelete: ConversationsDeleteInput;
+	conversationsComplete: ConversationsCompleteInput;
+
+	// Files
+	filesList: FilesListInput;
+	filesGet: FilesGetInput;
+	filesCreate: FilesCreateInput;
+	filesDelete: FilesDeleteInput;
+
+	// Tasks
+	tasksList: TasksListInput;
+	tasksGet: TasksGetInput;
+	tasksCreate: TasksCreateInput;
+	tasksUpdate: TasksUpdateInput;
+	tasksDelete: TasksDeleteInput;
 };
 
 export type ChatbotkitEndpointOutputs = {
+	// Bots
 	botsList: BotsListResponse;
 	botsGet: BotsGetResponse;
+	botsCreate: BotsCreateResponse;
+	botsUpdate: BotsUpdateResponse;
+	botsDelete: BotsDeleteResponse;
+	botsUpvote: BotsUpvoteResponse;
+	botsDownvote: BotsDownvoteResponse;
+
+	// Datasets
+	datasetsList: DatasetsListResponse;
+	datasetsGet: DatasetsGetResponse;
+	datasetsCreate: DatasetsCreateResponse;
+	datasetsUpdate: DatasetsUpdateResponse;
+	datasetsDelete: DatasetsDeleteResponse;
+	datasetsSearch: DatasetsSearchResponse;
+
+	// Skillsets
+	skillsetsList: SkillsetsListResponse;
+	skillsetsGet: SkillsetsGetResponse;
+	skillsetsCreate: SkillsetsCreateResponse;
+	skillsetsUpdate: SkillsetsUpdateResponse;
+	skillsetsDelete: SkillsetsDeleteResponse;
+
+	// Blueprints
+	blueprintsList: BlueprintsListResponse;
+	blueprintsGet: BlueprintsGetResponse;
+	blueprintsCreate: BlueprintsCreateResponse;
+	blueprintsUpdate: BlueprintsUpdateResponse;
+	blueprintsDelete: BlueprintsDeleteResponse;
+
+	// Secrets
+	secretsList: SecretsListResponse;
+	secretsGet: SecretsGetResponse;
+	secretsCreate: SecretsCreateResponse;
+	secretsUpdate: SecretsUpdateResponse;
+	secretsDelete: SecretsDeleteResponse;
+
+	// Conversations
+	conversationsList: ConversationsListResponse;
+	conversationsGet: ConversationsGetResponse;
+	conversationsCreate: ConversationsCreateResponse;
+	conversationsUpdate: ConversationsUpdateResponse;
+	conversationsDelete: ConversationsDeleteResponse;
+	conversationsComplete: ConversationsCompleteResponse;
+
+	// Files
+	filesList: FilesListResponse;
+	filesGet: FilesGetResponse;
+	filesCreate: FilesCreateResponse;
+	filesDelete: FilesDeleteResponse;
+
+	// Tasks
+	tasksList: TasksListResponse;
+	tasksGet: TasksGetResponse;
+	tasksCreate: TasksCreateResponse;
+	tasksUpdate: TasksUpdateResponse;
+	tasksDelete: TasksDeleteResponse;
 };
 
 export const ChatbotkitEndpointInputSchemas = {
+	// Bots
 	botsList: BotsListInputSchema,
 	botsGet: BotsGetInputSchema,
+	botsCreate: BotsCreateInputSchema,
+	botsUpdate: BotsUpdateInputSchema,
+	botsDelete: BotsDeleteInputSchema,
+	botsUpvote: BotsUpvoteInputSchema,
+	botsDownvote: BotsDownvoteInputSchema,
+
+	// Datasets
+	datasetsList: DatasetsListInputSchema,
+	datasetsGet: DatasetsGetInputSchema,
+	datasetsCreate: DatasetsCreateInputSchema,
+	datasetsUpdate: DatasetsUpdateInputSchema,
+	datasetsDelete: DatasetsDeleteInputSchema,
+	datasetsSearch: DatasetsSearchInputSchema,
+
+	// Skillsets
+	skillsetsList: SkillsetsListInputSchema,
+	skillsetsGet: SkillsetsGetInputSchema,
+	skillsetsCreate: SkillsetsCreateInputSchema,
+	skillsetsUpdate: SkillsetsUpdateInputSchema,
+	skillsetsDelete: SkillsetsDeleteInputSchema,
+
+	// Blueprints
+	blueprintsList: BlueprintsListInputSchema,
+	blueprintsGet: BlueprintsGetInputSchema,
+	blueprintsCreate: BlueprintsCreateInputSchema,
+	blueprintsUpdate: BlueprintsUpdateInputSchema,
+	blueprintsDelete: BlueprintsDeleteInputSchema,
+
+	// Secrets
+	secretsList: SecretsListInputSchema,
+	secretsGet: SecretsGetInputSchema,
+	secretsCreate: SecretsCreateInputSchema,
+	secretsUpdate: SecretsUpdateInputSchema,
+	secretsDelete: SecretsDeleteInputSchema,
+
+	// Conversations
+	conversationsList: ConversationsListInputSchema,
+	conversationsGet: ConversationsGetInputSchema,
+	conversationsCreate: ConversationsCreateInputSchema,
+	conversationsUpdate: ConversationsUpdateInputSchema,
+	conversationsDelete: ConversationsDeleteInputSchema,
+	conversationsComplete: ConversationsCompleteInputSchema,
+
+	// Files
+	filesList: FilesListInputSchema,
+	filesGet: FilesGetInputSchema,
+	filesCreate: FilesCreateInputSchema,
+	filesDelete: FilesDeleteInputSchema,
+
+	// Tasks
+	tasksList: TasksListInputSchema,
+	tasksGet: TasksGetInputSchema,
+	tasksCreate: TasksCreateInputSchema,
+	tasksUpdate: TasksUpdateInputSchema,
+	tasksDelete: TasksDeleteInputSchema,
 } as const;
 
 export const ChatbotkitEndpointOutputSchemas = {
+	// Bots
 	botsList: BotsListResponseSchema,
 	botsGet: BotsGetResponseSchema,
+	botsCreate: BotsCreateResponseSchema,
+	botsUpdate: BotsUpdateResponseSchema,
+	botsDelete: BotsDeleteResponseSchema,
+	botsUpvote: BotsUpvoteResponseSchema,
+	botsDownvote: BotsDownvoteResponseSchema,
+
+	// Datasets
+	datasetsList: DatasetsListResponseSchema,
+	datasetsGet: DatasetsGetResponseSchema,
+	datasetsCreate: DatasetsCreateResponseSchema,
+	datasetsUpdate: DatasetsUpdateResponseSchema,
+	datasetsDelete: DatasetsDeleteResponseSchema,
+	datasetsSearch: DatasetsSearchResponseSchema,
+
+	// Skillsets
+	skillsetsList: SkillsetsListResponseSchema,
+	skillsetsGet: SkillsetsGetResponseSchema,
+	skillsetsCreate: SkillsetsCreateResponseSchema,
+	skillsetsUpdate: SkillsetsUpdateResponseSchema,
+	skillsetsDelete: SkillsetsDeleteResponseSchema,
+
+	// Blueprints
+	blueprintsList: BlueprintsListResponseSchema,
+	blueprintsGet: BlueprintsGetResponseSchema,
+	blueprintsCreate: BlueprintsCreateResponseSchema,
+	blueprintsUpdate: BlueprintsUpdateResponseSchema,
+	blueprintsDelete: BlueprintsDeleteResponseSchema,
+
+	// Secrets
+	secretsList: SecretsListResponseSchema,
+	secretsGet: SecretsGetResponseSchema,
+	secretsCreate: SecretsCreateResponseSchema,
+	secretsUpdate: SecretsUpdateResponseSchema,
+	secretsDelete: SecretsDeleteResponseSchema,
+
+	// Conversations
+	conversationsList: ConversationsListResponseSchema,
+	conversationsGet: ConversationsGetResponseSchema,
+	conversationsCreate: ConversationsCreateResponseSchema,
+	conversationsUpdate: ConversationsUpdateResponseSchema,
+	conversationsDelete: ConversationsDeleteResponseSchema,
+	conversationsComplete: ConversationsCompleteResponseSchema,
+
+	// Files
+	filesList: FilesListResponseSchema,
+	filesGet: FilesGetResponseSchema,
+	filesCreate: FilesCreateResponseSchema,
+	filesDelete: FilesDeleteResponseSchema,
+
+	// Tasks
+	tasksList: TasksListResponseSchema,
+	tasksGet: TasksGetResponseSchema,
+	tasksCreate: TasksCreateResponseSchema,
+	tasksUpdate: TasksUpdateResponseSchema,
+	tasksDelete: TasksDeleteResponseSchema,
 } as const;

--- a/packages/chatbotkit/endpoints/types.ts
+++ b/packages/chatbotkit/endpoints/types.ts
@@ -1,35 +1,96 @@
 import { z } from 'zod';
 
-const BotSchema = z.object({
-	id: z.string(),
-	name: z.string(),
-	description: z.string().nullable().optional(),
-	model: z.string().nullable().optional(),
-	backstory: z.string().nullable().optional(),
-	createdAt: z.coerce.date().nullable().optional(),
-	updatedAt: z.coerce.date().nullable().optional(),
+export const BotSchema = z.object({
+	id: z.string().describe('Unique identifier of the bot'),
+	alias: z.string().nullable().optional().describe('Custom alias for the bot'),
+	name: z.string().describe('Descriptive name of the bot'),
+	description: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Brief description of the bot purpose'),
+	blueprintId: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Associated blueprint ID'),
+	datasetId: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Associated dataset ID for knowledge retrieval'),
+	skillsetId: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Associated skillset ID for tools and capabilities'),
+	backstory: z
+		.string()
+		.nullable()
+		.optional()
+		.describe(
+			'Natural language instructions defining bot personality and behavior',
+		),
+	model: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('AI model configured for the bot'),
+	visibility: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Visibility access setting (e.g. private, protected, public)'),
+	meta: z
+		.record(z.string(), z.unknown())
+		.nullable()
+		.optional()
+		.describe('Custom metadata attached to the bot'),
+	createdAt: z
+		.union([z.number(), z.string(), z.coerce.date()])
+		.nullable()
+		.optional()
+		.describe('Creation timestamp in milliseconds'),
+	updatedAt: z
+		.union([z.number(), z.string(), z.coerce.date()])
+		.nullable()
+		.optional()
+		.describe('Last updated timestamp in milliseconds'),
 });
 export type Bot = z.infer<typeof BotSchema>;
 
-const BotsListInputSchema = z.object({
-	cursor: z.string().optional(),
-	limit: z.number().int().positive().max(100).optional(),
-	order: z.enum(['asc', 'desc']).optional(),
+export const BotsListInputSchema = z.object({
+	cursor: z.string().optional().describe('Cursor for pagination'),
+	limit: z
+		.number()
+		.int()
+		.positive()
+		.max(100)
+		.optional()
+		.describe('Maximum number of items to return'),
+	order: z
+		.enum(['asc', 'desc'])
+		.optional()
+		.describe('Sort order by creation time'),
 });
 export type BotsListInput = z.infer<typeof BotsListInputSchema>;
 
-const BotsListResponseSchema = z.object({
-	data: z.array(BotSchema),
-	meta: z.object({ cursor: z.string().nullable().optional() }).optional(),
+export const BotsListResponseSchema = z.object({
+	items: z.array(BotSchema).describe('List of bots matching the query'),
+	cursor: z
+		.string()
+		.nullable()
+		.optional()
+		.describe('Pagination cursor for the next page of results'),
 });
 export type BotsListResponse = z.infer<typeof BotsListResponseSchema>;
 
-const BotsGetInputSchema = z.object({
-	id: z.string(),
+export const BotsGetInputSchema = z.object({
+	id: z.string().describe('Unique identifier or alias of the bot to fetch'),
 });
 export type BotsGetInput = z.infer<typeof BotsGetInputSchema>;
 
-const BotsGetResponseSchema = BotSchema;
+export const BotsGetResponseSchema = BotSchema;
 export type BotsGetResponse = z.infer<typeof BotsGetResponseSchema>;
 
 export type ChatbotkitEndpointInputs = {

--- a/packages/chatbotkit/endpoints/types.ts
+++ b/packages/chatbotkit/endpoints/types.ts
@@ -987,7 +987,7 @@ export const FileSchema = z.object({
 		.optional()
 		.describe('Last updated timestamp in milliseconds'),
 });
-export type File = z.infer<typeof FileSchema>;
+export type ChatbotkitFile = z.infer<typeof FileSchema>;
 
 export const FilesListInputSchema = ListQueryInputSchema;
 export type FilesListInput = z.infer<typeof FilesListInputSchema>;

--- a/packages/chatbotkit/error-handlers.ts
+++ b/packages/chatbotkit/error-handlers.ts
@@ -1,0 +1,38 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('429');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('unauthorized') || msg.includes('invalid_auth');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	NOT_FOUND_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 404) return true;
+			return error.message.toLowerCase().includes('not found');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/chatbotkit/index.ts
+++ b/packages/chatbotkit/index.ts
@@ -12,7 +12,16 @@ import type {
 	RequiredPluginEndpointSchemas,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
-import { Bots } from './endpoints';
+import {
+	Blueprints,
+	Bots,
+	Conversations,
+	Datasets,
+	Files,
+	Secrets,
+	Skillsets,
+	Tasks,
+} from './endpoints';
 import type {
 	ChatbotkitEndpointInputs,
 	ChatbotkitEndpointOutputs,
@@ -52,18 +61,130 @@ type ChatbotkitEndpoint<K extends keyof ChatbotkitEndpointOutputs> =
 	>;
 
 export type ChatbotkitEndpoints = {
+	// Bots
 	botsList: ChatbotkitEndpoint<'botsList'>;
 	botsGet: ChatbotkitEndpoint<'botsGet'>;
+	botsCreate: ChatbotkitEndpoint<'botsCreate'>;
+	botsUpdate: ChatbotkitEndpoint<'botsUpdate'>;
+	botsDelete: ChatbotkitEndpoint<'botsDelete'>;
+	botsUpvote: ChatbotkitEndpoint<'botsUpvote'>;
+	botsDownvote: ChatbotkitEndpoint<'botsDownvote'>;
+
+	// Datasets
+	datasetsList: ChatbotkitEndpoint<'datasetsList'>;
+	datasetsGet: ChatbotkitEndpoint<'datasetsGet'>;
+	datasetsCreate: ChatbotkitEndpoint<'datasetsCreate'>;
+	datasetsUpdate: ChatbotkitEndpoint<'datasetsUpdate'>;
+	datasetsDelete: ChatbotkitEndpoint<'datasetsDelete'>;
+	datasetsSearch: ChatbotkitEndpoint<'datasetsSearch'>;
+
+	// Skillsets
+	skillsetsList: ChatbotkitEndpoint<'skillsetsList'>;
+	skillsetsGet: ChatbotkitEndpoint<'skillsetsGet'>;
+	skillsetsCreate: ChatbotkitEndpoint<'skillsetsCreate'>;
+	skillsetsUpdate: ChatbotkitEndpoint<'skillsetsUpdate'>;
+	skillsetsDelete: ChatbotkitEndpoint<'skillsetsDelete'>;
+
+	// Blueprints
+	blueprintsList: ChatbotkitEndpoint<'blueprintsList'>;
+	blueprintsGet: ChatbotkitEndpoint<'blueprintsGet'>;
+	blueprintsCreate: ChatbotkitEndpoint<'blueprintsCreate'>;
+	blueprintsUpdate: ChatbotkitEndpoint<'blueprintsUpdate'>;
+	blueprintsDelete: ChatbotkitEndpoint<'blueprintsDelete'>;
+
+	// Secrets
+	secretsList: ChatbotkitEndpoint<'secretsList'>;
+	secretsGet: ChatbotkitEndpoint<'secretsGet'>;
+	secretsCreate: ChatbotkitEndpoint<'secretsCreate'>;
+	secretsUpdate: ChatbotkitEndpoint<'secretsUpdate'>;
+	secretsDelete: ChatbotkitEndpoint<'secretsDelete'>;
+
+	// Conversations
+	conversationsList: ChatbotkitEndpoint<'conversationsList'>;
+	conversationsGet: ChatbotkitEndpoint<'conversationsGet'>;
+	conversationsCreate: ChatbotkitEndpoint<'conversationsCreate'>;
+	conversationsUpdate: ChatbotkitEndpoint<'conversationsUpdate'>;
+	conversationsDelete: ChatbotkitEndpoint<'conversationsDelete'>;
+	conversationsComplete: ChatbotkitEndpoint<'conversationsComplete'>;
+
+	// Files
+	filesList: ChatbotkitEndpoint<'filesList'>;
+	filesGet: ChatbotkitEndpoint<'filesGet'>;
+	filesCreate: ChatbotkitEndpoint<'filesCreate'>;
+	filesDelete: ChatbotkitEndpoint<'filesDelete'>;
+
+	// Tasks
+	tasksList: ChatbotkitEndpoint<'tasksList'>;
+	tasksGet: ChatbotkitEndpoint<'tasksGet'>;
+	tasksCreate: ChatbotkitEndpoint<'tasksCreate'>;
+	tasksUpdate: ChatbotkitEndpoint<'tasksUpdate'>;
+	tasksDelete: ChatbotkitEndpoint<'tasksDelete'>;
 };
 
 const chatbotkitEndpointsNested = {
 	bots: {
 		list: Bots.list,
 		get: Bots.get,
+		create: Bots.create,
+		update: Bots.update,
+		delete: Bots.del,
+		upvote: Bots.upvote,
+		downvote: Bots.downvote,
+	},
+	datasets: {
+		list: Datasets.list,
+		get: Datasets.get,
+		create: Datasets.create,
+		update: Datasets.update,
+		delete: Datasets.del,
+		search: Datasets.search,
+	},
+	skillsets: {
+		list: Skillsets.list,
+		get: Skillsets.get,
+		create: Skillsets.create,
+		update: Skillsets.update,
+		delete: Skillsets.del,
+	},
+	blueprints: {
+		list: Blueprints.list,
+		get: Blueprints.get,
+		create: Blueprints.create,
+		update: Blueprints.update,
+		delete: Blueprints.del,
+	},
+	secrets: {
+		list: Secrets.list,
+		get: Secrets.get,
+		create: Secrets.create,
+		update: Secrets.update,
+		delete: Secrets.del,
+	},
+	conversations: {
+		list: Conversations.list,
+		get: Conversations.get,
+		create: Conversations.create,
+		update: Conversations.update,
+		delete: Conversations.del,
+		complete: Conversations.complete,
+	},
+	files: {
+		list: Files.list,
+		get: Files.get,
+		create: Files.create,
+		delete: Files.del,
+	},
+	tasks: {
+		list: Tasks.list,
+		get: Tasks.get,
+		create: Tasks.create,
+		update: Tasks.update,
+		delete: Tasks.del,
 	},
 } as const;
 
 export const chatbotkitEndpointSchemas = {
+	// Bots
 	'bots.list': {
 		input: ChatbotkitEndpointInputSchemas.botsList,
 		output: ChatbotkitEndpointOutputSchemas.botsList,
@@ -72,6 +193,184 @@ export const chatbotkitEndpointSchemas = {
 		input: ChatbotkitEndpointInputSchemas.botsGet,
 		output: ChatbotkitEndpointOutputSchemas.botsGet,
 	},
+	'bots.create': {
+		input: ChatbotkitEndpointInputSchemas.botsCreate,
+		output: ChatbotkitEndpointOutputSchemas.botsCreate,
+	},
+	'bots.update': {
+		input: ChatbotkitEndpointInputSchemas.botsUpdate,
+		output: ChatbotkitEndpointOutputSchemas.botsUpdate,
+	},
+	'bots.delete': {
+		input: ChatbotkitEndpointInputSchemas.botsDelete,
+		output: ChatbotkitEndpointOutputSchemas.botsDelete,
+	},
+	'bots.upvote': {
+		input: ChatbotkitEndpointInputSchemas.botsUpvote,
+		output: ChatbotkitEndpointOutputSchemas.botsUpvote,
+	},
+	'bots.downvote': {
+		input: ChatbotkitEndpointInputSchemas.botsDownvote,
+		output: ChatbotkitEndpointOutputSchemas.botsDownvote,
+	},
+
+	// Datasets
+	'datasets.list': {
+		input: ChatbotkitEndpointInputSchemas.datasetsList,
+		output: ChatbotkitEndpointOutputSchemas.datasetsList,
+	},
+	'datasets.get': {
+		input: ChatbotkitEndpointInputSchemas.datasetsGet,
+		output: ChatbotkitEndpointOutputSchemas.datasetsGet,
+	},
+	'datasets.create': {
+		input: ChatbotkitEndpointInputSchemas.datasetsCreate,
+		output: ChatbotkitEndpointOutputSchemas.datasetsCreate,
+	},
+	'datasets.update': {
+		input: ChatbotkitEndpointInputSchemas.datasetsUpdate,
+		output: ChatbotkitEndpointOutputSchemas.datasetsUpdate,
+	},
+	'datasets.delete': {
+		input: ChatbotkitEndpointInputSchemas.datasetsDelete,
+		output: ChatbotkitEndpointOutputSchemas.datasetsDelete,
+	},
+	'datasets.search': {
+		input: ChatbotkitEndpointInputSchemas.datasetsSearch,
+		output: ChatbotkitEndpointOutputSchemas.datasetsSearch,
+	},
+
+	// Skillsets
+	'skillsets.list': {
+		input: ChatbotkitEndpointInputSchemas.skillsetsList,
+		output: ChatbotkitEndpointOutputSchemas.skillsetsList,
+	},
+	'skillsets.get': {
+		input: ChatbotkitEndpointInputSchemas.skillsetsGet,
+		output: ChatbotkitEndpointOutputSchemas.skillsetsGet,
+	},
+	'skillsets.create': {
+		input: ChatbotkitEndpointInputSchemas.skillsetsCreate,
+		output: ChatbotkitEndpointOutputSchemas.skillsetsCreate,
+	},
+	'skillsets.update': {
+		input: ChatbotkitEndpointInputSchemas.skillsetsUpdate,
+		output: ChatbotkitEndpointOutputSchemas.skillsetsUpdate,
+	},
+	'skillsets.delete': {
+		input: ChatbotkitEndpointInputSchemas.skillsetsDelete,
+		output: ChatbotkitEndpointOutputSchemas.skillsetsDelete,
+	},
+
+	// Blueprints
+	'blueprints.list': {
+		input: ChatbotkitEndpointInputSchemas.blueprintsList,
+		output: ChatbotkitEndpointOutputSchemas.blueprintsList,
+	},
+	'blueprints.get': {
+		input: ChatbotkitEndpointInputSchemas.blueprintsGet,
+		output: ChatbotkitEndpointOutputSchemas.blueprintsGet,
+	},
+	'blueprints.create': {
+		input: ChatbotkitEndpointInputSchemas.blueprintsCreate,
+		output: ChatbotkitEndpointOutputSchemas.blueprintsCreate,
+	},
+	'blueprints.update': {
+		input: ChatbotkitEndpointInputSchemas.blueprintsUpdate,
+		output: ChatbotkitEndpointOutputSchemas.blueprintsUpdate,
+	},
+	'blueprints.delete': {
+		input: ChatbotkitEndpointInputSchemas.blueprintsDelete,
+		output: ChatbotkitEndpointOutputSchemas.blueprintsDelete,
+	},
+
+	// Secrets
+	'secrets.list': {
+		input: ChatbotkitEndpointInputSchemas.secretsList,
+		output: ChatbotkitEndpointOutputSchemas.secretsList,
+	},
+	'secrets.get': {
+		input: ChatbotkitEndpointInputSchemas.secretsGet,
+		output: ChatbotkitEndpointOutputSchemas.secretsGet,
+	},
+	'secrets.create': {
+		input: ChatbotkitEndpointInputSchemas.secretsCreate,
+		output: ChatbotkitEndpointOutputSchemas.secretsCreate,
+	},
+	'secrets.update': {
+		input: ChatbotkitEndpointInputSchemas.secretsUpdate,
+		output: ChatbotkitEndpointOutputSchemas.secretsUpdate,
+	},
+	'secrets.delete': {
+		input: ChatbotkitEndpointInputSchemas.secretsDelete,
+		output: ChatbotkitEndpointOutputSchemas.secretsDelete,
+	},
+
+	// Conversations
+	'conversations.list': {
+		input: ChatbotkitEndpointInputSchemas.conversationsList,
+		output: ChatbotkitEndpointOutputSchemas.conversationsList,
+	},
+	'conversations.get': {
+		input: ChatbotkitEndpointInputSchemas.conversationsGet,
+		output: ChatbotkitEndpointOutputSchemas.conversationsGet,
+	},
+	'conversations.create': {
+		input: ChatbotkitEndpointInputSchemas.conversationsCreate,
+		output: ChatbotkitEndpointOutputSchemas.conversationsCreate,
+	},
+	'conversations.update': {
+		input: ChatbotkitEndpointInputSchemas.conversationsUpdate,
+		output: ChatbotkitEndpointOutputSchemas.conversationsUpdate,
+	},
+	'conversations.delete': {
+		input: ChatbotkitEndpointInputSchemas.conversationsDelete,
+		output: ChatbotkitEndpointOutputSchemas.conversationsDelete,
+	},
+	'conversations.complete': {
+		input: ChatbotkitEndpointInputSchemas.conversationsComplete,
+		output: ChatbotkitEndpointOutputSchemas.conversationsComplete,
+	},
+
+	// Files
+	'files.list': {
+		input: ChatbotkitEndpointInputSchemas.filesList,
+		output: ChatbotkitEndpointOutputSchemas.filesList,
+	},
+	'files.get': {
+		input: ChatbotkitEndpointInputSchemas.filesGet,
+		output: ChatbotkitEndpointOutputSchemas.filesGet,
+	},
+	'files.create': {
+		input: ChatbotkitEndpointInputSchemas.filesCreate,
+		output: ChatbotkitEndpointOutputSchemas.filesCreate,
+	},
+	'files.delete': {
+		input: ChatbotkitEndpointInputSchemas.filesDelete,
+		output: ChatbotkitEndpointOutputSchemas.filesDelete,
+	},
+
+	// Tasks
+	'tasks.list': {
+		input: ChatbotkitEndpointInputSchemas.tasksList,
+		output: ChatbotkitEndpointOutputSchemas.tasksList,
+	},
+	'tasks.get': {
+		input: ChatbotkitEndpointInputSchemas.tasksGet,
+		output: ChatbotkitEndpointOutputSchemas.tasksGet,
+	},
+	'tasks.create': {
+		input: ChatbotkitEndpointInputSchemas.tasksCreate,
+		output: ChatbotkitEndpointOutputSchemas.tasksCreate,
+	},
+	'tasks.update': {
+		input: ChatbotkitEndpointInputSchemas.tasksUpdate,
+		output: ChatbotkitEndpointOutputSchemas.tasksUpdate,
+	},
+	'tasks.delete': {
+		input: ChatbotkitEndpointInputSchemas.tasksDelete,
+		output: ChatbotkitEndpointOutputSchemas.tasksDelete,
+	},
 } as const satisfies RequiredPluginEndpointSchemas<
 	typeof chatbotkitEndpointsNested
 >;
@@ -79,6 +378,7 @@ export const chatbotkitEndpointSchemas = {
 const defaultAuthType = 'api_key' as const;
 
 const chatbotkitEndpointMeta = {
+	// Bots
 	'bots.list': {
 		riskLevel: 'read',
 		description: 'List bots on the ChatBotKit account, cursor-paginated',
@@ -86,6 +386,184 @@ const chatbotkitEndpointMeta = {
 	'bots.get': {
 		riskLevel: 'read',
 		description: 'Fetch a single bot by ID or alias',
+	},
+	'bots.create': {
+		riskLevel: 'write',
+		description: 'Create a new AI bot',
+	},
+	'bots.update': {
+		riskLevel: 'write',
+		description: 'Update an existing bot configuration',
+	},
+	'bots.delete': {
+		riskLevel: 'destructive',
+		description: 'Permanently delete a bot',
+	},
+	'bots.upvote': {
+		riskLevel: 'write',
+		description: 'Register an upvote for a bot',
+	},
+	'bots.downvote': {
+		riskLevel: 'write',
+		description: 'Register a downvote for a bot',
+	},
+
+	// Datasets
+	'datasets.list': {
+		riskLevel: 'read',
+		description: 'List knowledge datasets, cursor-paginated',
+	},
+	'datasets.get': {
+		riskLevel: 'read',
+		description: 'Fetch a dataset by ID',
+	},
+	'datasets.create': {
+		riskLevel: 'write',
+		description: 'Create a new knowledge dataset',
+	},
+	'datasets.update': {
+		riskLevel: 'write',
+		description: 'Update dataset configuration',
+	},
+	'datasets.delete': {
+		riskLevel: 'destructive',
+		description: 'Permanently delete a dataset',
+	},
+	'datasets.search': {
+		riskLevel: 'read',
+		description: 'Search a dataset for relevant knowledge records',
+	},
+
+	// Skillsets
+	'skillsets.list': {
+		riskLevel: 'read',
+		description: 'List skillsets on the account, cursor-paginated',
+	},
+	'skillsets.get': {
+		riskLevel: 'read',
+		description: 'Fetch a skillset by ID',
+	},
+	'skillsets.create': {
+		riskLevel: 'write',
+		description: 'Create a new skillset container',
+	},
+	'skillsets.update': {
+		riskLevel: 'write',
+		description: 'Update skillset configuration or state',
+	},
+	'skillsets.delete': {
+		riskLevel: 'destructive',
+		description: 'Permanently delete a skillset',
+	},
+
+	// Blueprints
+	'blueprints.list': {
+		riskLevel: 'read',
+		description: 'List blueprint templates, cursor-paginated',
+	},
+	'blueprints.get': {
+		riskLevel: 'read',
+		description: 'Fetch a blueprint template by ID',
+	},
+	'blueprints.create': {
+		riskLevel: 'write',
+		description: 'Create a new blueprint configuration template',
+	},
+	'blueprints.update': {
+		riskLevel: 'write',
+		description: 'Update an existing blueprint template',
+	},
+	'blueprints.delete': {
+		riskLevel: 'destructive',
+		description: 'Permanently delete a blueprint template',
+	},
+
+	// Secrets
+	'secrets.list': {
+		riskLevel: 'read',
+		description: 'List integration secrets, cursor-paginated',
+	},
+	'secrets.get': {
+		riskLevel: 'read',
+		description: 'Fetch a secret credential by ID',
+	},
+	'secrets.create': {
+		riskLevel: 'write',
+		description: 'Create a new integration secret credential',
+	},
+	'secrets.update': {
+		riskLevel: 'write',
+		description: 'Update an existing integration secret credential',
+	},
+	'secrets.delete': {
+		riskLevel: 'destructive',
+		description: 'Permanently delete a secret credential',
+	},
+
+	// Conversations
+	'conversations.list': {
+		riskLevel: 'read',
+		description: 'List conversations, cursor-paginated',
+	},
+	'conversations.get': {
+		riskLevel: 'read',
+		description: 'Fetch a conversation by ID',
+	},
+	'conversations.create': {
+		riskLevel: 'write',
+		description: 'Create a new conversation chat session',
+	},
+	'conversations.update': {
+		riskLevel: 'write',
+		description: 'Update conversation metadata or bot association',
+	},
+	'conversations.delete': {
+		riskLevel: 'destructive',
+		description: 'Permanently delete a conversation session',
+	},
+	'conversations.complete': {
+		riskLevel: 'write',
+		description: 'Send message to conversation and get AI response',
+	},
+
+	// Files
+	'files.list': {
+		riskLevel: 'read',
+		description: 'List uploaded file resources, cursor-paginated',
+	},
+	'files.get': {
+		riskLevel: 'read',
+		description: 'Fetch file metadata by ID',
+	},
+	'files.create': {
+		riskLevel: 'write',
+		description: 'Create a new file record',
+	},
+	'files.delete': {
+		riskLevel: 'destructive',
+		description: 'Permanently delete a file resource',
+	},
+
+	// Tasks
+	'tasks.list': {
+		riskLevel: 'read',
+		description: 'List background tasks, cursor-paginated',
+	},
+	'tasks.get': {
+		riskLevel: 'read',
+		description: 'Fetch a task by ID',
+	},
+	'tasks.create': {
+		riskLevel: 'write',
+		description: 'Create a new background execution task',
+	},
+	'tasks.update': {
+		riskLevel: 'write',
+		description: 'Update task schedule or bot assignment',
+	},
+	'tasks.delete': {
+		riskLevel: 'destructive',
+		description: 'Permanently delete a background task',
 	},
 } as const satisfies RequiredPluginEndpointMeta<
 	typeof chatbotkitEndpointsNested
@@ -156,13 +634,111 @@ export function chatbotkit<const T extends ChatbotkitPluginOptions>(
 }
 
 export type {
+	// Blueprints
+	Blueprint,
+	BlueprintsCreateInput,
+	BlueprintsCreateResponse,
+	BlueprintsDeleteInput,
+	BlueprintsDeleteResponse,
+	BlueprintsGetInput,
+	BlueprintsGetResponse,
+	BlueprintsListInput,
+	BlueprintsListResponse,
+	BlueprintsUpdateInput,
+	BlueprintsUpdateResponse,
+	// Bots
 	Bot,
+	BotsCreateInput,
+	BotsCreateResponse,
+	BotsDeleteInput,
+	BotsDeleteResponse,
+	BotsDownvoteInput,
+	BotsDownvoteResponse,
 	BotsGetInput,
 	BotsGetResponse,
 	BotsListInput,
 	BotsListResponse,
+	BotsUpdateInput,
+	BotsUpdateResponse,
+	BotsUpvoteInput,
+	BotsUpvoteResponse,
 	ChatbotkitEndpointInputs,
 	ChatbotkitEndpointOutputs,
+	// Conversations
+	Conversation,
+	ConversationCompletionResponse,
+	ConversationsCompleteInput,
+	ConversationsCompleteResponse,
+	ConversationsCreateInput,
+	ConversationsCreateResponse,
+	ConversationsDeleteInput,
+	ConversationsDeleteResponse,
+	ConversationsGetInput,
+	ConversationsGetResponse,
+	ConversationsListInput,
+	ConversationsListResponse,
+	ConversationsUpdateInput,
+	ConversationsUpdateResponse,
+	// Datasets
+	Dataset,
+	DatasetsCreateInput,
+	DatasetsCreateResponse,
+	DatasetsDeleteInput,
+	DatasetsDeleteResponse,
+	DatasetsGetInput,
+	DatasetsGetResponse,
+	DatasetsListInput,
+	DatasetsListResponse,
+	DatasetsSearchInput,
+	DatasetsSearchResponse,
+	DatasetsUpdateInput,
+	DatasetsUpdateResponse,
+	// Files
+	File,
+	FilesCreateInput,
+	FilesCreateResponse,
+	FilesDeleteInput,
+	FilesDeleteResponse,
+	FilesGetInput,
+	FilesGetResponse,
+	FilesListInput,
+	FilesListResponse,
+	// Secrets
+	Secret,
+	SecretsCreateInput,
+	SecretsCreateResponse,
+	SecretsDeleteInput,
+	SecretsDeleteResponse,
+	SecretsGetInput,
+	SecretsGetResponse,
+	SecretsListInput,
+	SecretsListResponse,
+	SecretsUpdateInput,
+	SecretsUpdateResponse,
+	// Skillsets
+	Skillset,
+	SkillsetsCreateInput,
+	SkillsetsCreateResponse,
+	SkillsetsDeleteInput,
+	SkillsetsDeleteResponse,
+	SkillsetsGetInput,
+	SkillsetsGetResponse,
+	SkillsetsListInput,
+	SkillsetsListResponse,
+	SkillsetsUpdateInput,
+	SkillsetsUpdateResponse,
+	// Tasks
+	Task,
+	TasksCreateInput,
+	TasksCreateResponse,
+	TasksDeleteInput,
+	TasksDeleteResponse,
+	TasksGetInput,
+	TasksGetResponse,
+	TasksListInput,
+	TasksListResponse,
+	TasksUpdateInput,
+	TasksUpdateResponse,
 } from './endpoints/types';
 
 export type {

--- a/packages/chatbotkit/index.ts
+++ b/packages/chatbotkit/index.ts
@@ -81,11 +81,11 @@ const defaultAuthType = 'api_key' as const;
 const chatbotkitEndpointMeta = {
 	'bots.list': {
 		riskLevel: 'read',
-		description: 'List bots on the Chatbotkit account, cursor-paginated',
+		description: 'List bots on the ChatBotKit account, cursor-paginated',
 	},
 	'bots.get': {
 		riskLevel: 'read',
-		description: 'Fetch a single bot by ID',
+		description: 'Fetch a single bot by ID or alias',
 	},
 } as const satisfies RequiredPluginEndpointMeta<
 	typeof chatbotkitEndpointsNested
@@ -164,3 +164,11 @@ export type {
 	ChatbotkitEndpointInputs,
 	ChatbotkitEndpointOutputs,
 } from './endpoints/types';
+
+export type {
+	ChatbotkitBlueprint,
+	ChatbotkitBot,
+	ChatbotkitDataset,
+	ChatbotkitSecret,
+	ChatbotkitSkillset,
+} from './schema/database';

--- a/packages/chatbotkit/index.ts
+++ b/packages/chatbotkit/index.ts
@@ -664,6 +664,8 @@ export type {
 	BotsUpvoteResponse,
 	ChatbotkitEndpointInputs,
 	ChatbotkitEndpointOutputs,
+	// Files
+	ChatbotkitFile,
 	// Conversations
 	Conversation,
 	ConversationCompletionResponse,
@@ -693,8 +695,6 @@ export type {
 	DatasetsSearchResponse,
 	DatasetsUpdateInput,
 	DatasetsUpdateResponse,
-	// Files
-	File,
 	FilesCreateInput,
 	FilesCreateResponse,
 	FilesDeleteInput,

--- a/packages/chatbotkit/index.ts
+++ b/packages/chatbotkit/index.ts
@@ -1,0 +1,166 @@
+import type {
+	BindEndpoints,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+} from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
+import { Bots } from './endpoints';
+import type {
+	ChatbotkitEndpointInputs,
+	ChatbotkitEndpointOutputs,
+} from './endpoints/types';
+import {
+	ChatbotkitEndpointInputSchemas,
+	ChatbotkitEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { ChatbotkitSchema } from './schema';
+
+export type ChatbotkitPluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	hooks?: InternalChatbotkitPlugin['hooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof chatbotkitEndpointsNested>;
+};
+
+export type ChatbotkitContext = CorsairPluginContext<
+	typeof ChatbotkitSchema,
+	ChatbotkitPluginOptions
+>;
+
+export type ChatbotkitKeyBuilderContext =
+	KeyBuilderContext<ChatbotkitPluginOptions>;
+
+export type ChatbotkitBoundEndpoints = BindEndpoints<
+	typeof chatbotkitEndpointsNested
+>;
+
+type ChatbotkitEndpoint<K extends keyof ChatbotkitEndpointOutputs> =
+	CorsairEndpoint<
+		ChatbotkitContext,
+		ChatbotkitEndpointInputs[K],
+		ChatbotkitEndpointOutputs[K]
+	>;
+
+export type ChatbotkitEndpoints = {
+	botsList: ChatbotkitEndpoint<'botsList'>;
+	botsGet: ChatbotkitEndpoint<'botsGet'>;
+};
+
+const chatbotkitEndpointsNested = {
+	bots: {
+		list: Bots.list,
+		get: Bots.get,
+	},
+} as const;
+
+export const chatbotkitEndpointSchemas = {
+	'bots.list': {
+		input: ChatbotkitEndpointInputSchemas.botsList,
+		output: ChatbotkitEndpointOutputSchemas.botsList,
+	},
+	'bots.get': {
+		input: ChatbotkitEndpointInputSchemas.botsGet,
+		output: ChatbotkitEndpointOutputSchemas.botsGet,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<
+	typeof chatbotkitEndpointsNested
+>;
+
+const defaultAuthType = 'api_key' as const;
+
+const chatbotkitEndpointMeta = {
+	'bots.list': {
+		riskLevel: 'read',
+		description: 'List bots on the Chatbotkit account, cursor-paginated',
+	},
+	'bots.get': {
+		riskLevel: 'read',
+		description: 'Fetch a single bot by ID',
+	},
+} as const satisfies RequiredPluginEndpointMeta<
+	typeof chatbotkitEndpointsNested
+>;
+
+export const chatbotkitAuthConfig = {
+	api_key: {
+		account: ['tenant_external_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type BaseChatbotkitPlugin<T extends ChatbotkitPluginOptions> =
+	CorsairPlugin<
+		'chatbotkit',
+		typeof ChatbotkitSchema,
+		typeof chatbotkitEndpointsNested,
+		Record<string, never>,
+		T,
+		typeof defaultAuthType
+	>;
+
+export type InternalChatbotkitPlugin =
+	BaseChatbotkitPlugin<ChatbotkitPluginOptions>;
+
+export type ExternalChatbotkitPlugin<T extends ChatbotkitPluginOptions> =
+	BaseChatbotkitPlugin<T>;
+
+export function chatbotkit<const T extends ChatbotkitPluginOptions>(
+	incomingOptions: ChatbotkitPluginOptions & T = {} as ChatbotkitPluginOptions &
+		T,
+): ExternalChatbotkitPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'chatbotkit',
+		authConfig: chatbotkitAuthConfig,
+		schema: ChatbotkitSchema,
+		options: options,
+		hooks: options.hooks,
+		endpoints: chatbotkitEndpointsNested,
+		webhooks: {},
+		endpointMeta: chatbotkitEndpointMeta,
+		endpointSchemas: chatbotkitEndpointSchemas,
+		webhookSchemas: {},
+		pluginWebhookMatcher: () => false,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: ChatbotkitKeyBuilderContext, source) => {
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys?.get_api_key();
+				if (!res) {
+					throw new AuthMissingError('chatbotkit', 'api_key');
+				}
+				return res;
+			}
+
+			throw new AuthMissingError('chatbotkit', 'api_key');
+		},
+	} satisfies InternalChatbotkitPlugin;
+}
+
+export type {
+	Bot,
+	BotsGetInput,
+	BotsGetResponse,
+	BotsListInput,
+	BotsListResponse,
+	ChatbotkitEndpointInputs,
+	ChatbotkitEndpointOutputs,
+} from './endpoints/types';

--- a/packages/chatbotkit/jest.config.cjs
+++ b/packages/chatbotkit/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/chatbotkit/package.json
+++ b/packages/chatbotkit/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/chatbotkit",
+  "version": "0.1.0",
+  "description": "Chatbotkit plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "chatbotkit",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/chatbotkit/package.json
+++ b/packages/chatbotkit/package.json
@@ -8,7 +8,6 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "dev-source": "./index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
@@ -24,6 +23,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
+    "@types/node": "^20.17.19",
     "corsair": "workspace:*",
     "jest": "^29.7.0",
     "ts-jest": "^29.4.9",

--- a/packages/chatbotkit/schema.test.ts
+++ b/packages/chatbotkit/schema.test.ts
@@ -6,15 +6,21 @@ describe('Chatbotkit schema', () => {
 		expect(ChatbotkitSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
 	});
 
-	it('declares an entities map', () => {
+	it('declares all required database entities', () => {
 		expect(typeof ChatbotkitSchema.entities).toBe('object');
 		expect(ChatbotkitSchema.entities).not.toBeNull();
-		expect(Array.isArray(Object.keys(ChatbotkitSchema.entities))).toBe(true);
+		const entityKeys = Object.keys(ChatbotkitSchema.entities);
+		expect(entityKeys).toContain('bots');
+		expect(entityKeys).toContain('datasets');
+		expect(entityKeys).toContain('skillsets');
+		expect(entityKeys).toContain('blueprints');
+		expect(entityKeys).toContain('secrets');
 		for (const entity of Object.values(ChatbotkitSchema.entities)) {
 			expect(entity).toBeDefined();
 		}
 	});
-});
 
-// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
-// needs a corresponding test.
+	it('schema version is 1.0.0', () => {
+		expect(ChatbotkitSchema.version).toBe('1.0.0');
+	});
+});

--- a/packages/chatbotkit/schema.test.ts
+++ b/packages/chatbotkit/schema.test.ts
@@ -15,6 +15,9 @@ describe('Chatbotkit schema', () => {
 		expect(entityKeys).toContain('skillsets');
 		expect(entityKeys).toContain('blueprints');
 		expect(entityKeys).toContain('secrets');
+		expect(entityKeys).toContain('conversations');
+		expect(entityKeys).toContain('files');
+		expect(entityKeys).toContain('tasks');
 		for (const entity of Object.values(ChatbotkitSchema.entities)) {
 			expect(entity).toBeDefined();
 		}

--- a/packages/chatbotkit/schema.test.ts
+++ b/packages/chatbotkit/schema.test.ts
@@ -1,0 +1,20 @@
+import { ChatbotkitSchema } from './schema';
+
+describe('Chatbotkit schema', () => {
+	it('declares a semver version', () => {
+		expect(ChatbotkitSchema.version).toBeDefined();
+		expect(ChatbotkitSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof ChatbotkitSchema.entities).toBe('object');
+		expect(ChatbotkitSchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(ChatbotkitSchema.entities))).toBe(true);
+		for (const entity of Object.values(ChatbotkitSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/chatbotkit/schema/database.ts
+++ b/packages/chatbotkit/schema/database.ts
@@ -1,0 +1,8 @@
+// This plugin doesn't mirror API responses into ctx.db (Bots list/get are
+// read-only lookups); add entities here if a future endpoint needs caching.
+// export const ChatbotkitExample = z.object({
+// 	id: z.string(),
+// 	name: z.string(),
+// 	created_at: z.coerce.date().nullable().optional(),
+// });
+// export type ChatbotkitExample = z.infer<typeof ChatbotkitExample>;

--- a/packages/chatbotkit/schema/database.ts
+++ b/packages/chatbotkit/schema/database.ts
@@ -1,8 +1,168 @@
-// This plugin doesn't mirror API responses into ctx.db (Bots list/get are
-// read-only lookups); add entities here if a future endpoint needs caching.
-// export const ChatbotkitExample = z.object({
-// 	id: z.string(),
-// 	name: z.string(),
-// 	created_at: z.coerce.date().nullable().optional(),
-// });
-// export type ChatbotkitExample = z.infer<typeof ChatbotkitExample>;
+import { z } from 'zod';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ChatbotkitBot
+// Verified against official ChatBotKit API: GET /v1/bot/{botId}/fetch
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ChatbotkitBot = z.object({
+	/** Unique identifier of the bot. */
+	id: z.string(),
+	/** Custom alias assigned to the bot. */
+	alias: z.string().nullable().optional(),
+	/** Display name of the bot. */
+	name: z.string(),
+	/** Brief summary describing the bot's purpose. */
+	description: z.string().nullable().optional(),
+	/** Identifier of the blueprint template associated with the bot. */
+	blueprintId: z.string().nullable().optional(),
+	/** Identifier of the connected knowledge dataset. */
+	datasetId: z.string().nullable().optional(),
+	/** Identifier of the connected skillset containing bot tools. */
+	skillsetId: z.string().nullable().optional(),
+	/** System instructions defining bot personality and behavioral rules. */
+	backstory: z.string().nullable().optional(),
+	/** AI model configured for the bot (e.g. gpt-4o, claude-3-5-sonnet). */
+	model: z.string().nullable().optional(),
+	/** Access visibility level: private, protected, or public. */
+	visibility: z.string().nullable().optional(),
+	/** Custom key-value metadata attached to the bot. */
+	meta: z.record(z.string(), z.unknown()).nullable().optional(),
+	/** Resource creation timestamp. */
+	createdAt: z.coerce.date().nullable().optional(),
+	/** Resource last updated timestamp. */
+	updatedAt: z.coerce.date().nullable().optional(),
+});
+export type ChatbotkitBot = z.infer<typeof ChatbotkitBot>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ChatbotkitDataset
+// Verified against official ChatBotKit API: GET /v1/dataset/{datasetId}/fetch
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ChatbotkitDataset = z.object({
+	/** Unique identifier of the dataset. */
+	id: z.string(),
+	/** Custom alias assigned to the dataset. */
+	alias: z.string().nullable().optional(),
+	/** Display name of the dataset. */
+	name: z.string(),
+	/** Brief summary of the dataset contents. */
+	description: z.string().nullable().optional(),
+	/** Identifier of the blueprint associated with the dataset. */
+	blueprintId: z.string().nullable().optional(),
+	/** Reranker model configured for search relevance. */
+	reranker: z.string().nullable().optional(),
+	/** Maximum token limit per dataset record. */
+	recordMaxTokens: z.number().nullable().optional(),
+	/** Minimum similarity score threshold for search results. */
+	searchMinScore: z.number().nullable().optional(),
+	/** Maximum number of records returned per search query. */
+	searchMaxRecords: z.number().nullable().optional(),
+	/** Maximum tokens allocated for search context. */
+	searchMaxTokens: z.number().nullable().optional(),
+	/** Prompt instructions used when matching content is found. */
+	matchInstruction: z.string().nullable().optional(),
+	/** Prompt instructions used when no matching content is found. */
+	mismatchInstruction: z.string().nullable().optional(),
+	/** Separator characters used for chunking text records. */
+	separators: z.array(z.string()).nullable().optional(),
+	/** Access visibility level: private, protected, or public. */
+	visibility: z.string().nullable().optional(),
+	/** Custom key-value metadata attached to the dataset. */
+	meta: z.record(z.string(), z.unknown()).nullable().optional(),
+	/** Resource creation timestamp. */
+	createdAt: z.coerce.date().nullable().optional(),
+	/** Resource last updated timestamp. */
+	updatedAt: z.coerce.date().nullable().optional(),
+});
+export type ChatbotkitDataset = z.infer<typeof ChatbotkitDataset>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ChatbotkitSkillset
+// Verified against official ChatBotKit API: GET /v1/skillset/{skillsetId}/fetch
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ChatbotkitSkillset = z.object({
+	/** Unique identifier of the skillset. */
+	id: z.string(),
+	/** Custom alias assigned to the skillset. */
+	alias: z.string().nullable().optional(),
+	/** Display name of the skillset. */
+	name: z.string(),
+	/** Brief summary of the skillset tools and capabilities. */
+	description: z.string().nullable().optional(),
+	/** Identifier of the blueprint associated with the skillset. */
+	blueprintId: z.string().nullable().optional(),
+	/** Access visibility level: private, protected, or public. */
+	visibility: z.string().nullable().optional(),
+	/** Current operational state: enabled or disabled. */
+	state: z.string().nullable().optional(),
+	/** Custom key-value metadata attached to the skillset. */
+	meta: z.record(z.string(), z.unknown()).nullable().optional(),
+	/** Resource creation timestamp. */
+	createdAt: z.coerce.date().nullable().optional(),
+	/** Resource last updated timestamp. */
+	updatedAt: z.coerce.date().nullable().optional(),
+});
+export type ChatbotkitSkillset = z.infer<typeof ChatbotkitSkillset>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ChatbotkitBlueprint
+// Verified against official ChatBotKit API: GET /v1/blueprint/{blueprintId}/fetch
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ChatbotkitBlueprint = z.object({
+	/** Unique identifier of the blueprint. */
+	id: z.string(),
+	/** Custom alias assigned to the blueprint. */
+	alias: z.string().nullable().optional(),
+	/** Display name of the blueprint template. */
+	name: z.string(),
+	/** Brief summary of the blueprint template configuration. */
+	description: z.string().nullable().optional(),
+	/** Blueprint configuration parameters and initial resource setup. */
+	config: z.record(z.string(), z.unknown()).nullable().optional(),
+	/** Access visibility level: private, protected, or public. */
+	visibility: z.string().nullable().optional(),
+	/** Custom key-value metadata attached to the blueprint. */
+	meta: z.record(z.string(), z.unknown()).nullable().optional(),
+	/** Resource creation timestamp. */
+	createdAt: z.coerce.date().nullable().optional(),
+	/** Resource last updated timestamp. */
+	updatedAt: z.coerce.date().nullable().optional(),
+});
+export type ChatbotkitBlueprint = z.infer<typeof ChatbotkitBlueprint>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ChatbotkitSecret
+// Verified against official ChatBotKit API: GET /v1/secret/{secretId}/fetch
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ChatbotkitSecret = z.object({
+	/** Unique identifier of the secret credential. */
+	id: z.string(),
+	/** Custom alias assigned to the secret. */
+	alias: z.string().nullable().optional(),
+	/** Display name of the secret credential. */
+	name: z.string(),
+	/** Description of the service or integration using this secret. */
+	description: z.string().nullable().optional(),
+	/** Identifier of the blueprint associated with the secret. */
+	blueprintId: z.string().nullable().optional(),
+	/** Kind of secret (e.g. personal, shared). */
+	kind: z.string().nullable().optional(),
+	/** Type of credential template (e.g. template, custom). */
+	type: z.string().nullable().optional(),
+	/** Configuration details for the authenticated integration. */
+	config: z.record(z.string(), z.unknown()).nullable().optional(),
+	/** Access visibility level: private, protected, or public. */
+	visibility: z.string().nullable().optional(),
+	/** Custom key-value metadata attached to the secret. */
+	meta: z.record(z.string(), z.unknown()).nullable().optional(),
+	/** Resource creation timestamp. */
+	createdAt: z.coerce.date().nullable().optional(),
+	/** Resource last updated timestamp. */
+	updatedAt: z.coerce.date().nullable().optional(),
+});
+export type ChatbotkitSecret = z.infer<typeof ChatbotkitSecret>;

--- a/packages/chatbotkit/schema/database.ts
+++ b/packages/chatbotkit/schema/database.ts
@@ -24,6 +24,10 @@ export const ChatbotkitBot = z.object({
 	backstory: z.string().nullable().optional(),
 	/** AI model configured for the bot (e.g. gpt-4o, claude-3-5-sonnet). */
 	model: z.string().nullable().optional(),
+	/** Whether PII protection and anonymization is enabled. */
+	privacy: z.boolean().nullable().optional(),
+	/** Whether content safety and filtering is active. */
+	moderation: z.boolean().nullable().optional(),
 	/** Access visibility level: private, protected, or public. */
 	visibility: z.string().nullable().optional(),
 	/** Custom key-value metadata attached to the bot. */
@@ -166,3 +170,96 @@ export const ChatbotkitSecret = z.object({
 	updatedAt: z.coerce.date().nullable().optional(),
 });
 export type ChatbotkitSecret = z.infer<typeof ChatbotkitSecret>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ChatbotkitConversation
+// Verified against official ChatBotKit API: GET /v1/conversation/{conversationId}/fetch
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ChatbotkitConversation = z.object({
+	/** Unique identifier of the conversation session. */
+	id: z.string(),
+	/** Custom alias assigned to the conversation. */
+	alias: z.string().nullable().optional(),
+	/** Display name of the conversation session. */
+	name: z.string().nullable().optional(),
+	/** Brief summary of the conversation purpose. */
+	description: z.string().nullable().optional(),
+	/** Identifier of the associated bot. */
+	botId: z.string().nullable().optional(),
+	/** System instructions override for this conversation. */
+	backstory: z.string().nullable().optional(),
+	/** AI model override for this conversation. */
+	model: z.string().nullable().optional(),
+	/** Dataset ID override for this conversation. */
+	datasetId: z.string().nullable().optional(),
+	/** Skillset ID override for this conversation. */
+	skillsetId: z.string().nullable().optional(),
+	/** Identifier of the associated blueprint. */
+	blueprintId: z.string().nullable().optional(),
+	/** Access visibility level: private, protected, or public. */
+	visibility: z.string().nullable().optional(),
+	/** Custom key-value metadata attached to the conversation. */
+	meta: z.record(z.string(), z.unknown()).nullable().optional(),
+	/** Resource creation timestamp. */
+	createdAt: z.coerce.date().nullable().optional(),
+	/** Resource last updated timestamp. */
+	updatedAt: z.coerce.date().nullable().optional(),
+});
+export type ChatbotkitConversation = z.infer<typeof ChatbotkitConversation>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ChatbotkitFile
+// Verified against official ChatBotKit API: GET /v1/file/{fileId}/fetch
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ChatbotkitFile = z.object({
+	/** Unique identifier of the file resource. */
+	id: z.string(),
+	/** Original name of the uploaded file. */
+	name: z.string(),
+	/** Description of the file contents. */
+	description: z.string().nullable().optional(),
+	/** MIME type of the file. */
+	mimeType: z.string().nullable().optional(),
+	/** File size in bytes. */
+	size: z.number().nullable().optional(),
+	/** Access visibility level: private, protected, or public. */
+	visibility: z.string().nullable().optional(),
+	/** Custom key-value metadata attached to the file. */
+	meta: z.record(z.string(), z.unknown()).nullable().optional(),
+	/** Resource creation timestamp. */
+	createdAt: z.coerce.date().nullable().optional(),
+	/** Resource last updated timestamp. */
+	updatedAt: z.coerce.date().nullable().optional(),
+});
+export type ChatbotkitFile = z.infer<typeof ChatbotkitFile>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ChatbotkitTask
+// Verified against official ChatBotKit API: GET /v1/task/{taskId}/fetch
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ChatbotkitTask = z.object({
+	/** Unique identifier of the task. */
+	id: z.string(),
+	/** Descriptive name of the task. */
+	name: z.string(),
+	/** Description of the background task operation. */
+	description: z.string().nullable().optional(),
+	/** Identifier of the bot executing this task. */
+	botId: z.string().nullable().optional(),
+	/** Cron schedule expression for automated execution. */
+	schedule: z.string().nullable().optional(),
+	/** Current task execution status. */
+	status: z.string().nullable().optional(),
+	/** Access visibility level: private, protected, or public. */
+	visibility: z.string().nullable().optional(),
+	/** Custom key-value metadata attached to the task. */
+	meta: z.record(z.string(), z.unknown()).nullable().optional(),
+	/** Resource creation timestamp. */
+	createdAt: z.coerce.date().nullable().optional(),
+	/** Resource last updated timestamp. */
+	updatedAt: z.coerce.date().nullable().optional(),
+});
+export type ChatbotkitTask = z.infer<typeof ChatbotkitTask>;

--- a/packages/chatbotkit/schema/index.ts
+++ b/packages/chatbotkit/schema/index.ts
@@ -1,4 +1,18 @@
+import {
+	ChatbotkitBlueprint,
+	ChatbotkitBot,
+	ChatbotkitDataset,
+	ChatbotkitSecret,
+	ChatbotkitSkillset,
+} from './database';
+
 export const ChatbotkitSchema = {
 	version: '1.0.0',
-	entities: {},
+	entities: {
+		bots: ChatbotkitBot,
+		datasets: ChatbotkitDataset,
+		skillsets: ChatbotkitSkillset,
+		blueprints: ChatbotkitBlueprint,
+		secrets: ChatbotkitSecret,
+	},
 } as const;

--- a/packages/chatbotkit/schema/index.ts
+++ b/packages/chatbotkit/schema/index.ts
@@ -1,0 +1,4 @@
+export const ChatbotkitSchema = {
+	version: '1.0.0',
+	entities: {},
+} as const;

--- a/packages/chatbotkit/schema/index.ts
+++ b/packages/chatbotkit/schema/index.ts
@@ -1,9 +1,12 @@
 import {
 	ChatbotkitBlueprint,
 	ChatbotkitBot,
+	ChatbotkitConversation,
 	ChatbotkitDataset,
+	ChatbotkitFile,
 	ChatbotkitSecret,
 	ChatbotkitSkillset,
+	ChatbotkitTask,
 } from './database';
 
 export const ChatbotkitSchema = {
@@ -14,5 +17,8 @@ export const ChatbotkitSchema = {
 		skillsets: ChatbotkitSkillset,
 		blueprints: ChatbotkitBlueprint,
 		secrets: ChatbotkitSecret,
+		conversations: ChatbotkitConversation,
+		files: ChatbotkitFile,
+		tasks: ChatbotkitTask,
 	},
 } as const;

--- a/packages/chatbotkit/tsconfig.json
+++ b/packages/chatbotkit/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/chatbotkit/tsup.config.ts
+++ b/packages/chatbotkit/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -18,7 +18,6 @@ export const BaseProviders = [
 	'abyssale',
 	'accrediblecertificates',
 	'activecampaign',
-	'anchorbrowser',
 	'activetrail',
 	'addresszen',
 	'aeroleads',
@@ -40,14 +39,15 @@ export const BaseProviders = [
 	'ambientweather',
 	'amcards',
 	'amplitude',
+	'anchorbrowser',
 	'anthropicadministrator',
 	'apaleo',
 	'api2pdf',
 	'apibible',
-	'apipie',
 	'apify',
 	'apilabz',
 	'apininjas',
+	'apipie',
 	'apisports',
 	'asana',
 	'asindataapi',
@@ -70,6 +70,7 @@ export const BaseProviders = [
 	'calendly',
 	'canva',
 	'canvas',
+	'chatbotkit',
 	'circleci',
 	'clientary',
 	'cloudflare',
@@ -92,8 +93,8 @@ export const BaseProviders = [
 	'facebook',
 	'figma',
 	'firecrawl',
-	'formbricks',
 	'fireflies',
+	'formbricks',
 	'gemini',
 	'github',
 	'gitlab',
@@ -185,7 +186,6 @@ export const ProviderDisplayNames = {
 	abyssale: 'Abyssale',
 	accrediblecertificates: 'Accredible Certificates',
 	activecampaign: 'ActiveCampaign',
-	anchorbrowser: 'Anchor Browser',
 	activetrail: 'Active Trail',
 	addresszen: 'Addresszen',
 	aeroleads: 'Aeroleads',
@@ -207,14 +207,15 @@ export const ProviderDisplayNames = {
 	ambientweather: 'Ambient Weather',
 	amcards: 'AMcards',
 	amplitude: 'Amplitude',
+	anchorbrowser: 'Anchor Browser',
 	anthropicadministrator: 'Anthropic Administrator',
 	apaleo: 'Apaleo',
 	api2pdf: 'API2PDF',
 	apibible: 'API.Bible',
-	apipie: 'APIpie AI',
 	apify: 'Apify',
 	apilabz: 'API Labz',
 	apininjas: 'API Ninjas',
+	apipie: 'APIpie AI',
 	apisports: 'API-Sports',
 	asana: 'Asana',
 	asindataapi: 'ASIN Data API',
@@ -237,6 +238,7 @@ export const ProviderDisplayNames = {
 	calendly: 'Calendly',
 	canva: 'Canva',
 	canvas: 'Canvas LMS',
+	chatbotkit: 'Chatbotkit',
 	circleci: 'CircleCI',
 	clientary: 'Clientary',
 	cloudflare: 'Cloudflare',
@@ -259,8 +261,8 @@ export const ProviderDisplayNames = {
 	facebook: 'Facebook',
 	figma: 'Figma',
 	firecrawl: 'Firecrawl',
-	formbricks: 'Formbricks',
 	fireflies: 'Fireflies',
+	formbricks: 'Formbricks',
 	gemini: 'Gemini',
 	github: 'GitHub',
 	gitlab: 'GitLab',
@@ -359,7 +361,6 @@ export type AllProviders =
 	| 'abyssale'
 	| 'accrediblecertificates'
 	| 'activecampaign'
-	| 'anchorbrowser'
 	| 'activetrail'
 	| 'addresszen'
 	| 'aeroleads'
@@ -381,14 +382,15 @@ export type AllProviders =
 	| 'ambientweather'
 	| 'amcards'
 	| 'amplitude'
+	| 'anchorbrowser'
 	| 'anthropicadministrator'
 	| 'apaleo'
 	| 'api2pdf'
 	| 'apibible'
-	| 'apipie'
 	| 'apify'
 	| 'apilabz'
 	| 'apininjas'
+	| 'apipie'
 	| 'apisports'
 	| 'asana'
 	| 'asindataapi'
@@ -411,6 +413,7 @@ export type AllProviders =
 	| 'calendly'
 	| 'canva'
 	| 'canvas'
+	| 'chatbotkit'
 	| 'circleci'
 	| 'clientary'
 	| 'cloudflare'
@@ -433,8 +436,8 @@ export type AllProviders =
 	| 'facebook'
 	| 'figma'
 	| 'firecrawl'
-	| 'formbricks'
 	| 'fireflies'
+	| 'formbricks'
 	| 'gemini'
 	| 'github'
 	| 'gitlab'

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -238,7 +238,7 @@ export const ProviderDisplayNames = {
 	calendly: 'Calendly',
 	canva: 'Canva',
 	canvas: 'Canvas LMS',
-	chatbotkit: 'Chatbotkit',
+	chatbotkit: 'ChatBotKit',
 	circleci: 'CircleCI',
 	clientary: 'Clientary',
 	cloudflare: 'Cloudflare',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1722,15 +1722,18 @@ importers:
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
+      '@types/node':
+        specifier: ^20.17.19
+        version: 20.19.25
       corsair:
         specifier: workspace:*
         version: link:../corsair
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+        version: 29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -18372,6 +18375,41 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 24.10.1
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   '@jest/core@29.7.0(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
@@ -23030,6 +23068,21 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 4.7.0
 
+  create-jest@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   create-jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
@@ -24675,6 +24728,25 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-cli@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-cli@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
@@ -24693,6 +24765,68 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  jest-config@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.19.25
+      ts-node: 10.9.2(@types/node@20.19.25)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 24.10.1
+      ts-node: 10.9.2(@types/node@20.19.25)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   jest-config@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)):
     dependencies:
@@ -24979,6 +25113,18 @@ snapshots:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
+
+  jest@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)):
     dependencies:
@@ -27875,10 +28021,49 @@ snapshots:
       esbuild: 0.27.0
       jest-util: 30.4.1
 
+  ts-jest@29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3)))(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.9
+      jest: 29.7.0(@types/node@20.19.25)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3))
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.8.5
+      type-fest: 4.41.0
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.29.7
+      '@jest/transform': 29.7.0
+      '@jest/types': 30.4.1
+      babel-jest: 29.7.0(@babel/core@7.29.7)
+      jest-util: 30.4.1
+
   ts-morph@26.0.0:
     dependencies:
       '@ts-morph/common': 0.27.0
       code-block-writer: 13.0.3
+
+  ts-node@10.9.2(@types/node@20.19.25)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.19.25
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
 
   ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1717,6 +1717,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/chatbotkit:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/circleci:
     devDependencies:
       '@types/jest':


### PR DESCRIPTION
## Description

Adds a new `packages/chatbotkit/` plugin integrating ChatBotKit (chatbotkit.com)'s v1 REST API. Scoped to core `bots` operations for this PR:

- `bots.list` — cursor-paginated bot listing
- `bots.get` — fetch a single bot by ID

Auth: API secret key (`sk-...`) as a Bearer token, per https://chatbotkit.com/manuals/authentication. Responses are unwrapped from ChatBotKit's `{ success, data, meta }` envelope. Errors are routed through `error-handlers.ts` (auth, rate-limit with retry, not-found, default), inputs/outputs are zod-validated, and list pagination is supported via `cursor`/`limit`/`order`.

Generated with `pnpm generate:plugin Chatbotkit`; example/placeholder endpoints and unused webhook scaffolding were removed since this plugin doesn't need webhooks yet.

Closes #922 
## Checklist

- [x] Scoped to `packages/chatbotkit/**`, the `packages/corsair/core/constants.ts` registration, and `pnpm-lock.yaml` only
- [x] Tests included (`packages/chatbotkit/api.test.ts`, `schema.test.ts`) with real assertions covering both endpoints, auth config, and error classification
- [x] `pnpm typecheck` passes
- [x] `pnpm run validate:plugins` passes
- [x] `pnpm --filter @corsair-dev/chatbotkit test` passes (14/14)
- [x] Biome lint/format clean

## Screenshots / Demos
<img width="700" height="569" alt="Screenshot 2026-08-22 at 5 07 48 PM" src="https://github.com/user-attachments/assets/913fabd5-c13f-4193-9bd3-fbee35d2a8b3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded ChatBotKit integration beyond bots to datasets, skillsets, blueprints, secrets, conversations, files, and tasks.
  - Added listing, retrieval, creation, updating, and deletion for supported resources, plus search, voting, and conversation completion where available.
  - Added validated request and response schemas with pagination support.
  - Improved API response and error handling, including rate-limit retries and missing-resource handling.
  - Added ChatBotKit to the available provider integrations.

- **Tests**
  - Expanded coverage for resource operations, schemas, request contracts, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->