### PR TITLE
test(trello): add unit tests for verifyTrelloWebhookSignature

### DIFF
--- a/packages/trello/webhooks/types.test.ts
+++ b/packages/trello/webhooks/types.test.ts
@@ -1,80 +1,119 @@
+import * as crypto from 'node:crypto';
 import type { WebhookRequest } from 'corsair/core';
-import * as crypto from 'crypto';
 import { verifyTrelloWebhookSignature } from './types';
 
-const secret = 'my-trello-secret';
-const rawBody = '{"action":{"type":"commentCard"}}';
-const callbackURL = 'https://example.com/trello/webhook';
+describe('verifyTrelloWebhookSignature', () => {
+	const secret = 'my-trello-secret';
+	const rawBody = '{"action":{"type":"commentCard"}}';
+	const callbackURL = 'https://example.com/trello/webhook';
+	const payload = {
+		webhook: {
+			callbackURL,
+		},
+	};
 
-const payload = {
-	webhook: {
-		callbackURL,
-	},
-};
+	const sign = (key: string, content: string = rawBody + callbackURL): string =>
+		crypto.createHmac('sha1', key).update(content).digest('base64');
 
-function requestWith(
-	headers: Record<string, string | string[] | undefined>,
-): WebhookRequest<unknown> {
-	return {
+	// WebhookRequest payload is unknown because verification only reads
+	// webhook.callbackURL off the untyped Trello body
+	const requestWith = (
+		headers: Record<string, string | string[] | undefined>,
+		overrides: Partial<WebhookRequest<unknown>> = {},
+	): WebhookRequest<unknown> => ({
 		payload,
 		headers,
 		rawBody,
-	};
-}
+		...overrides,
+	});
 
-function signatureFor(secretValue: string): string {
-	return crypto
-		.createHmac('sha1', secretValue)
-		.update(rawBody + callbackURL)
-		.digest('base64');
-}
-
-describe('verifyTrelloWebhookSignature', () => {
-	it('returns an error when the secret is missing', () => {
+	it('should fail closed when secret is missing', () => {
 		const result = verifyTrelloWebhookSignature(
-			requestWith({
-				'x-trello-webhook': signatureFor(secret),
-			}),
+			requestWith({ 'x-trello-webhook': sign(secret) }),
 			'',
 		);
-
 		expect(result).toEqual({
 			valid: false,
 			error: 'Missing webhook secret',
 		});
 	});
 
-	it('returns an error when the signature header is missing', () => {
+	it('should return invalid if the signature header is missing', () => {
 		const result = verifyTrelloWebhookSignature(requestWith({}), secret);
-
 		expect(result).toEqual({
 			valid: false,
 			error: 'Missing x-trello-webhook header',
 		});
 	});
 
-	it('returns invalid for a wrong signature', () => {
+	it('should return invalid if raw body is missing', () => {
 		const result = verifyTrelloWebhookSignature(
-			requestWith({
-				'x-trello-webhook': 'wrong-signature',
-			}),
+			requestWith({ 'x-trello-webhook': sign(secret) }, { rawBody: '' }),
 			secret,
 		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing raw body for signature verification',
+		});
+	});
 
+	it('should return invalid if the signature does not match', () => {
+		const result = verifyTrelloWebhookSignature(
+			requestWith({ 'x-trello-webhook': sign('a-different-secret') }),
+			secret,
+		);
 		expect(result).toEqual({
 			valid: false,
 			error: 'Invalid signature',
 		});
 	});
 
-	it('returns valid for the correct HMAC-SHA1 signature', () => {
+	it('should return invalid if the signature length does not match', () => {
 		const result = verifyTrelloWebhookSignature(
-			requestWith({
-				'x-trello-webhook': signatureFor(secret),
-			}),
+			requestWith({ 'x-trello-webhook': 'wrong-signature' }),
 			secret,
 		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid signature',
+		});
+	});
 
+	it('should return valid for a correct HMAC-SHA1 signature over rawBody + callbackURL', () => {
+		const result = verifyTrelloWebhookSignature(
+			requestWith({ 'x-trello-webhook': sign(secret) }),
+			secret,
+		);
 		expect(result).toEqual({ valid: true });
+	});
+
+	it('should use the first value of a repeated signature header', () => {
+		const result = verifyTrelloWebhookSignature(
+			requestWith({ 'x-trello-webhook': [sign(secret), 'ignored'] }),
+			secret,
+		);
+		expect(result).toEqual({ valid: true });
+	});
+
+	it('should sign rawBody alone when callbackURL is missing', () => {
+		const result = verifyTrelloWebhookSignature(
+			requestWith(
+				{ 'x-trello-webhook': sign(secret, rawBody) },
+				{ payload: {} },
+			),
+			secret,
+		);
+		expect(result).toEqual({ valid: true });
+	});
+
+	it('should reject a concatenated signature when callbackURL is missing', () => {
+		const result = verifyTrelloWebhookSignature(
+			requestWith({ 'x-trello-webhook': sign(secret) }, { payload: {} }),
+			secret,
+		);
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid signature',
+		});
 	});
 });

--- a/packages/trello/webhooks/types.test.ts
+++ b/packages/trello/webhooks/types.test.ts
@@ -1,0 +1,80 @@
+import type { WebhookRequest } from 'corsair/core';
+import * as crypto from 'crypto';
+import { verifyTrelloWebhookSignature } from './types';
+
+const secret = 'my-trello-secret';
+const rawBody = '{"action":{"type":"commentCard"}}';
+const callbackURL = 'https://example.com/trello/webhook';
+
+const payload = {
+	webhook: {
+		callbackURL,
+	},
+};
+
+function requestWith(
+	headers: Record<string, string | string[] | undefined>,
+): WebhookRequest<unknown> {
+	return {
+		payload,
+		headers,
+		rawBody,
+	};
+}
+
+function signatureFor(secretValue: string): string {
+	return crypto
+		.createHmac('sha1', secretValue)
+		.update(rawBody + callbackURL)
+		.digest('base64');
+}
+
+describe('verifyTrelloWebhookSignature', () => {
+	it('returns an error when the secret is missing', () => {
+		const result = verifyTrelloWebhookSignature(
+			requestWith({
+				'x-trello-webhook': signatureFor(secret),
+			}),
+			'',
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing webhook secret',
+		});
+	});
+
+	it('returns an error when the signature header is missing', () => {
+		const result = verifyTrelloWebhookSignature(requestWith({}), secret);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Missing x-trello-webhook header',
+		});
+	});
+
+	it('returns invalid for a wrong signature', () => {
+		const result = verifyTrelloWebhookSignature(
+			requestWith({
+				'x-trello-webhook': 'wrong-signature',
+			}),
+			secret,
+		);
+
+		expect(result).toEqual({
+			valid: false,
+			error: 'Invalid signature',
+		});
+	});
+
+	it('returns valid for the correct HMAC-SHA1 signature', () => {
+		const result = verifyTrelloWebhookSignature(
+			requestWith({
+				'x-trello-webhook': signatureFor(secret),
+			}),
+			secret,
+		);
+
+		expect(result).toEqual({ valid: true });
+	});
+});


### PR DESCRIPTION
## Description

Add unit tests for `verifyTrelloWebhookSignature`.

## Covered cases

- Missing webhook secret
- Missing `x-trello-webhook` header
- Invalid signature
- Valid HMAC-SHA1 signature using `rawBody + callbackURL`

## Validation

- `pnpm --filter @corsair-dev/trello test -- --runInBand webhooks/types.test.ts`
- `pnpm exec biome check packages/trello/webhooks/types.test.ts`

Closes #701
## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

<img width="765" height="279" alt="Screenshot 2026-08-27 at 1 27 23 PM" src="https://github.com/user-attachments/assets/3809586f-774d-4547-9541-ed59adfc0417" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->



## Summary by CodeRabbit

## Tests

- Expanded coverage for Trello webhook signature verification.
- Validates missing request bodies, secrets, and headers are rejected with clear errors.
- Confirms mismatched and incorrectly sized signatures are rejected.
- Verifies repeated webhook headers are handled consistently.
- Confirms valid signatures are accepted with and without callback URLs, while improperly signed requests remain blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->