### PR TITLE
test(stripe): add unit tests for verifyStripeWebhookSignature

### DIFF
--- a/packages/stripe/webhooks/types.test.ts
+++ b/packages/stripe/webhooks/types.test.ts
@@ -18,14 +18,13 @@ describe('verifyStripeWebhookSignature', () => {
 				amount: 2000,
 				currency: 'usd',
 				status: 'succeeded',
+				description: 'café au lait',
 			},
 		},
 	};
 
-	/** Pretty-printed (2-space indent) — matches what Stripe actually sends over the wire. */
 	const stripeEventBody = JSON.stringify(stripeEvent, null, 2);
 
-	// unknown: the webhook payload type is generic at this layer; callers receive a typed payload after schema parsing
 	const requestWith = (
 		headers: Record<string, string | string[]>,
 		rawBody?: string,
@@ -41,10 +40,7 @@ describe('verifyStripeWebhookSignature', () => {
 			'',
 		);
 
-		expect(result).toEqual({
-			valid: false,
-			error: 'Missing webhook secret',
-		});
+		expect(result).toEqual({ valid: false, error: 'Missing webhook secret' });
 	});
 
 	it('should fail when rawBody is missing', () => {
@@ -83,6 +79,25 @@ describe('verifyStripeWebhookSignature', () => {
 		});
 	});
 
+	it('should use first element when stripe-signature is an array', () => {
+		const timestamp = Math.floor(Date.now() / 1000);
+
+		const sig = crypto
+			.createHmac('sha256', secret)
+			.update(`${timestamp}.${stripeEventBody}`)
+			.digest('hex');
+
+		const result = verifyStripeWebhookSignature(
+			requestWith(
+				{ 'stripe-signature': [`t=${timestamp},v1=${sig}`, 'ignored'] },
+				stripeEventBody,
+			),
+			secret,
+		);
+
+		expect(result).toEqual({ valid: true });
+	});
+
 	it('should fail for malformed stripe-signature header (no t= or v1=)', () => {
 		const result = verifyStripeWebhookSignature(
 			requestWith(
@@ -103,31 +118,26 @@ describe('verifyStripeWebhookSignature', () => {
 
 		const result = verifyStripeWebhookSignature(
 			requestWith(
-				{
-					'stripe-signature': `t=${timestamp},v1=wrong-v1`,
-				},
+				{ 'stripe-signature': `t=${timestamp},v1=wrong-v1` },
 				stripeEventBody,
 			),
 			secret,
 		);
 
-		expect(result).toEqual({
-			valid: false,
-			error: 'Invalid signature',
-		});
+		expect(result).toEqual({ valid: false, error: 'Invalid signature' });
 	});
 
-	it('should return valid with correct t=<unix>,v1=<hex> over ${timestamp}.${rawBody} with a fresh timestamp', () => {
+	it('should return valid with correct t=<unix>,v1=<hex> and a fresh timestamp', () => {
 		const timestamp = Math.floor(Date.now() / 1000);
 
-		const expectedSignature = crypto
+		const sig = crypto
 			.createHmac('sha256', secret)
 			.update(`${timestamp}.${stripeEventBody}`)
 			.digest('hex');
 
 		const result = verifyStripeWebhookSignature(
 			requestWith(
-				{ 'stripe-signature': `t=${timestamp},v1=${expectedSignature}` },
+				{ 'stripe-signature': `t=${timestamp},v1=${sig}` },
 				stripeEventBody,
 			),
 			secret,
@@ -136,22 +146,39 @@ describe('verifyStripeWebhookSignature', () => {
 		expect(result).toEqual({ valid: true });
 	});
 
-	it('should still validate when framework re-stringifies body to compact form (pretty-print fallback)', () => {
+	it('should accept any matching v1 when multiple v1= tokens are present', () => {
 		const timestamp = Math.floor(Date.now() / 1000);
 
-		// Stripe signs over the pretty-printed body
-		const signature = crypto
+		const goodSig = crypto
 			.createHmac('sha256', secret)
 			.update(`${timestamp}.${stripeEventBody}`)
 			.digest('hex');
 
-		// Framework parsed and re-stringified to compact form
+		const result = verifyStripeWebhookSignature(
+			requestWith(
+				{ 'stripe-signature': `t=${timestamp},v1=oldinvalidsig,v1=${goodSig}` },
+				stripeEventBody,
+			),
+			secret,
+		);
+
+		expect(result).toEqual({ valid: true });
+	});
+
+	it('should still validate when framework re-stringifies body to compact form', () => {
+		const timestamp = Math.floor(Date.now() / 1000);
+
+		const sig = crypto
+			.createHmac('sha256', secret)
+			.update(`${timestamp}.${stripeEventBody}`)
+			.digest('hex');
+
 		const compactBody = JSON.stringify(stripeEvent);
 
 		const result = verifyStripeWebhookSignature(
 			requestWith(
 				{
-					'stripe-signature': `t=${timestamp},v1=${signature}`,
+					'stripe-signature': `t=${timestamp},v1=${sig}`,
 					'content-length': String(stripeEventBody.length),
 				},
 				compactBody,
@@ -163,18 +190,16 @@ describe('verifyStripeWebhookSignature', () => {
 	});
 
 	it('should reject a timestamp outside the 5-minute tolerance', () => {
-		const staleTimestamp = Math.floor(Date.now() / 1000) - 600; // 10 minutes ago
+		const staleTimestamp = Math.floor(Date.now() / 1000) - 600;
 
-		const signature = crypto
+		const sig = crypto
 			.createHmac('sha256', secret)
 			.update(`${staleTimestamp}.${stripeEventBody}`)
 			.digest('hex');
 
 		const result = verifyStripeWebhookSignature(
 			requestWith(
-				{
-					'stripe-signature': `t=${staleTimestamp},v1=${signature}`,
-				},
+				{ 'stripe-signature': `t=${staleTimestamp},v1=${sig}` },
 				stripeEventBody,
 			),
 			secret,

--- a/packages/stripe/webhooks/types.test.ts
+++ b/packages/stripe/webhooks/types.test.ts
@@ -1,0 +1,188 @@
+import type { WebhookRequest } from 'corsair/core';
+import * as crypto from 'crypto';
+import { verifyStripeWebhookSignature } from './types';
+
+describe('verifyStripeWebhookSignature', () => {
+	const secret = 'whsec_test_secret';
+
+	const stripeEvent = {
+		id: 'evt_test_webhook',
+		object: 'event',
+		type: 'charge.succeeded',
+		created: 1_672_531_200,
+		livemode: false,
+		data: {
+			object: {
+				id: 'ch_test_123',
+				object: 'charge',
+				amount: 2000,
+				currency: 'usd',
+				status: 'succeeded',
+			},
+		},
+	};
+
+	/** Pretty-printed (2-space indent) — matches what Stripe actually sends over the wire. */
+	const stripeEventBody = JSON.stringify(stripeEvent, null, 2);
+
+	// unknown: the webhook payload type is generic at this layer; callers receive a typed payload after schema parsing
+	const requestWith = (
+		headers: Record<string, string | string[]>,
+		rawBody?: string,
+	): WebhookRequest<unknown> => ({
+		payload: {},
+		headers,
+		rawBody,
+	});
+
+	it('should fail closed when secret is missing', () => {
+		const result = verifyStripeWebhookSignature(
+			requestWith({ 'stripe-signature': 't=123,v1=abc' }, stripeEventBody),
+			'',
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('should fail when rawBody is missing', () => {
+		const result = verifyStripeWebhookSignature(
+			requestWith({ 'stripe-signature': 't=123,v1=abc' }),
+			secret,
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing raw body for signature verification',
+		});
+	});
+
+	it('should fail when stripe-signature header is missing', () => {
+		const result = verifyStripeWebhookSignature(
+			requestWith({}, stripeEventBody),
+			secret,
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing stripe-signature header',
+		});
+	});
+
+	it('should fail when stripe-signature header is empty', () => {
+		const result = verifyStripeWebhookSignature(
+			requestWith({ 'stripe-signature': '' }, stripeEventBody),
+			secret,
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing stripe-signature header',
+		});
+	});
+
+	it('should fail for malformed stripe-signature header (no t= or v1=)', () => {
+		const result = verifyStripeWebhookSignature(
+			requestWith(
+				{ 'stripe-signature': 'not-a-valid-header' },
+				stripeEventBody,
+			),
+			secret,
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Malformed stripe-signature header',
+		});
+	});
+
+	it('should return invalid for wrong v1 HMAC', () => {
+		const timestamp = Math.floor(Date.now() / 1000);
+
+		const result = verifyStripeWebhookSignature(
+			requestWith(
+				{
+					'stripe-signature': `t=${timestamp},v1=wrong-v1`,
+				},
+				stripeEventBody,
+			),
+			secret,
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid signature',
+		});
+	});
+
+	it('should return valid with correct t=<unix>,v1=<hex> over ${timestamp}.${rawBody} with a fresh timestamp', () => {
+		const timestamp = Math.floor(Date.now() / 1000);
+
+		const expectedSignature = crypto
+			.createHmac('sha256', secret)
+			.update(`${timestamp}.${stripeEventBody}`)
+			.digest('hex');
+
+		const result = verifyStripeWebhookSignature(
+			requestWith(
+				{ 'stripe-signature': `t=${timestamp},v1=${expectedSignature}` },
+				stripeEventBody,
+			),
+			secret,
+		);
+
+		expect(result).toEqual({ valid: true });
+	});
+
+	it('should still validate when framework re-stringifies body to compact form (pretty-print fallback)', () => {
+		const timestamp = Math.floor(Date.now() / 1000);
+
+		// Stripe signs over the pretty-printed body
+		const signature = crypto
+			.createHmac('sha256', secret)
+			.update(`${timestamp}.${stripeEventBody}`)
+			.digest('hex');
+
+		// Framework parsed and re-stringified to compact form
+		const compactBody = JSON.stringify(stripeEvent);
+
+		const result = verifyStripeWebhookSignature(
+			requestWith(
+				{
+					'stripe-signature': `t=${timestamp},v1=${signature}`,
+					'content-length': String(stripeEventBody.length),
+				},
+				compactBody,
+			),
+			secret,
+		);
+
+		expect(result).toEqual({ valid: true });
+	});
+
+	it('should reject a timestamp outside the 5-minute tolerance', () => {
+		const staleTimestamp = Math.floor(Date.now() / 1000) - 600; // 10 minutes ago
+
+		const signature = crypto
+			.createHmac('sha256', secret)
+			.update(`${staleTimestamp}.${stripeEventBody}`)
+			.digest('hex');
+
+		const result = verifyStripeWebhookSignature(
+			requestWith(
+				{
+					'stripe-signature': `t=${staleTimestamp},v1=${signature}`,
+				},
+				stripeEventBody,
+			),
+			secret,
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Webhook timestamp is too old (possible replay attack)',
+		});
+	});
+});


### PR DESCRIPTION
## Description

Add unit tests for `verifyStripeWebhookSignature` in `packages/stripe/webhooks/types.ts`.

Fixes #699

The function previously had zero test coverage. This PR adds 9 tests covering every branch:

| # | Test case | Expected error / result |
|---|-----------|------------------------|
| 1 | Missing webhook secret | `Missing webhook secret` |
| 2 | Missing `rawBody` | `Missing raw body for signature verification` |
| 3 | Missing `stripe-signature` header | `Missing stripe-signature header` |
| 4 | Empty `stripe-signature` header | `Missing stripe-signature header` |
| 5 | Malformed header (no `t=` or `v1=`) | `Malformed stripe-signature header` |
| 6 | Wrong `v1` HMAC | `Invalid signature` |
| 7 | Correct `t=<unix>,v1=<hex>` with fresh timestamp | `{ valid: true }` |
| 8 | Pretty-print fallback (framework re-stringified body to compact form) | `{ valid: true }` |
| 9 | Stale timestamp (outside 5-min tolerance) | `Webhook timestamp is too old (possible replay attack)` |

The test fixture uses a realistic Stripe `charge.succeeded` event envelope, pretty-printed with 2-space indent to match what Stripe actually sends over the wire.

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable

## Screenshots / Demos (if applicable)
<img width="999" height="314" alt="Screenshot 2026-08-25 at 11 09 55 AM" src="https://github.com/user-attachments/assets/f0883654-3ea2-40db-9938-57fc5b7c85a8" />


## Additional Notes

- Only touches one new file: `packages/stripe/webhooks/types.test.ts`
- No production code changes
- Test 8 (pretty-print fallback) covers the `content-length` mismatch recovery logic in the production code where frameworks re-serialize the body to compact JSON, breaking the HMAC unless the function re-pretty-prints and retries


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for Stripe webhook signature verification.
  * Validated missing or malformed request data, invalid signatures, stale timestamps, and valid signatures.
  * Added coverage for compacted bodies, non-ASCII payloads, array-formatted headers, and matching `v1` signatures among multiple tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->