### PR TITLE
feat: add CountdownApi plugin scaffold

### DIFF
--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -90,6 +90,7 @@ export const BaseProviders = [
 	'collegefootballdata',
 	'confluence',
 	'contentfulgraphql',
+	'countdownapi',
 	'crowterminal',
 	'cursor',
 	'customgpt',
@@ -285,6 +286,7 @@ export const ProviderDisplayNames = {
 	collegefootballdata: 'College Football Data',
 	confluence: 'Confluence',
 	contentfulgraphql: 'Contentful GraphQL',
+	countdownapi: 'CountdownApi',
 	crowterminal: 'CrowTerminal',
 	cursor: 'Cursor',
 	customgpt: 'CustomGPT',
@@ -487,6 +489,7 @@ export type AllProviders =
 	| 'collegefootballdata'
 	| 'confluence'
 	| 'contentfulgraphql'
+	| 'countdownapi'
 	| 'crowterminal'
 	| 'cursor'
 	| 'customgpt'

--- a/packages/countdownapi/client.ts
+++ b/packages/countdownapi/client.ts
@@ -1,0 +1,60 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { request } from 'corsair/http';
+
+export class CountdownApiAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly code?: string,
+	) {
+		super(message);
+		this.name = 'CountdownApiAPIError';
+	}
+}
+
+// TODO: Update with your API base URL
+const COUNTDOWNAPI_API_BASE = 'https://api.example.com';
+
+export async function makeCountdownApiRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	options: {
+		method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+		body?: Record<string, unknown>;
+		query?: Record<string, string | number | boolean | undefined>;
+	} = {},
+): Promise<T> {
+	const { method = 'GET', body, query } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: COUNTDOWNAPI_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: apiKey,
+		HEADERS: {
+			'Content-Type': 'application/json',
+			// TODO: Add authentication headers
+			// 'Authorization': \`Bearer \${apiKey}\`
+		},
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint,
+		body:
+			method === 'POST' || method === 'PUT' || method === 'PATCH'
+				? body
+				: undefined,
+		mediaType: 'application/json; charset=utf-8',
+		query: method === 'GET' ? query : undefined,
+	};
+
+	try {
+		return await request<T>(config, requestOptions);
+	} catch (error) {
+		if (error instanceof Error) {
+			throw new CountdownApiAPIError(error.message);
+		}
+		throw new CountdownApiAPIError('Unknown error');
+	}
+}

--- a/packages/countdownapi/endpoints/example.ts
+++ b/packages/countdownapi/endpoints/example.ts
@@ -1,0 +1,18 @@
+import { logEventFromContext } from 'corsair/core';
+import type { CountdownApiEndpoints } from '..';
+import { makeCountdownApiRequest } from '../client';
+import type { CountdownApiEndpointOutputs } from './types';
+
+export const get: CountdownApiEndpoints['exampleGet'] = async (ctx, input) => {
+	const response = await makeCountdownApiRequest<
+		CountdownApiEndpointOutputs['exampleGet']
+	>(`example/${input.id}`, ctx.key, { method: 'GET' });
+
+	await logEventFromContext(
+		ctx,
+		'countdownapi.example.get',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};

--- a/packages/countdownapi/endpoints/index.ts
+++ b/packages/countdownapi/endpoints/index.ts
@@ -1,0 +1,7 @@
+import { get as exampleGet } from './example';
+
+export const Example = {
+	get: exampleGet,
+};
+
+export * from './types';

--- a/packages/countdownapi/endpoints/types.ts
+++ b/packages/countdownapi/endpoints/types.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+const ExampleGetInputSchema = z.object({
+	id: z.string(),
+});
+
+export type ExampleGetInput = z.infer<typeof ExampleGetInputSchema>;
+
+const ExampleGetResponseSchema = z.object({
+	id: z.string(),
+});
+
+export type ExampleGetResponse = z.infer<typeof ExampleGetResponseSchema>;
+
+export type CountdownApiEndpointInputs = {
+	exampleGet: ExampleGetInput;
+};
+
+export type CountdownApiEndpointOutputs = {
+	exampleGet: ExampleGetResponse;
+};
+
+export const CountdownApiEndpointInputSchemas = {
+	exampleGet: ExampleGetInputSchema,
+} as const;
+
+export const CountdownApiEndpointOutputSchemas = {
+	exampleGet: ExampleGetResponseSchema,
+} as const;

--- a/packages/countdownapi/error-handlers.ts
+++ b/packages/countdownapi/error-handlers.ts
@@ -1,0 +1,31 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('429');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('unauthorized') || msg.includes('invalid_auth');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/countdownapi/index.ts
+++ b/packages/countdownapi/index.ts
@@ -1,0 +1,218 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	BindWebhooks,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	CorsairWebhook,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+	RequiredPluginWebhookSchemas,
+} from 'corsair/core';
+import { Example } from './endpoints';
+import type {
+	CountdownApiEndpointInputs,
+	CountdownApiEndpointOutputs,
+} from './endpoints/types';
+import {
+	CountdownApiEndpointInputSchemas,
+	CountdownApiEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { CountdownApiSchema } from './schema';
+import { ExampleWebhooks } from './webhooks';
+import { resolveCountdownApiOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
+import { matchCountdownApiTenantWebhook } from './webhooks/tenant-matcher';
+import type {
+	CountdownApiWebhookOutputs,
+	ExampleEvent,
+} from './webhooks/types';
+import { ExampleEventSchema } from './webhooks/types';
+
+export type CountdownApiPluginOptions = {
+	authType?: PickAuth<'api_key' | 'oauth_2'>;
+	key?: string;
+	webhookSecret?: string;
+	hooks?: InternalCountdownApiPlugin['hooks'];
+	webhookHooks?: InternalCountdownApiPlugin['webhookHooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof countdownApiEndpointsNested>;
+};
+
+export type CountdownApiContext = CorsairPluginContext<
+	typeof CountdownApiSchema,
+	CountdownApiPluginOptions
+>;
+
+export type CountdownApiKeyBuilderContext =
+	KeyBuilderContext<CountdownApiPluginOptions>;
+
+export type CountdownApiBoundEndpoints = BindEndpoints<
+	typeof countdownApiEndpointsNested
+>;
+
+type CountdownApiEndpoint<K extends keyof CountdownApiEndpointOutputs> =
+	CorsairEndpoint<
+		CountdownApiContext,
+		CountdownApiEndpointInputs[K],
+		CountdownApiEndpointOutputs[K]
+	>;
+
+export type CountdownApiEndpoints = {
+	exampleGet: CountdownApiEndpoint<'exampleGet'>;
+};
+
+type CountdownApiWebhook<
+	K extends keyof CountdownApiWebhookOutputs,
+	TEvent,
+> = CorsairWebhook<CountdownApiContext, TEvent, CountdownApiWebhookOutputs[K]>;
+
+export type CountdownApiWebhooks = {
+	example: CountdownApiWebhook<'example', ExampleEvent>;
+};
+
+export type CountdownApiBoundWebhooks = BindWebhooks<CountdownApiWebhooks>;
+
+const countdownApiEndpointsNested = {
+	example: {
+		get: Example.get,
+	},
+} as const;
+
+const countdownApiWebhooksNested = {
+	example: {
+		example: ExampleWebhooks.example,
+	},
+} as const;
+
+export const countdownApiEndpointSchemas = {
+	'example.get': {
+		input: CountdownApiEndpointInputSchemas.exampleGet,
+		output: CountdownApiEndpointOutputSchemas.exampleGet,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<
+	typeof countdownApiEndpointsNested
+>;
+
+const countdownApiWebhookSchemas = {
+	'example.example': {
+		description: 'An example webhook event',
+		payload: ExampleEventSchema,
+		response: ExampleEventSchema,
+	},
+} as const satisfies RequiredPluginWebhookSchemas<
+	typeof countdownApiWebhooksNested
+>;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const countdownApiEndpointMeta = {
+	'example.get': {
+		riskLevel: 'read',
+		description: 'Get an example resource by ID',
+	},
+} as const satisfies RequiredPluginEndpointMeta<
+	typeof countdownApiEndpointsNested
+>;
+
+export const countdownApiAuthConfig = {
+	api_key: {
+		account: ['tenant_external_id'] as const,
+	},
+	oauth_2: {
+		account: ['tenant_external_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type BaseCountdownApiPlugin<T extends CountdownApiPluginOptions> =
+	CorsairPlugin<
+		'countdownapi',
+		typeof CountdownApiSchema,
+		typeof countdownApiEndpointsNested,
+		typeof countdownApiWebhooksNested,
+		T,
+		typeof defaultAuthType
+	>;
+
+export type InternalCountdownApiPlugin =
+	BaseCountdownApiPlugin<CountdownApiPluginOptions>;
+
+export type ExternalCountdownApiPlugin<T extends CountdownApiPluginOptions> =
+	BaseCountdownApiPlugin<T>;
+
+export function countdownapi<const T extends CountdownApiPluginOptions>(
+	incomingOptions: CountdownApiPluginOptions &
+		T = {} as CountdownApiPluginOptions & T,
+): ExternalCountdownApiPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'countdownapi',
+		authConfig: countdownApiAuthConfig,
+		schema: CountdownApiSchema,
+		options: options,
+		hooks: options.hooks,
+		webhookHooks: options.webhookHooks,
+		endpoints: countdownApiEndpointsNested,
+		webhooks: countdownApiWebhooksNested,
+		endpointMeta: countdownApiEndpointMeta,
+		endpointSchemas: countdownApiEndpointSchemas,
+		webhookSchemas: countdownApiWebhookSchemas,
+		pluginWebhookMatcher: (request) => {
+			const headers = request.headers;
+			// TODO: Update to match your webhook signature headers
+			return 'x-countdownapi-signature' in headers;
+		},
+		pluginTenantWebhookMatcher: matchCountdownApiTenantWebhook,
+		oauthWebhookTenantLinkResolver: resolveCountdownApiOAuthWebhookTenantLink,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: CountdownApiKeyBuilderContext, source) => {
+			if (source === 'webhook' && options.webhookSecret) {
+				return options.webhookSecret;
+			}
+
+			if (source === 'webhook') {
+				const res = await ctx.keys.get_webhook_signature();
+				return res ?? '';
+			}
+
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys.get_api_key();
+				return res ?? '';
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'oauth_2') {
+				const res = await ctx.keys.get_access_token();
+				return res ?? '';
+			}
+
+			return '';
+		},
+	} satisfies InternalCountdownApiPlugin;
+}
+
+export type {
+	CountdownApiEndpointInputs,
+	CountdownApiEndpointOutputs,
+	ExampleGetInput,
+	ExampleGetResponse,
+} from './endpoints/types';
+export type {
+	CountdownApiWebhookOutputs,
+	ExampleEvent,
+} from './webhooks/types';

--- a/packages/countdownapi/jest.config.cjs
+++ b/packages/countdownapi/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/countdownapi/package.json
+++ b/packages/countdownapi/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/countdownapi",
+  "version": "0.1.0",
+  "description": "CountdownApi plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "countdownapi",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/countdownapi/schema.test.ts
+++ b/packages/countdownapi/schema.test.ts
@@ -1,0 +1,20 @@
+import { CountdownApiSchema } from './schema';
+
+describe('CountdownApi schema', () => {
+	it('declares a semver version', () => {
+		expect(CountdownApiSchema.version).toBeDefined();
+		expect(CountdownApiSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof CountdownApiSchema.entities).toBe('object');
+		expect(CountdownApiSchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(CountdownApiSchema.entities))).toBe(true);
+		for (const entity of Object.values(CountdownApiSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/countdownapi/schema/database.ts
+++ b/packages/countdownapi/schema/database.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+// TODO: Define your database entities here
+// export const CountdownApiExample = z.object({
+// 	id: z.string(),
+// 	name: z.string(),
+// 	created_at: z.coerce.date().nullable().optional(),
+// });
+// export type CountdownApiExample = z.infer<typeof CountdownApiExample>;

--- a/packages/countdownapi/schema/index.ts
+++ b/packages/countdownapi/schema/index.ts
@@ -1,0 +1,4 @@
+export const CountdownApiSchema = {
+	version: '1.0.0',
+	entities: {},
+} as const;

--- a/packages/countdownapi/tsconfig.json
+++ b/packages/countdownapi/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/countdownapi/tsup.config.ts
+++ b/packages/countdownapi/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/countdownapi/webhooks/example.ts
+++ b/packages/countdownapi/webhooks/example.ts
@@ -1,0 +1,35 @@
+import { logEventFromContext } from 'corsair/core';
+import type { CountdownApiWebhooks } from '..';
+import {
+	createCountdownApiMatch,
+	verifyCountdownApiWebhookSignature,
+} from './types';
+
+export const example: CountdownApiWebhooks['example'] = {
+	match: createCountdownApiMatch('example'),
+
+	handler: async (ctx, request) => {
+		const verification = verifyCountdownApiWebhookSignature(request, ctx.key);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
+
+		const event = request.payload;
+		if (event.type !== 'example') {
+			return { success: true, data: undefined };
+		}
+
+		await logEventFromContext(
+			ctx,
+			'countdownapi.webhook.example',
+			{ ...event },
+			'completed',
+		);
+
+		return { success: true, data: event };
+	},
+};

--- a/packages/countdownapi/webhooks/index.ts
+++ b/packages/countdownapi/webhooks/index.ts
@@ -1,0 +1,9 @@
+import { example } from './example';
+
+export const ExampleWebhooks = {
+	example: example,
+};
+
+export * from './oauth-tenant-link';
+export * from './tenant-matcher';
+export * from './types';

--- a/packages/countdownapi/webhooks/oauth-tenant-link.ts
+++ b/packages/countdownapi/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,31 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, toExternalId } from 'corsair/core';
+
+// TODO: Rename linkType 'tenant_external_id' to match pluginTenantWebhookMatcher.
+// Called after OAuth to store the routing id on corsair_accounts.config.
+export async function resolveCountdownApiOAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): Promise<WebhookTenantMatch | null> {
+	// TODO: Read from token response when the provider includes a stable id.
+	// const externalId = toExternalId(asRecord(tokens.team)?.id);
+	const externalId = toExternalId(tokens.tenant_external_id);
+	if (externalId) {
+		return { linkType: 'tenant_external_id', externalId };
+	}
+
+	const accessToken = tokens.access_token;
+	if (!accessToken) return null;
+
+	// TODO: Fetch from provider API when the token response omits the id.
+	// const response = await fetch('https://api.example.com/me', {
+	// 	headers: { Authorization: `Bearer ${accessToken}` },
+	// });
+	// if (!response.ok) return null;
+	// const payload = (await response.json()) as { id?: string };
+	// const fetchedId = toExternalId(payload.id);
+	// return fetchedId
+	// 	? { linkType: 'tenant_external_id', externalId: fetchedId }
+	// 	: null;
+
+	return null;
+}

--- a/packages/countdownapi/webhooks/tenant-matcher.ts
+++ b/packages/countdownapi/webhooks/tenant-matcher.ts
@@ -1,0 +1,25 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// TODO: Rename linkType 'tenant_external_id' to match the provider field
+// (e.g. team_id, installation_id, organization_id). Must match authConfig.account
+// and oauthWebhookTenantLinkResolver.
+// Return null for URL verification / handshake payloads that have no tenant id.
+export function matchCountdownApiTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	// TODO: Extract the stable external id from the webhook payload.
+	// Example:
+	// const externalId = firstString([body.tenant_external_id, asRecord(body.data)?.id]);
+	const externalId = firstString([
+		body.tenant_external_id,
+		asRecord(body.data)?.tenant_external_id,
+	]);
+
+	if (!externalId) return null;
+
+	return { linkType: 'tenant_external_id', externalId };
+}

--- a/packages/countdownapi/webhooks/types.ts
+++ b/packages/countdownapi/webhooks/types.ts
@@ -1,0 +1,66 @@
+import type {
+	CorsairWebhookMatcher,
+	RawWebhookRequest,
+	WebhookRequest,
+} from 'corsair/core';
+import { z } from 'zod';
+
+export const CountdownApiWebhookPayloadSchema = z.object({
+	type: z.string(),
+	created_at: z.string(),
+	data: z.record(z.string(), z.unknown()),
+});
+
+export type CountdownApiWebhookPayload = z.infer<
+	typeof CountdownApiWebhookPayloadSchema
+>;
+
+export const ExampleEventSchema = CountdownApiWebhookPayloadSchema.extend({
+	type: z.literal('example'),
+	data: z
+		.object({
+			id: z.string(),
+		})
+		.loose(),
+});
+
+export type ExampleEvent = z.infer<typeof ExampleEventSchema>;
+
+export type CountdownApiWebhookOutputs = {
+	example: ExampleEvent;
+};
+
+function parseBody(body: unknown): Record<string, unknown> | null {
+	if (typeof body === 'string') {
+		try {
+			const parsed = JSON.parse(body);
+			return parsed !== null &&
+				typeof parsed === 'object' &&
+				!Array.isArray(parsed)
+				? (parsed as Record<string, unknown>)
+				: null;
+		} catch {
+			return null;
+		}
+	}
+	return body !== null && typeof body === 'object' && !Array.isArray(body)
+		? (body as Record<string, unknown>)
+		: null;
+}
+
+export function createCountdownApiMatch(
+	eventType: string,
+): CorsairWebhookMatcher {
+	return (request: RawWebhookRequest) => {
+		const parsedBody = parseBody(request.body);
+		return parsedBody !== null && parsedBody.type === eventType;
+	};
+}
+
+export function verifyCountdownApiWebhookSignature(
+	request: WebhookRequest<CountdownApiWebhookPayload>,
+	secret: string,
+): { valid: boolean; error?: string } {
+	// TODO: Implement webhook signature verification
+	return { valid: true };
+}


### PR DESCRIPTION
Adds the initial CountdownApi plugin scaffold generated using the Corsair plugin generator.

The real Countdown API integration, endpoints, tests, and documentation will be added in subsequent commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CountdownApi as a supported integration provider.
  * Introduced the Countdown API plugin with authenticated API requests and typed endpoint support.
  * Added example API endpoint and webhook handling, including payload validation and tenant matching.
  * Added rate-limit retry handling and authentication error detection.
  * Added initial schema support and package configuration for distribution.

* **Tests**
  * Added validation tests for the Countdown API schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->