### PR TITLE
feat: add Contentful plugin

### DIFF
--- a/demo/testing/package.json
+++ b/demo/testing/package.json
@@ -27,6 +27,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.0",
     "@corsair-dev/agentql": "workspace:*",
     "@corsair-dev/bitwarden": "workspace:*",
+    "@corsair-dev/contentful": "workspace:*",
     "@corsair-dev/cursor": "workspace:*",
     "@corsair-dev/firecrawl": "workspace:*",
     "@corsair-dev/github": "workspace:*",

--- a/demo/testing/src/scripts/test-script.ts
+++ b/demo/testing/src/scripts/test-script.ts
@@ -35,7 +35,9 @@ const main = async () => {
 		});
 		console.log('Contentful Space:', contentfulRes.name);
 	} else {
-		console.log('Skipping Contentful demo test: missing CONTENTFUL_API_KEY or CONTENTFUL_SPACE_ID in .env');
+		console.log(
+			'Skipping Contentful demo test: missing CONTENTFUL_API_KEY or CONTENTFUL_SPACE_ID in .env',
+		);
 	}
 
 	// Keep existing slack test to not break other things

--- a/demo/testing/src/scripts/test-script.ts
+++ b/demo/testing/src/scripts/test-script.ts
@@ -18,11 +18,36 @@ async function setInstagramCredentials() {
 	}
 }
 
+async function setContentfulCredentials() {
+	const { CONTENTFUL_API_KEY } = process.env;
+	if (CONTENTFUL_API_KEY) {
+		await corsair.contentful.keys.set_api_key(CONTENTFUL_API_KEY);
+	}
+}
+
 const main = async () => {
-	const res = await corsair.slack.api.messages.post({
-		channel: 'general',
-		text: 'hello',
-	});
+	const { CONTENTFUL_API_KEY, CONTENTFUL_SPACE_ID } = process.env;
+
+	if (CONTENTFUL_API_KEY && CONTENTFUL_SPACE_ID) {
+		await setContentfulCredentials();
+		const contentfulRes = await corsair.contentful.api.spaces.get({
+			spaceId: CONTENTFUL_SPACE_ID,
+		});
+		console.log('Contentful Space:', contentfulRes.name);
+	} else {
+		console.log('Skipping Contentful demo test: missing CONTENTFUL_API_KEY or CONTENTFUL_SPACE_ID in .env');
+	}
+
+	// Keep existing slack test to not break other things
+	if (process.env.SLACK_BOT_TOKEN) {
+		const res = await corsair.slack.api.messages.post({
+			channel: 'general',
+			text: 'hello',
+		});
+		console.log('Slack response:', res.ok);
+	} else {
+		console.log('Skipping Slack demo test: missing SLACK_BOT_TOKEN');
+	}
 };
 
 main().catch((err) => {

--- a/demo/testing/src/server/corsair.ts
+++ b/demo/testing/src/server/corsair.ts
@@ -3,6 +3,7 @@ import dotenv from 'dotenv';
 dotenv.config({ path: '../.env' });
 
 import { agentql } from '@corsair-dev/agentql';
+import { contentful } from '@corsair-dev/contentful';
 import { gmail } from '@corsair-dev/gmail';
 import { googlecalendar } from '@corsair-dev/googlecalendar';
 import { googlesheets } from '@corsair-dev/googlesheets';
@@ -63,6 +64,7 @@ export const corsair = createCorsair({
 			key: process.env.VAPI_API_KEY,
 			webhookSecret: process.env.VAPI_WEBHOOK_SECRET,
 		}),
+		contentful(),
 		instagram(),
 	],
 });

--- a/packages/contentful/client.ts
+++ b/packages/contentful/client.ts
@@ -14,6 +14,7 @@ export class ContentfulAPIError extends Error {
 
 const CONTENTFUL_API_BASE = 'https://api.contentful.com';
 
+/** Executes an authenticated request to the Contentful Content Management API. */
 export async function makeContentfulRequest<T>(
 	endpoint: string,
 	apiKey: string,

--- a/packages/contentful/client.ts
+++ b/packages/contentful/client.ts
@@ -1,0 +1,75 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { request } from 'corsair/http';
+
+export class ContentfulAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly code?: number,
+		public readonly retryAfter?: number,
+	) {
+		super(message);
+		this.name = 'ContentfulAPIError';
+	}
+}
+
+const CONTENTFUL_API_BASE = 'https://api.contentful.com';
+
+export async function makeContentfulRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	options: {
+		method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+		body?: Record<string, unknown>;
+		query?: Record<string, string | number | boolean | undefined>;
+		headers?: Record<string, string>;
+	} = {},
+): Promise<T> {
+	const { method = 'GET', body, query, headers = {} } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: CONTENTFUL_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: apiKey,
+		HEADERS: {
+			'Content-Type': 'application/vnd.contentful.management.v1+json',
+			...headers,
+		},
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint,
+		body:
+			method === 'POST' || method === 'PUT' || method === 'PATCH'
+				? body
+				: undefined,
+		mediaType: 'application/vnd.contentful.management.v1+json',
+		query: method === 'GET' ? query : undefined,
+	};
+
+	try {
+		return await request<T>(config, requestOptions);
+	} catch (error) {
+		if (
+			error &&
+			typeof error === 'object' &&
+			'status' in error &&
+			typeof error.status === 'number'
+		) {
+			const retryAfter =
+				'retryAfter' in error && typeof error.retryAfter === 'number'
+					? error.retryAfter
+					: undefined;
+			throw new ContentfulAPIError(
+				error instanceof Error ? error.message : 'Contentful API error',
+				error.status,
+				retryAfter,
+			);
+		}
+		throw new ContentfulAPIError(
+			error instanceof Error ? error.message : 'Unknown error',
+		);
+	}
+}

--- a/packages/contentful/endpoints.test.ts
+++ b/packages/contentful/endpoints.test.ts
@@ -1,6 +1,12 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeContentfulRequest } from './client';
-import { Entries, Environments, Spaces } from './endpoints';
+import {
+	Assets,
+	ContentTypes,
+	Entries,
+	Environments,
+	Spaces,
+} from './endpoints';
 
 jest.mock('./client', () => ({
 	makeContentfulRequest: jest.fn(),
@@ -107,6 +113,155 @@ describe('Contentful Endpoints', () => {
 						skip: 10,
 						limit: 20,
 						'sys.id': 'entry-123',
+					},
+				},
+			);
+			expect(response).toEqual({ sys: { type: 'Array' }, items: [] });
+		});
+	});
+
+	describe('entries.create', () => {
+		it('constructs correct URL and payload and returns response', async () => {
+			(makeContentfulRequest as jest.Mock).mockResolvedValue({
+				sys: { id: 'new-entry' },
+			});
+
+			const response = await Entries.create(mockCtx, {
+				spaceId: 'space-123',
+				environmentId: 'master',
+				contentTypeId: 'post',
+				fields: { title: { 'en-US': 'Hello' } },
+			});
+
+			expect(makeContentfulRequest).toHaveBeenCalledWith(
+				'/spaces/space-123/environments/master/entries',
+				'test-api-key',
+				{
+					method: 'POST',
+					headers: { 'X-Contentful-Content-Type': 'post' },
+					body: { fields: { title: { 'en-US': 'Hello' } } },
+				},
+			);
+			expect(response).toEqual({ sys: { id: 'new-entry' } });
+		});
+	});
+
+	describe('entries.update', () => {
+		it('constructs correct URL and payload and returns response', async () => {
+			(makeContentfulRequest as jest.Mock).mockResolvedValue({
+				sys: { id: 'entry-123', version: 3 },
+			});
+
+			const response = await Entries.update(mockCtx, {
+				spaceId: 'space-123',
+				environmentId: 'master',
+				entryId: 'entry-123',
+				version: 2,
+				fields: { title: { 'en-US': 'Updated' } },
+			});
+
+			expect(makeContentfulRequest).toHaveBeenCalledWith(
+				'/spaces/space-123/environments/master/entries/entry-123',
+				'test-api-key',
+				{
+					method: 'PUT',
+					headers: { 'X-Contentful-Version': '2' },
+					body: { fields: { title: { 'en-US': 'Updated' } } },
+				},
+			);
+			expect(response).toEqual({ sys: { id: 'entry-123', version: 3 } });
+		});
+	});
+
+	describe('content_types.get', () => {
+		it('constructs correct URL and returns response', async () => {
+			(makeContentfulRequest as jest.Mock).mockResolvedValue({
+				sys: { id: 'post' },
+			});
+
+			const response = await ContentTypes.get(mockCtx, {
+				spaceId: 'space-123',
+				environmentId: 'master',
+				contentTypeId: 'post',
+			});
+
+			expect(makeContentfulRequest).toHaveBeenCalledWith(
+				'/spaces/space-123/environments/master/content_types/post',
+				'test-api-key',
+				{ method: 'GET' },
+			);
+			expect(response).toEqual({ sys: { id: 'post' } });
+		});
+	});
+
+	describe('content_types.list', () => {
+		it('constructs correct URL and returns response', async () => {
+			(makeContentfulRequest as jest.Mock).mockResolvedValue({
+				sys: { type: 'Array' },
+				items: [],
+			});
+
+			const response = await ContentTypes.list(mockCtx, {
+				spaceId: 'space-123',
+				environmentId: 'master',
+			});
+
+			expect(makeContentfulRequest).toHaveBeenCalledWith(
+				'/spaces/space-123/environments/master/content_types',
+				'test-api-key',
+				{
+					method: 'GET',
+					query: {
+						skip: undefined,
+						limit: undefined,
+					},
+				},
+			);
+			expect(response).toEqual({ sys: { type: 'Array' }, items: [] });
+		});
+	});
+
+	describe('assets.get', () => {
+		it('constructs correct URL and returns response', async () => {
+			(makeContentfulRequest as jest.Mock).mockResolvedValue({
+				sys: { id: 'asset-123' },
+			});
+
+			const response = await Assets.get(mockCtx, {
+				spaceId: 'space-123',
+				environmentId: 'master',
+				assetId: 'asset-123',
+			});
+
+			expect(makeContentfulRequest).toHaveBeenCalledWith(
+				'/spaces/space-123/environments/master/assets/asset-123',
+				'test-api-key',
+				{ method: 'GET' },
+			);
+			expect(response).toEqual({ sys: { id: 'asset-123' } });
+		});
+	});
+
+	describe('assets.list', () => {
+		it('constructs correct URL and returns response', async () => {
+			(makeContentfulRequest as jest.Mock).mockResolvedValue({
+				sys: { type: 'Array' },
+				items: [],
+			});
+
+			const response = await Assets.list(mockCtx, {
+				spaceId: 'space-123',
+				environmentId: 'master',
+			});
+
+			expect(makeContentfulRequest).toHaveBeenCalledWith(
+				'/spaces/space-123/environments/master/assets',
+				'test-api-key',
+				{
+					method: 'GET',
+					query: {
+						skip: undefined,
+						limit: undefined,
 					},
 				},
 			);

--- a/packages/contentful/endpoints.test.ts
+++ b/packages/contentful/endpoints.test.ts
@@ -1,0 +1,116 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeContentfulRequest } from './client';
+import { Entries, Environments, Spaces } from './endpoints';
+
+jest.mock('./client', () => ({
+	makeContentfulRequest: jest.fn(),
+}));
+
+jest.mock('corsair/core', () => ({
+	logEventFromContext: jest.fn(),
+}));
+
+describe('Contentful Endpoints', () => {
+	const mockCtx = {
+		key: 'test-api-key',
+	} as any;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('spaces.get', () => {
+		it('constructs correct URL and returns response', async () => {
+			(makeContentfulRequest as jest.Mock).mockResolvedValue({
+				sys: { id: 'space-123' },
+			});
+
+			const response = await Spaces.get(mockCtx, { spaceId: 'space-123' });
+
+			expect(makeContentfulRequest).toHaveBeenCalledWith(
+				'/spaces/space-123',
+				'test-api-key',
+				{ method: 'GET' },
+			);
+			expect(logEventFromContext).toHaveBeenCalledWith(
+				mockCtx,
+				'contentful.spaces.get',
+				{ spaceId: 'space-123' },
+				'completed',
+			);
+			expect(response).toEqual({ sys: { id: 'space-123' } });
+		});
+	});
+
+	describe('environments.get', () => {
+		it('constructs correct URL and returns response', async () => {
+			(makeContentfulRequest as jest.Mock).mockResolvedValue({
+				sys: { id: 'master' },
+			});
+
+			const response = await Environments.get(mockCtx, {
+				spaceId: 'space-123',
+				environmentId: 'master',
+			});
+
+			expect(makeContentfulRequest).toHaveBeenCalledWith(
+				'/spaces/space-123/environments/master',
+				'test-api-key',
+				{ method: 'GET' },
+			);
+			expect(response).toEqual({ sys: { id: 'master' } });
+		});
+	});
+
+	describe('entries.get', () => {
+		it('constructs correct URL and returns response', async () => {
+			(makeContentfulRequest as jest.Mock).mockResolvedValue({
+				sys: { id: 'entry-123' },
+			});
+
+			const response = await Entries.get(mockCtx, {
+				spaceId: 'space-123',
+				environmentId: 'master',
+				entryId: 'entry-123',
+			});
+
+			expect(makeContentfulRequest).toHaveBeenCalledWith(
+				'/spaces/space-123/environments/master/entries/entry-123',
+				'test-api-key',
+				{ method: 'GET' },
+			);
+			expect(response).toEqual({ sys: { id: 'entry-123' } });
+		});
+	});
+
+	describe('entries.list', () => {
+		it('constructs correct URL, sends query parameters, and returns response', async () => {
+			(makeContentfulRequest as jest.Mock).mockResolvedValue({
+				sys: { type: 'Array' },
+				items: [],
+			});
+
+			const response = await Entries.list(mockCtx, {
+				spaceId: 'space-123',
+				environmentId: 'master',
+				skip: 10,
+				limit: 20,
+				query: { 'sys.id': 'entry-123' },
+			});
+
+			expect(makeContentfulRequest).toHaveBeenCalledWith(
+				'/spaces/space-123/environments/master/entries',
+				'test-api-key',
+				{
+					method: 'GET',
+					query: {
+						skip: 10,
+						limit: 20,
+						'sys.id': 'entry-123',
+					},
+				},
+			);
+			expect(response).toEqual({ sys: { type: 'Array' }, items: [] });
+		});
+	});
+});

--- a/packages/contentful/endpoints/assets.ts
+++ b/packages/contentful/endpoints/assets.ts
@@ -1,0 +1,48 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ContentfulEndpoints } from '..';
+import { makeContentfulRequest } from '../client';
+import type { ContentfulEndpointOutputs } from './types';
+
+/** Retrieves a specific asset from the Contentful Management API. */
+export const get: ContentfulEndpoints['assetsGet'] = async (ctx, input) => {
+	const response = await makeContentfulRequest<
+		ContentfulEndpointOutputs['assetsGet']
+	>(
+		`/spaces/${input.spaceId}/environments/${input.environmentId}/assets/${input.assetId}`,
+		ctx.key,
+		{ method: 'GET' },
+	);
+
+	await logEventFromContext(
+		ctx,
+		'contentful.assets.get',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+/** Retrieves a list of assets from the Contentful Management API. */
+export const list: ContentfulEndpoints['assetsList'] = async (ctx, input) => {
+	const query: Record<string, string | number | boolean | undefined> = {
+		skip: input.skip,
+		limit: input.limit,
+		...input.query,
+	};
+
+	const response = await makeContentfulRequest<
+		ContentfulEndpointOutputs['assetsList']
+	>(
+		`/spaces/${input.spaceId}/environments/${input.environmentId}/assets`,
+		ctx.key,
+		{ method: 'GET', query },
+	);
+
+	await logEventFromContext(
+		ctx,
+		'contentful.assets.list',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};

--- a/packages/contentful/endpoints/content-types.ts
+++ b/packages/contentful/endpoints/content-types.ts
@@ -1,0 +1,54 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ContentfulEndpoints } from '..';
+import { makeContentfulRequest } from '../client';
+import type { ContentfulEndpointOutputs } from './types';
+
+/** Retrieves a specific content type from the Contentful Management API. */
+export const get: ContentfulEndpoints['contentTypesGet'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeContentfulRequest<
+		ContentfulEndpointOutputs['contentTypesGet']
+	>(
+		`/spaces/${input.spaceId}/environments/${input.environmentId}/content_types/${input.contentTypeId}`,
+		ctx.key,
+		{ method: 'GET' },
+	);
+
+	await logEventFromContext(
+		ctx,
+		'contentful.content_types.get',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+/** Retrieves a list of content types from the Contentful Management API. */
+export const list: ContentfulEndpoints['contentTypesList'] = async (
+	ctx,
+	input,
+) => {
+	const query: Record<string, string | number | boolean | undefined> = {
+		skip: input.skip,
+		limit: input.limit,
+		...input.query,
+	};
+
+	const response = await makeContentfulRequest<
+		ContentfulEndpointOutputs['contentTypesList']
+	>(
+		`/spaces/${input.spaceId}/environments/${input.environmentId}/content_types`,
+		ctx.key,
+		{ method: 'GET', query },
+	);
+
+	await logEventFromContext(
+		ctx,
+		'contentful.content_types.list',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};

--- a/packages/contentful/endpoints/entries.ts
+++ b/packages/contentful/endpoints/entries.ts
@@ -1,0 +1,46 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ContentfulEndpoints } from '..';
+import { makeContentfulRequest } from '../client';
+import type { ContentfulEndpointOutputs } from './types';
+
+export const get: ContentfulEndpoints['entriesGet'] = async (ctx, input) => {
+	const response = await makeContentfulRequest<
+		ContentfulEndpointOutputs['entriesGet']
+	>(
+		`/spaces/${input.spaceId}/environments/${input.environmentId}/entries/${input.entryId}`,
+		ctx.key,
+		{ method: 'GET' },
+	);
+
+	await logEventFromContext(
+		ctx,
+		'contentful.entries.get',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+export const list: ContentfulEndpoints['entriesList'] = async (ctx, input) => {
+	const query: Record<string, string | number | boolean | undefined> = {
+		skip: input.skip,
+		limit: input.limit,
+		...input.query,
+	};
+
+	const response = await makeContentfulRequest<
+		ContentfulEndpointOutputs['entriesList']
+	>(
+		`/spaces/${input.spaceId}/environments/${input.environmentId}/entries`,
+		ctx.key,
+		{ method: 'GET', query },
+	);
+
+	await logEventFromContext(
+		ctx,
+		'contentful.entries.list',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};

--- a/packages/contentful/endpoints/entries.ts
+++ b/packages/contentful/endpoints/entries.ts
@@ -3,6 +3,7 @@ import type { ContentfulEndpoints } from '..';
 import { makeContentfulRequest } from '../client';
 import type { ContentfulEndpointOutputs } from './types';
 
+/** Retrieves a specific entry from the Contentful Management API. */
 export const get: ContentfulEndpoints['entriesGet'] = async (ctx, input) => {
 	const response = await makeContentfulRequest<
 		ContentfulEndpointOutputs['entriesGet']
@@ -21,6 +22,7 @@ export const get: ContentfulEndpoints['entriesGet'] = async (ctx, input) => {
 	return response;
 };
 
+/** Retrieves a list of entries from the Contentful Management API. */
 export const list: ContentfulEndpoints['entriesList'] = async (ctx, input) => {
 	const query: Record<string, string | number | boolean | undefined> = {
 		skip: input.skip,
@@ -39,6 +41,58 @@ export const list: ContentfulEndpoints['entriesList'] = async (ctx, input) => {
 	await logEventFromContext(
 		ctx,
 		'contentful.entries.list',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+/** Creates a new entry in the Contentful Management API. */
+export const create: ContentfulEndpoints['entriesCreate'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeContentfulRequest<
+		ContentfulEndpointOutputs['entriesCreate']
+	>(
+		`/spaces/${input.spaceId}/environments/${input.environmentId}/entries`,
+		ctx.key,
+		{
+			method: 'POST',
+			headers: { 'X-Contentful-Content-Type': input.contentTypeId },
+			body: { fields: input.fields },
+		},
+	);
+
+	await logEventFromContext(
+		ctx,
+		'contentful.entries.create',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+/** Updates an existing entry in the Contentful Management API. */
+export const update: ContentfulEndpoints['entriesUpdate'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeContentfulRequest<
+		ContentfulEndpointOutputs['entriesUpdate']
+	>(
+		`/spaces/${input.spaceId}/environments/${input.environmentId}/entries/${input.entryId}`,
+		ctx.key,
+		{
+			method: 'PUT',
+			headers: { 'X-Contentful-Version': input.version.toString() },
+			body: { fields: input.fields },
+		},
+	);
+
+	await logEventFromContext(
+		ctx,
+		'contentful.entries.update',
 		{ ...input },
 		'completed',
 	);

--- a/packages/contentful/endpoints/environments.ts
+++ b/packages/contentful/endpoints/environments.ts
@@ -1,0 +1,23 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ContentfulEndpoints } from '..';
+import { makeContentfulRequest } from '../client';
+import type { ContentfulEndpointOutputs } from './types';
+
+export const get: ContentfulEndpoints['environmentsGet'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeContentfulRequest<
+		ContentfulEndpointOutputs['environmentsGet']
+	>(`/spaces/${input.spaceId}/environments/${input.environmentId}`, ctx.key, {
+		method: 'GET',
+	});
+
+	await logEventFromContext(
+		ctx,
+		'contentful.environments.get',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};

--- a/packages/contentful/endpoints/index.ts
+++ b/packages/contentful/endpoints/index.ts
@@ -1,3 +1,5 @@
+export * as Assets from './assets';
+export * as ContentTypes from './content-types';
 export * as Entries from './entries';
 export * as Environments from './environments';
 export * as Spaces from './spaces';

--- a/packages/contentful/endpoints/index.ts
+++ b/packages/contentful/endpoints/index.ts
@@ -1,0 +1,3 @@
+export * as Entries from './entries';
+export * as Environments from './environments';
+export * as Spaces from './spaces';

--- a/packages/contentful/endpoints/spaces.ts
+++ b/packages/contentful/endpoints/spaces.ts
@@ -1,0 +1,18 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ContentfulEndpoints } from '..';
+import { makeContentfulRequest } from '../client';
+import type { ContentfulEndpointOutputs } from './types';
+
+export const get: ContentfulEndpoints['spacesGet'] = async (ctx, input) => {
+	const response = await makeContentfulRequest<
+		ContentfulEndpointOutputs['spacesGet']
+	>(`/spaces/${input.spaceId}`, ctx.key, { method: 'GET' });
+
+	await logEventFromContext(
+		ctx,
+		'contentful.spaces.get',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};

--- a/packages/contentful/endpoints/types.ts
+++ b/packages/contentful/endpoints/types.ts
@@ -41,6 +41,42 @@ const EntryListSchema = z
 	})
 	.passthrough();
 
+const ContentTypeSchema = z
+	.object({
+		sys: SysSchema,
+		name: z.string().optional(),
+		description: z.string().optional(),
+		fields: z.array(z.record(z.string(), z.any())).optional(),
+	})
+	.passthrough();
+
+const ContentTypeListSchema = z
+	.object({
+		sys: z.object({ type: z.string() }).passthrough(),
+		total: z.number(),
+		skip: z.number(),
+		limit: z.number(),
+		items: z.array(ContentTypeSchema),
+	})
+	.passthrough();
+
+const AssetSchema = z
+	.object({
+		sys: SysSchema,
+		fields: z.record(z.string(), z.any()).optional(),
+	})
+	.passthrough();
+
+const AssetListSchema = z
+	.object({
+		sys: z.object({ type: z.string() }).passthrough(),
+		total: z.number(),
+		skip: z.number(),
+		limit: z.number(),
+		items: z.array(AssetSchema),
+	})
+	.passthrough();
+
 export const SpacesGetInputSchema = z.object({
 	spaceId: z.string(),
 });
@@ -64,6 +100,49 @@ export const EntriesListInputSchema = z.object({
 	query: z.record(z.string(), z.string()).optional(),
 });
 
+export const EntriesCreateInputSchema = z.object({
+	spaceId: z.string(),
+	environmentId: z.string(),
+	contentTypeId: z.string(),
+	fields: z.record(z.string(), z.any()),
+});
+
+export const EntriesUpdateInputSchema = z.object({
+	spaceId: z.string(),
+	environmentId: z.string(),
+	entryId: z.string(),
+	version: z.number(),
+	fields: z.record(z.string(), z.any()),
+});
+
+export const ContentTypesGetInputSchema = z.object({
+	spaceId: z.string(),
+	environmentId: z.string(),
+	contentTypeId: z.string(),
+});
+
+export const ContentTypesListInputSchema = z.object({
+	spaceId: z.string(),
+	environmentId: z.string(),
+	skip: z.number().optional(),
+	limit: z.number().optional(),
+	query: z.record(z.string(), z.string()).optional(),
+});
+
+export const AssetsGetInputSchema = z.object({
+	spaceId: z.string(),
+	environmentId: z.string(),
+	assetId: z.string(),
+});
+
+export const AssetsListInputSchema = z.object({
+	spaceId: z.string(),
+	environmentId: z.string(),
+	skip: z.number().optional(),
+	limit: z.number().optional(),
+	query: z.record(z.string(), z.string()).optional(),
+});
+
 export type SpacesGetInput = z.infer<typeof SpacesGetInputSchema>;
 export type SpacesGetResponse = z.infer<typeof SpaceSchema>;
 
@@ -76,11 +155,35 @@ export type EntriesGetResponse = z.infer<typeof EntrySchema>;
 export type EntriesListInput = z.infer<typeof EntriesListInputSchema>;
 export type EntriesListResponse = z.infer<typeof EntryListSchema>;
 
+export type EntriesCreateInput = z.infer<typeof EntriesCreateInputSchema>;
+export type EntriesCreateResponse = z.infer<typeof EntrySchema>;
+
+export type EntriesUpdateInput = z.infer<typeof EntriesUpdateInputSchema>;
+export type EntriesUpdateResponse = z.infer<typeof EntrySchema>;
+
+export type ContentTypesGetInput = z.infer<typeof ContentTypesGetInputSchema>;
+export type ContentTypesGetResponse = z.infer<typeof ContentTypeSchema>;
+
+export type ContentTypesListInput = z.infer<typeof ContentTypesListInputSchema>;
+export type ContentTypesListResponse = z.infer<typeof ContentTypeListSchema>;
+
+export type AssetsGetInput = z.infer<typeof AssetsGetInputSchema>;
+export type AssetsGetResponse = z.infer<typeof AssetSchema>;
+
+export type AssetsListInput = z.infer<typeof AssetsListInputSchema>;
+export type AssetsListResponse = z.infer<typeof AssetListSchema>;
+
 export type ContentfulEndpointInputs = {
 	spacesGet: SpacesGetInput;
 	environmentsGet: EnvironmentsGetInput;
 	entriesGet: EntriesGetInput;
 	entriesList: EntriesListInput;
+	entriesCreate: EntriesCreateInput;
+	entriesUpdate: EntriesUpdateInput;
+	contentTypesGet: ContentTypesGetInput;
+	contentTypesList: ContentTypesListInput;
+	assetsGet: AssetsGetInput;
+	assetsList: AssetsListInput;
 };
 
 export type ContentfulEndpointOutputs = {
@@ -88,6 +191,12 @@ export type ContentfulEndpointOutputs = {
 	environmentsGet: EnvironmentsGetResponse;
 	entriesGet: EntriesGetResponse;
 	entriesList: EntriesListResponse;
+	entriesCreate: EntriesCreateResponse;
+	entriesUpdate: EntriesUpdateResponse;
+	contentTypesGet: ContentTypesGetResponse;
+	contentTypesList: ContentTypesListResponse;
+	assetsGet: AssetsGetResponse;
+	assetsList: AssetsListResponse;
 };
 
 export const ContentfulEndpointInputSchemas = {
@@ -95,6 +204,12 @@ export const ContentfulEndpointInputSchemas = {
 	environmentsGet: EnvironmentsGetInputSchema,
 	entriesGet: EntriesGetInputSchema,
 	entriesList: EntriesListInputSchema,
+	entriesCreate: EntriesCreateInputSchema,
+	entriesUpdate: EntriesUpdateInputSchema,
+	contentTypesGet: ContentTypesGetInputSchema,
+	contentTypesList: ContentTypesListInputSchema,
+	assetsGet: AssetsGetInputSchema,
+	assetsList: AssetsListInputSchema,
 } as const;
 
 export const ContentfulEndpointOutputSchemas = {
@@ -102,4 +217,10 @@ export const ContentfulEndpointOutputSchemas = {
 	environmentsGet: EnvironmentSchema,
 	entriesGet: EntrySchema,
 	entriesList: EntryListSchema,
+	entriesCreate: EntrySchema,
+	entriesUpdate: EntrySchema,
+	contentTypesGet: ContentTypeSchema,
+	contentTypesList: ContentTypeListSchema,
+	assetsGet: AssetSchema,
+	assetsList: AssetListSchema,
 } as const;

--- a/packages/contentful/endpoints/types.ts
+++ b/packages/contentful/endpoints/types.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod';
+
+const SysSchema = z
+	.object({
+		id: z.string(),
+		type: z.string(),
+		createdAt: z.string().optional(),
+		updatedAt: z.string().optional(),
+		version: z.number().optional(),
+	})
+	.passthrough();
+
+const SpaceSchema = z
+	.object({
+		sys: SysSchema,
+		name: z.string().optional(),
+	})
+	.passthrough();
+
+const EnvironmentSchema = z
+	.object({
+		sys: SysSchema,
+		name: z.string().optional(),
+	})
+	.passthrough();
+
+const EntrySchema = z
+	.object({
+		sys: SysSchema,
+		fields: z.record(z.string(), z.any()).optional(),
+	})
+	.passthrough();
+
+const EntryListSchema = z
+	.object({
+		sys: z.object({ type: z.string() }).passthrough(),
+		total: z.number(),
+		skip: z.number(),
+		limit: z.number(),
+		items: z.array(EntrySchema),
+	})
+	.passthrough();
+
+export const SpacesGetInputSchema = z.object({
+	spaceId: z.string(),
+});
+
+export const EnvironmentsGetInputSchema = z.object({
+	spaceId: z.string(),
+	environmentId: z.string(),
+});
+
+export const EntriesGetInputSchema = z.object({
+	spaceId: z.string(),
+	environmentId: z.string(),
+	entryId: z.string(),
+});
+
+export const EntriesListInputSchema = z.object({
+	spaceId: z.string(),
+	environmentId: z.string(),
+	skip: z.number().optional(),
+	limit: z.number().optional(),
+	query: z.record(z.string(), z.string()).optional(),
+});
+
+export type SpacesGetInput = z.infer<typeof SpacesGetInputSchema>;
+export type SpacesGetResponse = z.infer<typeof SpaceSchema>;
+
+export type EnvironmentsGetInput = z.infer<typeof EnvironmentsGetInputSchema>;
+export type EnvironmentsGetResponse = z.infer<typeof EnvironmentSchema>;
+
+export type EntriesGetInput = z.infer<typeof EntriesGetInputSchema>;
+export type EntriesGetResponse = z.infer<typeof EntrySchema>;
+
+export type EntriesListInput = z.infer<typeof EntriesListInputSchema>;
+export type EntriesListResponse = z.infer<typeof EntryListSchema>;
+
+export type ContentfulEndpointInputs = {
+	spacesGet: SpacesGetInput;
+	environmentsGet: EnvironmentsGetInput;
+	entriesGet: EntriesGetInput;
+	entriesList: EntriesListInput;
+};
+
+export type ContentfulEndpointOutputs = {
+	spacesGet: SpacesGetResponse;
+	environmentsGet: EnvironmentsGetResponse;
+	entriesGet: EntriesGetResponse;
+	entriesList: EntriesListResponse;
+};
+
+export const ContentfulEndpointInputSchemas = {
+	spacesGet: SpacesGetInputSchema,
+	environmentsGet: EnvironmentsGetInputSchema,
+	entriesGet: EntriesGetInputSchema,
+	entriesList: EntriesListInputSchema,
+} as const;
+
+export const ContentfulEndpointOutputSchemas = {
+	spacesGet: SpaceSchema,
+	environmentsGet: EnvironmentSchema,
+	entriesGet: EntrySchema,
+	entriesList: EntryListSchema,
+} as const;

--- a/packages/contentful/error-handlers.ts
+++ b/packages/contentful/error-handlers.ts
@@ -1,0 +1,36 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ContentfulAPIError } from './client';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ContentfulAPIError && error.code === 429)
+				return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('429');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (
+				error instanceof ContentfulAPIError &&
+				error.retryAfter !== undefined
+			) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ContentfulAPIError && error.code === 401)
+				return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('unauthorized') || msg.includes('invalid_auth');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/contentful/index.ts
+++ b/packages/contentful/index.ts
@@ -1,0 +1,254 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	BindWebhooks,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	CorsairWebhook,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+	RequiredPluginWebhookSchemas,
+} from 'corsair/core';
+import { Entries, Environments, Spaces } from './endpoints';
+import type {
+	ContentfulEndpointInputs,
+	ContentfulEndpointOutputs,
+} from './endpoints/types';
+import {
+	ContentfulEndpointInputSchemas,
+	ContentfulEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { ContentfulSchema } from './schema';
+import { EntriesWebhooks } from './webhooks';
+import { matchContentfulTenantWebhook } from './webhooks/tenant-matcher';
+import type {
+	ContentfulWebhookOutputs,
+	ContentfulWebhookPayload,
+} from './webhooks/types';
+import { ContentfulWebhookPayloadSchema } from './webhooks/types';
+
+export type ContentfulPluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	webhookSecret?: string;
+	hooks?: InternalContentfulPlugin['hooks'];
+	webhookHooks?: InternalContentfulPlugin['webhookHooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof contentfulEndpointsNested>;
+};
+
+export type ContentfulContext = CorsairPluginContext<
+	typeof ContentfulSchema,
+	ContentfulPluginOptions
+>;
+
+export type ContentfulKeyBuilderContext =
+	KeyBuilderContext<ContentfulPluginOptions>;
+
+export type ContentfulBoundEndpoints = BindEndpoints<
+	typeof contentfulEndpointsNested
+>;
+
+type ContentfulEndpoint<K extends keyof ContentfulEndpointOutputs> =
+	CorsairEndpoint<
+		ContentfulContext,
+		ContentfulEndpointInputs[K],
+		ContentfulEndpointOutputs[K]
+	>;
+
+export type ContentfulEndpoints = {
+	spacesGet: ContentfulEndpoint<'spacesGet'>;
+	environmentsGet: ContentfulEndpoint<'environmentsGet'>;
+	entriesGet: ContentfulEndpoint<'entriesGet'>;
+	entriesList: ContentfulEndpoint<'entriesList'>;
+};
+
+type ContentfulWebhook<
+	K extends keyof ContentfulWebhookOutputs,
+	TEvent,
+> = CorsairWebhook<ContentfulContext, TEvent, ContentfulWebhookOutputs[K]>;
+
+export type ContentfulWebhooks = {
+	entryPublish: ContentfulWebhook<'entryPublish', ContentfulWebhookPayload>;
+	entryUnpublish: ContentfulWebhook<'entryUnpublish', ContentfulWebhookPayload>;
+};
+
+export type ContentfulBoundWebhooks = BindWebhooks<ContentfulWebhooks>;
+
+const contentfulEndpointsNested = {
+	spaces: {
+		get: Spaces.get,
+	},
+	environments: {
+		get: Environments.get,
+	},
+	entries: {
+		get: Entries.get,
+		list: Entries.list,
+	},
+} as const;
+
+const contentfulWebhooksNested = {
+	entry: {
+		publish: EntriesWebhooks.publish,
+		unpublish: EntriesWebhooks.unpublish,
+	},
+} as const;
+
+export const contentfulEndpointSchemas = {
+	'spaces.get': {
+		input: ContentfulEndpointInputSchemas.spacesGet,
+		output: ContentfulEndpointOutputSchemas.spacesGet,
+	},
+	'environments.get': {
+		input: ContentfulEndpointInputSchemas.environmentsGet,
+		output: ContentfulEndpointOutputSchemas.environmentsGet,
+	},
+	'entries.get': {
+		input: ContentfulEndpointInputSchemas.entriesGet,
+		output: ContentfulEndpointOutputSchemas.entriesGet,
+	},
+	'entries.list': {
+		input: ContentfulEndpointInputSchemas.entriesList,
+		output: ContentfulEndpointOutputSchemas.entriesList,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<
+	typeof contentfulEndpointsNested
+>;
+
+const contentfulWebhookSchemas = {
+	'entry.publish': {
+		description: 'A Contentful entry was published',
+		payload: ContentfulWebhookPayloadSchema,
+		response: ContentfulWebhookPayloadSchema,
+	},
+	'entry.unpublish': {
+		description: 'A Contentful entry was unpublished',
+		payload: ContentfulWebhookPayloadSchema,
+		response: ContentfulWebhookPayloadSchema,
+	},
+} as const satisfies RequiredPluginWebhookSchemas<
+	typeof contentfulWebhooksNested
+>;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const contentfulEndpointMeta = {
+	'spaces.get': {
+		riskLevel: 'read',
+		description: 'Get a space by ID',
+	},
+	'environments.get': {
+		riskLevel: 'read',
+		description: 'Get an environment by ID',
+	},
+	'entries.get': {
+		riskLevel: 'read',
+		description: 'Get an entry by ID',
+	},
+	'entries.list': {
+		riskLevel: 'read',
+		description: 'List entries',
+	},
+} as const satisfies RequiredPluginEndpointMeta<
+	typeof contentfulEndpointsNested
+>;
+
+export const contentfulAuthConfig = {
+	api_key: {
+		account: ['account_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type BaseContentfulPlugin<T extends ContentfulPluginOptions> =
+	CorsairPlugin<
+		'contentful',
+		typeof ContentfulSchema,
+		typeof contentfulEndpointsNested,
+		typeof contentfulWebhooksNested,
+		T,
+		typeof defaultAuthType
+	>;
+
+export type InternalContentfulPlugin =
+	BaseContentfulPlugin<ContentfulPluginOptions>;
+
+export type ExternalContentfulPlugin<T extends ContentfulPluginOptions> =
+	BaseContentfulPlugin<T>;
+
+export function contentful<const T extends ContentfulPluginOptions>(
+	incomingOptions: ContentfulPluginOptions & T = {} as ContentfulPluginOptions &
+		T,
+): ExternalContentfulPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'contentful',
+		authConfig: contentfulAuthConfig,
+		schema: ContentfulSchema,
+		options: options,
+		hooks: options.hooks,
+		webhookHooks: options.webhookHooks,
+		endpoints: contentfulEndpointsNested,
+		webhooks: contentfulWebhooksNested,
+		endpointMeta: contentfulEndpointMeta,
+		endpointSchemas: contentfulEndpointSchemas,
+		webhookSchemas: contentfulWebhookSchemas,
+		pluginWebhookMatcher: (request) => {
+			const headers = request.headers;
+			return 'x-contentful-topic' in headers;
+		},
+		pluginTenantWebhookMatcher: matchContentfulTenantWebhook,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: ContentfulKeyBuilderContext, source) => {
+			if (source === 'webhook' && options.webhookSecret) {
+				return options.webhookSecret;
+			}
+
+			if (source === 'webhook') {
+				const res = await ctx.keys.get_webhook_signature();
+				return res ?? '';
+			}
+
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys.get_api_key();
+				return res ?? '';
+			}
+
+			return '';
+		},
+	} satisfies InternalContentfulPlugin;
+}
+
+export type {
+	ContentfulEndpointInputs,
+	ContentfulEndpointOutputs,
+	EntriesGetInput,
+	EntriesGetResponse,
+	EntriesListInput,
+	EntriesListResponse,
+	EnvironmentsGetInput,
+	EnvironmentsGetResponse,
+	SpacesGetInput,
+	SpacesGetResponse,
+} from './endpoints/types';
+export type {
+	ContentfulWebhookOutputs,
+	ContentfulWebhookPayload,
+} from './webhooks/types';

--- a/packages/contentful/index.ts
+++ b/packages/contentful/index.ts
@@ -15,7 +15,13 @@ import type {
 	RequiredPluginEndpointSchemas,
 	RequiredPluginWebhookSchemas,
 } from 'corsair/core';
-import { Entries, Environments, Spaces } from './endpoints';
+import {
+	Assets,
+	ContentTypes,
+	Entries,
+	Environments,
+	Spaces,
+} from './endpoints';
 import type {
 	ContentfulEndpointInputs,
 	ContentfulEndpointOutputs,
@@ -26,7 +32,7 @@ import {
 } from './endpoints/types';
 import { errorHandlers } from './error-handlers';
 import { ContentfulSchema } from './schema';
-import { EntriesWebhooks } from './webhooks';
+import { AssetsWebhooks, EntriesWebhooks } from './webhooks';
 import { matchContentfulTenantWebhook } from './webhooks/tenant-matcher';
 import type {
 	ContentfulWebhookOutputs,
@@ -68,6 +74,12 @@ export type ContentfulEndpoints = {
 	environmentsGet: ContentfulEndpoint<'environmentsGet'>;
 	entriesGet: ContentfulEndpoint<'entriesGet'>;
 	entriesList: ContentfulEndpoint<'entriesList'>;
+	entriesCreate: ContentfulEndpoint<'entriesCreate'>;
+	entriesUpdate: ContentfulEndpoint<'entriesUpdate'>;
+	contentTypesGet: ContentfulEndpoint<'contentTypesGet'>;
+	contentTypesList: ContentfulEndpoint<'contentTypesList'>;
+	assetsGet: ContentfulEndpoint<'assetsGet'>;
+	assetsList: ContentfulEndpoint<'assetsList'>;
 };
 
 type ContentfulWebhook<
@@ -78,6 +90,8 @@ type ContentfulWebhook<
 export type ContentfulWebhooks = {
 	entryPublish: ContentfulWebhook<'entryPublish', ContentfulWebhookPayload>;
 	entryUnpublish: ContentfulWebhook<'entryUnpublish', ContentfulWebhookPayload>;
+	assetPublish: ContentfulWebhook<'assetPublish', ContentfulWebhookPayload>;
+	assetUnpublish: ContentfulWebhook<'assetUnpublish', ContentfulWebhookPayload>;
 };
 
 export type ContentfulBoundWebhooks = BindWebhooks<ContentfulWebhooks>;
@@ -92,6 +106,16 @@ const contentfulEndpointsNested = {
 	entries: {
 		get: Entries.get,
 		list: Entries.list,
+		create: Entries.create,
+		update: Entries.update,
+	},
+	content_types: {
+		get: ContentTypes.get,
+		list: ContentTypes.list,
+	},
+	assets: {
+		get: Assets.get,
+		list: Assets.list,
 	},
 } as const;
 
@@ -99,6 +123,10 @@ const contentfulWebhooksNested = {
 	entry: {
 		publish: EntriesWebhooks.publish,
 		unpublish: EntriesWebhooks.unpublish,
+	},
+	asset: {
+		publish: AssetsWebhooks.publish,
+		unpublish: AssetsWebhooks.unpublish,
 	},
 } as const;
 
@@ -119,6 +147,30 @@ export const contentfulEndpointSchemas = {
 		input: ContentfulEndpointInputSchemas.entriesList,
 		output: ContentfulEndpointOutputSchemas.entriesList,
 	},
+	'entries.create': {
+		input: ContentfulEndpointInputSchemas.entriesCreate,
+		output: ContentfulEndpointOutputSchemas.entriesCreate,
+	},
+	'entries.update': {
+		input: ContentfulEndpointInputSchemas.entriesUpdate,
+		output: ContentfulEndpointOutputSchemas.entriesUpdate,
+	},
+	'content_types.get': {
+		input: ContentfulEndpointInputSchemas.contentTypesGet,
+		output: ContentfulEndpointOutputSchemas.contentTypesGet,
+	},
+	'content_types.list': {
+		input: ContentfulEndpointInputSchemas.contentTypesList,
+		output: ContentfulEndpointOutputSchemas.contentTypesList,
+	},
+	'assets.get': {
+		input: ContentfulEndpointInputSchemas.assetsGet,
+		output: ContentfulEndpointOutputSchemas.assetsGet,
+	},
+	'assets.list': {
+		input: ContentfulEndpointInputSchemas.assetsList,
+		output: ContentfulEndpointOutputSchemas.assetsList,
+	},
 } as const satisfies RequiredPluginEndpointSchemas<
 	typeof contentfulEndpointsNested
 >;
@@ -131,6 +183,16 @@ const contentfulWebhookSchemas = {
 	},
 	'entry.unpublish': {
 		description: 'A Contentful entry was unpublished',
+		payload: ContentfulWebhookPayloadSchema,
+		response: ContentfulWebhookPayloadSchema,
+	},
+	'asset.publish': {
+		description: 'A Contentful asset was published',
+		payload: ContentfulWebhookPayloadSchema,
+		response: ContentfulWebhookPayloadSchema,
+	},
+	'asset.unpublish': {
+		description: 'A Contentful asset was unpublished',
 		payload: ContentfulWebhookPayloadSchema,
 		response: ContentfulWebhookPayloadSchema,
 	},
@@ -156,6 +218,30 @@ const contentfulEndpointMeta = {
 	'entries.list': {
 		riskLevel: 'read',
 		description: 'List entries',
+	},
+	'entries.create': {
+		riskLevel: 'write',
+		description: 'Create an entry',
+	},
+	'entries.update': {
+		riskLevel: 'write',
+		description: 'Update an entry',
+	},
+	'content_types.get': {
+		riskLevel: 'read',
+		description: 'Get a content type by ID',
+	},
+	'content_types.list': {
+		riskLevel: 'read',
+		description: 'List content types',
+	},
+	'assets.get': {
+		riskLevel: 'read',
+		description: 'Get an asset by ID',
+	},
+	'assets.list': {
+		riskLevel: 'read',
+		description: 'List assets',
 	},
 } as const satisfies RequiredPluginEndpointMeta<
 	typeof contentfulEndpointsNested
@@ -183,6 +269,7 @@ export type InternalContentfulPlugin =
 export type ExternalContentfulPlugin<T extends ContentfulPluginOptions> =
 	BaseContentfulPlugin<T>;
 
+/** Initializes the Contentful API plugin for the Corsair platform. */
 export function contentful<const T extends ContentfulPluginOptions>(
 	incomingOptions: ContentfulPluginOptions & T = {} as ContentfulPluginOptions &
 		T,
@@ -237,12 +324,24 @@ export function contentful<const T extends ContentfulPluginOptions>(
 }
 
 export type {
+	AssetsGetInput,
+	AssetsGetResponse,
+	AssetsListInput,
+	AssetsListResponse,
 	ContentfulEndpointInputs,
 	ContentfulEndpointOutputs,
+	ContentTypesGetInput,
+	ContentTypesGetResponse,
+	ContentTypesListInput,
+	ContentTypesListResponse,
+	EntriesCreateInput,
+	EntriesCreateResponse,
 	EntriesGetInput,
 	EntriesGetResponse,
 	EntriesListInput,
 	EntriesListResponse,
+	EntriesUpdateInput,
+	EntriesUpdateResponse,
 	EnvironmentsGetInput,
 	EnvironmentsGetResponse,
 	SpacesGetInput,

--- a/packages/contentful/jest.config.cjs
+++ b/packages/contentful/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/contentful/package.json
+++ b/packages/contentful/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/contentful",
+  "version": "0.1.0",
+  "description": "Contentful plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "contentful",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/contentful/schema.test.ts
+++ b/packages/contentful/schema.test.ts
@@ -1,0 +1,20 @@
+import { ContentfulSchema } from './schema';
+
+describe('Contentful schema', () => {
+	it('declares a semver version', () => {
+		expect(ContentfulSchema.version).toBeDefined();
+		expect(ContentfulSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof ContentfulSchema.entities).toBe('object');
+		expect(ContentfulSchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(ContentfulSchema.entities))).toBe(true);
+		for (const entity of Object.values(ContentfulSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/contentful/schema/database.ts
+++ b/packages/contentful/schema/database.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const ContentfulSpace = z.object({
+	id: z.string(),
+	name: z.string(),
+	organization_id: z.string().optional(),
+	created_at: z.coerce.date().nullable().optional(),
+	updated_at: z.coerce.date().nullable().optional(),
+});
+export type ContentfulSpace = z.infer<typeof ContentfulSpace>;

--- a/packages/contentful/schema/index.ts
+++ b/packages/contentful/schema/index.ts
@@ -1,0 +1,8 @@
+import { ContentfulSpace } from './database';
+
+export const ContentfulSchema = {
+	version: '1.0.0',
+	entities: {
+		space: ContentfulSpace,
+	},
+} as const;

--- a/packages/contentful/tsconfig.json
+++ b/packages/contentful/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/contentful/tsup.config.ts
+++ b/packages/contentful/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/contentful/webhooks.test.ts
+++ b/packages/contentful/webhooks.test.ts
@@ -1,0 +1,130 @@
+import { matchContentfulTenantWebhook } from './webhooks/tenant-matcher';
+import {
+	createContentfulMatch,
+	verifyContentfulWebhookSignature,
+} from './webhooks/types';
+
+describe('Contentful Webhooks', () => {
+	describe('Webhook matching', () => {
+		it('matches the correct topic', () => {
+			const matcher = createContentfulMatch('ContentManagement.Entry.publish');
+			expect(
+				matcher({
+					headers: { 'x-contentful-topic': 'ContentManagement.Entry.publish' },
+					body: {},
+				}),
+			).toBe(true);
+			expect(
+				matcher({
+					headers: {
+						'x-contentful-topic': 'ContentManagement.Entry.unpublish',
+					},
+					body: {},
+				}),
+			).toBe(false);
+			expect(matcher({ headers: {}, body: {} })).toBe(false);
+		});
+	});
+
+	describe('Signature verification', () => {
+		it('rejects missing secrets', () => {
+			const result = verifyContentfulWebhookSignature(
+				{ headers: {}, payload: {}, rawBody: '{}' } as any,
+				'',
+			);
+			expect(result.valid).toBe(false);
+			expect(result.error).toBe('Missing webhook secret');
+		});
+
+		it('rejects missing signatures', () => {
+			const result = verifyContentfulWebhookSignature(
+				{ headers: {}, payload: {}, rawBody: '{}' } as any,
+				'secret',
+			);
+			expect(result.valid).toBe(false);
+			expect(result.error).toBe('Missing x-contentful-signature header');
+		});
+
+		it('rejects missing rawBody', () => {
+			const result = verifyContentfulWebhookSignature(
+				{ headers: { 'x-contentful-signature': 'abc' }, payload: {} } as any,
+				'secret',
+			);
+			expect(result.valid).toBe(false);
+			expect(result.error).toBe('Missing raw body for signature verification');
+		});
+
+		it('accepts valid signatures', () => {
+			// To generate valid signature for testing:
+			const crypto = require('crypto');
+			const secret = 'my-secret';
+			const rawBody = '{"sys":{"id":"123"}}';
+			const hmac = crypto.createHmac('sha256', secret);
+			hmac.update(rawBody);
+			const expectedSignature = hmac.digest('base64');
+
+			const result = verifyContentfulWebhookSignature(
+				{
+					headers: { 'x-contentful-signature': expectedSignature },
+					payload: JSON.parse(rawBody),
+					rawBody,
+				} as any,
+				secret,
+			);
+
+			expect(result.valid).toBe(true);
+		});
+
+		it('rejects invalid signatures', () => {
+			const result = verifyContentfulWebhookSignature(
+				{
+					headers: { 'x-contentful-signature': 'invalid-signature' },
+					payload: {},
+					rawBody: '{}',
+				} as any,
+				'secret',
+			);
+
+			expect(result.valid).toBe(false);
+			expect(result.error).toBe('Invalid webhook signature');
+		});
+	});
+
+	describe('Tenant matcher', () => {
+		it('returns null on missing body', () => {
+			expect(
+				matchContentfulTenantWebhook({ headers: {}, body: null }),
+			).toBeNull();
+		});
+
+		it('returns null on malformed body', () => {
+			expect(
+				matchContentfulTenantWebhook({ headers: {}, body: { foo: 'bar' } }),
+			).toBeNull();
+			expect(
+				matchContentfulTenantWebhook({ headers: {}, body: { sys: {} } }),
+			).toBeNull();
+			expect(
+				matchContentfulTenantWebhook({
+					headers: {},
+					body: { sys: { space: {} } },
+				}),
+			).toBeNull();
+		});
+
+		it('extracts space ID', () => {
+			const payload = {
+				sys: {
+					space: {
+						sys: {
+							id: 'space-123',
+						},
+					},
+				},
+			};
+			expect(
+				matchContentfulTenantWebhook({ headers: {}, body: payload }),
+			).toEqual({ linkType: 'account_id', externalId: 'space-123' });
+		});
+	});
+});

--- a/packages/contentful/webhooks.test.ts
+++ b/packages/contentful/webhooks.test.ts
@@ -6,7 +6,7 @@ import {
 
 describe('Contentful Webhooks', () => {
 	describe('Webhook matching', () => {
-		it('matches the correct topic', () => {
+		it('matches the correct topic for entries', () => {
 			const matcher = createContentfulMatch('ContentManagement.Entry.publish');
 			expect(
 				matcher({
@@ -23,6 +23,24 @@ describe('Contentful Webhooks', () => {
 				}),
 			).toBe(false);
 			expect(matcher({ headers: {}, body: {} })).toBe(false);
+		});
+
+		it('matches the correct topic for assets', () => {
+			const matcher = createContentfulMatch('ContentManagement.Asset.publish');
+			expect(
+				matcher({
+					headers: { 'x-contentful-topic': 'ContentManagement.Asset.publish' },
+					body: {},
+				}),
+			).toBe(true);
+			expect(
+				matcher({
+					headers: {
+						'x-contentful-topic': 'ContentManagement.Asset.unpublish',
+					},
+					body: {},
+				}),
+			).toBe(false);
 		});
 	});
 
@@ -55,17 +73,37 @@ describe('Contentful Webhooks', () => {
 		});
 
 		it('accepts valid signatures', () => {
-			// To generate valid signature for testing:
 			const crypto = require('crypto');
 			const secret = 'my-secret';
 			const rawBody = '{"sys":{"id":"123"}}';
+
+			const method = 'POST';
+			const path = '/api/webhooks/contentful';
+			const timestamp = '1710000000';
+			const signedHeadersStr = 'x-contentful-timestamp,x-custom-header';
+
+			const stringifiedHeaders = `x-contentful-timestamp:${timestamp};x-custom-header:my-custom-value`;
+			const stringifiedRequest = [
+				method,
+				path,
+				stringifiedHeaders,
+				rawBody,
+			].join('\n');
+
 			const hmac = crypto.createHmac('sha256', secret);
-			hmac.update(rawBody);
-			const expectedSignature = hmac.digest('base64');
+			hmac.update(stringifiedRequest);
+			const expectedSignature = hmac.digest('hex');
 
 			const result = verifyContentfulWebhookSignature(
 				{
-					headers: { 'x-contentful-signature': expectedSignature },
+					headers: {
+						'x-contentful-signature': expectedSignature,
+						'x-contentful-timestamp': timestamp,
+						'x-contentful-signed-headers': signedHeadersStr,
+						'x-custom-header': 'my-custom-value',
+						'x-forwarded-method': method,
+						'x-envoy-original-path': path,
+					},
 					payload: JSON.parse(rawBody),
 					rawBody,
 				} as any,
@@ -78,7 +116,13 @@ describe('Contentful Webhooks', () => {
 		it('rejects invalid signatures', () => {
 			const result = verifyContentfulWebhookSignature(
 				{
-					headers: { 'x-contentful-signature': 'invalid-signature' },
+					headers: {
+						'x-contentful-signature': 'invalid-signature',
+						'x-contentful-timestamp': '1710000000',
+						'x-contentful-signed-headers': 'x-contentful-timestamp',
+						'x-forwarded-method': 'POST',
+						'x-envoy-original-path': '/path',
+					},
 					payload: {},
 					rawBody: '{}',
 				} as any,
@@ -87,6 +131,54 @@ describe('Contentful Webhooks', () => {
 
 			expect(result.valid).toBe(false);
 			expect(result.error).toBe('Invalid webhook signature');
+		});
+
+		it('rejects missing proxy method/path headers', () => {
+			const result = verifyContentfulWebhookSignature(
+				{
+					headers: {
+						'x-contentful-signature': 'dummy',
+						'x-contentful-timestamp': '1710000000',
+						'x-contentful-signed-headers': 'x-contentful-timestamp',
+					},
+					payload: {},
+					rawBody: '{}',
+				} as any,
+				'secret',
+			);
+
+			expect(result.valid).toBe(false);
+			expect(result.error).toMatch(
+				/Direct Contentful webhooks require HTTP method and path/,
+			);
+		});
+
+		it('accepts hub-delivered webhooks without secret', () => {
+			const result = verifyContentfulWebhookSignature(
+				{
+					hubVerified: true,
+					headers: {},
+					payload: {},
+					rawBody: '{}',
+				} as any,
+				'',
+			);
+			expect(result.valid).toBe(true);
+		});
+
+		it('accepts hub-delivered webhooks with invalid signature', () => {
+			const result = verifyContentfulWebhookSignature(
+				{
+					hubVerified: true,
+					headers: {
+						'x-contentful-signature': 'invalid',
+					},
+					payload: {},
+					rawBody: '{}',
+				} as any,
+				'secret',
+			);
+			expect(result.valid).toBe(true);
 		});
 	});
 

--- a/packages/contentful/webhooks/assets.ts
+++ b/packages/contentful/webhooks/assets.ts
@@ -1,0 +1,68 @@
+import type { WebhookRequest } from 'corsair/core';
+import { logEventFromContext } from 'corsair/core';
+import type { ContentfulContext, ContentfulWebhooks } from '..';
+import type { ContentfulWebhookPayload } from './types';
+import {
+	createContentfulMatch,
+	verifyContentfulWebhookSignature,
+} from './types';
+
+/** Handles Contentful Asset publish webhooks. */
+export const publish: ContentfulWebhooks['assetPublish'] = {
+	match: createContentfulMatch('ContentManagement.Asset.publish'),
+	handler: async (
+		ctx: ContentfulContext,
+		request: WebhookRequest<ContentfulWebhookPayload>,
+	) => {
+		const verification = verifyContentfulWebhookSignature(
+			request,
+			ctx.key || '',
+		);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
+
+		await logEventFromContext(
+			ctx,
+			'contentful.assetPublish',
+			request.payload,
+			'completed',
+		);
+
+		return { success: true, data: request.payload };
+	},
+};
+
+/** Handles Contentful Asset unpublish webhooks. */
+export const unpublish: ContentfulWebhooks['assetUnpublish'] = {
+	match: createContentfulMatch('ContentManagement.Asset.unpublish'),
+	handler: async (
+		ctx: ContentfulContext,
+		request: WebhookRequest<ContentfulWebhookPayload>,
+	) => {
+		const verification = verifyContentfulWebhookSignature(
+			request,
+			ctx.key || '',
+		);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
+
+		await logEventFromContext(
+			ctx,
+			'contentful.assetUnpublish',
+			request.payload,
+			'completed',
+		);
+
+		return { success: true, data: request.payload };
+	},
+};

--- a/packages/contentful/webhooks/entries.ts
+++ b/packages/contentful/webhooks/entries.ts
@@ -1,0 +1,66 @@
+import type { WebhookRequest } from 'corsair/core';
+import { logEventFromContext } from 'corsair/core';
+import type { ContentfulContext, ContentfulWebhooks } from '..';
+import type { ContentfulWebhookPayload } from './types';
+import {
+	createContentfulMatch,
+	verifyContentfulWebhookSignature,
+} from './types';
+
+export const publish: ContentfulWebhooks['entryPublish'] = {
+	match: createContentfulMatch('ContentManagement.Entry.publish'),
+	handler: async (
+		ctx: ContentfulContext,
+		request: WebhookRequest<ContentfulWebhookPayload>,
+	) => {
+		const verification = verifyContentfulWebhookSignature(
+			request,
+			ctx.key || '',
+		);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
+
+		await logEventFromContext(
+			ctx,
+			'contentful.entryPublish',
+			request.payload,
+			'completed',
+		);
+
+		return { success: true, data: request.payload };
+	},
+};
+
+export const unpublish: ContentfulWebhooks['entryUnpublish'] = {
+	match: createContentfulMatch('ContentManagement.Entry.unpublish'),
+	handler: async (
+		ctx: ContentfulContext,
+		request: WebhookRequest<ContentfulWebhookPayload>,
+	) => {
+		const verification = verifyContentfulWebhookSignature(
+			request,
+			ctx.key || '',
+		);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
+
+		await logEventFromContext(
+			ctx,
+			'contentful.entryUnpublish',
+			request.payload,
+			'completed',
+		);
+
+		return { success: true, data: request.payload };
+	},
+};

--- a/packages/contentful/webhooks/index.ts
+++ b/packages/contentful/webhooks/index.ts
@@ -1,0 +1,1 @@
+export * as EntriesWebhooks from './entries';

--- a/packages/contentful/webhooks/index.ts
+++ b/packages/contentful/webhooks/index.ts
@@ -1,1 +1,2 @@
+export * as AssetsWebhooks from './assets';
 export * as EntriesWebhooks from './entries';

--- a/packages/contentful/webhooks/tenant-matcher.ts
+++ b/packages/contentful/webhooks/tenant-matcher.ts
@@ -1,0 +1,24 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, readBodyRecord } from 'corsair/core';
+
+export function matchContentfulTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const sys = asRecord(body.sys);
+	if (!sys) return null;
+
+	const space = asRecord(sys.space);
+	if (!space) return null;
+
+	const spaceSys = asRecord(space.sys);
+	if (!spaceSys) return null;
+
+	const spaceId = typeof spaceSys.id === 'string' ? spaceSys.id : undefined;
+
+	if (!spaceId) return null;
+
+	return { linkType: 'account_id', externalId: spaceId };
+}

--- a/packages/contentful/webhooks/tenant-matcher.ts
+++ b/packages/contentful/webhooks/tenant-matcher.ts
@@ -1,6 +1,7 @@
 import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
 import { asRecord, readBodyRecord } from 'corsair/core';
 
+/** Extracts the space ID from a Contentful webhook payload to resolve the target tenant account. */
 export function matchContentfulTenantWebhook(
 	request: RawWebhookRequest,
 ): WebhookTenantMatch | null {

--- a/packages/contentful/webhooks/types.ts
+++ b/packages/contentful/webhooks/types.ts
@@ -36,6 +36,8 @@ export type ContentfulWebhookPayload = z.infer<
 export type ContentfulWebhookOutputs = {
 	entryPublish: ContentfulWebhookPayload;
 	entryUnpublish: ContentfulWebhookPayload;
+	assetPublish: ContentfulWebhookPayload;
+	assetUnpublish: ContentfulWebhookPayload;
 };
 
 function parseBody(body: unknown): Record<string, unknown> | null {
@@ -56,6 +58,7 @@ function parseBody(body: unknown): Record<string, unknown> | null {
 		: null;
 }
 
+/** Creates a webhook matcher that filters incoming requests by the specified Contentful topic. */
 export function createContentfulMatch(topic: string): CorsairWebhookMatcher {
 	return (request: RawWebhookRequest) => {
 		const headerTopic = request.headers['x-contentful-topic'];
@@ -66,10 +69,15 @@ export function createContentfulMatch(topic: string): CorsairWebhookMatcher {
 	};
 }
 
+/** Verifies the authenticity of an incoming Contentful webhook using the HMAC-SHA256 canonical signature. */
 export function verifyContentfulWebhookSignature(
 	request: WebhookRequest<ContentfulWebhookPayload>,
 	secret: string,
 ): { valid: boolean; error?: string } {
+	if (request.hubVerified === true) {
+		return { valid: true };
+	}
+
 	if (!secret) {
 		return { valid: false, error: 'Missing webhook secret' };
 	}
@@ -89,17 +97,109 @@ export function verifyContentfulWebhookSignature(
 		return { valid: false, error: 'Missing x-contentful-signature header' };
 	}
 
-	try {
-		const hmac = createHmac('sha256', secret);
-		hmac.update(rawBody);
-		const expectedSignature = hmac.digest('base64');
+	const timestampHeader = request.headers['x-contentful-timestamp'];
+	const signedHeadersHeader = request.headers['x-contentful-signed-headers'];
 
+	const timestamp = Array.isArray(timestampHeader)
+		? timestampHeader[0]
+		: timestampHeader;
+	const signedHeadersStr = Array.isArray(signedHeadersHeader)
+		? signedHeadersHeader[0]
+		: signedHeadersHeader;
+
+	if (!timestamp || !signedHeadersStr) {
+		return {
+			valid: false,
+			error: 'Missing timestamp or signed-headers header',
+		};
+	}
+
+	let method: string | undefined;
+	for (const key of [
+		'x-forwarded-method',
+		'x-http-method',
+		'x-original-method',
+	]) {
+		const val = request.headers[key];
+		const str = Array.isArray(val) ? val[0] : val;
+		if (str) {
+			method = str;
+			break;
+		}
+	}
+
+	let path: string | undefined;
+	for (const key of [
+		'x-original-url',
+		'x-rewrite-url',
+		'x-envoy-original-path',
+		'x-forwarded-uri',
+		'x-original-uri',
+	]) {
+		const val = request.headers[key];
+		const str = Array.isArray(val) ? val[0] : val;
+		if (str) {
+			path = str;
+			break;
+		}
+	}
+
+	if (!method || !path) {
+		return {
+			valid: false,
+			error:
+				'Direct Contentful webhooks require HTTP method and path for signature verification, which are not currently available in Corsair WebhookRequest unless proxy headers (e.g. x-envoy-original-path, x-forwarded-method) are present.',
+		};
+	}
+
+	try {
+		const signedHeadersList = signedHeadersStr.split(',');
+
+		const headersToSign: Record<string, string> = {};
+		for (const h of signedHeadersList) {
+			const key = h.trim();
+			if (!key) continue;
+
+			let val = request.headers[key];
+			if (Array.isArray(val)) val = val[0];
+
+			if (val !== undefined) {
+				headersToSign[key] = val;
+			}
+		}
+
+		const sortedKeys = Object.keys(headersToSign).sort();
+		const stringifiedHeaders = sortedKeys
+			.map((key) => `${key}:${headersToSign[key]}`)
+			.join(';');
+
+		const stringifiedRequest = [method, path, stringifiedHeaders, rawBody].join(
+			'\n',
+		);
+
+		const hmac = createHmac('sha256', secret);
+		hmac.update(stringifiedRequest);
+		const expectedSignature = hmac.digest('hex');
+
+		// The Node.js crypto timingSafeEqual requires buffers of the same length
 		const signatureBuffer = Buffer.from(signatureHeader, 'utf8');
 		const expectedBuffer = Buffer.from(expectedSignature, 'utf8');
 
 		if (
 			signatureBuffer.length === expectedBuffer.length &&
 			timingSafeEqual(signatureBuffer, expectedBuffer)
+		) {
+			return { valid: true };
+		}
+
+		// Also check base64 just in case it is encoded that way
+		const expectedSignatureBase64 = createHmac('sha256', secret)
+			.update(stringifiedRequest)
+			.digest('base64');
+		const expectedBufferBase64 = Buffer.from(expectedSignatureBase64, 'utf8');
+		if (
+			signatureBuffer.length === expectedBufferBase64.length &&
+			timingSafeEqual(signatureBuffer, expectedBufferBase64)
 		) {
 			return { valid: true };
 		}

--- a/packages/contentful/webhooks/types.ts
+++ b/packages/contentful/webhooks/types.ts
@@ -1,0 +1,111 @@
+import type {
+	CorsairWebhookMatcher,
+	RawWebhookRequest,
+	WebhookRequest,
+} from 'corsair/core';
+import { createHmac, timingSafeEqual } from 'crypto';
+import { z } from 'zod';
+
+export const ContentfulWebhookPayloadSchema = z
+	.object({
+		sys: z
+			.object({
+				type: z.string(),
+				id: z.string(),
+				space: z
+					.object({
+						sys: z.object({ id: z.string() }).passthrough(),
+					})
+					.passthrough()
+					.optional(),
+				environment: z
+					.object({
+						sys: z.object({ id: z.string() }).passthrough(),
+					})
+					.passthrough()
+					.optional(),
+			})
+			.passthrough(),
+	})
+	.passthrough();
+
+export type ContentfulWebhookPayload = z.infer<
+	typeof ContentfulWebhookPayloadSchema
+>;
+
+export type ContentfulWebhookOutputs = {
+	entryPublish: ContentfulWebhookPayload;
+	entryUnpublish: ContentfulWebhookPayload;
+};
+
+function parseBody(body: unknown): Record<string, unknown> | null {
+	if (typeof body === 'string') {
+		try {
+			const parsed = JSON.parse(body);
+			return parsed !== null &&
+				typeof parsed === 'object' &&
+				!Array.isArray(parsed)
+				? (parsed as Record<string, unknown>)
+				: null;
+		} catch {
+			return null;
+		}
+	}
+	return body !== null && typeof body === 'object' && !Array.isArray(body)
+		? (body as Record<string, unknown>)
+		: null;
+}
+
+export function createContentfulMatch(topic: string): CorsairWebhookMatcher {
+	return (request: RawWebhookRequest) => {
+		const headerTopic = request.headers['x-contentful-topic'];
+		if (headerTopic && typeof headerTopic === 'string') {
+			return headerTopic === topic;
+		}
+		return false;
+	};
+}
+
+export function verifyContentfulWebhookSignature(
+	request: WebhookRequest<ContentfulWebhookPayload>,
+	secret: string,
+): { valid: boolean; error?: string } {
+	if (!secret) {
+		return { valid: false, error: 'Missing webhook secret' };
+	}
+
+	const rawBody = request.rawBody;
+	if (!rawBody) {
+		return {
+			valid: false,
+			error: 'Missing raw body for signature verification',
+		};
+	}
+
+	const header = request.headers['x-contentful-signature'];
+	const signatureHeader = Array.isArray(header) ? header[0] : header;
+
+	if (!signatureHeader || typeof signatureHeader !== 'string') {
+		return { valid: false, error: 'Missing x-contentful-signature header' };
+	}
+
+	try {
+		const hmac = createHmac('sha256', secret);
+		hmac.update(rawBody);
+		const expectedSignature = hmac.digest('base64');
+
+		const signatureBuffer = Buffer.from(signatureHeader, 'utf8');
+		const expectedBuffer = Buffer.from(expectedSignature, 'utf8');
+
+		if (
+			signatureBuffer.length === expectedBuffer.length &&
+			timingSafeEqual(signatureBuffer, expectedBuffer)
+		) {
+			return { valid: true };
+		}
+
+		return { valid: false, error: 'Invalid webhook signature' };
+	} catch (e) {
+		return { valid: false, error: 'Error computing signature' };
+	}
+}

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -76,6 +76,7 @@ export const BaseProviders = [
 	'cloudinary',
 	'collegefootballdata',
 	'confluence',
+	'contentful',
 	'contentfulgraphql',
 	'cursor',
 	'databricks',
@@ -243,6 +244,7 @@ export const ProviderDisplayNames = {
 	cloudinary: 'Cloudinary',
 	collegefootballdata: 'College Football Data',
 	confluence: 'Confluence',
+	contentful: 'Contentful',
 	contentfulgraphql: 'Contentful GraphQL',
 	cursor: 'Cursor',
 	databricks: 'Databricks',
@@ -417,6 +419,7 @@ export type AllProviders =
 	| 'cloudinary'
 	| 'collegefootballdata'
 	| 'confluence'
+	| 'contentful'
 	| 'contentfulgraphql'
 	| 'cursor'
 	| 'databricks'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       '@corsair-dev/bitwarden':
         specifier: workspace:*
         version: link:../../packages/bitwarden
+      '@corsair-dev/contentful':
+        specifier: workspace:*
+        version: link:../../packages/contentful
       '@corsair-dev/cursor':
         specifier: workspace:*
         version: link:../../packages/cursor

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1931,6 +1931,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/contentful:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/contentfulgraphql:
     devDependencies:
       '@types/jest':

--- a/www/src/components/landing/menu/site-menu.tsx
+++ b/www/src/components/landing/menu/site-menu.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
 import { APP_URL, DISCORD_URL, DOCS_URL, GITHUB_URL } from '@/lib/site-links';
-import { ArrowRightIcon, PlusCorner } from '../icons';
+import { PlusCorner } from '../icons';
 
 function MenuIcon() {
 	return (


### PR DESCRIPTION
## Description

Adds the Contentful plugin to Corsair, providing integration with the Contentful API.

The plugin includes:
- Contentful client configuration
- Spaces and environments endpoints
- Entries endpoints
- Webhook handling for entries
- Tenant matching
- Contentful database schema support
- Error handling
- Unit tests for endpoints, schemas, and webhooks
- Registration of Contentful as a Corsair provider

# closes #939 

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [ ] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation



## Additional Notes

The Contentful package itself was independently verified with TypeScript compilation and `tsup` bundling.

The full workspace `pnpm build` was attempted, but the Windows environment encountered unrelated existing packages whose build scripts use Unix-specific commands such as `rm -rf`. These failures occurred outside the Contentful package.

The Contentful plugin passed structural validation with `pnpm run validate:plugins`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Contentful integration with authenticated API access.
  * Added support for spaces, environments, entries, content types, and assets, including listing, creation, and updates where applicable.
  * Added entry and asset publish/unpublish webhook handling with signature verification.
  * Added rate-limit and authentication error handling.
  * Added Contentful schema support and package exports.

* **Tests**
  * Expanded coverage for API endpoints, schemas, and webhook validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->