### PR TITLE
test(resend): use dynamic dummy secret for webhook signature tests

### DIFF
--- a/packages/resend/webhooks/types.test.ts
+++ b/packages/resend/webhooks/types.test.ts
@@ -7,9 +7,7 @@ import { verifyResendWebhookSignature } from './types';
 const TIMESTAMP = Math.floor(Date.now() / 1000);
 const RECENT_TIMESTAMP = String(TIMESTAMP);
 
-const secret =
-	'whsec_' +
-	Buffer.from('test_secret_for_mock_webhook_verification').toString('base64');
+const secret = 'whsec_' + crypto.randomBytes(32).toString('base64');
 const payload: ResendWebhookPayload = {
 	type: 'email.sent',
 	created_at: '2026-01-01T00:00:00.000Z',

--- a/packages/resend/webhooks/types.test.ts
+++ b/packages/resend/webhooks/types.test.ts
@@ -7,7 +7,9 @@ import { verifyResendWebhookSignature } from './types';
 const TIMESTAMP = Math.floor(Date.now() / 1000);
 const RECENT_TIMESTAMP = String(TIMESTAMP);
 
-const secret = 'whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2gAqNLy';
+const secret =
+	'whsec_' +
+	Buffer.from('test_secret_for_mock_webhook_verification').toString('base64');
 const payload: ResendWebhookPayload = {
 	type: 'email.sent',
 	created_at: '2026-01-01T00:00:00.000Z',


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

<!-- Briefly describe the changes you've made and why they're necessary. -->
<!-- Link to any related issues (e.g. "Fixes #123"). -->

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

<!-- If your changes affect the UI or CLI output, please include screenshots or terminal recordings. -->

## Additional Notes

<!-- Any other information that reviewers should know? (e.g. breaking changes, new dependencies) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated webhook test secret generation to use 32 cryptographically random bytes encoded with Base64, improving consistency and realism in automated testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->