### PR TITLE
fix(corsair): rewrite Windows cert paths for frpc TOML config

### DIFF
--- a/packages/corsair/hub/tunnel/frpc-config.ts
+++ b/packages/corsair/hub/tunnel/frpc-config.ts
@@ -32,6 +32,13 @@ export function buildFrpcConfig(opts: {
 			'deliveryPath must be an absolute URL path (e.g. /api/corsair)',
 		);
 	}
+	// Backslashes in caCertPath are normalized below; a quote or control char
+	// would still break out of the trustedCaFile basic string.
+	if (opts.caCertPath && /["\x00-\x1F\x7F]/.test(opts.caCertPath)) {
+		throw new Error(
+			'caCertPath contains invalid characters (quotes or control chars)',
+		);
+	}
 	const lines = [
 		`serverAddr = "${opts.serverAddr}"`,
 		`serverPort = ${opts.serverPort}`,

--- a/packages/corsair/hub/tunnel/frpc-config.ts
+++ b/packages/corsair/hub/tunnel/frpc-config.ts
@@ -46,7 +46,10 @@ export function buildFrpcConfig(opts: {
 		// unicode-escape prefix — frpc dies with "non-hex character" on
 		// C:\Users\... (found live on Windows; POSIX paths never hit it).
 		// Forward slashes are valid for Windows filesystem consumers.
-		const caFile = opts.caCertPath.replace(/\\/g, '/');
+		const isWindowsPath = /^[A-Za-z]:[\\/]|^\\\\/.test(opts.caCertPath);
+		const caFile = isWindowsPath
+			? opts.caCertPath.replace(/\\/g, '/')
+			: opts.caCertPath.replace(/\\/g, '\\\\');
 		lines.push(
 			'transport.tls.enable = true',
 			`transport.tls.serverName = "${opts.serverName ?? opts.serverAddr}"`,

--- a/packages/corsair/hub/tunnel/frpc-config.ts
+++ b/packages/corsair/hub/tunnel/frpc-config.ts
@@ -42,10 +42,15 @@ export function buildFrpcConfig(opts: {
 		lines.push(`metadatas.path = "${opts.deliveryPath}"`);
 	}
 	if (opts.caCertPath) {
+		// Windows paths carry backslashes, and `\U` in a TOML basic string is a
+		// unicode-escape prefix — frpc dies with "non-hex character" on
+		// C:\Users\... (found live on Windows; POSIX paths never hit it).
+		// Forward slashes are valid for Windows filesystem consumers.
+		const caFile = opts.caCertPath.replace(/\\/g, '/');
 		lines.push(
 			'transport.tls.enable = true',
 			`transport.tls.serverName = "${opts.serverName ?? opts.serverAddr}"`,
-			`transport.tls.trustedCaFile = "${opts.caCertPath}"`,
+			`transport.tls.trustedCaFile = "${caFile}"`,
 		);
 	}
 	lines.push(

--- a/packages/corsair/package.json
+++ b/packages/corsair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corsair",
-  "version": "0.1.121",
+  "version": "0.1.122",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/corsair/tests/frpc-config.test.ts
+++ b/packages/corsair/tests/frpc-config.test.ts
@@ -92,7 +92,7 @@ describe('buildFrpcConfig', () => {
 			expect(t).toContain('transport.tls.serverName = "127.0.0.1"');
 		});
 
-		it('rewrites Windows backslash paths — \U is a TOML unicode escape, so C:\Users breaks frpc parsing', () => {
+		it('rewrites Windows backslash paths — \\U is a TOML unicode escape, so C:\\Users breaks frpc parsing', () => {
 			const t = buildFrpcConfig({
 				serverAddr: 'tunnel.corsair.cloud',
 				serverPort: 7000,
@@ -106,6 +106,21 @@ describe('buildFrpcConfig', () => {
 				'transport.tls.trustedCaFile = "C:/Users/dev/AppData/Local/Temp/corsair-frpc-x/ca.crt"',
 			);
 			expect(t).not.toContain('\\U');
+		});
+
+		it('throws on a caCertPath that would break out of the toml string', () => {
+			for (const bad of ['/tmp/a"b/ca.crt', '/tmp/a\nb/ca.crt']) {
+				expect(() =>
+					buildFrpcConfig({
+						serverAddr: 'tunnel.corsair.cloud',
+						serverPort: 7000,
+						apiKey: 'ck_dev_abc',
+						slug: 'slug-1',
+						localPort: 41234,
+						caCertPath: bad,
+					}),
+				).toThrow(/caCertPath/);
+			}
 		});
 	});
 });

--- a/packages/corsair/tests/frpc-config.test.ts
+++ b/packages/corsair/tests/frpc-config.test.ts
@@ -91,5 +91,21 @@ describe('buildFrpcConfig', () => {
 			});
 			expect(t).toContain('transport.tls.serverName = "127.0.0.1"');
 		});
+
+		it('rewrites Windows backslash paths — \U is a TOML unicode escape, so C:\Users breaks frpc parsing', () => {
+			const t = buildFrpcConfig({
+				serverAddr: 'tunnel.corsair.cloud',
+				serverPort: 7000,
+				apiKey: 'ck_dev_abc',
+				slug: 'slug-1',
+				localPort: 41234,
+				caCertPath:
+					'C:\\Users\\dev\\AppData\\Local\\Temp\\corsair-frpc-x\\ca.crt',
+			});
+			expect(t).toContain(
+				'transport.tls.trustedCaFile = "C:/Users/dev/AppData/Local/Temp/corsair-frpc-x/ca.crt"',
+			);
+			expect(t).not.toContain('\\U');
+		});
 	});
 });


### PR DESCRIPTION
## Problem

On Windows the self-hosted frp dev tunnel never starts. The spawned `frpc` dies at startup with:

```
toml: line 8, column 36: non-hex character
```

## Root cause

`buildFrpcConfig` emits the TLS CA path as a TOML basic string:

```
transport.tls.trustedCaFile = "<caCertPath>"
```

On Windows the tunnel CA cert lives under a temp directory, so the emitted line becomes e.g. `"C:\Users\dev\AppData\Local\Temp\corsair-frpc-x\ca.crt"`. In TOML basic strings `\U` is a unicode-escape prefix, so frpc's parser hits `\Use` and fails with "non-hex character" before ever connecting. POSIX users never hit this; every Windows user always does.

Reproduced live on Windows 11 with frpc 0.71.0 against auth.corsair.dev.

## Fix

Rewrite backslashes to forward slashes before emitting the path. Forward slashes are valid paths for Windows filesystem consumers, so Windows now parses correctly and POSIX output is unchanged:

```ts
const caFile = opts.caCertPath.replace(/\/g, '/');
```

## Testing

- New regression test in `packages/corsair/tests/frpc-config.test.ts`: asserts a `C:\Users\...` caCertPath is emitted as `C:/Users/...` and that the generated TOML contains no `\U`. Suite passes 9/9.
- Verified live end-to-end on Windows 11: after the fix the real dev tunnel starts, and signed hub deliveries flow through it (GET / OPTIONS / valid-signed POST / tampered-signature-rejected contract probes).

Found while running hub E2E tests across the framework adapters in #859.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows CA certificate paths in TLS configurations so they work correctly when used in tunnel connections.
  * Prevented certificate paths from being misinterpreted due to backslash escape sequences.
  * Rejected certificate paths containing invalid quotes or control characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->