### PR TITLE
fix(github): return error when webhook secret is missing

### DIFF
--- a/packages/github/webhooks.test.ts
+++ b/packages/github/webhooks.test.ts
@@ -1,12 +1,23 @@
-import type { WebhookRequest } from 'corsair/core';
-import { verifyGithubWebhookSignature } from './webhooks/types';
+import type { RawWebhookRequest, WebhookRequest } from 'corsair/core';
+import crypto from 'crypto';
+import {
+	createGithubEventMatch,
+	verifyGithubWebhookSignature,
+} from './webhooks/types';
 
 describe('verifyGithubWebhookSignature', () => {
+	const secret = 'github-webhook-secret';
+	const payload = { action: 'opened', issue: { id: 12345 } };
+	const rawBody = JSON.stringify(payload);
+
+	const sign = (key: string, body: string = rawBody) =>
+		`sha256=${crypto.createHmac('sha256', key).update(body).digest('hex')}`;
+
 	it('returns valid when the delivery is hub-verified, even with no secret', () => {
 		const request: WebhookRequest = {
-			payload: {},
+			payload,
 			headers: {},
-			rawBody: '{}',
+			rawBody,
 			hubVerified: true,
 		};
 		expect(verifyGithubWebhookSignature(request, undefined)).toEqual({
@@ -14,15 +25,132 @@ describe('verifyGithubWebhookSignature', () => {
 		});
 	});
 
-	it('still fails a non-hub-verified request with no secret', () => {
-		const request: WebhookRequest = { payload: {}, headers: {}, rawBody: '{}' };
+	it('returns error when webhook secret is undefined', () => {
+		const request: WebhookRequest = {
+			payload,
+			headers: { 'x-hub-signature-256': sign(secret) },
+			rawBody,
+		};
 		expect(verifyGithubWebhookSignature(request, undefined)).toEqual({
 			valid: false,
 			error: 'Missing webhook secret',
 		});
+	});
+
+	it('returns error when webhook secret is empty string', () => {
+		const request: WebhookRequest = {
+			payload,
+			headers: { 'x-hub-signature-256': sign(secret) },
+			rawBody,
+		};
 		expect(verifyGithubWebhookSignature(request, '')).toEqual({
 			valid: false,
 			error: 'Missing webhook secret',
 		});
+	});
+
+	it('returns error when raw body is missing', () => {
+		const request: WebhookRequest = {
+			payload,
+			headers: { 'x-hub-signature-256': sign(secret) },
+			rawBody: undefined as unknown as string,
+		};
+		expect(verifyGithubWebhookSignature(request, secret)).toEqual({
+			valid: false,
+			error: 'Missing raw body for signature verification',
+		});
+	});
+
+	it('returns error when x-hub-signature-256 header is missing', () => {
+		const request: WebhookRequest = {
+			payload,
+			headers: {},
+			rawBody,
+		};
+		expect(verifyGithubWebhookSignature(request, secret)).toEqual({
+			valid: false,
+			error: 'Missing x-hub-signature-256 header',
+		});
+	});
+
+	it('returns error when signature is invalid', () => {
+		const request: WebhookRequest = {
+			payload,
+			headers: { 'x-hub-signature-256': sign('wrong-secret') },
+			rawBody,
+		};
+		expect(verifyGithubWebhookSignature(request, secret)).toEqual({
+			valid: false,
+			error: 'Invalid signature',
+		});
+	});
+
+	it('returns valid for a correctly signed request', () => {
+		const request: WebhookRequest = {
+			payload,
+			headers: { 'x-hub-signature-256': sign(secret) },
+			rawBody,
+		};
+		expect(verifyGithubWebhookSignature(request, secret)).toEqual({
+			valid: true,
+		});
+	});
+
+	it('accepts signature header as an array', () => {
+		const request: WebhookRequest = {
+			payload,
+			headers: { 'x-hub-signature-256': [sign(secret)] },
+			rawBody,
+		};
+		expect(verifyGithubWebhookSignature(request, secret)).toEqual({
+			valid: true,
+		});
+	});
+});
+
+describe('createGithubEventMatch', () => {
+	it('matches request with correct x-github-event header', () => {
+		const matcher = createGithubEventMatch('issues');
+		const request: RawWebhookRequest = {
+			headers: { 'x-github-event': 'issues' },
+			body: { action: 'opened' },
+		};
+		expect(matcher(request)).toBe(true);
+	});
+
+	it('returns false when x-github-event does not match', () => {
+		const matcher = createGithubEventMatch('issues');
+		const request: RawWebhookRequest = {
+			headers: { 'x-github-event': 'push' },
+			body: {},
+		};
+		expect(matcher(request)).toBe(false);
+	});
+
+	it('matches request with both event type and action', () => {
+		const matcher = createGithubEventMatch('issues', 'opened');
+		const request: RawWebhookRequest = {
+			headers: { 'x-github-event': 'issues' },
+			body: { action: 'opened' },
+		};
+		expect(matcher(request)).toBe(true);
+	});
+
+	it('returns false when action does not match', () => {
+		const matcher = createGithubEventMatch('issues', 'closed');
+		const request: RawWebhookRequest = {
+			headers: { 'x-github-event': 'issues' },
+			body: { action: 'opened' },
+		};
+		expect(matcher(request)).toBe(false);
+	});
+
+	it('parses JSON string body when checking action', () => {
+		const matcher = createGithubEventMatch('pull_request', 'opened');
+		const request: RawWebhookRequest = {
+			headers: { 'x-github-event': 'pull_request' },
+			body: JSON.stringify({ action: 'opened' }),
+		};
+		expect(matcher(request)).toBe(true);
 	});
 });

--- a/packages/github/webhooks.test.ts
+++ b/packages/github/webhooks.test.ts
@@ -18,6 +18,7 @@ describe('verifyGithubWebhookSignature', () => {
 		const request: WebhookRequest = { payload: {}, headers: {}, rawBody: '{}' };
 		expect(verifyGithubWebhookSignature(request, undefined)).toEqual({
 			valid: false,
+			error: 'Missing webhook secret',
 		});
 	});
 });

--- a/packages/github/webhooks.test.ts
+++ b/packages/github/webhooks.test.ts
@@ -20,5 +20,9 @@ describe('verifyGithubWebhookSignature', () => {
 			valid: false,
 			error: 'Missing webhook secret',
 		});
+		expect(verifyGithubWebhookSignature(request, '')).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
 	});
 });

--- a/packages/github/webhooks/types.ts
+++ b/packages/github/webhooks/types.ts
@@ -2186,7 +2186,7 @@ export function verifyGithubWebhookSignature(
 		return { valid: true };
 	}
 	if (!webhookSecret) {
-		return { valid: false };
+		return { valid: false, error: 'Missing webhook secret' };
 	}
 
 	const rawBody = request.rawBody;


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

Closes https://github.com/corsairdev/corsair/issues/688

When `webhookSecret` was missing or empty, `verifyGithubWebhookSignature` previously returned `{ valid: false }` without an `error` property. This caused downstream webhook handlers to fall back to generic error messages, obscuring the actual root cause (missing configuration).

### Changes:
- Updated `verifyGithubWebhookSignature` in `packages/github/webhooks/types.ts` to return `{ valid: false, error: 'Missing webhook secret' }` when `webhookSecret` is missing.
- Updated unit tests in `packages/github/webhooks.test.ts` to assert that `{ valid: false, error: 'Missing webhook secret' }` is returned.

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

<img width="627" height="90" alt="Screenshot 2026-08-24 193340" src="https://github.com/user-attachments/assets/16b37d9d-241a-480e-935b-b048ed3e3f94" />

## Additional Notes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* GitHub webhook validation now provides a clear “Missing webhook secret” error when no secret is configured.
* Webhook signature verification continues to correctly handle valid and invalid signatures, missing request data, and supported signature header formats.
* Event matching now reliably supports event types, actions, and JSON request bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->