### PR TITLE
ci: scope PR Checks on main from the push diff

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -43,6 +43,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -74,7 +74,7 @@ jobs:
         run: pnpm install --frozen-lockfile --filter . --filter "@corsair/www..."
 
       - name: Turbo cache for main
-        if: github.event_name == 'push' && steps.scope.outputs.skip_heavy != 'true'
+        if: github.event_name == 'push' && steps.scope.outputs.lane == 'full'
         uses: actions/cache@v4
         with:
           path: .turbo

--- a/scripts/pr-review/pr-scope-main.ts
+++ b/scripts/pr-review/pr-scope-main.ts
@@ -1,7 +1,13 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
-import type { PrScope } from './pr-scope.ts';
-import { classifyPrScope, filtersForScope } from './pr-scope.ts';
+import type { PrScope, PushChangeSet } from './pr-scope.ts';
+import {
+	changeSetForPush,
+	classifyPrScope,
+	classifyPushChangeSet,
+	filtersForScope,
+	pushRangeFromGithubEvent,
+} from './pr-scope.ts';
 
 function gh(args: string[]): string {
 	return execFileSync('gh', args, {
@@ -10,10 +16,13 @@ function gh(args: string[]): string {
 	});
 }
 
-function pullRequestNumber(): string {
-	const event: unknown = JSON.parse(
+function githubEvent(): unknown {
+	return JSON.parse(
 		fs.readFileSync(process.env.GITHUB_EVENT_PATH ?? '', 'utf8'),
 	);
+}
+
+function pullRequestNumber(event: unknown): string {
 	if (
 		typeof event !== 'object' ||
 		event === null ||
@@ -41,21 +50,76 @@ function changedFilesForPullRequest(repo: string, pr: string): string[] {
 		.filter(Boolean);
 }
 
+function gitDiffNameOnly(before: string, after: string): string[] {
+	const diff = (): string[] =>
+		execFileSync('git', ['diff', '--name-only', before, after], {
+			encoding: 'utf8',
+			maxBuffer: 64 * 1024 * 1024,
+		})
+			.trim()
+			.split('\n')
+			.filter(Boolean);
+	try {
+		return diff();
+	} catch {
+		execFileSync('git', ['fetch', '--depth=1', 'origin', before], {
+			encoding: 'utf8',
+			maxBuffer: 64 * 1024 * 1024,
+		});
+		return diff();
+	}
+}
+
 function writeOutput(name: string, value: string): void {
 	const output = process.env.GITHUB_OUTPUT;
 	if (!output) throw new Error('GITHUB_OUTPUT is not set');
 	fs.appendFileSync(output, `${name}=${value}\n`);
 }
 
-let scope: PrScope = { lane: 'full', includeWww: false };
-if (process.env.GITHUB_EVENT_NAME === 'pull_request') {
-	const repo = process.env.GITHUB_REPOSITORY;
-	if (!repo) throw new Error('GITHUB_REPOSITORY is not set');
-	scope = classifyPrScope(
-		changedFilesForPullRequest(repo, pullRequestNumber()),
+function unknownPush(reason: string): PushChangeSet {
+	console.warn(`CI lane fallback: full with www (${reason})`);
+	return { kind: 'unknown', reason };
+}
+
+function scopeForCurrentEvent(): PrScope {
+	const eventName = process.env.GITHUB_EVENT_NAME;
+	const event = githubEvent();
+	if (eventName === 'pull_request') {
+		const repo = process.env.GITHUB_REPOSITORY;
+		if (!repo) throw new Error('GITHUB_REPOSITORY is not set');
+		return classifyPrScope(
+			changedFilesForPullRequest(repo, pullRequestNumber(event)),
+		);
+	}
+	if (eventName === 'push') {
+		const range = pushRangeFromGithubEvent(event);
+		if (range === null) {
+			return classifyPushChangeSet(
+				unknownPush('push event has no before/after'),
+			);
+		}
+		try {
+			const changeSet = changeSetForPush({
+				before: range.before,
+				after: range.after,
+				diff: gitDiffNameOnly,
+			});
+			if (changeSet.kind === 'unknown') {
+				console.warn(`CI lane fallback: full with www (${changeSet.reason})`);
+			}
+			return classifyPushChangeSet(changeSet);
+		} catch {
+			return classifyPushChangeSet(
+				unknownPush(`git diff failed for ${range.before}..${range.after}`),
+			);
+		}
+	}
+	return classifyPushChangeSet(
+		unknownPush(`unsupported event ${eventName ?? ''}`),
 	);
 }
 
+const scope = scopeForCurrentEvent();
 const filters = filtersForScope(scope);
 writeOutput('lane', filters.lane);
 writeOutput('turbo_filter', filters.turboFilter);
@@ -66,5 +130,7 @@ writeOutput('www_test_filter', filters.wwwTestFilter);
 console.log(
 	scope.lane === 'plugin'
 		? `CI lane: plugin (${scope.plugin}, filter ${filters.turboFilter})`
-		: `CI lane: ${scope.lane}`,
+		: scope.lane === 'full'
+			? `CI lane: full (www=${scope.includeWww})`
+			: `CI lane: ${scope.lane}`,
 );

--- a/scripts/pr-review/pr-scope.test.ts
+++ b/scripts/pr-review/pr-scope.test.ts
@@ -1,9 +1,13 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import {
+	changeSetForPush,
 	classifyPrScope,
+	classifyPushChangeSet,
 	filtersForScope,
+	isGitZeroOid,
 	packageNameForPlugin,
+	pushRangeFromGithubEvent,
 } from './pr-scope.ts';
 
 test('uses the plugin lane for one plugin plus gate-approved extra files', () => {
@@ -108,5 +112,96 @@ test('mixed www filters keep package globs out of the www extra flags', () => {
 		includeWww: true,
 		wwwInstallFilter: '--filter=@corsair/www...',
 		wwwTestFilter: '--filter=@corsair/www',
+	});
+});
+
+test('treats an all-zero git oid as an unborn push', () => {
+	assert.equal(isGitZeroOid('0000000000000000000000000000000000000000'), true);
+	assert.equal(isGitZeroOid('1dd80230fe63df54c05ee15dcfd92bd72038c522'), false);
+});
+
+test('reads before and after shas from a GitHub push event', () => {
+	assert.deepEqual(
+		pushRangeFromGithubEvent({
+			before: 'aaa111bbb222ccc333ddd444eee555fff666aaa1',
+			after: 'bbb222ccc333ddd444eee555fff666aaa111bbb2',
+		}),
+		{
+			before: 'aaa111bbb222ccc333ddd444eee555fff666aaa1',
+			after: 'bbb222ccc333ddd444eee555fff666aaa111bbb2',
+		},
+	);
+});
+
+test('rejects a GitHub event that is not a push range', () => {
+	assert.equal(pushRangeFromGithubEvent(null), null);
+	assert.equal(pushRangeFromGithubEvent({ pull_request: { number: 1 } }), null);
+	assert.equal(pushRangeFromGithubEvent({ before: '', after: 'abc' }), null);
+});
+
+test('treats an unborn push as unknown so CI includes www', () => {
+	const changeSet = changeSetForPush({
+		before: '0000000000000000000000000000000000000000',
+		after: 'bbb222ccc333ddd444eee555fff666aaa111bbb2',
+		diff: () => {
+			throw new Error('diff should not run');
+		},
+	});
+	assert.deepEqual(changeSet, {
+		kind: 'unknown',
+		reason: 'unborn revision',
+	});
+	assert.deepEqual(classifyPushChangeSet(changeSet), {
+		lane: 'full',
+		includeWww: true,
+	});
+});
+
+test('keeps a known empty push in packages-only full', () => {
+	assert.deepEqual(classifyPushChangeSet({ kind: 'known', files: [] }), {
+		lane: 'full',
+		includeWww: false,
+	});
+});
+
+test('fails closed to full with www when the push diff is unknown', () => {
+	assert.deepEqual(
+		classifyPushChangeSet({ kind: 'unknown', reason: 'git diff failed' }),
+		{
+			lane: 'full',
+			includeWww: true,
+		},
+	);
+	assert.deepEqual(
+		filtersForScope({ lane: 'full', includeWww: true }).wwwTestFilter,
+		'--filter=@corsair/www',
+	);
+});
+
+test('uses the push diff so a plugin land on main stays in the plugin lane', () => {
+	const changeSet = changeSetForPush({
+		before: 'aaa111bbb222ccc333ddd444eee555fff666aaa1',
+		after: 'bbb222ccc333ddd444eee555fff666aaa111bbb2',
+		diff: (before, after) => {
+			assert.equal(before, 'aaa111bbb222ccc333ddd444eee555fff666aaa1');
+			assert.equal(after, 'bbb222ccc333ddd444eee555fff666aaa111bbb2');
+			return [
+				'packages/slack/index.ts',
+				'packages/corsair/core/constants.ts',
+				'pnpm-lock.yaml',
+			];
+		},
+	});
+	assert.deepEqual(changeSet, {
+		kind: 'known',
+		files: [
+			'packages/slack/index.ts',
+			'packages/corsair/core/constants.ts',
+			'pnpm-lock.yaml',
+		],
+	});
+	assert.deepEqual(classifyPushChangeSet(changeSet), {
+		lane: 'plugin',
+		plugin: 'slack',
 	});
 });

--- a/scripts/pr-review/pr-scope.ts
+++ b/scripts/pr-review/pr-scope.ts
@@ -29,6 +29,50 @@ function isWwwFile(file: string): boolean {
 	return file === 'www' || file.startsWith('www/');
 }
 
+export function isGitZeroOid(oid: string): boolean {
+	return oid.length > 0 && /^0+$/.test(oid);
+}
+
+export type PushChangeSet =
+	| { kind: 'known'; files: string[] }
+	| { kind: 'unknown'; reason: string };
+
+export function pushRangeFromGithubEvent(
+	event: unknown,
+): { before: string; after: string } | null {
+	if (typeof event !== 'object' || event === null) {
+		return null;
+	}
+	if (!('before' in event) || !('after' in event)) {
+		return null;
+	}
+	if (typeof event.before !== 'string' || typeof event.after !== 'string') {
+		return null;
+	}
+	if (event.before.length === 0 || event.after.length === 0) {
+		return null;
+	}
+	return { before: event.before, after: event.after };
+}
+
+export function changeSetForPush(options: {
+	before: string;
+	after: string;
+	diff: (before: string, after: string) => string[];
+}): PushChangeSet {
+	if (isGitZeroOid(options.before)) {
+		return { kind: 'unknown', reason: 'unborn revision' };
+	}
+	return { kind: 'known', files: options.diff(options.before, options.after) };
+}
+
+export function classifyPushChangeSet(changeSet: PushChangeSet): PrScope {
+	if (changeSet.kind === 'unknown') {
+		return { lane: 'full', includeWww: true };
+	}
+	return classifyPrScope(changeSet.files);
+}
+
 export function classifyPrScope(changedFiles: string[]): PrScope {
 	const plugins = new Set(
 		changedFiles


### PR DESCRIPTION
## Summary
- Plugin PRs already only build/test that plugin + corsair. Pushes to `main` still always ran the full graph (~30 min per merge).
- Classify `main` with the same rules, using `git diff` of the push `before`/`after`. One-plugin lands should log `CI lane: plugin`.
- If the diff is unknown (unborn SHA, missing range, git failure), fail closed to full **including www**. A known empty diff stays packages-only full.

## Test plan
- [ ] Classifier tests: `node --experimental-strip-types --test scripts/pr-review/pr-scope.test.ts`
- [ ] After merge, a one-plugin land on `main` logs `CI lane: plugin` and finishes in ~1–2 min, not ~30
- [ ] A core or two-plugin land on `main` still logs `CI lane: full`
- [ ] This PR itself is a workflow/scripts change, so its own CI is the full lane

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI checks for push-triggered changes by accurately identifying affected files and selecting the appropriate review scope.
  * Added safer handling for incomplete, invalid, or initial push events, with a comprehensive fallback when the change range cannot be determined.
  * Improved cache handling so it is used only for full-scope checks, helping ensure reliable validation results.

* **Tests**
  * Added coverage for push-event processing, revision detection, changed-file resolution, and scope classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->