### PR TITLE
fix(ci): isolate npm publish failures and sort lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -737,6 +737,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/allimagesai:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/alphavantage:
     devDependencies:
       '@types/jest':
@@ -864,30 +888,6 @@ importers:
         version: 4.4.3
 
   packages/ambientweather:
-    devDependencies:
-      '@types/jest':
-        specifier: ^29.5.14
-        version: 29.5.14
-      corsair:
-        specifier: workspace:*
-        version: link:../corsair
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
-      ts-jest:
-        specifier: ^29.4.9
-        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
-      tsup:
-        specifier: ^8.0.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
-      typescript:
-        specifier: 'catalog:'
-        version: 5.9.3
-      zod:
-        specifier: 4.4.3
-        version: 4.4.3
-
-  packages/allimagesai:
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14

--- a/scripts/npm-publish-errors.mjs
+++ b/scripts/npm-publish-errors.mjs
@@ -1,0 +1,11 @@
+// npm/pnpm reject re-publishing an existing version with E403. npm's registry
+// read replica lags its write side, so a version published seconds earlier can
+// still look absent to `npm view`, get re-queued, and hit this on publish —
+// which means it's already up, not a failure. Everything else (auth, network,
+// real permission denials, a bare 409 rate-limit) must surface so the deploy
+// fails loudly — so match only the two duplicate-specific signals, not 409.
+export function isAlreadyPublished(output) {
+	return /cannot publish over the previously published versions|EPUBLISHCONFLICT/i.test(
+		output ?? '',
+	);
+}

--- a/scripts/npm-publish-errors.test.mjs
+++ b/scripts/npm-publish-errors.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { isAlreadyPublished } from './npm-publish-errors.mjs';
+
+// The real E403 npm returns when the version already exists — must be skipped.
+assert.equal(
+	isAlreadyPublished(
+		'npm error code E403\nnpm error 403 You cannot publish over the previously published versions: 0.1.0.',
+	),
+	true,
+);
+assert.equal(
+	isAlreadyPublished('EPUBLISHCONFLICT: cannot modify pre-existing version'),
+	true,
+);
+
+// Real failures must NOT be swallowed — the deploy has to go red on these.
+// A bare 409 is ambiguous (e.g. rate-limit), not proof of a duplicate.
+assert.equal(
+	isAlreadyPublished('npm error 409 Conflict - too many requests'),
+	false,
+);
+assert.equal(
+	isAlreadyPublished('npm error code E401\nnpm error 401 Unauthorized'),
+	false,
+);
+assert.equal(isAlreadyPublished('npm error code ENEEDAUTH'), false);
+assert.equal(
+	isAlreadyPublished(
+		'npm error 403 Forbidden - you do not have permission to publish',
+	),
+	false,
+);
+assert.equal(isAlreadyPublished('npm error network ETIMEDOUT'), false);
+assert.equal(isAlreadyPublished(''), false);
+assert.equal(isAlreadyPublished(undefined), false);
+
+console.log('npm-publish-errors: all assertions passed');

--- a/scripts/publish-changed.mjs
+++ b/scripts/publish-changed.mjs
@@ -6,11 +6,15 @@ import { orderForPublish } from './publish-order.mjs';
 
 const PACKAGES_DIR = 'packages';
 
-// Runtime deps declared with the workspace protocol get their spec rewritten to
-// a fixed version on publish, so a dependent must not ship before its dependency
-// lands on npm. peer/dev deps don't affect a consumer's install, so ignore them.
+// Deps declared with the workspace protocol get their spec rewritten to a fixed
+// version on publish, so a dependent must not ship before its dependency lands
+// on npm. Covers runtime deps and optional deps (corsair's platform-gated frpc
+// binaries); peer/dev deps don't affect a consumer's install, so skip them.
 function workspaceDeps(pkg) {
-	return Object.entries(pkg.dependencies ?? {})
+	return Object.entries({
+		...(pkg.dependencies ?? {}),
+		...(pkg.optionalDependencies ?? {}),
+	})
 		.filter(
 			([, spec]) => typeof spec === 'string' && spec.startsWith('workspace:'),
 		)

--- a/scripts/publish-changed.mjs
+++ b/scripts/publish-changed.mjs
@@ -2,8 +2,20 @@ import { execSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { isAlreadyPublished } from './npm-publish-errors.mjs';
+import { orderForPublish } from './publish-order.mjs';
 
 const PACKAGES_DIR = 'packages';
+
+// Runtime deps declared with the workspace protocol get their spec rewritten to
+// a fixed version on publish, so a dependent must not ship before its dependency
+// lands on npm. peer/dev deps don't affect a consumer's install, so ignore them.
+function workspaceDeps(pkg) {
+	return Object.entries(pkg.dependencies ?? {})
+		.filter(
+			([, spec]) => typeof spec === 'string' && spec.startsWith('workspace:'),
+		)
+		.map(([name]) => name);
+}
 
 function getPublishedVersion(name) {
 	try {
@@ -39,7 +51,12 @@ for (const dir of dirs) {
 	console.log(
 		`QUEUE ${pkg.name}@${pkg.version} (npm has ${published ?? 'nothing'})`,
 	);
-	toPublish.push({ dir, name: pkg.name, version: pkg.version });
+	toPublish.push({
+		dir,
+		name: pkg.name,
+		version: pkg.version,
+		workspaceDeps: workspaceDeps(pkg),
+	});
 }
 
 if (toPublish.length === 0) {
@@ -47,27 +64,46 @@ if (toPublish.length === 0) {
 	process.exit(0);
 }
 
-console.log(`\nBuilding ${toPublish.length} package(s)...`);
-for (const { name } of toPublish) {
+// Only deps published in this same run need ordering — anything already on npm
+// is available regardless of order.
+const publishNames = new Set(toPublish.map((p) => p.name));
+for (const p of toPublish) {
+	p.deps = p.workspaceDeps.filter((d) => publishNames.has(d));
+}
+const ordered = orderForPublish(toPublish);
+
+console.log(`\nBuilding ${ordered.length} package(s)...`);
+for (const { name } of ordered) {
 	console.log(`  Building ${name}...`);
 	execSync(`pnpm --filter ${name} build`, { stdio: 'inherit' });
 }
 
-console.log(`\nPublishing ${toPublish.length} package(s)...`);
+console.log(`\nPublishing ${ordered.length} package(s)...`);
 
 const npmToken = process.env.NPM_TOKEN;
 const corsairDevToken = process.env.NPM_CORSAIR_DEV_TOKEN;
 
 let publishedCount = 0;
-const failures = [];
+const failed = new Set();
 
-for (const { name, version } of toPublish) {
+for (const { name, version, deps } of ordered) {
+	// Never publish a dependent whose in-release dependency failed — its
+	// rewritten version wouldn't exist on npm, so the release would be broken.
+	const blockedBy = deps.filter((d) => failed.has(d));
+	if (blockedBy.length > 0) {
+		console.error(
+			`  FAILED ${name}@${version} — dependency failed: ${blockedBy.join(', ')}`,
+		);
+		failed.add(name);
+		continue;
+	}
+
 	const token = name === 'corsair' ? npmToken : corsairDevToken;
 	if (!token) {
 		console.error(
 			`  FAILED ${name} — missing token (${name === 'corsair' ? 'NPM_TOKEN' : 'NPM_CORSAIR_DEV_TOKEN'})`,
 		);
-		failures.push(name);
+		failed.add(name);
 		continue;
 	}
 
@@ -93,13 +129,13 @@ for (const { name, version } of toPublish) {
 			continue;
 		}
 		console.error(`  FAILED ${name}@${version}`);
-		failures.push(name);
+		failed.add(name);
 	}
 }
 
-if (failures.length > 0) {
+if (failed.size > 0) {
 	console.error(
-		`\nFailed to publish ${failures.length}: ${failures.join(', ')}`,
+		`\nFailed to publish ${failed.size}: ${[...failed].join(', ')}`,
 	);
 	process.exit(1);
 }

--- a/scripts/publish-changed.mjs
+++ b/scripts/publish-changed.mjs
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { isAlreadyPublished } from './npm-publish-errors.mjs';
 
 const PACKAGES_DIR = 'packages';
 
@@ -57,23 +58,50 @@ console.log(`\nPublishing ${toPublish.length} package(s)...`);
 const npmToken = process.env.NPM_TOKEN;
 const corsairDevToken = process.env.NPM_CORSAIR_DEV_TOKEN;
 
-for (const { name } of toPublish) {
+let publishedCount = 0;
+const failures = [];
+
+for (const { name, version } of toPublish) {
 	const token = name === 'corsair' ? npmToken : corsairDevToken;
 	if (!token) {
 		console.error(
-			`  SKIP ${name} — missing token (${name === 'corsair' ? 'NPM_TOKEN' : 'NPM_CORSAIR_DEV_TOKEN'})`,
+			`  FAILED ${name} — missing token (${name === 'corsair' ? 'NPM_TOKEN' : 'NPM_CORSAIR_DEV_TOKEN'})`,
 		);
+		failures.push(name);
 		continue;
 	}
 
-	console.log(`  Publishing ${name}...`);
-	execSync(
-		`pnpm --filter ${name} publish --provenance --access public --no-git-checks`,
-		{
-			stdio: 'inherit',
-			env: { ...process.env, NODE_AUTH_TOKEN: token },
-		},
-	);
+	console.log(`  Publishing ${name}@${version}...`);
+	try {
+		// npm writes errors to stderr but execSync only returns stdout, so redirect
+		// stderr into stdout to capture the failure text for classification below.
+		const out = execSync(
+			`pnpm --filter ${name} publish --provenance --access public --no-git-checks 2>&1`,
+			{
+				encoding: 'utf-8',
+				maxBuffer: 10 * 1024 * 1024,
+				env: { ...process.env, NODE_AUTH_TOKEN: token },
+			},
+		);
+		process.stdout.write(out);
+		publishedCount++;
+	} catch (err) {
+		const out = err.stdout ?? '';
+		process.stdout.write(out);
+		if (isAlreadyPublished(out)) {
+			console.log(`  SKIP ${name}@${version} (already on npm)`);
+			continue;
+		}
+		console.error(`  FAILED ${name}@${version}`);
+		failures.push(name);
+	}
 }
 
-console.log(`\nDone. Published ${toPublish.length} package(s).`);
+if (failures.length > 0) {
+	console.error(
+		`\nFailed to publish ${failures.length}: ${failures.join(', ')}`,
+	);
+	process.exit(1);
+}
+
+console.log(`\nDone. Published ${publishedCount} package(s).`);

--- a/scripts/publish-order.mjs
+++ b/scripts/publish-order.mjs
@@ -1,23 +1,28 @@
 // Publish a package only after the packages it depends on *within this release*.
 // `entries` are { name, deps }, deps listing dependency names also being
 // published now (deps already on npm need no ordering). Post-order DFS emits
-// deps before dependents; an already-emitted node is skipped, and a dependency
-// cycle — which the workspace shouldn't have — falls back to input order for the
-// stuck nodes rather than hanging.
+// deps before dependents. A dependency cycle is a malformed release graph —
+// throw rather than linearize it, since a linearized cycle would let a member
+// publish before a later member fails, defeating the failed-dependency guard.
 export function orderForPublish(entries) {
 	const byName = new Map(entries.map((e) => [e.name, e]));
 	const done = new Set();
+	const visiting = new Set();
 	const ordered = [];
-	const visit = (entry, seen) => {
-		if (done.has(entry.name) || seen.has(entry.name)) return;
-		seen.add(entry.name);
+	const visit = (entry) => {
+		if (done.has(entry.name)) return;
+		if (visiting.has(entry.name)) {
+			throw new Error(`Dependency cycle includes ${entry.name}`);
+		}
+		visiting.add(entry.name);
 		for (const dep of entry.deps) {
 			const d = byName.get(dep);
-			if (d) visit(d, seen);
+			if (d) visit(d);
 		}
+		visiting.delete(entry.name);
 		done.add(entry.name);
 		ordered.push(entry);
 	};
-	for (const entry of entries) visit(entry, new Set());
+	for (const entry of entries) visit(entry);
 	return ordered;
 }

--- a/scripts/publish-order.mjs
+++ b/scripts/publish-order.mjs
@@ -1,0 +1,23 @@
+// Publish a package only after the packages it depends on *within this release*.
+// `entries` are { name, deps }, deps listing dependency names also being
+// published now (deps already on npm need no ordering). Post-order DFS emits
+// deps before dependents; an already-emitted node is skipped, and a dependency
+// cycle — which the workspace shouldn't have — falls back to input order for the
+// stuck nodes rather than hanging.
+export function orderForPublish(entries) {
+	const byName = new Map(entries.map((e) => [e.name, e]));
+	const done = new Set();
+	const ordered = [];
+	const visit = (entry, seen) => {
+		if (done.has(entry.name) || seen.has(entry.name)) return;
+		seen.add(entry.name);
+		for (const dep of entry.deps) {
+			const d = byName.get(dep);
+			if (d) visit(d, seen);
+		}
+		done.add(entry.name);
+		ordered.push(entry);
+	};
+	for (const entry of entries) visit(entry, new Set());
+	return ordered;
+}

--- a/scripts/publish-order.test.mjs
+++ b/scripts/publish-order.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { orderForPublish } from './publish-order.mjs';
+
+const order = (entries) => orderForPublish(entries).map((e) => e.name);
+
+// A dependency publishes before its dependent, even when the dependent sorts
+// first alphabetically — the real `cli` -> `corsair` case.
+assert.deepEqual(
+	order([
+		{ name: 'cli', deps: ['corsair'] },
+		{ name: 'corsair', deps: [] },
+	]),
+	['corsair', 'cli'],
+);
+
+// Transitive chain: corsair -> cli -> studio.
+assert.deepEqual(
+	order([
+		{ name: 'studio', deps: ['cli', 'corsair'] },
+		{ name: 'cli', deps: ['corsair'] },
+		{ name: 'corsair', deps: [] },
+	]),
+	['corsair', 'cli', 'studio'],
+);
+
+// Independent leaves (the ~700 plugins) keep input order.
+assert.deepEqual(
+	order([
+		{ name: 'attio', deps: [] },
+		{ name: 'openrouter', deps: [] },
+	]),
+	['attio', 'openrouter'],
+);
+
+// A cycle must not hang and must still emit every node exactly once.
+const cyc = order([
+	{ name: 'a', deps: ['b'] },
+	{ name: 'b', deps: ['a'] },
+]);
+assert.deepEqual([...cyc].sort(), ['a', 'b']);
+
+console.log('publish-order: all assertions passed');

--- a/scripts/publish-order.test.mjs
+++ b/scripts/publish-order.test.mjs
@@ -32,11 +32,15 @@ assert.deepEqual(
 	['attio', 'openrouter'],
 );
 
-// A cycle must not hang and must still emit every node exactly once.
-const cyc = order([
-	{ name: 'a', deps: ['b'] },
-	{ name: 'b', deps: ['a'] },
-]);
-assert.deepEqual([...cyc].sort(), ['a', 'b']);
+// A dependency cycle is a malformed release graph — reject it loudly rather
+// than linearize, which would let a member publish before another member fails.
+assert.throws(
+	() =>
+		orderForPublish([
+			{ name: 'a', deps: ['b'] },
+			{ name: 'b', deps: ['a'] },
+		]),
+	/cycle/i,
+);
 
 console.log('publish-order: all assertions passed');


### PR DESCRIPTION
Two independent CI fixes, both off fresh `main`.

## 1. Isolate npm publish failures (`scripts/publish-changed.mjs`)

The publish loop had no error handling, so a single package's `npm publish` failure aborted the whole **Deploy Packages to NPM** job and stranded every later package. The usual trigger is a spurious E403: npm's registry read replica lags its write side, so a version published seconds earlier still looks absent to `npm view`, gets re-queued, and 403s on publish. `@corsair-dev/openrouter` sat unpublished for a day behind `attio`'s 403 this way.

Now each publish is isolated: an already-published version is skipped, and genuine errors (auth, network, permission, missing token) are collected so the job exits non-zero at the end. Error classification lives in `scripts/npm-publish-errors.mjs` with a `node:assert` self-test that pins the boundary — duplicate-403 is skipped; auth/permission/network/rate-limit-409 are **not** swallowed.

## 2. Sort `pnpm-lock.yaml` to canonical order

`packages/allimagesai` was committed out of alphabetical order, so every `pnpm install --lockfile-only` re-sorted it — the recurring 13-line diff the **Lockfile Sync** job kept trying (and failing, 403) to push back to protected main. Regenerated with the pinned pnpm (10.20.0); pure reordering, zero dependency changes. Once merged, Lockfile Sync finds nothing to push and goes green.

## Verify

- `node scripts/npm-publish-errors.test.mjs` → passes
- `pnpm install --frozen-lockfile` → exit 0
- biome clean

## Note

The lockfile is canonical against current `main`. If other plugin PRs merge before this one, rebase and re-run `pnpm install --lockfile-only`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package publishing reliability by recognizing packages that have already been published.
  * Packages are published in dependency order, including workspace and optional dependencies.
  * Dependents are blocked when required packages fail, while already-published packages are skipped.
  * Authentication, network, permission, and other publication errors are reported accurately.
  * Circular dependencies are detected and reported instead of being silently accepted.
  * The process returns a failure status when any package cannot be published.

* **Tests**
  * Added coverage for duplicate publication detection, dependency ordering, independent packages, and circular dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->