### PR TITLE
feat(dynapictures): add dynapictures plugin with 7 core tools

### DIFF
--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -104,6 +104,7 @@ export const BaseProviders = [
 	'dodopayments',
 	'doppler',
 	'dropbox',
+	'dynapictures',
 	'epicgames',
 	'exa',
 	'facebook',
@@ -299,6 +300,7 @@ export const ProviderDisplayNames = {
 	dodopayments: 'Dodo Payments',
 	doppler: 'Doppler',
 	dropbox: 'Dropbox',
+	dynapictures: 'DynaPictures',
 	epicgames: 'Epic Games',
 	exa: 'Exa',
 	facebook: 'Facebook',
@@ -501,6 +503,7 @@ export type AllProviders =
 	| 'dodopayments'
 	| 'doppler'
 	| 'dropbox'
+	| 'dynapictures'
 	| 'epicgames'
 	| 'exa'
 	| 'facebook'

--- a/packages/dynapictures/api.test.ts
+++ b/packages/dynapictures/api.test.ts
@@ -147,17 +147,20 @@ describe('DynaPictures Plugin Definition', () => {
 		expect(DYNAPICTURES_UNSUBSCRIBE_WEBHOOK.id).toBe(
 			'DYNAPICTURES_UNSUBSCRIBE_WEBHOOK',
 		);
-		expect(DYNAPICTURES_UNSUBSCRIBE_WEBHOOK.method).toBe('POST');
-		expect(DYNAPICTURES_UNSUBSCRIBE_WEBHOOK.path).toBe('/webhooks/unsubscribe');
+		expect(DYNAPICTURES_UNSUBSCRIBE_WEBHOOK.method).toBe('DELETE');
+		expect(DYNAPICTURES_UNSUBSCRIBE_WEBHOOK.path).toBe('/hooks');
 		expect(
 			DYNAPICTURES_UNSUBSCRIBE_WEBHOOK.parameters.safeParse({
 				targetUrl: 'https://example.com/webhook',
-				event: 'image.generated',
+				eventType: 'image.generated',
+				templateId: 'tpl_123',
 			}).success,
 		).toBe(true);
 		expect(
 			DYNAPICTURES_UNSUBSCRIBE_WEBHOOK.parameters.safeParse({
 				targetUrl: 'invalid-url',
+				eventType: 'image.generated',
+				templateId: 'tpl_123',
 			}).success,
 		).toBe(false);
 
@@ -219,8 +222,8 @@ describe('DynaPictures Client', () => {
 			{ method: string; url: string },
 		];
 
-		expect(config.BASE).toBe('https://dynapictures.com/api/v1');
-		expect(DYNAPICTURES_API_BASE).toBe('https://dynapictures.com/api/v1');
+		expect(config.BASE).toBe('https://api.dynapictures.com');
+		expect(DYNAPICTURES_API_BASE).toBe('https://api.dynapictures.com');
 		expect(config.TOKEN).toBe('my-secret-token');
 		expect(config.HEADERS['Authorization']).toBe('Bearer my-secret-token');
 		expect(options.method).toBe('GET');
@@ -335,26 +338,32 @@ describe('DynaPictures Endpoints', () => {
 		);
 	});
 
-	it('webhooks.unsubscribe: sends POST /webhooks/unsubscribe', async () => {
+	it('webhooks.unsubscribe: sends DELETE /hooks', async () => {
 		requestMock.mockResolvedValueOnce({ success: true });
 
 		const result = await Webhooks.unsubscribe(ctx, {
 			targetUrl: 'https://example.com/hook',
-			event: 'image.ready',
+			eventType: 'image.ready',
+			templateId: 'tpl_123',
 		});
 
 		expect(result).toEqual({ success: true });
 		const [, options] = requestMock.mock.calls[0] as any;
-		expect(options.method).toBe('POST');
-		expect(options.url).toBe('/webhooks/unsubscribe');
+		expect(options.method).toBe('DELETE');
+		expect(options.url).toBe('/hooks');
 		expect(options.body).toEqual({
 			targetUrl: 'https://example.com/hook',
-			event: 'image.ready',
+			eventType: 'image.ready',
+			templateId: 'tpl_123',
 		});
 		expect(mockLog).toHaveBeenCalledWith(
 			ctx,
 			'dynapictures.webhooks.unsubscribe',
-			{ targetUrl: 'https://example.com/hook', event: 'image.ready' },
+			{
+				targetUrl: 'https://example.com/hook',
+				eventType: 'image.ready',
+				templateId: 'tpl_123',
+			},
 			'completed',
 		);
 	});

--- a/packages/dynapictures/api.test.ts
+++ b/packages/dynapictures/api.test.ts
@@ -230,15 +230,80 @@ describe('DynaPictures Client', () => {
 		expect(options.url).toBe('/workspaces');
 	});
 
-	it('wraps ApiError into DynapicturesAPIError preserving status', async () => {
+	it('wraps ApiError into DynapicturesAPIError preserving status and retry metadata', async () => {
 		const MockApiError = ApiError as any;
 		requestMock.mockRejectedValueOnce(
-			new MockApiError(404, 'Workspace not found'),
+			new MockApiError(429, 'Too Many Requests', 'Too Many Requests', {
+				error: 'rate_limited',
+			}, 15_000),
 		);
 
 		await expect(
-			makeDynapicturesRequest('/workspaces/unknown', 'key'),
-		).rejects.toThrow(DynapicturesAPIError);
+			makeDynapicturesRequest('/workspaces', 'key', { method: 'GET' }),
+		).rejects.toMatchObject({
+			name: 'DynapicturesAPIError',
+			status: 429,
+			retryAfter: 15_000,
+			statusText: 'Too Many Requests',
+		});
+	});
+
+	it('keeps auth failures distinct from rate-limits after wrapping', async () => {
+		const MockApiError = ApiError as any;
+		requestMock.mockRejectedValueOnce(
+			new MockApiError(401, 'Unauthorized', 'Unauthorized'),
+		);
+
+		await expect(
+			makeDynapicturesRequest('/workspaces', 'key', { method: 'GET' }),
+		).rejects.toMatchObject({
+			name: 'DynapicturesAPIError',
+			status: 401,
+			retryAfter: undefined,
+		});
+	});
+});
+
+describe('DynaPictures error handlers', () => {
+	it('recognizes wrapped 429 errors and forwards retry metadata', async () => {
+		const MockApiError = ApiError as any;
+		const cause = new MockApiError(
+			429,
+			'Too Many Requests',
+			'Too Many Requests',
+			undefined,
+			12_500,
+		);
+		const wrapped = new DynapicturesAPIError(cause.message, cause.status, {
+			cause,
+		});
+
+		const { errorHandlers } = await import('./error-handlers');
+		expect(errorHandlers.RATE_LIMIT_ERROR.match(wrapped)).toBe(true);
+		await expect(errorHandlers.RATE_LIMIT_ERROR.handler(wrapped)).resolves.toEqual({
+			maxRetries: 5,
+			headersRetryAfterMs: 12_500,
+		});
+	});
+
+	it('keeps authentication errors separate from rate-limit errors', async () => {
+		const MockApiError = ApiError as any;
+		const cause = new MockApiError(401, 'Unauthorized', 'Unauthorized');
+		const wrapped = new DynapicturesAPIError(cause.message, cause.status, {
+			cause,
+		});
+
+		const { errorHandlers } = await import('./error-handlers');
+		expect(errorHandlers.RATE_LIMIT_ERROR.match(wrapped)).toBe(false);
+		expect(errorHandlers.AUTH_ERROR.match(wrapped)).toBe(true);
+	});
+});
+
+describe('DynaPictures tenant routing', () => {
+	it('does not register unsupported OAuth tenant resolution callbacks', () => {
+		const plugin = dynapictures({ key: 'test-key' });
+		expect(plugin.oauthWebhookTenantLinkResolver).toBeUndefined();
+		expect(plugin.pluginTenantWebhookMatcher).toBeUndefined();
 	});
 });
 

--- a/packages/dynapictures/api.test.ts
+++ b/packages/dynapictures/api.test.ts
@@ -1,0 +1,391 @@
+import { logEventFromContext } from 'corsair/core';
+import { ApiError, request } from 'corsair/http';
+import {
+	DYNAPICTURES_API_BASE,
+	DynapicturesAPIError,
+	makeDynapicturesRequest,
+} from './client';
+import { Media, Templates, Webhooks, Workspaces } from './endpoints';
+import {
+	DYNAPICTURES_CREATE_WORKSPACE,
+	DYNAPICTURES_DELETE_WORKSPACE,
+	DYNAPICTURES_LIST_TEMPLATES,
+	DYNAPICTURES_LIST_WORKSPACES,
+	DYNAPICTURES_TOOLS,
+	DYNAPICTURES_UNSUBSCRIBE_WEBHOOK,
+	DYNAPICTURES_UPDATE_WORKSPACE,
+	DYNAPICTURES_UPLOAD_MEDIA_ASSET,
+	dynapictures,
+	dynapicturesAuth,
+} from './index';
+
+jest.mock('corsair/core', () => ({
+	logEventFromContext: jest.fn(),
+	AuthMissingError: class AuthMissingError extends Error {
+		constructor(plugin: string, authType: string) {
+			super(`Missing auth for ${plugin} (${authType})`);
+			this.name = 'AuthMissingError';
+		}
+	},
+}));
+
+jest.mock('corsair/http', () => {
+	class MockApiError extends Error {
+		status: number;
+		statusText: string;
+		body: unknown;
+		retryAfter: number | undefined;
+
+		constructor(
+			status: number,
+			message: string,
+			statusText = '',
+			body: unknown = undefined,
+			retryAfter: number | undefined = undefined,
+		) {
+			super(message);
+			this.name = 'ApiError';
+			this.status = status;
+			this.statusText = statusText;
+			this.body = body;
+			this.retryAfter = retryAfter;
+		}
+	}
+
+	return {
+		ApiError: MockApiError,
+		request: jest.fn(),
+	};
+});
+
+const requestMock = request as any;
+const mockLog = logEventFromContext as any;
+
+function createMockContext(apiKey = 'test-dynapictures-key') {
+	return {
+		key: apiKey,
+		authType: 'api_key' as const,
+		options: { authType: 'api_key' as const, key: apiKey },
+		keys: {
+			get_api_key: jest.fn().mockResolvedValue(apiKey),
+		},
+	} as any;
+}
+
+beforeEach(() => {
+	requestMock.mockReset();
+	mockLog.mockReset();
+});
+
+describe('DynaPictures Plugin Definition', () => {
+	it('defines plugin object with correct metadata and auth configuration', () => {
+		const plugin = dynapictures({ key: 'test-key' });
+		expect(plugin.id).toBe('dynapictures');
+		expect(plugin.name).toBe('DynaPictures');
+		expect(plugin.auth).toEqual({
+			type: 'apiKey',
+			header: 'Authorization',
+			prefix: 'Bearer ',
+		});
+		expect(dynapicturesAuth).toEqual({
+			type: 'apiKey',
+			header: 'Authorization',
+			prefix: 'Bearer ',
+		});
+	});
+
+	it('exports 7 tool operations with strict Zod parameter schemas', () => {
+		expect(DYNAPICTURES_CREATE_WORKSPACE.id).toBe(
+			'DYNAPICTURES_CREATE_WORKSPACE',
+		);
+		expect(DYNAPICTURES_CREATE_WORKSPACE.method).toBe('POST');
+		expect(DYNAPICTURES_CREATE_WORKSPACE.path).toBe('/workspaces');
+		expect(
+			DYNAPICTURES_CREATE_WORKSPACE.parameters.safeParse({
+				name: 'My Workspace',
+			}).success,
+		).toBe(true);
+		expect(DYNAPICTURES_CREATE_WORKSPACE.parameters.safeParse({}).success).toBe(
+			false,
+		);
+
+		expect(DYNAPICTURES_DELETE_WORKSPACE.id).toBe(
+			'DYNAPICTURES_DELETE_WORKSPACE',
+		);
+		expect(DYNAPICTURES_DELETE_WORKSPACE.method).toBe('DELETE');
+		expect(DYNAPICTURES_DELETE_WORKSPACE.path).toBe('/workspaces/:workspaceId');
+		expect(
+			DYNAPICTURES_DELETE_WORKSPACE.parameters.safeParse({
+				workspaceId: 'ws_123',
+			}).success,
+		).toBe(true);
+		expect(DYNAPICTURES_DELETE_WORKSPACE.parameters.safeParse({}).success).toBe(
+			false,
+		);
+
+		expect(DYNAPICTURES_LIST_TEMPLATES.id).toBe('DYNAPICTURES_LIST_TEMPLATES');
+		expect(DYNAPICTURES_LIST_TEMPLATES.method).toBe('GET');
+		expect(DYNAPICTURES_LIST_TEMPLATES.path).toBe('/templates');
+		expect(
+			DYNAPICTURES_LIST_TEMPLATES.parameters.safeParse({
+				workspaceId: 'ws_123',
+			}).success,
+		).toBe(true);
+		expect(DYNAPICTURES_LIST_TEMPLATES.parameters.safeParse({}).success).toBe(
+			true,
+		);
+
+		expect(DYNAPICTURES_LIST_WORKSPACES.id).toBe(
+			'DYNAPICTURES_LIST_WORKSPACES',
+		);
+		expect(DYNAPICTURES_LIST_WORKSPACES.method).toBe('GET');
+		expect(DYNAPICTURES_LIST_WORKSPACES.path).toBe('/workspaces');
+		expect(DYNAPICTURES_LIST_WORKSPACES.parameters.safeParse({}).success).toBe(
+			true,
+		);
+
+		expect(DYNAPICTURES_UNSUBSCRIBE_WEBHOOK.id).toBe(
+			'DYNAPICTURES_UNSUBSCRIBE_WEBHOOK',
+		);
+		expect(DYNAPICTURES_UNSUBSCRIBE_WEBHOOK.method).toBe('POST');
+		expect(DYNAPICTURES_UNSUBSCRIBE_WEBHOOK.path).toBe('/webhooks/unsubscribe');
+		expect(
+			DYNAPICTURES_UNSUBSCRIBE_WEBHOOK.parameters.safeParse({
+				targetUrl: 'https://example.com/webhook',
+				event: 'image.generated',
+			}).success,
+		).toBe(true);
+		expect(
+			DYNAPICTURES_UNSUBSCRIBE_WEBHOOK.parameters.safeParse({
+				targetUrl: 'invalid-url',
+			}).success,
+		).toBe(false);
+
+		expect(DYNAPICTURES_UPDATE_WORKSPACE.id).toBe(
+			'DYNAPICTURES_UPDATE_WORKSPACE',
+		);
+		expect(DYNAPICTURES_UPDATE_WORKSPACE.method).toBe('PUT');
+		expect(DYNAPICTURES_UPDATE_WORKSPACE.path).toBe('/workspaces/:workspaceId');
+		expect(
+			DYNAPICTURES_UPDATE_WORKSPACE.parameters.safeParse({
+				workspaceId: 'ws_123',
+				name: 'Renamed Workspace',
+			}).success,
+		).toBe(true);
+		expect(
+			DYNAPICTURES_UPDATE_WORKSPACE.parameters.safeParse({
+				workspaceId: 'ws_123',
+			}).success,
+		).toBe(false);
+
+		expect(DYNAPICTURES_UPLOAD_MEDIA_ASSET.id).toBe(
+			'DYNAPICTURES_UPLOAD_MEDIA_ASSET',
+		);
+		expect(DYNAPICTURES_UPLOAD_MEDIA_ASSET.method).toBe('POST');
+		expect(DYNAPICTURES_UPLOAD_MEDIA_ASSET.path).toBe('/media');
+		expect(
+			DYNAPICTURES_UPLOAD_MEDIA_ASSET.parameters.safeParse({
+				imageUrl: 'https://example.com/photo.jpg',
+				name: 'My Photo',
+			}).success,
+		).toBe(true);
+		expect(
+			DYNAPICTURES_UPLOAD_MEDIA_ASSET.parameters.safeParse({
+				imageUrl: 'not-a-url',
+			}).success,
+		).toBe(false);
+
+		expect(Object.keys(DYNAPICTURES_TOOLS)).toHaveLength(7);
+	});
+});
+
+describe('DynaPictures Client', () => {
+	it('uses correct baseUrl and bearer token auth', async () => {
+		requestMock.mockResolvedValueOnce({ id: 'ws_1', name: 'Workspace 1' });
+
+		const result = await makeDynapicturesRequest(
+			'/workspaces',
+			'my-secret-token',
+			{
+				method: 'GET',
+			},
+		);
+
+		expect(result).toEqual({ id: 'ws_1', name: 'Workspace 1' });
+		expect(requestMock).toHaveBeenCalledTimes(1);
+
+		const [config, options] = requestMock.mock.calls[0] as [
+			{ BASE: string; TOKEN: string; HEADERS: Record<string, string> },
+			{ method: string; url: string },
+		];
+
+		expect(config.BASE).toBe('https://dynapictures.com/api/v1');
+		expect(DYNAPICTURES_API_BASE).toBe('https://dynapictures.com/api/v1');
+		expect(config.TOKEN).toBe('my-secret-token');
+		expect(config.HEADERS['Authorization']).toBe('Bearer my-secret-token');
+		expect(options.method).toBe('GET');
+		expect(options.url).toBe('/workspaces');
+	});
+
+	it('wraps ApiError into DynapicturesAPIError preserving status', async () => {
+		const MockApiError = ApiError as any;
+		requestMock.mockRejectedValueOnce(
+			new MockApiError(404, 'Workspace not found'),
+		);
+
+		await expect(
+			makeDynapicturesRequest('/workspaces/unknown', 'key'),
+		).rejects.toThrow(DynapicturesAPIError);
+	});
+});
+
+describe('DynaPictures Endpoints', () => {
+	const ctx = createMockContext('secret_api_key_123');
+
+	it('workspaces.create: sends POST /workspaces with name', async () => {
+		requestMock.mockResolvedValueOnce({ id: 'ws_1', name: 'Team Workspace' });
+
+		const result = await Workspaces.create(ctx, { name: 'Team Workspace' });
+
+		expect(result).toEqual({ id: 'ws_1', name: 'Team Workspace' });
+		const [, options] = requestMock.mock.calls[0] as any;
+		expect(options.method).toBe('POST');
+		expect(options.url).toBe('/workspaces');
+		expect(options.body).toEqual({ name: 'Team Workspace' });
+		expect(mockLog).toHaveBeenCalledWith(
+			ctx,
+			'dynapictures.workspaces.create',
+			{ name: 'Team Workspace' },
+			'completed',
+		);
+	});
+
+	it('workspaces.delete: sends DELETE /workspaces/:workspaceId', async () => {
+		requestMock.mockResolvedValueOnce({ success: true });
+
+		const result = await Workspaces.deleteWorkspace(ctx, {
+			workspaceId: 'ws_123',
+		});
+
+		expect(result).toEqual({ success: true });
+		const [, options] = requestMock.mock.calls[0] as any;
+		expect(options.method).toBe('DELETE');
+		expect(options.url).toBe('/workspaces/ws_123');
+		expect(mockLog).toHaveBeenCalledWith(
+			ctx,
+			'dynapictures.workspaces.delete',
+			{ workspaceId: 'ws_123' },
+			'completed',
+		);
+	});
+
+	it('workspaces.list: sends GET /workspaces', async () => {
+		requestMock.mockResolvedValueOnce([{ id: 'ws_1' }, { id: 'ws_2' }]);
+
+		const result = await Workspaces.list(ctx, {});
+
+		expect(result).toEqual([{ id: 'ws_1' }, { id: 'ws_2' }]);
+		const [, options] = requestMock.mock.calls[0] as any;
+		expect(options.method).toBe('GET');
+		expect(options.url).toBe('/workspaces');
+		expect(mockLog).toHaveBeenCalledWith(
+			ctx,
+			'dynapictures.workspaces.list',
+			{},
+			'completed',
+		);
+	});
+
+	it('workspaces.update: sends PUT /workspaces/:workspaceId with name', async () => {
+		requestMock.mockResolvedValueOnce({ id: 'ws_123', name: 'Updated Name' });
+
+		const result = await Workspaces.update(ctx, {
+			workspaceId: 'ws_123',
+			name: 'Updated Name',
+		});
+
+		expect(result).toEqual({ id: 'ws_123', name: 'Updated Name' });
+		const [, options] = requestMock.mock.calls[0] as any;
+		expect(options.method).toBe('PUT');
+		expect(options.url).toBe('/workspaces/ws_123');
+		expect(options.body).toEqual({ name: 'Updated Name' });
+		expect(mockLog).toHaveBeenCalledWith(
+			ctx,
+			'dynapictures.workspaces.update',
+			{ workspaceId: 'ws_123', name: 'Updated Name' },
+			'completed',
+		);
+	});
+
+	it('templates.list: sends GET /templates with optional workspaceId query', async () => {
+		requestMock.mockResolvedValueOnce([{ id: 'tpl_1', name: 'Banner' }]);
+
+		const result = await Templates.list(ctx, { workspaceId: 'ws_abc' });
+
+		expect(result).toEqual([{ id: 'tpl_1', name: 'Banner' }]);
+		const [, options] = requestMock.mock.calls[0] as any;
+		expect(options.method).toBe('GET');
+		expect(options.url).toBe('/templates');
+		expect(options.query).toEqual({ workspaceId: 'ws_abc' });
+		expect(mockLog).toHaveBeenCalledWith(
+			ctx,
+			'dynapictures.templates.list',
+			{ workspaceId: 'ws_abc' },
+			'completed',
+		);
+	});
+
+	it('webhooks.unsubscribe: sends POST /webhooks/unsubscribe', async () => {
+		requestMock.mockResolvedValueOnce({ success: true });
+
+		const result = await Webhooks.unsubscribe(ctx, {
+			targetUrl: 'https://example.com/hook',
+			event: 'image.ready',
+		});
+
+		expect(result).toEqual({ success: true });
+		const [, options] = requestMock.mock.calls[0] as any;
+		expect(options.method).toBe('POST');
+		expect(options.url).toBe('/webhooks/unsubscribe');
+		expect(options.body).toEqual({
+			targetUrl: 'https://example.com/hook',
+			event: 'image.ready',
+		});
+		expect(mockLog).toHaveBeenCalledWith(
+			ctx,
+			'dynapictures.webhooks.unsubscribe',
+			{ targetUrl: 'https://example.com/hook', event: 'image.ready' },
+			'completed',
+		);
+	});
+
+	it('media.upload: sends POST /media with imageUrl and optional name', async () => {
+		requestMock.mockResolvedValueOnce({
+			id: 'media_1',
+			url: 'https://dynapictures.com/cdn/img.png',
+		});
+
+		const result = await Media.upload(ctx, {
+			imageUrl: 'https://source.unsplash.com/random',
+			name: 'Hero Image',
+		});
+
+		expect(result).toEqual({
+			id: 'media_1',
+			url: 'https://dynapictures.com/cdn/img.png',
+		});
+		const [, options] = requestMock.mock.calls[0] as any;
+		expect(options.method).toBe('POST');
+		expect(options.url).toBe('/media');
+		expect(options.body).toEqual({
+			imageUrl: 'https://source.unsplash.com/random',
+			name: 'Hero Image',
+		});
+		expect(mockLog).toHaveBeenCalledWith(
+			ctx,
+			'dynapictures.media.upload',
+			{ imageUrl: 'https://source.unsplash.com/random', name: 'Hero Image' },
+			'completed',
+		);
+	});
+});

--- a/packages/dynapictures/client.ts
+++ b/packages/dynapictures/client.ts
@@ -1,11 +1,15 @@
 import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
 import { ApiError, request } from 'corsair/http';
 
+/** Wraps a DynaPictures API failure while surfacing the transport status and retry information. */
 export class DynapicturesAPIError extends Error {
 	public readonly status?: number;
 	public readonly statusText?: string;
 	public readonly body?: unknown;
 	public readonly retryAfter?: number;
+	public readonly rateLimitReset?: number;
+	public readonly rateLimitRemaining?: number;
+	public readonly rateLimitLimit?: number;
 
 	constructor(
 		message: string,
@@ -20,12 +24,16 @@ export class DynapicturesAPIError extends Error {
 			this.statusText = options.cause.statusText;
 			this.body = options.cause.body;
 			this.retryAfter = options.cause.retryAfter;
+			this.rateLimitReset = options.cause.rateLimitReset;
+			this.rateLimitRemaining = options.cause.rateLimitRemaining;
+			this.rateLimitLimit = options.cause.rateLimitLimit;
 		}
 	}
 }
 
 export const DYNAPICTURES_API_BASE = 'https://api.dynapictures.com';
 
+/** Performs a request against the canonical DynaPictures API host using bearer-token auth. */
 export async function makeDynapicturesRequest<T>(
 	endpoint: string,
 	apiKey: string,

--- a/packages/dynapictures/client.ts
+++ b/packages/dynapictures/client.ts
@@ -24,7 +24,7 @@ export class DynapicturesAPIError extends Error {
 	}
 }
 
-export const DYNAPICTURES_API_BASE = 'https://dynapictures.com/api/v1';
+export const DYNAPICTURES_API_BASE = 'https://api.dynapictures.com';
 
 export async function makeDynapicturesRequest<T>(
 	endpoint: string,
@@ -53,7 +53,7 @@ export async function makeDynapicturesRequest<T>(
 		method,
 		url: endpoint,
 		body:
-			method === 'POST' || method === 'PUT' || method === 'PATCH'
+			method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE'
 				? body
 				: undefined,
 		mediaType: 'application/json; charset=utf-8',

--- a/packages/dynapictures/client.ts
+++ b/packages/dynapictures/client.ts
@@ -1,0 +1,78 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+
+export class DynapicturesAPIError extends Error {
+	public readonly status?: number;
+	public readonly statusText?: string;
+	public readonly body?: unknown;
+	public readonly retryAfter?: number;
+
+	constructor(
+		message: string,
+		public readonly code?: string | number,
+		options?: { cause?: Error },
+	) {
+		super(message, options);
+		this.name = 'DynapicturesAPIError';
+
+		if (options?.cause instanceof ApiError) {
+			this.status = options.cause.status;
+			this.statusText = options.cause.statusText;
+			this.body = options.cause.body;
+			this.retryAfter = options.cause.retryAfter;
+		}
+	}
+}
+
+export const DYNAPICTURES_API_BASE = 'https://dynapictures.com/api/v1';
+
+export async function makeDynapicturesRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	options: {
+		method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+		body?: Record<string, unknown>;
+		query?: Record<string, string | number | boolean | undefined>;
+	} = {},
+): Promise<T> {
+	const { method = 'GET', body, query } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: DYNAPICTURES_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: apiKey,
+		HEADERS: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${apiKey}`,
+		},
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint,
+		body:
+			method === 'POST' || method === 'PUT' || method === 'PATCH'
+				? body
+				: undefined,
+		mediaType: 'application/json; charset=utf-8',
+		query: method === 'GET' ? query : undefined,
+	};
+
+	try {
+		return await request<T>(config, requestOptions);
+	} catch (error) {
+		if (error instanceof ApiError) {
+			throw new DynapicturesAPIError(error.message, error.status, {
+				cause: error,
+			});
+		}
+		if (error instanceof Error) {
+			throw new DynapicturesAPIError(error.message, undefined, {
+				cause: error,
+			});
+		}
+		throw new DynapicturesAPIError('Unknown error');
+	}
+}

--- a/packages/dynapictures/endpoints/index.ts
+++ b/packages/dynapictures/endpoints/index.ts
@@ -1,0 +1,7 @@
+import * as Media from './media';
+import * as Templates from './templates';
+import * as Webhooks from './webhooks';
+import * as Workspaces from './workspaces';
+
+export { Workspaces, Templates, Webhooks, Media };
+export * from './types';

--- a/packages/dynapictures/endpoints/media.ts
+++ b/packages/dynapictures/endpoints/media.ts
@@ -1,0 +1,28 @@
+import { logEventFromContext } from 'corsair/core';
+import type { DynapicturesEndpoints } from '..';
+import { makeDynapicturesRequest } from '../client';
+import type { UploadMediaAssetResponse } from './types';
+
+export const upload: DynapicturesEndpoints['uploadMediaAsset'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeDynapicturesRequest<UploadMediaAssetResponse>(
+		'/media',
+		ctx.key,
+		{
+			method: 'POST',
+			body: {
+				imageUrl: input.imageUrl,
+				...(input.name ? { name: input.name } : {}),
+			},
+		},
+	);
+	await logEventFromContext(
+		ctx,
+		'dynapictures.media.upload',
+		{ imageUrl: input.imageUrl, name: input.name },
+		'completed',
+	);
+	return response;
+};

--- a/packages/dynapictures/endpoints/templates.ts
+++ b/packages/dynapictures/endpoints/templates.ts
@@ -1,0 +1,27 @@
+import { logEventFromContext } from 'corsair/core';
+import type { DynapicturesEndpoints } from '..';
+import { makeDynapicturesRequest } from '../client';
+import type { ListTemplatesResponse } from './types';
+
+export const list: DynapicturesEndpoints['listTemplates'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeDynapicturesRequest<ListTemplatesResponse>(
+		'/templates',
+		ctx.key,
+		{
+			method: 'GET',
+			query: input?.workspaceId
+				? { workspaceId: input.workspaceId }
+				: undefined,
+		},
+	);
+	await logEventFromContext(
+		ctx,
+		'dynapictures.templates.list',
+		input ?? {},
+		'completed',
+	);
+	return response;
+};

--- a/packages/dynapictures/endpoints/types.ts
+++ b/packages/dynapictures/endpoints/types.ts
@@ -91,10 +91,8 @@ export type ListTemplatesResponse = z.infer<typeof ListTemplatesResponseSchema>;
 
 export const UnsubscribeWebhookInputSchema = z.object({
 	targetUrl: z.string().url().describe('The webhook target URL to unsubscribe'),
-	event: z
-		.string()
-		.optional()
-		.describe('Optional event type name to unsubscribe from'),
+	eventType: z.string().describe('Event type name to unsubscribe from'),
+	templateId: z.string().describe('Template ID associated with the webhook'),
 });
 export type UnsubscribeWebhookInput = z.infer<
 	typeof UnsubscribeWebhookInputSchema

--- a/packages/dynapictures/endpoints/types.ts
+++ b/packages/dynapictures/endpoints/types.ts
@@ -1,0 +1,175 @@
+import { z } from 'zod';
+
+// ── Workspace Schemas ────────────────────────────────────────────────────────
+
+export const CreateWorkspaceInputSchema = z.object({
+	name: z.string().describe('Name of the workspace'),
+});
+export type CreateWorkspaceInput = z.infer<typeof CreateWorkspaceInputSchema>;
+
+export const CreateWorkspaceResponseSchema = z
+	.object({
+		id: z.string().optional(),
+		name: z.string().optional(),
+	})
+	.passthrough();
+export type CreateWorkspaceResponse = z.infer<
+	typeof CreateWorkspaceResponseSchema
+>;
+
+export const DeleteWorkspaceInputSchema = z.object({
+	workspaceId: z
+		.string()
+		.describe('Unique identifier of the workspace to delete'),
+});
+export type DeleteWorkspaceInput = z.infer<typeof DeleteWorkspaceInputSchema>;
+
+export const DeleteWorkspaceResponseSchema = z
+	.object({
+		success: z.boolean().optional(),
+		message: z.string().optional(),
+	})
+	.passthrough();
+export type DeleteWorkspaceResponse = z.infer<
+	typeof DeleteWorkspaceResponseSchema
+>;
+
+export const ListWorkspacesInputSchema = z.object({});
+export type ListWorkspacesInput = z.infer<typeof ListWorkspacesInputSchema>;
+
+export const ListWorkspacesResponseSchema = z.union([
+	z.array(z.record(z.string(), z.unknown())),
+	z
+		.object({
+			workspaces: z.array(z.record(z.string(), z.unknown())).optional(),
+		})
+		.passthrough(),
+]);
+export type ListWorkspacesResponse = z.infer<
+	typeof ListWorkspacesResponseSchema
+>;
+
+export const UpdateWorkspaceInputSchema = z.object({
+	workspaceId: z
+		.string()
+		.describe('Unique identifier of the workspace to update'),
+	name: z.string().describe('New name for the workspace'),
+});
+export type UpdateWorkspaceInput = z.infer<typeof UpdateWorkspaceInputSchema>;
+
+export const UpdateWorkspaceResponseSchema = z
+	.object({
+		id: z.string().optional(),
+		name: z.string().optional(),
+	})
+	.passthrough();
+export type UpdateWorkspaceResponse = z.infer<
+	typeof UpdateWorkspaceResponseSchema
+>;
+
+// ── Template Schemas ─────────────────────────────────────────────────────────
+
+export const ListTemplatesInputSchema = z.object({
+	workspaceId: z
+		.string()
+		.optional()
+		.describe('Optional workspace ID to filter templates by'),
+});
+export type ListTemplatesInput = z.infer<typeof ListTemplatesInputSchema>;
+
+export const ListTemplatesResponseSchema = z.union([
+	z.array(z.record(z.string(), z.unknown())),
+	z
+		.object({
+			templates: z.array(z.record(z.string(), z.unknown())).optional(),
+		})
+		.passthrough(),
+]);
+export type ListTemplatesResponse = z.infer<typeof ListTemplatesResponseSchema>;
+
+// ── Webhook Schemas ──────────────────────────────────────────────────────────
+
+export const UnsubscribeWebhookInputSchema = z.object({
+	targetUrl: z.string().url().describe('The webhook target URL to unsubscribe'),
+	event: z
+		.string()
+		.optional()
+		.describe('Optional event type name to unsubscribe from'),
+});
+export type UnsubscribeWebhookInput = z.infer<
+	typeof UnsubscribeWebhookInputSchema
+>;
+
+export const UnsubscribeWebhookResponseSchema = z
+	.object({
+		success: z.boolean().optional(),
+		message: z.string().optional(),
+	})
+	.passthrough();
+export type UnsubscribeWebhookResponse = z.infer<
+	typeof UnsubscribeWebhookResponseSchema
+>;
+
+// ── Media Schemas ────────────────────────────────────────────────────────────
+
+export const UploadMediaAssetInputSchema = z.object({
+	imageUrl: z
+		.string()
+		.url()
+		.describe('Publicly accessible URL of the image to upload'),
+	name: z.string().optional().describe('Optional name for the media asset'),
+});
+export type UploadMediaAssetInput = z.infer<typeof UploadMediaAssetInputSchema>;
+
+export const UploadMediaAssetResponseSchema = z
+	.object({
+		id: z.string().optional(),
+		url: z.string().optional(),
+		name: z.string().optional(),
+	})
+	.passthrough();
+export type UploadMediaAssetResponse = z.infer<
+	typeof UploadMediaAssetResponseSchema
+>;
+
+// ── Endpoint Inputs and Outputs Maps ─────────────────────────────────────────
+
+export const DynapicturesEndpointInputSchemas = {
+	createWorkspace: CreateWorkspaceInputSchema,
+	deleteWorkspace: DeleteWorkspaceInputSchema,
+	listTemplates: ListTemplatesInputSchema,
+	listWorkspaces: ListWorkspacesInputSchema,
+	unsubscribeWebhook: UnsubscribeWebhookInputSchema,
+	updateWorkspace: UpdateWorkspaceInputSchema,
+	uploadMediaAsset: UploadMediaAssetInputSchema,
+} as const;
+
+export type DynapicturesEndpointInputs = {
+	createWorkspace: CreateWorkspaceInput;
+	deleteWorkspace: DeleteWorkspaceInput;
+	listTemplates: ListTemplatesInput;
+	listWorkspaces: ListWorkspacesInput;
+	unsubscribeWebhook: UnsubscribeWebhookInput;
+	updateWorkspace: UpdateWorkspaceInput;
+	uploadMediaAsset: UploadMediaAssetInput;
+};
+
+export const DynapicturesEndpointOutputSchemas = {
+	createWorkspace: CreateWorkspaceResponseSchema,
+	deleteWorkspace: DeleteWorkspaceResponseSchema,
+	listTemplates: ListTemplatesResponseSchema,
+	listWorkspaces: ListWorkspacesResponseSchema,
+	unsubscribeWebhook: UnsubscribeWebhookResponseSchema,
+	updateWorkspace: UpdateWorkspaceResponseSchema,
+	uploadMediaAsset: UploadMediaAssetResponseSchema,
+} as const;
+
+export type DynapicturesEndpointOutputs = {
+	createWorkspace: CreateWorkspaceResponse;
+	deleteWorkspace: DeleteWorkspaceResponse;
+	listTemplates: ListTemplatesResponse;
+	listWorkspaces: ListWorkspacesResponse;
+	unsubscribeWebhook: UnsubscribeWebhookResponse;
+	updateWorkspace: UpdateWorkspaceResponse;
+	uploadMediaAsset: UploadMediaAssetResponse;
+};

--- a/packages/dynapictures/endpoints/webhooks.ts
+++ b/packages/dynapictures/endpoints/webhooks.ts
@@ -8,20 +8,25 @@ export const unsubscribe: DynapicturesEndpoints['unsubscribeWebhook'] = async (
 	input,
 ) => {
 	const response = await makeDynapicturesRequest<UnsubscribeWebhookResponse>(
-		'/webhooks/unsubscribe',
+		'/hooks',
 		ctx.key,
 		{
-			method: 'POST',
+			method: 'DELETE',
 			body: {
 				targetUrl: input.targetUrl,
-				...(input.event ? { event: input.event } : {}),
+				eventType: input.eventType,
+				templateId: input.templateId,
 			},
 		},
 	);
 	await logEventFromContext(
 		ctx,
 		'dynapictures.webhooks.unsubscribe',
-		{ targetUrl: input.targetUrl, event: input.event },
+		{
+			targetUrl: input.targetUrl,
+			eventType: input.eventType,
+			templateId: input.templateId,
+		},
 		'completed',
 	);
 	return response;

--- a/packages/dynapictures/endpoints/webhooks.ts
+++ b/packages/dynapictures/endpoints/webhooks.ts
@@ -1,0 +1,28 @@
+import { logEventFromContext } from 'corsair/core';
+import type { DynapicturesEndpoints } from '..';
+import { makeDynapicturesRequest } from '../client';
+import type { UnsubscribeWebhookResponse } from './types';
+
+export const unsubscribe: DynapicturesEndpoints['unsubscribeWebhook'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeDynapicturesRequest<UnsubscribeWebhookResponse>(
+		'/webhooks/unsubscribe',
+		ctx.key,
+		{
+			method: 'POST',
+			body: {
+				targetUrl: input.targetUrl,
+				...(input.event ? { event: input.event } : {}),
+			},
+		},
+	);
+	await logEventFromContext(
+		ctx,
+		'dynapictures.webhooks.unsubscribe',
+		{ targetUrl: input.targetUrl, event: input.event },
+		'completed',
+	);
+	return response;
+};

--- a/packages/dynapictures/endpoints/workspaces.ts
+++ b/packages/dynapictures/endpoints/workspaces.ts
@@ -1,0 +1,91 @@
+import { logEventFromContext } from 'corsair/core';
+import type { DynapicturesEndpoints } from '..';
+import { makeDynapicturesRequest } from '../client';
+import type {
+	CreateWorkspaceResponse,
+	DeleteWorkspaceResponse,
+	ListWorkspacesResponse,
+	UpdateWorkspaceResponse,
+} from './types';
+
+export const create: DynapicturesEndpoints['createWorkspace'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeDynapicturesRequest<CreateWorkspaceResponse>(
+		'/workspaces',
+		ctx.key,
+		{
+			method: 'POST',
+			body: { name: input.name },
+		},
+	);
+	await logEventFromContext(
+		ctx,
+		'dynapictures.workspaces.create',
+		{ name: input.name },
+		'completed',
+	);
+	return response;
+};
+
+export const deleteWorkspace: DynapicturesEndpoints['deleteWorkspace'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeDynapicturesRequest<DeleteWorkspaceResponse>(
+		`/workspaces/${encodeURIComponent(input.workspaceId)}`,
+		ctx.key,
+		{
+			method: 'DELETE',
+		},
+	);
+	await logEventFromContext(
+		ctx,
+		'dynapictures.workspaces.delete',
+		{ workspaceId: input.workspaceId },
+		'completed',
+	);
+	return response;
+};
+
+export const list: DynapicturesEndpoints['listWorkspaces'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeDynapicturesRequest<ListWorkspacesResponse>(
+		'/workspaces',
+		ctx.key,
+		{
+			method: 'GET',
+		},
+	);
+	await logEventFromContext(
+		ctx,
+		'dynapictures.workspaces.list',
+		input ?? {},
+		'completed',
+	);
+	return response;
+};
+
+export const update: DynapicturesEndpoints['updateWorkspace'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeDynapicturesRequest<UpdateWorkspaceResponse>(
+		`/workspaces/${encodeURIComponent(input.workspaceId)}`,
+		ctx.key,
+		{
+			method: 'PUT',
+			body: { name: input.name },
+		},
+	);
+	await logEventFromContext(
+		ctx,
+		'dynapictures.workspaces.update',
+		{ workspaceId: input.workspaceId, name: input.name },
+		'completed',
+	);
+	return response;
+};

--- a/packages/dynapictures/error-handlers.ts
+++ b/packages/dynapictures/error-handlers.ts
@@ -1,0 +1,31 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('429');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('unauthorized') || msg.includes('invalid_auth');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/dynapictures/error-handlers.ts
+++ b/packages/dynapictures/error-handlers.ts
@@ -1,24 +1,52 @@
 import type { CorsairErrorHandler } from 'corsair/core';
 import { ApiError } from 'corsair/http';
 
+function getStatus(error: Error): number | undefined {
+	if (error instanceof ApiError) {
+		return error.status;
+	}
+
+	const status = (error as { status?: number; cause?: { status?: number } }).status;
+	if (typeof status === 'number') {
+		return status;
+	}
+
+	const causeStatus = (error as { cause?: { status?: number } }).cause?.status;
+	return typeof causeStatus === 'number' ? causeStatus : undefined;
+}
+
+function getRetryAfter(error: Error): number | undefined {
+	if (error instanceof ApiError) {
+		return error.retryAfter;
+	}
+
+	const retryAfter = (error as {
+		retryAfter?: number;
+		cause?: { retryAfter?: number };
+	}).retryAfter;
+	if (typeof retryAfter === 'number') {
+		return retryAfter;
+	}
+
+	const causeRetryAfter = (error as { cause?: { retryAfter?: number } }).cause?.retryAfter;
+	return typeof causeRetryAfter === 'number' ? causeRetryAfter : undefined;
+}
+
 export const errorHandlers = {
 	RATE_LIMIT_ERROR: {
 		match: (error: Error) => {
-			if (error instanceof ApiError && error.status === 429) return true;
+			if (getStatus(error) === 429) return true;
 			const msg = error.message.toLowerCase();
 			return msg.includes('rate_limited') || msg.includes('429');
 		},
-		handler: async (error: Error) => {
-			let retryAfterMs: number | undefined;
-			if (error instanceof ApiError && error.retryAfter !== undefined) {
-				retryAfterMs = error.retryAfter;
-			}
-			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
-		},
+		handler: async (error: Error) => ({
+			maxRetries: 5,
+			headersRetryAfterMs: getRetryAfter(error),
+		}),
 	},
 	AUTH_ERROR: {
 		match: (error: Error) => {
-			if (error instanceof ApiError && error.status === 401) return true;
+			if (getStatus(error) === 401) return true;
 			const msg = error.message.toLowerCase();
 			return msg.includes('unauthorized') || msg.includes('invalid_auth');
 		},

--- a/packages/dynapictures/error-handlers.ts
+++ b/packages/dynapictures/error-handlers.ts
@@ -6,7 +6,8 @@ function getStatus(error: Error): number | undefined {
 		return error.status;
 	}
 
-	const status = (error as { status?: number; cause?: { status?: number } }).status;
+	const status = (error as { status?: number; cause?: { status?: number } })
+		.status;
 	if (typeof status === 'number') {
 		return status;
 	}
@@ -20,15 +21,18 @@ function getRetryAfter(error: Error): number | undefined {
 		return error.retryAfter;
 	}
 
-	const retryAfter = (error as {
-		retryAfter?: number;
-		cause?: { retryAfter?: number };
-	}).retryAfter;
+	const retryAfter = (
+		error as {
+			retryAfter?: number;
+			cause?: { retryAfter?: number };
+		}
+	).retryAfter;
 	if (typeof retryAfter === 'number') {
 		return retryAfter;
 	}
 
-	const causeRetryAfter = (error as { cause?: { retryAfter?: number } }).cause?.retryAfter;
+	const causeRetryAfter = (error as { cause?: { retryAfter?: number } }).cause
+		?.retryAfter;
 	return typeof causeRetryAfter === 'number' ? causeRetryAfter : undefined;
 }
 

--- a/packages/dynapictures/index.ts
+++ b/packages/dynapictures/index.ts
@@ -82,8 +82,8 @@ export const DYNAPICTURES_UNSUBSCRIBE_WEBHOOK = {
 	id: 'DYNAPICTURES_UNSUBSCRIBE_WEBHOOK',
 	name: 'Unsubscribe Webhook',
 	description: 'Unsubscribe a webhook URL from DynaPictures events',
-	method: 'POST',
-	path: '/webhooks/unsubscribe',
+	method: 'DELETE',
+	path: '/hooks',
 	parameters: UnsubscribeWebhookInputSchema,
 	schema: UnsubscribeWebhookInputSchema,
 } as const;

--- a/packages/dynapictures/index.ts
+++ b/packages/dynapictures/index.ts
@@ -1,0 +1,373 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	BindWebhooks,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+	RequiredPluginWebhookSchemas,
+} from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
+import { Media, Templates, Webhooks, Workspaces } from './endpoints';
+import type {
+	DynapicturesEndpointInputs,
+	DynapicturesEndpointOutputs,
+} from './endpoints/types';
+import {
+	CreateWorkspaceInputSchema,
+	DeleteWorkspaceInputSchema,
+	DynapicturesEndpointInputSchemas,
+	DynapicturesEndpointOutputSchemas,
+	ListTemplatesInputSchema,
+	ListWorkspacesInputSchema,
+	UnsubscribeWebhookInputSchema,
+	UpdateWorkspaceInputSchema,
+	UploadMediaAssetInputSchema,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { DynapicturesSchema } from './schema';
+import { resolveDynapicturesOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
+import { matchDynapicturesTenantWebhook } from './webhooks/tenant-matcher';
+
+// ── Tool Operation Definitions ───────────────────────────────────────────────
+
+export const DYNAPICTURES_CREATE_WORKSPACE = {
+	id: 'DYNAPICTURES_CREATE_WORKSPACE',
+	name: 'Create Workspace',
+	description: 'Create a new DynaPictures workspace',
+	method: 'POST',
+	path: '/workspaces',
+	parameters: CreateWorkspaceInputSchema,
+	schema: CreateWorkspaceInputSchema,
+} as const;
+
+export const DYNAPICTURES_DELETE_WORKSPACE = {
+	id: 'DYNAPICTURES_DELETE_WORKSPACE',
+	name: 'Delete Workspace',
+	description: 'Delete a DynaPictures workspace by ID',
+	method: 'DELETE',
+	path: '/workspaces/:workspaceId',
+	parameters: DeleteWorkspaceInputSchema,
+	schema: DeleteWorkspaceInputSchema,
+} as const;
+
+export const DYNAPICTURES_LIST_TEMPLATES = {
+	id: 'DYNAPICTURES_LIST_TEMPLATES',
+	name: 'List Templates',
+	description: 'List DynaPictures templates with optional workspace ID filter',
+	method: 'GET',
+	path: '/templates',
+	parameters: ListTemplatesInputSchema,
+	schema: ListTemplatesInputSchema,
+} as const;
+
+export const DYNAPICTURES_LIST_WORKSPACES = {
+	id: 'DYNAPICTURES_LIST_WORKSPACES',
+	name: 'List Workspaces',
+	description: 'List all DynaPictures workspaces',
+	method: 'GET',
+	path: '/workspaces',
+	parameters: ListWorkspacesInputSchema,
+	schema: ListWorkspacesInputSchema,
+} as const;
+
+export const DYNAPICTURES_UNSUBSCRIBE_WEBHOOK = {
+	id: 'DYNAPICTURES_UNSUBSCRIBE_WEBHOOK',
+	name: 'Unsubscribe Webhook',
+	description: 'Unsubscribe a webhook URL from DynaPictures events',
+	method: 'POST',
+	path: '/webhooks/unsubscribe',
+	parameters: UnsubscribeWebhookInputSchema,
+	schema: UnsubscribeWebhookInputSchema,
+} as const;
+
+export const DYNAPICTURES_UPDATE_WORKSPACE = {
+	id: 'DYNAPICTURES_UPDATE_WORKSPACE',
+	name: 'Update Workspace',
+	description: 'Update a DynaPictures workspace by ID',
+	method: 'PUT',
+	path: '/workspaces/:workspaceId',
+	parameters: UpdateWorkspaceInputSchema,
+	schema: UpdateWorkspaceInputSchema,
+} as const;
+
+export const DYNAPICTURES_UPLOAD_MEDIA_ASSET = {
+	id: 'DYNAPICTURES_UPLOAD_MEDIA_ASSET',
+	name: 'Upload Media Asset',
+	description: 'Upload a media asset via image URL to DynaPictures',
+	method: 'POST',
+	path: '/media',
+	parameters: UploadMediaAssetInputSchema,
+	schema: UploadMediaAssetInputSchema,
+} as const;
+
+export const DYNAPICTURES_TOOLS = {
+	DYNAPICTURES_CREATE_WORKSPACE,
+	DYNAPICTURES_DELETE_WORKSPACE,
+	DYNAPICTURES_LIST_TEMPLATES,
+	DYNAPICTURES_LIST_WORKSPACES,
+	DYNAPICTURES_UNSUBSCRIBE_WEBHOOK,
+	DYNAPICTURES_UPDATE_WORKSPACE,
+	DYNAPICTURES_UPLOAD_MEDIA_ASSET,
+} as const;
+
+export const dynapicturesAuth = {
+	type: 'apiKey',
+	header: 'Authorization',
+	prefix: 'Bearer ',
+} as const;
+
+export type DynapicturesPluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	hooks?: InternalDynapicturesPlugin['hooks'];
+	webhookHooks?: InternalDynapicturesPlugin['webhookHooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof dynapicturesEndpointsNested>;
+};
+
+export type DynapicturesContext = CorsairPluginContext<
+	typeof DynapicturesSchema,
+	DynapicturesPluginOptions
+>;
+
+export type DynapicturesKeyBuilderContext =
+	KeyBuilderContext<DynapicturesPluginOptions>;
+
+export type DynapicturesBoundEndpoints = BindEndpoints<
+	typeof dynapicturesEndpointsNested
+>;
+
+type DynapicturesEndpoint<K extends keyof DynapicturesEndpointOutputs> =
+	CorsairEndpoint<
+		DynapicturesContext,
+		DynapicturesEndpointInputs[K],
+		DynapicturesEndpointOutputs[K]
+	>;
+
+export type DynapicturesEndpoints = {
+	createWorkspace: DynapicturesEndpoint<'createWorkspace'>;
+	deleteWorkspace: DynapicturesEndpoint<'deleteWorkspace'>;
+	listTemplates: DynapicturesEndpoint<'listTemplates'>;
+	listWorkspaces: DynapicturesEndpoint<'listWorkspaces'>;
+	unsubscribeWebhook: DynapicturesEndpoint<'unsubscribeWebhook'>;
+	updateWorkspace: DynapicturesEndpoint<'updateWorkspace'>;
+	uploadMediaAsset: DynapicturesEndpoint<'uploadMediaAsset'>;
+};
+
+export type DynapicturesBoundWebhooks = BindWebhooks<Record<string, never>>;
+
+const dynapicturesEndpointsNested = {
+	workspaces: {
+		create: Workspaces.create,
+		delete: Workspaces.deleteWorkspace,
+		list: Workspaces.list,
+		update: Workspaces.update,
+	},
+	templates: {
+		list: Templates.list,
+	},
+	webhooks: {
+		unsubscribe: Webhooks.unsubscribe,
+	},
+	media: {
+		upload: Media.upload,
+	},
+} as const;
+
+const dynapicturesWebhooksNested = {} as const;
+
+export const dynapicturesEndpointSchemas = {
+	'workspaces.create': {
+		input: DynapicturesEndpointInputSchemas.createWorkspace,
+		output: DynapicturesEndpointOutputSchemas.createWorkspace,
+	},
+	'workspaces.delete': {
+		input: DynapicturesEndpointInputSchemas.deleteWorkspace,
+		output: DynapicturesEndpointOutputSchemas.deleteWorkspace,
+	},
+	'templates.list': {
+		input: DynapicturesEndpointInputSchemas.listTemplates,
+		output: DynapicturesEndpointOutputSchemas.listTemplates,
+	},
+	'workspaces.list': {
+		input: DynapicturesEndpointInputSchemas.listWorkspaces,
+		output: DynapicturesEndpointOutputSchemas.listWorkspaces,
+	},
+	'webhooks.unsubscribe': {
+		input: DynapicturesEndpointInputSchemas.unsubscribeWebhook,
+		output: DynapicturesEndpointOutputSchemas.unsubscribeWebhook,
+	},
+	'workspaces.update': {
+		input: DynapicturesEndpointInputSchemas.updateWorkspace,
+		output: DynapicturesEndpointOutputSchemas.updateWorkspace,
+	},
+	'media.upload': {
+		input: DynapicturesEndpointInputSchemas.uploadMediaAsset,
+		output: DynapicturesEndpointOutputSchemas.uploadMediaAsset,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<
+	typeof dynapicturesEndpointsNested
+>;
+
+const dynapicturesWebhookSchemas =
+	{} as const satisfies RequiredPluginWebhookSchemas<
+		typeof dynapicturesWebhooksNested
+	>;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const dynapicturesEndpointMeta = {
+	'workspaces.create': {
+		riskLevel: 'write',
+		description: 'Create a new DynaPictures workspace',
+	},
+	'workspaces.delete': {
+		riskLevel: 'destructive',
+		irreversible: true,
+		description: 'Delete a DynaPictures workspace [DESTRUCTIVE · IRREVERSIBLE]',
+	},
+	'templates.list': {
+		riskLevel: 'read',
+		description:
+			'List DynaPictures templates with optional workspace ID filter',
+	},
+	'workspaces.list': {
+		riskLevel: 'read',
+		description: 'List all DynaPictures workspaces',
+	},
+	'webhooks.unsubscribe': {
+		riskLevel: 'write',
+		description: 'Unsubscribe a webhook endpoint from DynaPictures',
+	},
+	'workspaces.update': {
+		riskLevel: 'write',
+		description: 'Update an existing DynaPictures workspace',
+	},
+	'media.upload': {
+		riskLevel: 'write',
+		description: 'Upload a media asset from a URL to DynaPictures',
+	},
+} as const satisfies RequiredPluginEndpointMeta<
+	typeof dynapicturesEndpointsNested
+>;
+
+export const dynapicturesAuthConfig = {
+	api_key: {
+		account: ['tenant_external_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type BaseDynapicturesPlugin<T extends DynapicturesPluginOptions> =
+	CorsairPlugin<
+		'dynapictures',
+		typeof DynapicturesSchema,
+		typeof dynapicturesEndpointsNested,
+		typeof dynapicturesWebhooksNested,
+		T,
+		typeof defaultAuthType
+	> & {
+		name: 'DynaPictures';
+		auth: typeof dynapicturesAuth;
+		tools: typeof DYNAPICTURES_TOOLS;
+	};
+
+export type InternalDynapicturesPlugin =
+	BaseDynapicturesPlugin<DynapicturesPluginOptions>;
+
+export type ExternalDynapicturesPlugin<T extends DynapicturesPluginOptions> =
+	BaseDynapicturesPlugin<T>;
+
+export function dynapictures<const T extends DynapicturesPluginOptions>(
+	incomingOptions: DynapicturesPluginOptions &
+		T = {} as DynapicturesPluginOptions & T,
+): ExternalDynapicturesPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'dynapictures',
+		name: 'DynaPictures',
+		auth: dynapicturesAuth,
+		tools: DYNAPICTURES_TOOLS,
+		authConfig: dynapicturesAuthConfig,
+		schema: DynapicturesSchema,
+		options: options,
+		hooks: options.hooks,
+		webhookHooks: options.webhookHooks,
+		endpoints: dynapicturesEndpointsNested,
+		webhooks: dynapicturesWebhooksNested,
+		endpointMeta: dynapicturesEndpointMeta,
+		endpointSchemas: dynapicturesEndpointSchemas,
+		webhookSchemas: dynapicturesWebhookSchemas,
+		pluginWebhookMatcher: undefined,
+		pluginTenantWebhookMatcher: matchDynapicturesTenantWebhook,
+		oauthWebhookTenantLinkResolver: resolveDynapicturesOAuthWebhookTenantLink,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: DynapicturesKeyBuilderContext, source) => {
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys?.get_api_key();
+				if (!res) {
+					throw new AuthMissingError('dynapictures', 'api_key');
+				}
+				return res;
+			}
+
+			throw new AuthMissingError('dynapictures', 'api_key');
+		},
+	} satisfies InternalDynapicturesPlugin;
+}
+
+export type {
+	CreateWorkspaceInput,
+	CreateWorkspaceResponse,
+	DeleteWorkspaceInput,
+	DeleteWorkspaceResponse,
+	DynapicturesEndpointInputs,
+	DynapicturesEndpointOutputs,
+	ListTemplatesInput,
+	ListTemplatesResponse,
+	ListWorkspacesInput,
+	ListWorkspacesResponse,
+	UnsubscribeWebhookInput,
+	UnsubscribeWebhookResponse,
+	UpdateWorkspaceInput,
+	UpdateWorkspaceResponse,
+	UploadMediaAssetInput,
+	UploadMediaAssetResponse,
+} from './endpoints/types';
+export {
+	CreateWorkspaceInputSchema,
+	CreateWorkspaceResponseSchema,
+	DeleteWorkspaceInputSchema,
+	DeleteWorkspaceResponseSchema,
+	DynapicturesEndpointInputSchemas,
+	DynapicturesEndpointOutputSchemas,
+	ListTemplatesInputSchema,
+	ListTemplatesResponseSchema,
+	ListWorkspacesInputSchema,
+	ListWorkspacesResponseSchema,
+	UnsubscribeWebhookInputSchema,
+	UnsubscribeWebhookResponseSchema,
+	UpdateWorkspaceInputSchema,
+	UpdateWorkspaceResponseSchema,
+	UploadMediaAssetInputSchema,
+	UploadMediaAssetResponseSchema,
+} from './endpoints/types';
+export { DynapicturesSchema } from './schema';
+export type { DynapicturesWebhookOutputs } from './webhooks/types';

--- a/packages/dynapictures/index.ts
+++ b/packages/dynapictures/index.ts
@@ -33,8 +33,6 @@ import {
 } from './endpoints/types';
 import { errorHandlers } from './error-handlers';
 import { DynapicturesSchema } from './schema';
-import { resolveDynapicturesOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
-import { matchDynapicturesTenantWebhook } from './webhooks/tenant-matcher';
 
 // ── Tool Operation Definitions ───────────────────────────────────────────────
 
@@ -309,8 +307,8 @@ export function dynapictures<const T extends DynapicturesPluginOptions>(
 		endpointSchemas: dynapicturesEndpointSchemas,
 		webhookSchemas: dynapicturesWebhookSchemas,
 		pluginWebhookMatcher: undefined,
-		pluginTenantWebhookMatcher: matchDynapicturesTenantWebhook,
-		oauthWebhookTenantLinkResolver: resolveDynapicturesOAuthWebhookTenantLink,
+		pluginTenantWebhookMatcher: undefined,
+		oauthWebhookTenantLinkResolver: undefined,
 		errorHandlers: {
 			...errorHandlers,
 			...options.errorHandlers,

--- a/packages/dynapictures/jest.config.cjs
+++ b/packages/dynapictures/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/dynapictures/package.json
+++ b/packages/dynapictures/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/dynapictures",
+  "version": "0.1.0",
+  "description": "Dynapictures plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "dynapictures",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/dynapictures/schema.test.ts
+++ b/packages/dynapictures/schema.test.ts
@@ -1,0 +1,20 @@
+import { DynapicturesSchema } from './schema';
+
+describe('Dynapictures schema', () => {
+	it('declares a semver version', () => {
+		expect(DynapicturesSchema.version).toBeDefined();
+		expect(DynapicturesSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof DynapicturesSchema.entities).toBe('object');
+		expect(DynapicturesSchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(DynapicturesSchema.entities))).toBe(true);
+		for (const entity of Object.values(DynapicturesSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/dynapictures/schema/database.ts
+++ b/packages/dynapictures/schema/database.ts
@@ -1,0 +1,7 @@
+// TODO: Define your database entities here
+// export const DynapicturesExample = z.object({
+// 	id: z.string(),
+// 	name: z.string(),
+// 	created_at: z.coerce.date().nullable().optional(),
+// });
+// export type DynapicturesExample = z.infer<typeof DynapicturesExample>;

--- a/packages/dynapictures/schema/database.ts
+++ b/packages/dynapictures/schema/database.ts
@@ -1,7 +1,0 @@
-// TODO: Define your database entities here
-// export const DynapicturesExample = z.object({
-// 	id: z.string(),
-// 	name: z.string(),
-// 	created_at: z.coerce.date().nullable().optional(),
-// });
-// export type DynapicturesExample = z.infer<typeof DynapicturesExample>;

--- a/packages/dynapictures/schema/index.ts
+++ b/packages/dynapictures/schema/index.ts
@@ -1,0 +1,4 @@
+export const DynapicturesSchema = {
+	version: '1.0.0',
+	entities: {},
+} as const;

--- a/packages/dynapictures/src/client.ts
+++ b/packages/dynapictures/src/client.ts
@@ -1,0 +1,1 @@
+export * from '../client';

--- a/packages/dynapictures/src/index.ts
+++ b/packages/dynapictures/src/index.ts
@@ -1,0 +1,2 @@
+export * from '../index';
+export { default } from '../index';

--- a/packages/dynapictures/src/index.ts
+++ b/packages/dynapictures/src/index.ts
@@ -1,2 +1,1 @@
 export * from '../index';
-export { default } from '../index';

--- a/packages/dynapictures/tsconfig.json
+++ b/packages/dynapictures/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/dynapictures/tsup.config.ts
+++ b/packages/dynapictures/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/dynapictures/webhooks/index.ts
+++ b/packages/dynapictures/webhooks/index.ts
@@ -1,0 +1,3 @@
+export * from './oauth-tenant-link';
+export * from './tenant-matcher';
+export * from './types';

--- a/packages/dynapictures/webhooks/oauth-tenant-link.ts
+++ b/packages/dynapictures/webhooks/oauth-tenant-link.ts
@@ -1,31 +1,13 @@
 import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
 import { toExternalId } from 'corsair/core';
 
-// TODO: Rename linkType 'tenant_external_id' to match pluginTenantWebhookMatcher.
-// Called after OAuth to store the routing id on corsair_accounts.config.
 export async function resolveDynapicturesOAuthWebhookTenantLink(
 	tokens: TokenResponse,
 ): Promise<WebhookTenantMatch | null> {
-	// TODO: Read from token response when the provider includes a stable id.
-	// const externalId = toExternalId(asRecord(tokens.team)?.id);
 	const externalId = toExternalId(tokens.tenant_external_id);
 	if (externalId) {
 		return { linkType: 'tenant_external_id', externalId };
 	}
-
-	const accessToken = tokens.access_token;
-	if (!accessToken) return null;
-
-	// TODO: Fetch from provider API when the token response omits the id.
-	// const response = await fetch('https://api.example.com/me', {
-	// 	headers: { Authorization: `Bearer ${accessToken}` },
-	// });
-	// if (!response.ok) return null;
-	// const payload = (await response.json()) as { id?: string };
-	// const fetchedId = toExternalId(payload.id);
-	// return fetchedId
-	// 	? { linkType: 'tenant_external_id', externalId: fetchedId }
-	// 	: null;
 
 	return null;
 }

--- a/packages/dynapictures/webhooks/oauth-tenant-link.ts
+++ b/packages/dynapictures/webhooks/oauth-tenant-link.ts
@@ -1,13 +1,8 @@
 import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
-import { toExternalId } from 'corsair/core';
 
+/** DynaPictures does not support OAuth tenant linking for webhook routing in this plugin. */
 export async function resolveDynapicturesOAuthWebhookTenantLink(
-	tokens: TokenResponse,
-): Promise<WebhookTenantMatch | null> {
-	const externalId = toExternalId(tokens.tenant_external_id);
-	if (externalId) {
-		return { linkType: 'tenant_external_id', externalId };
-	}
-
-	return null;
+	_tokens: TokenResponse,
+): Promise<WebhookTenantMatch | undefined> {
+	return undefined;
 }

--- a/packages/dynapictures/webhooks/oauth-tenant-link.ts
+++ b/packages/dynapictures/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,31 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { toExternalId } from 'corsair/core';
+
+// TODO: Rename linkType 'tenant_external_id' to match pluginTenantWebhookMatcher.
+// Called after OAuth to store the routing id on corsair_accounts.config.
+export async function resolveDynapicturesOAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): Promise<WebhookTenantMatch | null> {
+	// TODO: Read from token response when the provider includes a stable id.
+	// const externalId = toExternalId(asRecord(tokens.team)?.id);
+	const externalId = toExternalId(tokens.tenant_external_id);
+	if (externalId) {
+		return { linkType: 'tenant_external_id', externalId };
+	}
+
+	const accessToken = tokens.access_token;
+	if (!accessToken) return null;
+
+	// TODO: Fetch from provider API when the token response omits the id.
+	// const response = await fetch('https://api.example.com/me', {
+	// 	headers: { Authorization: `Bearer ${accessToken}` },
+	// });
+	// if (!response.ok) return null;
+	// const payload = (await response.json()) as { id?: string };
+	// const fetchedId = toExternalId(payload.id);
+	// return fetchedId
+	// 	? { linkType: 'tenant_external_id', externalId: fetchedId }
+	// 	: null;
+
+	return null;
+}

--- a/packages/dynapictures/webhooks/tenant-matcher.ts
+++ b/packages/dynapictures/webhooks/tenant-matcher.ts
@@ -1,19 +1,12 @@
 import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
 import { asRecord, firstString, readBodyRecord } from 'corsair/core';
 
-// TODO: Rename linkType 'tenant_external_id' to match the provider field
-// (e.g. team_id, installation_id, organization_id). Must match authConfig.account
-// and oauthWebhookTenantLinkResolver.
-// Return null for URL verification / handshake payloads that have no tenant id.
 export function matchDynapicturesTenantWebhook(
 	request: RawWebhookRequest,
 ): WebhookTenantMatch | null {
 	const body = readBodyRecord(request);
 	if (!body) return null;
 
-	// TODO: Extract the stable external id from the webhook payload.
-	// Example:
-	// const externalId = firstString([body.tenant_external_id, asRecord(body.data)?.id]);
 	const externalId = firstString([
 		body.tenant_external_id,
 		asRecord(body.data)?.tenant_external_id,

--- a/packages/dynapictures/webhooks/tenant-matcher.ts
+++ b/packages/dynapictures/webhooks/tenant-matcher.ts
@@ -1,18 +1,8 @@
 import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
-import { asRecord, firstString, readBodyRecord } from 'corsair/core';
 
+/** DynaPictures does not register a tenant webhook matcher for this plugin. */
 export function matchDynapicturesTenantWebhook(
-	request: RawWebhookRequest,
-): WebhookTenantMatch | null {
-	const body = readBodyRecord(request);
-	if (!body) return null;
-
-	const externalId = firstString([
-		body.tenant_external_id,
-		asRecord(body.data)?.tenant_external_id,
-	]);
-
-	if (!externalId) return null;
-
-	return { linkType: 'tenant_external_id', externalId };
+	_request: RawWebhookRequest,
+): WebhookTenantMatch | undefined {
+	return undefined;
 }

--- a/packages/dynapictures/webhooks/tenant-matcher.ts
+++ b/packages/dynapictures/webhooks/tenant-matcher.ts
@@ -1,0 +1,25 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// TODO: Rename linkType 'tenant_external_id' to match the provider field
+// (e.g. team_id, installation_id, organization_id). Must match authConfig.account
+// and oauthWebhookTenantLinkResolver.
+// Return null for URL verification / handshake payloads that have no tenant id.
+export function matchDynapicturesTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	// TODO: Extract the stable external id from the webhook payload.
+	// Example:
+	// const externalId = firstString([body.tenant_external_id, asRecord(body.data)?.id]);
+	const externalId = firstString([
+		body.tenant_external_id,
+		asRecord(body.data)?.tenant_external_id,
+	]);
+
+	if (!externalId) return null;
+
+	return { linkType: 'tenant_external_id', externalId };
+}

--- a/packages/dynapictures/webhooks/types.ts
+++ b/packages/dynapictures/webhooks/types.ts
@@ -1,0 +1,1 @@
+export type DynapicturesWebhookOutputs = Record<string, never>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1040,7 +1040,7 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
-  packages/anonyflow:
+  packages/anchorbrowser:
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -1064,7 +1064,7 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
-  packages/anchorbrowser:
+  packages/anonyflow:
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -2690,6 +2690,30 @@ importers:
         version: 4.4.3
 
   packages/dropbox:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
+  packages/dynapictures:
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14


### PR DESCRIPTION
### Description
Added DynaPictures plugin integration with 7 core operations: create workspace, delete workspace, list templates, list workspaces, unsubscribe webhook, update workspace, and upload media asset.

### Checklist
- [x] I have run pnpm lint and all checks pass
- [x] I have run pnpm typecheck and there are no TypeScript errors
- [x] I have run pnpm build and all packages build successfully
- [x] I have run pnpm test and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

### Screenshots / Demos (if applicable)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/bf2e7ade-0375-4a24-979c-1c463fbab5d0" />

### Additional Notes
Resolves #641

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DynaPictures as a supported provider.
  * Added workspace, template, webhook, and media operations.
  * Added API-key authentication and typed request/response validation.
  * Added media uploads, template and workspace management, and webhook unsubscription.
* **Bug Fixes**
  * Improved authentication, rate-limit, retry, and API error handling.
  * Updated webhook unsubscription to use the current API endpoint and request format.
* **Tests**
  * Added comprehensive coverage for integration behavior, validation, authentication, errors, and endpoint operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->