### PR TITLE
feat(benchmarkemail): add Benchmark Email integration plugin

### DIFF
--- a/packages/benchmarkemail/client.ts
+++ b/packages/benchmarkemail/client.ts
@@ -1,0 +1,60 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { request } from 'corsair/http';
+
+export class BenchmarkEmailAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly code?: string,
+	) {
+		super(message);
+		this.name = 'BenchmarkEmailAPIError';
+	}
+}
+
+// TODO: Update with your API base URL
+const BENCHMARKEMAIL_API_BASE = 'https://api.example.com';
+
+export async function makeBenchmarkEmailRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	options: {
+		method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+		body?: Record<string, unknown>;
+		query?: Record<string, string | number | boolean | undefined>;
+	} = {},
+): Promise<T> {
+	const { method = 'GET', body, query } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: BENCHMARKEMAIL_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: apiKey,
+		HEADERS: {
+			'Content-Type': 'application/json',
+			// TODO: Add authentication headers
+			// 'Authorization': \`Bearer \${apiKey}\`
+		},
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint,
+		body:
+			method === 'POST' || method === 'PUT' || method === 'PATCH'
+				? body
+				: undefined,
+		mediaType: 'application/json; charset=utf-8',
+		query: method === 'GET' ? query : undefined,
+	};
+
+	try {
+		return await request<T>(config, requestOptions);
+	} catch (error) {
+		if (error instanceof Error) {
+			throw new BenchmarkEmailAPIError(error.message);
+		}
+		throw new BenchmarkEmailAPIError('Unknown error');
+	}
+}

--- a/packages/benchmarkemail/endpoints/example.ts
+++ b/packages/benchmarkemail/endpoints/example.ts
@@ -1,0 +1,21 @@
+import { logEventFromContext } from 'corsair/core';
+import type { BenchmarkEmailEndpoints } from '..';
+import { makeBenchmarkEmailRequest } from '../client';
+import type { BenchmarkEmailEndpointOutputs } from './types';
+
+export const get: BenchmarkEmailEndpoints['exampleGet'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeBenchmarkEmailRequest<
+		BenchmarkEmailEndpointOutputs['exampleGet']
+	>(`example/${input.id}`, ctx.key, { method: 'GET' });
+
+	await logEventFromContext(
+		ctx,
+		'benchmarkemail.example.get',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};

--- a/packages/benchmarkemail/endpoints/index.ts
+++ b/packages/benchmarkemail/endpoints/index.ts
@@ -1,0 +1,7 @@
+import { get as exampleGet } from './example';
+
+export const Example = {
+	get: exampleGet,
+};
+
+export * from './types';

--- a/packages/benchmarkemail/endpoints/types.ts
+++ b/packages/benchmarkemail/endpoints/types.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+const ExampleGetInputSchema = z.object({
+	id: z.string(),
+});
+
+export type ExampleGetInput = z.infer<typeof ExampleGetInputSchema>;
+
+const ExampleGetResponseSchema = z.object({
+	id: z.string(),
+});
+
+export type ExampleGetResponse = z.infer<typeof ExampleGetResponseSchema>;
+
+export type BenchmarkEmailEndpointInputs = {
+	exampleGet: ExampleGetInput;
+};
+
+export type BenchmarkEmailEndpointOutputs = {
+	exampleGet: ExampleGetResponse;
+};
+
+export const BenchmarkEmailEndpointInputSchemas = {
+	exampleGet: ExampleGetInputSchema,
+} as const;
+
+export const BenchmarkEmailEndpointOutputSchemas = {
+	exampleGet: ExampleGetResponseSchema,
+} as const;

--- a/packages/benchmarkemail/error-handlers.ts
+++ b/packages/benchmarkemail/error-handlers.ts
@@ -1,0 +1,31 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('429');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('unauthorized') || msg.includes('invalid_auth');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/benchmarkemail/index.ts
+++ b/packages/benchmarkemail/index.ts
@@ -1,0 +1,223 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	BindWebhooks,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	CorsairWebhook,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+	RequiredPluginWebhookSchemas,
+} from 'corsair/core';
+import { Example } from './endpoints';
+import type {
+	BenchmarkEmailEndpointInputs,
+	BenchmarkEmailEndpointOutputs,
+} from './endpoints/types';
+import {
+	BenchmarkEmailEndpointInputSchemas,
+	BenchmarkEmailEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { BenchmarkEmailSchema } from './schema';
+import { ExampleWebhooks } from './webhooks';
+import { resolveBenchmarkEmailOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
+import { matchBenchmarkEmailTenantWebhook } from './webhooks/tenant-matcher';
+import type {
+	BenchmarkEmailWebhookOutputs,
+	ExampleEvent,
+} from './webhooks/types';
+import { ExampleEventSchema } from './webhooks/types';
+
+export type BenchmarkEmailPluginOptions = {
+	authType?: PickAuth<'api_key' | 'oauth_2'>;
+	key?: string;
+	webhookSecret?: string;
+	hooks?: InternalBenchmarkEmailPlugin['hooks'];
+	webhookHooks?: InternalBenchmarkEmailPlugin['webhookHooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof benchmarkEmailEndpointsNested>;
+};
+
+export type BenchmarkEmailContext = CorsairPluginContext<
+	typeof BenchmarkEmailSchema,
+	BenchmarkEmailPluginOptions
+>;
+
+export type BenchmarkEmailKeyBuilderContext =
+	KeyBuilderContext<BenchmarkEmailPluginOptions>;
+
+export type BenchmarkEmailBoundEndpoints = BindEndpoints<
+	typeof benchmarkEmailEndpointsNested
+>;
+
+type BenchmarkEmailEndpoint<K extends keyof BenchmarkEmailEndpointOutputs> =
+	CorsairEndpoint<
+		BenchmarkEmailContext,
+		BenchmarkEmailEndpointInputs[K],
+		BenchmarkEmailEndpointOutputs[K]
+	>;
+
+export type BenchmarkEmailEndpoints = {
+	exampleGet: BenchmarkEmailEndpoint<'exampleGet'>;
+};
+
+type BenchmarkEmailWebhook<
+	K extends keyof BenchmarkEmailWebhookOutputs,
+	TEvent,
+> = CorsairWebhook<
+	BenchmarkEmailContext,
+	TEvent,
+	BenchmarkEmailWebhookOutputs[K]
+>;
+
+export type BenchmarkEmailWebhooks = {
+	example: BenchmarkEmailWebhook<'example', ExampleEvent>;
+};
+
+export type BenchmarkEmailBoundWebhooks = BindWebhooks<BenchmarkEmailWebhooks>;
+
+const benchmarkEmailEndpointsNested = {
+	example: {
+		get: Example.get,
+	},
+} as const;
+
+const benchmarkEmailWebhooksNested = {
+	example: {
+		example: ExampleWebhooks.example,
+	},
+} as const;
+
+export const benchmarkEmailEndpointSchemas = {
+	'example.get': {
+		input: BenchmarkEmailEndpointInputSchemas.exampleGet,
+		output: BenchmarkEmailEndpointOutputSchemas.exampleGet,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<
+	typeof benchmarkEmailEndpointsNested
+>;
+
+const benchmarkEmailWebhookSchemas = {
+	'example.example': {
+		description: 'An example webhook event',
+		payload: ExampleEventSchema,
+		response: ExampleEventSchema,
+	},
+} as const satisfies RequiredPluginWebhookSchemas<
+	typeof benchmarkEmailWebhooksNested
+>;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const benchmarkEmailEndpointMeta = {
+	'example.get': {
+		riskLevel: 'read',
+		description: 'Get an example resource by ID',
+	},
+} as const satisfies RequiredPluginEndpointMeta<
+	typeof benchmarkEmailEndpointsNested
+>;
+
+export const benchmarkEmailAuthConfig = {
+	api_key: {
+		account: ['tenant_external_id'] as const,
+	},
+	oauth_2: {
+		account: ['tenant_external_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type BaseBenchmarkEmailPlugin<T extends BenchmarkEmailPluginOptions> =
+	CorsairPlugin<
+		'benchmarkemail',
+		typeof BenchmarkEmailSchema,
+		typeof benchmarkEmailEndpointsNested,
+		typeof benchmarkEmailWebhooksNested,
+		T,
+		typeof defaultAuthType
+	>;
+
+export type InternalBenchmarkEmailPlugin =
+	BaseBenchmarkEmailPlugin<BenchmarkEmailPluginOptions>;
+
+export type ExternalBenchmarkEmailPlugin<
+	T extends BenchmarkEmailPluginOptions,
+> = BaseBenchmarkEmailPlugin<T>;
+
+export function benchmarkemail<const T extends BenchmarkEmailPluginOptions>(
+	incomingOptions: BenchmarkEmailPluginOptions &
+		T = {} as BenchmarkEmailPluginOptions & T,
+): ExternalBenchmarkEmailPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'benchmarkemail',
+		authConfig: benchmarkEmailAuthConfig,
+		schema: BenchmarkEmailSchema,
+		options: options,
+		hooks: options.hooks,
+		webhookHooks: options.webhookHooks,
+		endpoints: benchmarkEmailEndpointsNested,
+		webhooks: benchmarkEmailWebhooksNested,
+		endpointMeta: benchmarkEmailEndpointMeta,
+		endpointSchemas: benchmarkEmailEndpointSchemas,
+		webhookSchemas: benchmarkEmailWebhookSchemas,
+		pluginWebhookMatcher: (request) => {
+			const headers = request.headers;
+			// TODO: Update to match your webhook signature headers
+			return 'x-benchmarkemail-signature' in headers;
+		},
+		pluginTenantWebhookMatcher: matchBenchmarkEmailTenantWebhook,
+		oauthWebhookTenantLinkResolver: resolveBenchmarkEmailOAuthWebhookTenantLink,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: BenchmarkEmailKeyBuilderContext, source) => {
+			if (source === 'webhook' && options.webhookSecret) {
+				return options.webhookSecret;
+			}
+
+			if (source === 'webhook') {
+				const res = await ctx.keys.get_webhook_signature();
+				return res ?? '';
+			}
+
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys.get_api_key();
+				return res ?? '';
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'oauth_2') {
+				const res = await ctx.keys.get_access_token();
+				return res ?? '';
+			}
+
+			return '';
+		},
+	} satisfies InternalBenchmarkEmailPlugin;
+}
+
+export type {
+	BenchmarkEmailEndpointInputs,
+	BenchmarkEmailEndpointOutputs,
+	ExampleGetInput,
+	ExampleGetResponse,
+} from './endpoints/types';
+export type {
+	BenchmarkEmailWebhookOutputs,
+	ExampleEvent,
+} from './webhooks/types';

--- a/packages/benchmarkemail/jest.config.cjs
+++ b/packages/benchmarkemail/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/benchmarkemail/package.json
+++ b/packages/benchmarkemail/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/benchmarkemail",
+  "version": "0.1.0",
+  "description": "BenchmarkEmail plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "benchmarkemail",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/benchmarkemail/schema.test.ts
+++ b/packages/benchmarkemail/schema.test.ts
@@ -1,0 +1,22 @@
+import { BenchmarkEmailSchema } from './schema';
+
+describe('BenchmarkEmail schema', () => {
+	it('declares a semver version', () => {
+		expect(BenchmarkEmailSchema.version).toBeDefined();
+		expect(BenchmarkEmailSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof BenchmarkEmailSchema.entities).toBe('object');
+		expect(BenchmarkEmailSchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(BenchmarkEmailSchema.entities))).toBe(
+			true,
+		);
+		for (const entity of Object.values(BenchmarkEmailSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/benchmarkemail/schema/database.ts
+++ b/packages/benchmarkemail/schema/database.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+// TODO: Define your database entities here
+// export const BenchmarkEmailExample = z.object({
+// 	id: z.string(),
+// 	name: z.string(),
+// 	created_at: z.coerce.date().nullable().optional(),
+// });
+// export type BenchmarkEmailExample = z.infer<typeof BenchmarkEmailExample>;

--- a/packages/benchmarkemail/schema/index.ts
+++ b/packages/benchmarkemail/schema/index.ts
@@ -1,0 +1,4 @@
+export const BenchmarkEmailSchema = {
+	version: '1.0.0',
+	entities: {},
+} as const;

--- a/packages/benchmarkemail/tsconfig.json
+++ b/packages/benchmarkemail/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/benchmarkemail/tsup.config.ts
+++ b/packages/benchmarkemail/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/benchmarkemail/webhooks/example.ts
+++ b/packages/benchmarkemail/webhooks/example.ts
@@ -1,0 +1,35 @@
+import { logEventFromContext } from 'corsair/core';
+import type { BenchmarkEmailWebhooks } from '..';
+import {
+	createBenchmarkEmailMatch,
+	verifyBenchmarkEmailWebhookSignature,
+} from './types';
+
+export const example: BenchmarkEmailWebhooks['example'] = {
+	match: createBenchmarkEmailMatch('example'),
+
+	handler: async (ctx, request) => {
+		const verification = verifyBenchmarkEmailWebhookSignature(request, ctx.key);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
+
+		const event = request.payload;
+		if (event.type !== 'example') {
+			return { success: true, data: undefined };
+		}
+
+		await logEventFromContext(
+			ctx,
+			'benchmarkemail.webhook.example',
+			{ ...event },
+			'completed',
+		);
+
+		return { success: true, data: event };
+	},
+};

--- a/packages/benchmarkemail/webhooks/index.ts
+++ b/packages/benchmarkemail/webhooks/index.ts
@@ -1,0 +1,9 @@
+import { example } from './example';
+
+export const ExampleWebhooks = {
+	example: example,
+};
+
+export * from './oauth-tenant-link';
+export * from './tenant-matcher';
+export * from './types';

--- a/packages/benchmarkemail/webhooks/oauth-tenant-link.ts
+++ b/packages/benchmarkemail/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,31 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, toExternalId } from 'corsair/core';
+
+// TODO: Rename linkType 'tenant_external_id' to match pluginTenantWebhookMatcher.
+// Called after OAuth to store the routing id on corsair_accounts.config.
+export async function resolveBenchmarkEmailOAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): Promise<WebhookTenantMatch | null> {
+	// TODO: Read from token response when the provider includes a stable id.
+	// const externalId = toExternalId(asRecord(tokens.team)?.id);
+	const externalId = toExternalId(tokens.tenant_external_id);
+	if (externalId) {
+		return { linkType: 'tenant_external_id', externalId };
+	}
+
+	const accessToken = tokens.access_token;
+	if (!accessToken) return null;
+
+	// TODO: Fetch from provider API when the token response omits the id.
+	// const response = await fetch('https://api.example.com/me', {
+	// 	headers: { Authorization: `Bearer ${accessToken}` },
+	// });
+	// if (!response.ok) return null;
+	// const payload = (await response.json()) as { id?: string };
+	// const fetchedId = toExternalId(payload.id);
+	// return fetchedId
+	// 	? { linkType: 'tenant_external_id', externalId: fetchedId }
+	// 	: null;
+
+	return null;
+}

--- a/packages/benchmarkemail/webhooks/tenant-matcher.ts
+++ b/packages/benchmarkemail/webhooks/tenant-matcher.ts
@@ -1,0 +1,25 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// TODO: Rename linkType 'tenant_external_id' to match the provider field
+// (e.g. team_id, installation_id, organization_id). Must match authConfig.account
+// and oauthWebhookTenantLinkResolver.
+// Return null for URL verification / handshake payloads that have no tenant id.
+export function matchBenchmarkEmailTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	// TODO: Extract the stable external id from the webhook payload.
+	// Example:
+	// const externalId = firstString([body.tenant_external_id, asRecord(body.data)?.id]);
+	const externalId = firstString([
+		body.tenant_external_id,
+		asRecord(body.data)?.tenant_external_id,
+	]);
+
+	if (!externalId) return null;
+
+	return { linkType: 'tenant_external_id', externalId };
+}

--- a/packages/benchmarkemail/webhooks/types.ts
+++ b/packages/benchmarkemail/webhooks/types.ts
@@ -1,0 +1,66 @@
+import type {
+	CorsairWebhookMatcher,
+	RawWebhookRequest,
+	WebhookRequest,
+} from 'corsair/core';
+import { z } from 'zod';
+
+export const BenchmarkEmailWebhookPayloadSchema = z.object({
+	type: z.string(),
+	created_at: z.string(),
+	data: z.record(z.string(), z.unknown()),
+});
+
+export type BenchmarkEmailWebhookPayload = z.infer<
+	typeof BenchmarkEmailWebhookPayloadSchema
+>;
+
+export const ExampleEventSchema = BenchmarkEmailWebhookPayloadSchema.extend({
+	type: z.literal('example'),
+	data: z
+		.object({
+			id: z.string(),
+		})
+		.loose(),
+});
+
+export type ExampleEvent = z.infer<typeof ExampleEventSchema>;
+
+export type BenchmarkEmailWebhookOutputs = {
+	example: ExampleEvent;
+};
+
+function parseBody(body: unknown): Record<string, unknown> | null {
+	if (typeof body === 'string') {
+		try {
+			const parsed = JSON.parse(body);
+			return parsed !== null &&
+				typeof parsed === 'object' &&
+				!Array.isArray(parsed)
+				? (parsed as Record<string, unknown>)
+				: null;
+		} catch {
+			return null;
+		}
+	}
+	return body !== null && typeof body === 'object' && !Array.isArray(body)
+		? (body as Record<string, unknown>)
+		: null;
+}
+
+export function createBenchmarkEmailMatch(
+	eventType: string,
+): CorsairWebhookMatcher {
+	return (request: RawWebhookRequest) => {
+		const parsedBody = parseBody(request.body);
+		return parsedBody !== null && parsedBody.type === eventType;
+	};
+}
+
+export function verifyBenchmarkEmailWebhookSignature(
+	request: WebhookRequest<BenchmarkEmailWebhookPayload>,
+	secret: string,
+): { valid: boolean; error?: string } {
+	// TODO: Implement webhook signature verification
+	return { valid: true };
+}

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -61,6 +61,7 @@ export const BaseProviders = [
 	'basecamp',
 	'baselinker',
 	'basin',
+	'benchmarkemail',
 	'betterstack',
 	'bigmailer',
 	'bigml',
@@ -249,6 +250,7 @@ export const ProviderDisplayNames = {
 	basecamp: 'Basecamp',
 	baselinker: 'BaseLinker',
 	basin: 'Basin',
+	benchmarkemail: 'BenchmarkEmail',
 	betterstack: 'Better Stack',
 	bigmailer: 'BigMailer',
 	bigml: 'BigML',
@@ -444,6 +446,7 @@ export type AllProviders =
 	| 'basecamp'
 	| 'baselinker'
 	| 'basin'
+	| 'benchmarkemail'
 	| 'betterstack'
 	| 'bigmailer'
 	| 'bigml'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1510,6 +1510,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/benchmarkemail:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/betterstack:
     devDependencies:
       '@types/jest':


### PR DESCRIPTION
added Benchmark Email plugin scaffolding, endpoints, and client export.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Benchmark Email integration with API access, authentication, tenant matching, and webhook handling.
  * Added an example API endpoint and webhook event with validation and event logging.
  * Added rate-limit handling with automatic retries and authentication error handling.
  * Added Benchmark Email to the available provider list.
* **Tests**
  * Added schema validation tests and package test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->