### PR TITLE
fix(oss): cap contributor integration claims at one

### DIFF
--- a/www/src/lib/integration-claim-limits.test.ts
+++ b/www/src/lib/integration-claim-limits.test.ts
@@ -7,10 +7,10 @@ import {
 } from './integration-claim-limits';
 
 describe('canClaimMore', () => {
-	it('caps a contributor at two held claims', () => {
-		assert.equal(MAX_USER_BUILT_INTEGRATIONS, 2);
+	it('caps a contributor at one held claim', () => {
+		assert.equal(MAX_USER_BUILT_INTEGRATIONS, 1);
 		assert.equal(canClaimMore(0), true);
-		assert.equal(canClaimMore(1), true);
+		assert.equal(canClaimMore(1), false);
 		assert.equal(canClaimMore(2), false);
 	});
 

--- a/www/src/lib/integration-claim-limits.ts
+++ b/www/src/lib/integration-claim-limits.ts
@@ -1,4 +1,4 @@
-export const MAX_USER_BUILT_INTEGRATIONS = 2;
+export const MAX_USER_BUILT_INTEGRATIONS = 1;
 
 export type ClaimBlockReason = 'limit_reached';
 


### PR DESCRIPTION
## What

Lower the OSS contributor claim cap from 2 to 1.

`MAX_USER_BUILT_INTEGRATIONS` is the single source of truth — the claim button tooltip, the server `PRECONDITION_FAILED` message, and the `getUserClaimEligibility` DB gate all derive from it, so the one-line change propagates everywhere.

## Change
- `MAX_USER_BUILT_INTEGRATIONS = 2 → 1`
- Test updated to the cap-of-one contract (`canClaimMore(1)` is now `false`).

## Verification
- `node --import tsx --test integration-claim-limits.test.ts` → 2/2 pass
- biome clean

Note: user-facing strings now read "maximum of 1 integrations" (pre-existing `${n} integrations` phrasing, left as-is).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Reduced the maximum number of user-built integrations each contributor can claim from two to one.
  - Updated claim-limit validation to reflect the new one-integration cap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->