### PR TITLE
Add label to GitHub username input

### DIFF
--- a/www/src/app/oss/github-username-callout.tsx
+++ b/www/src/app/oss/github-username-callout.tsx
@@ -46,15 +46,16 @@ export function GithubUsernameCallout() {
 				onSubmit={handleSubmit}
 				className="flex flex-wrap items-center gap-2"
 			>
-				<input
-					type="text"
-					name="username"
-					required
-					value={username}
-					onChange={(event) => setUsername(event.target.value)}
-					placeholder="octocat"
-					className="min-w-[200px] flex-1 rounded-lg border border-border/70 bg-background px-3 py-2 text-sm shadow-sm transition-all focus:border-border focus:ring-2 focus:ring-foreground/5 focus:outline-none"
-				/>
+              <input
+                type="text"
+                name="username"
+                required
+                value={username}
+                onChange={(event) => setUsername(event.target.value)}
+                placeholder="octocat"
+                aria-label="GitHub username"
+                className="min-w-[200px] flex-1 rounded-lg border border-border/70 bg-background px-3 py-2 text-sm shadow-sm transition-all focus:border-border focus:ring-2 focus:ring-foreground/5 focus:outline-none"
+              />
 				<Button
 					type="submit"
 					disabled={loading}


### PR DESCRIPTION
## What was broken
The username field in `www/src/app/oss/github-username-callout.tsx` had no accessible label.
## What changed
Added `aria-label` to the input field.
## How to test
Verify the input field now has an accessible label.

Closes #721.

---
<sub>The patch was drafted with LLM assistance and reviewed by me before submitting. Happy to revise or close this if it isn't useful.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added an accessible label to the GitHub username input for improved screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->