### PR TITLE
fix(oss): count only in-progress claims against the claim cap

### DIFF
--- a/www/src/db/integration-status.ts
+++ b/www/src/db/integration-status.ts
@@ -6,7 +6,10 @@ import type { IntegrationPhase, IntegrationReleaseReason } from '@/db/schema';
 import { integrationStatus, integrations } from '@/db/schema';
 import type { ClaimBlockReason } from '@/lib/integration-claim-limits';
 import { canClaimMore } from '@/lib/integration-claim-limits';
-import { isIntegrationActivelyClaimed } from '@/lib/integration-phases';
+import {
+	holdsClaimSlot,
+	isIntegrationActivelyClaimed,
+} from '@/lib/integration-phases';
 
 export type { ClaimBlockReason } from '@/lib/integration-claim-limits';
 
@@ -241,11 +244,13 @@ export async function getUserClaimEligibility(
 	db: DB,
 	userId: string,
 ): Promise<UserClaimEligibility> {
-	// Every claim the user still holds counts against the cap — in progress,
-	// ready to review, and finished alike. A slot frees up only when a claim is
-	// released, by unclaiming or by a deadline timeout.
+	// Only claims the contributor can still act on count against the cap. A
+	// `ready_to_review` claim is waiting on a maintainer and `finished` is done,
+	// so neither is work the contributor could drop to free a slot.
 	const activeClaims = await getActiveClaimsForUser(db, userId);
-	const builtCount = activeClaims.length;
+	const builtCount = activeClaims.filter((claim) =>
+		holdsClaimSlot(claim.phase),
+	).length;
 
 	if (!canClaimMore(builtCount)) {
 		return {

--- a/www/src/lib/integration-claim-limits.ts
+++ b/www/src/lib/integration-claim-limits.ts
@@ -3,8 +3,10 @@ export const MAX_USER_BUILT_INTEGRATIONS = 1;
 export type ClaimBlockReason = 'limit_reached';
 
 /**
- * Every claim a user still holds counts against the cap — in progress, ready to
- * review, and finished alike.
+ * Counts only the claims a contributor can still act on, which is what
+ * `holdsClaimSlot` selects. A claim stops counting once it is handed off for
+ * review, finished, or released, so the cap limits work in flight rather than
+ * work completed.
  */
 export function canClaimMore(activeClaimCount: number): boolean {
 	return activeClaimCount < MAX_USER_BUILT_INTEGRATIONS;

--- a/www/src/lib/integration-phases.test.ts
+++ b/www/src/lib/integration-phases.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import type { IntegrationPhase } from '@/db/schema';
+
+import {
+	holdsClaimSlot,
+	isIntegrationActivelyClaimed,
+	isWipPhase,
+} from './integration-phases';
+
+const ALL_PHASES = [
+	'awaiting_issue',
+	'awaiting_pr',
+	'building',
+	'ready_to_review',
+	'finished',
+	'released',
+] as const satisfies readonly IntegrationPhase[];
+
+describe('holdsClaimSlot', () => {
+	it('holds a slot only while the contributor can still act', () => {
+		assert.equal(holdsClaimSlot('awaiting_issue'), true);
+		assert.equal(holdsClaimSlot('awaiting_pr'), true);
+		assert.equal(holdsClaimSlot('building'), true);
+	});
+
+	it('frees the slot once the work is out of the contributor’s hands', () => {
+		// The next move on a submitted PR belongs to a maintainer, and review has
+		// taken over a week in practice. Holding the slot through it caps a
+		// contributor at one integration for as long as the queue runs.
+		assert.equal(holdsClaimSlot('ready_to_review'), false);
+		assert.equal(holdsClaimSlot('finished'), false);
+	});
+
+	it('does not hold a slot for a released claim', () => {
+		assert.equal(holdsClaimSlot('released'), false);
+		assert.equal(holdsClaimSlot(null), false);
+		assert.equal(holdsClaimSlot(undefined), false);
+	});
+
+	it('agrees with isWipPhase on every real phase', () => {
+		for (const phase of ALL_PHASES) {
+			assert.equal(holdsClaimSlot(phase), isWipPhase(phase), phase);
+		}
+	});
+});
+
+describe('isIntegrationActivelyClaimed', () => {
+	it('still treats every unreleased phase as claimed', () => {
+		// Display and points attribution keep the wider meaning: a finished
+		// integration stays attached to its contributor even though it no longer
+		// holds a claim slot.
+		for (const phase of ALL_PHASES) {
+			assert.equal(isIntegrationActivelyClaimed(phase), phase !== 'released');
+		}
+	});
+});

--- a/www/src/lib/integration-phases.ts
+++ b/www/src/lib/integration-phases.ts
@@ -39,6 +39,17 @@ export function isWipPhase(phase: IntegrationPhase) {
 	return (WIP_PHASES as readonly IntegrationPhase[]).includes(phase);
 }
 
+/**
+ * Whether a claim occupies one of the contributor's claim slots.
+ *
+ * Only work the contributor can still act on counts. Once a claim reaches
+ * `ready_to_review` the next move belongs to a maintainer, and `finished` is
+ * done for good, so neither should hold a slot the contributor cannot free.
+ */
+export function holdsClaimSlot(phase: IntegrationPhase | null | undefined) {
+	return phase != null && isWipPhase(phase);
+}
+
 export function legacyStatusFromPhase(
 	phase: IntegrationPhase | null,
 ): 'in_progress' | 'finished' | null {


### PR DESCRIPTION
@yuvrxj-afk quick follow-up to #1159, while it's fresh.

## Problem

The cap counts every claim that isn't `released`, so `ready_to_review` and `finished` hold a slot forever. A contributor is blocked the moment they submit their first PR, and merging never gives the slot back. With the cap at 1, that is one integration per contributor, permanently.

## Why it matters

The current #1 contributor built 16 integrations between 08-12 and 08-18, back when `ready_to_review` did not hold a slot. Build time was 1 to 14 hours each. Time to `finished` was 7 to 11 days. The review queue ran fully in parallel:

```
bigmailer ready 08-16 15:40:04  ->  bigml    claimed 15:40:14
bigml     ready 08-16 16:57:14  ->  botpress claimed 16:57:24
botpress  ready 08-16 22:13:13  ->  mailtrap claimed 22:13:26
```

#826 removed that gate and their last claim was 08-18, the same day. Under today's rules the same record would take 16 separate contributors.

## Change

`getUserClaimEligibility` counts only WIP phases now, through a new `holdsClaimSlot` helper over the existing `WIP_PHASES`. One integration in flight at a time is preserved, which is what #1159 intends. Waiting on a maintainer no longer costs a slot.

`isIntegrationActivelyClaimed` is untouched, so `listMine`, the claimed-by-you badge and points attribution keep the wider meaning. A finished integration stays attached to its contributor.

## Verification

- `pnpm --filter @corsair/www test` passes 21/21, 7 of them new
- biome and typecheck clean

Disclosure: this blocks me right now, since #1149 and #1162 are both sitting in `ready_to_review`. Judge it on the merits. Happy to adjust if you would rather `ready_to_review` keep holding a slot and only `finished` release one, which is a one word change to the helper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Contributor claim limits now count only active work that still requires action.
  - Claims awaiting review or already finished no longer occupy a contributor’s available claim slots, allowing new work to be claimed sooner.
  - Claim status handling is now more consistent across integration phases.
  - Claim availability more accurately reflects work that is currently in progress and actionable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->