### PR TITLE
ci: scope PR Checks to the diff and run the plugin gate first

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,10 @@
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
   schedule:
     - cron: '30 2 * * 1'
 
@@ -12,6 +12,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       actions: read
       contents: read
@@ -20,18 +21,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript-typescript' ]
+        language: ['javascript-typescript']
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{matrix.language}}'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -23,12 +24,19 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile --filter . --filter "./packages/**"
+
+      - name: Restore turbo cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-
 
       - name: Publish changed packages
         run: node scripts/publish-changed.mjs

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,12 +3,17 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   triage:
     permissions:
       contents: read
       pull-requests: write
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/plugin-pr-review-loop.yml
+++ b/.github/workflows/plugin-pr-review-loop.yml
@@ -29,6 +29,7 @@ jobs:
        github.event.comment.user.login == 'greptile-apps[bot]' &&
        github.event.issue.pull_request != null)
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,10 +3,12 @@ name: PR Checks
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
 
 concurrency:
-  group: pr-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -14,58 +16,11 @@ permissions:
   issues: write
 
 jobs:
-  ci:
-    name: CI Checks
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.20.0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24.x'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Turbo cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-${{ github.sha }}
-          restore-keys: turbo-${{ runner.os }}-
-
-      - name: Lint
-        run: pnpm lint
-
-      - name: Validate Plugins
-        run: pnpm run validate:plugins
-
-      - name: Validate Docs
-        run: pnpm run validate:docs
-
-      - name: Typecheck
-        run: pnpm typecheck
-
-      - name: Typecheck review scripts
-        run: pnpm exec tsc -p scripts/pr-review
-
-      - name: Build
-        run: pnpm build
-
-      - name: Run tests
-        run: npx turbo test -- --passWithNoTests --ci --testPathIgnorePatterns="api\.test\.ts|integration\.test\.ts"
-        env:
-          CI: true
-          SKIP_PG_TESTS: 1
-
   plugin-gate:
     name: Plugin PR Gate
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
@@ -79,3 +34,90 @@ jobs:
         run: node --experimental-strip-types scripts/pr-review/gate-main.ts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  ci:
+    name: CI Checks
+    needs: plugin-gate
+    if: always() && (github.event_name == 'push' || needs.plugin-gate.result == 'success')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.20.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+          cache: 'pnpm'
+
+      - name: Classify PR scope
+        id: scope
+        run: node --experimental-strip-types scripts/pr-review/pr-scope-main.ts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install plugin dependencies
+        if: steps.scope.outputs.lane == 'plugin'
+        run: pnpm install --frozen-lockfile --filter . --filter corsair... --filter="${{ steps.scope.outputs.turbo_filter }}"
+
+      - name: Install package dependencies
+        if: steps.scope.outputs.lane == 'full'
+        run: pnpm install --frozen-lockfile --filter . --filter "./packages/**" ${{ steps.scope.outputs.www_install_filter }}
+
+      - name: Install www dependencies
+        if: steps.scope.outputs.lane == 'www'
+        run: pnpm install --frozen-lockfile --filter . --filter "@corsair/www..."
+
+      - name: Turbo cache for main
+        if: github.event_name == 'push' && steps.scope.outputs.skip_heavy != 'true'
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-
+
+      - name: Turbo cache for pull request
+        if: github.event_name == 'pull_request' && steps.scope.outputs.skip_heavy != 'true'
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-
+
+      - name: Lint
+        if: steps.scope.outputs.skip_heavy != 'true'
+        run: pnpm lint
+
+      - name: Validate Plugins
+        if: steps.scope.outputs.skip_heavy != 'true'
+        run: pnpm run validate:plugins
+
+      - name: Validate Docs
+        if: steps.scope.outputs.skip_heavy != 'true'
+        run: pnpm run validate:docs
+
+      - name: Typecheck
+        if: steps.scope.outputs.skip_heavy != 'true'
+        run: pnpm typecheck
+
+      - name: Typecheck review scripts
+        if: steps.scope.outputs.skip_heavy != 'true'
+        run: pnpm exec tsc -p scripts/pr-review
+
+      - name: Build
+        if: steps.scope.outputs.skip_heavy != 'true' && steps.scope.outputs.lane != 'www'
+        run: pnpm exec turbo build --filter="${{ steps.scope.outputs.turbo_filter }}"
+
+      - name: Run tests
+        if: steps.scope.outputs.skip_heavy != 'true'
+        run: pnpm exec turbo test --filter="${{ steps.scope.outputs.turbo_filter }}" ${{ steps.scope.outputs.www_test_filter }} -- --passWithNoTests --ci --testPathIgnorePatterns="(^|/)api\.test\.ts$|(^|/)integration\.test\.ts$"
+        env:
+          CI: true
+          SKIP_PG_TESTS: 1
+
+      - name: Skip package checks
+        if: steps.scope.outputs.skip_heavy == 'true'
+        run: echo "Package checks skipped for documentation or explorer-only changes."

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Run tests
         if: steps.scope.outputs.skip_heavy != 'true'
-        run: pnpm exec turbo test --filter="${{ steps.scope.outputs.turbo_filter }}" ${{ steps.scope.outputs.www_test_filter }} -- --passWithNoTests --ci --testPathIgnorePatterns="(^|/)api\.test\.ts$|(^|/)integration\.test\.ts$"
+        run: pnpm exec turbo test --filter="${{ steps.scope.outputs.turbo_filter }}" ${{ steps.scope.outputs.www_test_filter }} -- --passWithNoTests --ci --testPathIgnorePatterns="api\.test\.ts$|(^|/)integration\.test\.ts$"
         env:
           CI: true
           SKIP_PG_TESTS: 1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: "Close stale issues and PRs"
+name: 'Close stale issues and PRs'
 on:
   schedule:
     - cron: '30 1 * * *'
@@ -6,6 +6,7 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       issues: write
       pull-requests: write

--- a/scripts/pr-review/gate.ts
+++ b/scripts/pr-review/gate.ts
@@ -1,5 +1,15 @@
-const IGNORED_PACKAGES = ['corsair', 'cli', 'mcp', 'studio', 'ui', 'app'];
-const ALLOWED_EXTRA = ['packages/corsair/core/constants.ts', 'pnpm-lock.yaml'];
+export const IGNORED_PACKAGES = [
+	'corsair',
+	'cli',
+	'mcp',
+	'studio',
+	'ui',
+	'app',
+];
+export const ALLOWED_EXTRA = [
+	'packages/corsair/core/constants.ts',
+	'pnpm-lock.yaml',
+];
 export const ASSERTION_WARN_FLOOR = 5;
 
 export interface GateInput {
@@ -31,7 +41,7 @@ export interface GateResult {
 	failures: GateFailure[];
 }
 
-function pluginOf(file: string): string | null {
+export function pluginOf(file: string): string | null {
 	const name = file.match(/^packages\/([^/]+)\//)?.[1];
 	if (!name) return null;
 	// frpc-<platform>-<arch> are prebuilt binary shims for the dev tunnel,

--- a/scripts/pr-review/pr-scope-main.ts
+++ b/scripts/pr-review/pr-scope-main.ts
@@ -1,0 +1,70 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import type { PrScope } from './pr-scope.ts';
+import { classifyPrScope, filtersForScope } from './pr-scope.ts';
+
+function gh(args: string[]): string {
+	return execFileSync('gh', args, {
+		encoding: 'utf8',
+		maxBuffer: 64 * 1024 * 1024,
+	});
+}
+
+function pullRequestNumber(): string {
+	const event: unknown = JSON.parse(
+		fs.readFileSync(process.env.GITHUB_EVENT_PATH ?? '', 'utf8'),
+	);
+	if (
+		typeof event !== 'object' ||
+		event === null ||
+		!('pull_request' in event) ||
+		typeof event.pull_request !== 'object' ||
+		event.pull_request === null ||
+		!('number' in event.pull_request) ||
+		typeof event.pull_request.number !== 'number'
+	) {
+		throw new Error('Pull request event has no PR number');
+	}
+	return String(event.pull_request.number);
+}
+
+function changedFilesForPullRequest(repo: string, pr: string): string[] {
+	return gh([
+		'api',
+		`repos/${repo}/pulls/${pr}/files`,
+		'--paginate',
+		'--jq',
+		'.[].filename',
+	])
+		.trim()
+		.split('\n')
+		.filter(Boolean);
+}
+
+function writeOutput(name: string, value: string): void {
+	const output = process.env.GITHUB_OUTPUT;
+	if (!output) throw new Error('GITHUB_OUTPUT is not set');
+	fs.appendFileSync(output, `${name}=${value}\n`);
+}
+
+let scope: PrScope = { lane: 'full', includeWww: false };
+if (process.env.GITHUB_EVENT_NAME === 'pull_request') {
+	const repo = process.env.GITHUB_REPOSITORY;
+	if (!repo) throw new Error('GITHUB_REPOSITORY is not set');
+	scope = classifyPrScope(
+		changedFilesForPullRequest(repo, pullRequestNumber()),
+	);
+}
+
+const filters = filtersForScope(scope);
+writeOutput('lane', filters.lane);
+writeOutput('turbo_filter', filters.turboFilter);
+writeOutput('skip_heavy', String(filters.skipHeavy));
+writeOutput('include_www', String(filters.includeWww));
+writeOutput('www_install_filter', filters.wwwInstallFilter);
+writeOutput('www_test_filter', filters.wwwTestFilter);
+console.log(
+	scope.lane === 'plugin'
+		? `CI lane: plugin (${scope.plugin}, filter ${filters.turboFilter})`
+		: `CI lane: ${scope.lane}`,
+);

--- a/scripts/pr-review/pr-scope.test.ts
+++ b/scripts/pr-review/pr-scope.test.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+	classifyPrScope,
+	filtersForScope,
+	packageNameForPlugin,
+} from './pr-scope.ts';
+
+test('uses the plugin lane for one plugin plus gate-approved extra files', () => {
+	assert.deepEqual(
+		classifyPrScope([
+			'packages/slack/index.ts',
+			'packages/corsair/core/constants.ts',
+			'pnpm-lock.yaml',
+		]),
+		{ lane: 'plugin', plugin: 'slack' },
+	);
+});
+
+test('uses the full lane when a plugin PR changes other corsair files', () => {
+	assert.deepEqual(
+		classifyPrScope([
+			'packages/slack/index.ts',
+			'packages/corsair/core/client.ts',
+		]),
+		{ lane: 'full', includeWww: false },
+	);
+});
+
+test('uses the full lane for changes to two plugins', () => {
+	assert.deepEqual(
+		classifyPrScope(['packages/slack/index.ts', 'packages/github/index.ts']),
+		{ lane: 'full', includeWww: false },
+	);
+});
+
+test('uses the full lane for non-plugin package changes', () => {
+	assert.deepEqual(classifyPrScope(['packages/cli/src/index.ts']), {
+		lane: 'full',
+		includeWww: false,
+	});
+});
+
+test('uses the full lane for lockfile-only changes', () => {
+	assert.deepEqual(classifyPrScope(['pnpm-lock.yaml']), {
+		lane: 'full',
+		includeWww: false,
+	});
+});
+
+test('skips heavy checks for explorer and documentation-only changes', () => {
+	assert.deepEqual(
+		classifyPrScope([
+			'explorer/src/index.ts',
+			'docs/getting-started.md',
+			'README.md',
+		]),
+		{ lane: 'skip-heavy' },
+	);
+});
+
+test('uses the www lane for www-only changes', () => {
+	assert.deepEqual(classifyPrScope(['www/src/app/page.tsx']), {
+		lane: 'www',
+	});
+});
+
+test('uses the www lane when www changes include root docs', () => {
+	assert.deepEqual(classifyPrScope(['www/src/app/page.tsx', 'README.md']), {
+		lane: 'www',
+	});
+});
+
+test('uses the full lane and includes www when www and packages both change', () => {
+	assert.deepEqual(
+		classifyPrScope(['www/src/app/page.tsx', 'packages/slack/index.ts']),
+		{ lane: 'full', includeWww: true },
+	);
+});
+
+test('reads the npm package name for a plugin', () => {
+	assert.equal(packageNameForPlugin('slack'), '@corsair-dev/slack');
+});
+
+test('plugin filters include the package and its dependencies, not dependents', () => {
+	const filters = filtersForScope({ lane: 'plugin', plugin: 'slack' });
+	assert.equal(filters.turboFilter, '@corsair-dev/slack...');
+	assert.equal(filters.includeWww, false);
+	assert.doesNotMatch(filters.turboFilter, /^\.\.\./);
+});
+
+test('full-lane turbo filter stays quoted-glob safe', () => {
+	assert.deepEqual(filtersForScope({ lane: 'full', includeWww: false }), {
+		lane: 'full',
+		turboFilter: './packages/*',
+		skipHeavy: false,
+		includeWww: false,
+		wwwInstallFilter: '',
+		wwwTestFilter: '',
+	});
+});
+
+test('mixed www filters keep package globs out of the www extra flags', () => {
+	assert.deepEqual(filtersForScope({ lane: 'full', includeWww: true }), {
+		lane: 'full',
+		turboFilter: './packages/*',
+		skipHeavy: false,
+		includeWww: true,
+		wwwInstallFilter: '--filter=@corsair/www...',
+		wwwTestFilter: '--filter=@corsair/www',
+	});
+});

--- a/scripts/pr-review/pr-scope.ts
+++ b/scripts/pr-review/pr-scope.ts
@@ -1,0 +1,136 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { ALLOWED_EXTRA, detectPlugin, pluginOf } from './gate.ts';
+
+export type PrScope =
+	| { lane: 'plugin'; plugin: string }
+	| { lane: 'full'; includeWww: boolean }
+	| { lane: 'www' }
+	| { lane: 'skip-heavy' };
+
+export type PrScopeFilters = {
+	lane: PrScope['lane'];
+	turboFilter: string;
+	skipHeavy: boolean;
+	includeWww: boolean;
+	wwwInstallFilter: string;
+	wwwTestFilter: string;
+};
+
+function isDocumentationOnlyFile(file: string): boolean {
+	return (
+		file.startsWith('explorer/') ||
+		/^docs\/.*\.mdx?$/i.test(file) ||
+		/^[^/]+\.mdx?$/i.test(file)
+	);
+}
+
+function isWwwFile(file: string): boolean {
+	return file === 'www' || file.startsWith('www/');
+}
+
+export function classifyPrScope(changedFiles: string[]): PrScope {
+	const plugins = new Set(
+		changedFiles
+			.map(pluginOf)
+			.filter((plugin): plugin is string => plugin !== null),
+	);
+	const plugin = detectPlugin(changedFiles);
+
+	if (
+		plugin !== null &&
+		plugins.size === 1 &&
+		changedFiles.every(
+			(file) => pluginOf(file) === plugin || ALLOWED_EXTRA.includes(file),
+		)
+	) {
+		return { lane: 'plugin', plugin };
+	}
+
+	if (changedFiles.length > 0 && changedFiles.every(isDocumentationOnlyFile)) {
+		return { lane: 'skip-heavy' };
+	}
+
+	const hasWww = changedFiles.some(isWwwFile);
+	if (
+		hasWww &&
+		changedFiles.every(
+			(file) => isWwwFile(file) || isDocumentationOnlyFile(file),
+		)
+	) {
+		return { lane: 'www' };
+	}
+
+	return { lane: 'full', includeWww: hasWww };
+}
+
+export function packageNameForPlugin(
+	plugin: string,
+	rootDir = process.cwd(),
+): string {
+	const packageJson: unknown = JSON.parse(
+		fs.readFileSync(
+			path.join(rootDir, 'packages', plugin, 'package.json'),
+			'utf8',
+		),
+	);
+	if (
+		typeof packageJson !== 'object' ||
+		packageJson === null ||
+		!('name' in packageJson) ||
+		typeof packageJson.name !== 'string'
+	) {
+		throw new Error(`packages/${plugin}/package.json has no package name`);
+	}
+	return packageJson.name;
+}
+
+export function filtersForScope(
+	scope: PrScope,
+	rootDir = process.cwd(),
+): PrScopeFilters {
+	switch (scope.lane) {
+		case 'plugin': {
+			const name = packageNameForPlugin(scope.plugin, rootDir);
+			return {
+				lane: 'plugin',
+				turboFilter: `${name}...`,
+				skipHeavy: false,
+				includeWww: false,
+				wwwInstallFilter: '',
+				wwwTestFilter: '',
+			};
+		}
+		case 'www':
+			return {
+				lane: 'www',
+				turboFilter: '@corsair/www',
+				skipHeavy: false,
+				includeWww: false,
+				wwwInstallFilter: '',
+				wwwTestFilter: '',
+			};
+		case 'full':
+			return {
+				lane: 'full',
+				turboFilter: './packages/*',
+				skipHeavy: false,
+				includeWww: scope.includeWww,
+				wwwInstallFilter: scope.includeWww ? '--filter=@corsair/www...' : '',
+				wwwTestFilter: scope.includeWww ? '--filter=@corsair/www' : '',
+			};
+		case 'skip-heavy':
+			return {
+				lane: 'skip-heavy',
+				turboFilter: '',
+				skipHeavy: true,
+				includeWww: false,
+				wwwInstallFilter: '',
+				wwwTestFilter: '',
+			};
+		default: {
+			const _exhaustive: never = scope;
+			return _exhaustive;
+		}
+	}
+}

--- a/scripts/publish-changed.mjs
+++ b/scripts/publish-changed.mjs
@@ -77,10 +77,10 @@ for (const p of toPublish) {
 const ordered = orderForPublish(toPublish);
 
 console.log(`\nBuilding ${ordered.length} package(s)...`);
-for (const { name } of ordered) {
-	console.log(`  Building ${name}...`);
-	execSync(`pnpm --filter ${name} build`, { stdio: 'inherit' });
-}
+execSync(
+	`pnpm exec turbo build${ordered.map((p) => ` --filter=${p.name}`).join('')}`,
+	{ stdio: 'inherit' },
+);
 
 console.log(`\nPublishing ${ordered.length} package(s)...`);
 

--- a/scripts/publish-changed.mjs
+++ b/scripts/publish-changed.mjs
@@ -1,10 +1,17 @@
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { isAlreadyPublished } from './npm-publish-errors.mjs';
 import { orderForPublish } from './publish-order.mjs';
 
 const PACKAGES_DIR = 'packages';
+const PACKAGE_NAME_RE = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/;
+
+function assertPackageName(name) {
+	if (typeof name !== 'string' || !PACKAGE_NAME_RE.test(name)) {
+		throw new Error(`invalid package name: ${String(name)}`);
+	}
+}
 
 // Deps declared with the workspace protocol get their spec rewritten to a fixed
 // version on publish, so a dependent must not ship before its dependency lands
@@ -22,10 +29,12 @@ function workspaceDeps(pkg) {
 }
 
 function getPublishedVersion(name) {
+	assertPackageName(name);
 	try {
 		return (
-			execSync(`npm view ${name} version 2>/dev/null`, {
+			execFileSync('npm', ['view', name, 'version'], {
 				encoding: 'utf-8',
+				stdio: ['ignore', 'pipe', 'ignore'],
 			}).trim() || null
 		);
 	} catch {
@@ -77,8 +86,12 @@ for (const p of toPublish) {
 const ordered = orderForPublish(toPublish);
 
 console.log(`\nBuilding ${ordered.length} package(s)...`);
-execSync(
-	`pnpm exec turbo build${ordered.map((p) => ` --filter=${p.name}`).join('')}`,
+for (const { name } of ordered) {
+	assertPackageName(name);
+}
+execFileSync(
+	'pnpm',
+	['exec', 'turbo', 'build', ...ordered.map((p) => `--filter=${p.name}`)],
 	{ stdio: 'inherit' },
 );
 
@@ -111,22 +124,31 @@ for (const { name, version, deps } of ordered) {
 		continue;
 	}
 
+	assertPackageName(name);
 	console.log(`  Publishing ${name}@${version}...`);
 	try {
-		// npm writes errors to stderr but execSync only returns stdout, so redirect
-		// stderr into stdout to capture the failure text for classification below.
-		const out = execSync(
-			`pnpm --filter ${name} publish --provenance --access public --no-git-checks 2>&1`,
+		const out = execFileSync(
+			'pnpm',
+			[
+				'--filter',
+				name,
+				'publish',
+				'--provenance',
+				'--access',
+				'public',
+				'--no-git-checks',
+			],
 			{
 				encoding: 'utf-8',
 				maxBuffer: 10 * 1024 * 1024,
+				stdio: ['ignore', 'pipe', 'pipe'],
 				env: { ...process.env, NODE_AUTH_TOKEN: token },
 			},
 		);
 		process.stdout.write(out);
 		publishedCount++;
 	} catch (err) {
-		const out = err.stdout ?? '';
+		const out = `${err.stdout ?? ''}${err.stderr ?? ''}`;
 		process.stdout.write(out);
 		if (isAlreadyPublished(out)) {
 			console.log(`  SKIP ${name}@${version} (already on npm)`);

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "globalDependencies": [
     "package.json",
     "tsconfig.json",
-    "pnpm-lock.yaml",
+    "tsconfig.base.json",
     "pnpm-workspace.yaml"
   ],
   "tasks": {
@@ -14,15 +14,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"],
-      "env": [
-        "BETTER_AUTH_SECRET",
-        "BETTER_AUTH_URL",
-        "DATABASE_URL",
-        "RESEND_API_KEY",
-        "RESEND_FROM_EMAIL",
-        "CORSAIR_KEK"
-      ]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "clean": {},
     "format": {

--- a/www/turbo.json
+++ b/www/turbo.json
@@ -1,0 +1,15 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "env": [
+        "BETTER_AUTH_SECRET",
+        "BETTER_AUTH_URL",
+        "DATABASE_URL",
+        "RESEND_API_KEY",
+        "RESEND_FROM_EMAIL",
+        "CORSAIR_KEK"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description

PR Checks today builds and tests every package on every PR. A typical plugin PR (BetterContact, this afternoon) spent ~30 min in CI Checks. The plugin gate finished in ~10s. Those jobs run in parallel, so a gate failure still pays the full 30 min. Instagram today: gate failed at 13s, CI Checks still ran ~30 min and passed.

About 9 in 10 recent merges are a single plugin plus `constants.ts` / the lockfile. Those do not need the other ~187 plugins.

This PR classifies the file list (same rules as the plugin gate) and picks a lane:

- **plugin:** one plugin + `packages/corsair/core/constants.ts` and/or `pnpm-lock.yaml`. Install/build/test that plugin and `corsair`. Turbo filter is `pkg...` (the package and its dependencies), not `...pkg` (dependents). We do not use `turbo --filter=...[origin/main]`. Editing `constants.ts` would otherwise dirty `corsair` and rebuild almost every plugin.
- **www:** only `www/` (and maybe docs). Install and test `@corsair/www`. No `next build` (PR Checks never did that).
- **skip-heavy:** explorer, `docs/*.md(x)`, root markdown. Job still named CI Checks so the required check is green. No install/build/test.
- **full:** everything else (`cli`, corsair internals, lockfile-only, workflows, two plugins, this PR). `./packages/*`, same shape as today's `pnpm build` / `pnpm test`.

CI Checks `needs` the plugin gate. Gate fail skips the expensive job. Push to `main` still runs CI Checks (gate has no PR payload) so turbo cache can be seeded.

Turbo cache: PR Checks on `main` writes `turbo-Linux-<sha>`. PRs restore that and save under a PR-specific key. Deploy is restore-only so it cannot freeze a tiny cache on the same sha key. `cancel-in-progress` is PR-only so a merge burst does not kill the seed.

Deploy: Node 24 (was 22), `--frozen-lockfile`, packages-only install, one `turbo build` for the publish set. `pnpm-lock.yaml` is out of Turbo `globalDependencies` (workspace lockfile hashing). www auth/db env vars move to `www/turbo.json`.

Unchanged: biome, typecheck, plugin gate R1-R7, frozen lockfile on PR install, `SKIP_PG_TESTS`, ignoring only `api.test.ts` / `integration.test.ts` (so `webhooks.integration.test.ts` still runs). No Jest cache.

## Test plan

- [ ] This PR is a full-lane run (it touches workflows + scripts). CI Checks should still install `./packages/**` and run `turbo` with `--filter=./packages/*`.
- [ ] After merge, a plugin PR log should print `CI lane: plugin (...)` and not build the other plugins.
- [ ] A PR that fails the gate should skip CI Checks.
- [ ] Docs/explorer-only: CI Checks succeeds without install/build/test.

## Checklist

- [x] Classifier tests (`scripts/pr-review/pr-scope.test.ts` + existing gate tests)
- [x] `tsc -p scripts/pr-review`
- [ ] Full `pnpm build` / `pnpm test` of the monorepo (this is what CI Checks on this PR is for)

## Additional notes

Forks still cannot read `main`'s GitHub Actions cache. First push from a fork stays cold. The graph is just smaller for plugin PRs.

This PR's own CI does not prove the plugin install filter. That needs a real plugin PR after merge (or a draft that only touches one plugin).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Pull request checks now select only relevant validation tasks, reducing unnecessary build and test time.
  * Documentation-only and narrowly scoped changes can skip heavy checks.
  * Continuous integration also runs for updates merged directly to the main branch.
  * Deployment workflows use updated runtime support, caching, and dependency installation for more reliable releases.
  * Automated workflows now have safeguards against stalled or duplicate runs.
* **Bug Fixes**
  * Publishing now validates packages and handles already-published releases more safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->