### PR TITLE
docs(workday): clarify authConfig tenant vs withTenant

### DIFF
--- a/docs/plugins/workday/overview.mdx
+++ b/docs/plugins/workday/overview.mdx
@@ -61,8 +61,13 @@ Multi-tenancy is the default — scope calls with `corsair.withTenant(id)`. See 
 
 Open [hub.corsair.dev](https://hub.corsair.dev/dashboard), navigate to your project, and enter the **client ID** and **client secret** from your Workday OAuth app.
 
+Pass Workday’s **API hostname** and **tenant name** too — they go in Workday URLs (`https://{host}/ccx/oauth2/{tenant}/…`). That’s not the same as `corsair.withTenant()` ([Multi-tenancy](/concepts/multi-tenancy)). See Workday’s docs: [token endpoint shape](https://doc.workday.com/adaptive-planning/en-us/workday-adaptive-planning-documentation/integration/managing-data-integration/api-documentation/understanding-the-adaptive-planning-rest-api/bit1623710301264.html).
+
 ```ts
-workday()
+workday({
+	host: 'wd2-impl-services1.workday.com',
+	tenant: 'acme',
+})
 ```
 
 More: [OAuth 2.0](/concepts/oauth)

--- a/docs/plugins/workday/overview.mdx
+++ b/docs/plugins/workday/overview.mdx
@@ -61,13 +61,8 @@ Multi-tenancy is the default — scope calls with `corsair.withTenant(id)`. See 
 
 Open [hub.corsair.dev](https://hub.corsair.dev/dashboard), navigate to your project, and enter the **client ID** and **client secret** from your Workday OAuth app.
 
-Pass Workday’s **API hostname** and **tenant name** too — they go in Workday URLs (`https://{host}/ccx/oauth2/{tenant}/…`). That’s not the same as `corsair.withTenant()` ([Multi-tenancy](/concepts/multi-tenancy)). See Workday’s docs: [token endpoint shape](https://doc.workday.com/adaptive-planning/en-us/workday-adaptive-planning-documentation/integration/managing-data-integration/api-documentation/understanding-the-adaptive-planning-rest-api/bit1623710301264.html).
-
 ```ts
-workday({
-	host: 'wd2-impl-services1.workday.com',
-	tenant: 'acme',
-})
+workday()
 ```
 
 More: [OAuth 2.0](/concepts/oauth)

--- a/packages/workday/index.ts
+++ b/packages/workday/index.ts
@@ -32,6 +32,9 @@ import { resolveWorkdayOAuthWebhookTenantLink } from './webhooks/oauth-tenant-li
 import { matchWorkdayTenantWebhook } from './webhooks/tenant-matcher';
 import { workdayWebhooksNested } from './webhooks/triggers';
 
+// naming collision: `tenant` here is Workday's tenant name (goes in their URL path),
+// not corsair.withTenant() / corsair_accounts.tenant_id. host is the WD datacenter.
+// tenant_external_id is just for routing webhooks to the right connected account.
 export const workdayAuthConfig = {
 	oauth_2: {
 		account: ['tenant', 'host', 'tenant_external_id'] as const,

--- a/packages/workday/index.ts
+++ b/packages/workday/index.ts
@@ -36,6 +36,8 @@ import { workdayWebhooksNested } from './webhooks/triggers';
 // not corsair.withTenant() / corsair_accounts.tenant_id.
 // host is the API hostname (e.g. wd2-impl-services1.workday.com), not a datacenter code.
 // tenant_external_id is just for routing webhooks to the right connected account.
+// Workday puts host+tenant in the token URL — see:
+// https://doc.workday.com/adaptive-planning/en-us/workday-adaptive-planning-documentation/integration/managing-data-integration/api-documentation/understanding-the-adaptive-planning-rest-api/bit1623710301264.html
 export const workdayAuthConfig = {
 	oauth_2: {
 		account: ['tenant', 'host', 'tenant_external_id'] as const,

--- a/packages/workday/index.ts
+++ b/packages/workday/index.ts
@@ -33,7 +33,8 @@ import { matchWorkdayTenantWebhook } from './webhooks/tenant-matcher';
 import { workdayWebhooksNested } from './webhooks/triggers';
 
 // naming collision: `tenant` here is Workday's tenant name (goes in their URL path),
-// not corsair.withTenant() / corsair_accounts.tenant_id. host is the WD datacenter.
+// not corsair.withTenant() / corsair_accounts.tenant_id.
+// host is the API hostname (e.g. wd2-impl-services1.workday.com), not a datacenter code.
 // tenant_external_id is just for routing webhooks to the right connected account.
 export const workdayAuthConfig = {
 	oauth_2: {


### PR DESCRIPTION
## Description

Adds a short comment above `workdayAuthConfig` clarifying the naming collision between Corsair and Workday tenants:

- `corsair.withTenant()` / `corsair_accounts.tenant_id` = our platform customer
- `tenant` + `host` in authConfig = Workday URL fields (`/ccx/oauth2/{tenant}/…`, `/ccx/api/.../{tenant}/…`)
- `tenant_external_id` = webhook → connected-account routing only

No behavior change comment only in `packages/workday/index.ts`.

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

N/A comment-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Workday authentication configuration guidance, including the API hostname format.
  * Documented how Workday uses the host and tenant values in token URLs.
  * Added a link to Workday’s Adaptive Planning REST API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->