### PR TITLE
ci: skip plugin gate for plugin-docs.yaml PRs

### DIFF
--- a/.github/PLUGIN_PR_RULES.md
+++ b/.github/PLUGIN_PR_RULES.md
@@ -13,9 +13,15 @@ A plugin PR may only touch:
 - `packages/<plugin>/**` (exactly one plugin per PR)
 - the registration edit in `packages/corsair/core/constants.ts`
 - `pnpm-lock.yaml`
+- `docs/plugins/<plugin>/**` (generated docs for that same plugin)
 
 Anything else fails the gate. Use `pnpm generate:plugin` to scaffold — it
-produces exactly this footprint.
+produces exactly this footprint. Docs for a *different* plugin are still out
+of scope.
+
+PRs that only touch `packages/<plugin>/plugin-docs.yaml` and/or
+`docs/plugins/<plugin>/**` are docs PRs: the plugin gate is skipped (no demo
+video / R2–R4), and CI uses the documentation skip-heavy lane.
 
 ## R2 — Tests required
 

--- a/.github/PLUGIN_PR_RULES.md
+++ b/.github/PLUGIN_PR_RULES.md
@@ -14,14 +14,16 @@ A plugin PR may only touch:
 - the registration edit in `packages/corsair/core/constants.ts`
 - `pnpm-lock.yaml`
 - `docs/plugins/<plugin>/**` (generated docs for that same plugin)
+- `docs/docs.json` (Mintlify nav; `generate:docs` updates this)
 
 Anything else fails the gate. Use `pnpm generate:plugin` to scaffold — it
 produces exactly this footprint. Docs for a *different* plugin are still out
 of scope.
 
 PRs that only touch `packages/<plugin>/plugin-docs.yaml` and/or
-`docs/plugins/<plugin>/**` are docs PRs: the plugin gate is skipped (no demo
-video / R2–R4), and CI uses the documentation skip-heavy lane.
+`docs/plugins/<plugin>/**` (and `docs/docs.json` if generate rewrote nav)
+are docs PRs: the plugin gate is skipped (no demo video / R2–R4), and CI
+uses the documentation skip-heavy lane.
 
 ## R2 — Tests required
 

--- a/greptile.json
+++ b/greptile.json
@@ -9,7 +9,7 @@
     "rules": [
       {
         "scope": ["packages/**"],
-        "rule": "A plugin PR must only modify files inside a single packages/<plugin>/ directory, plus packages/corsair/core/constants.ts, pnpm-lock.yaml, and docs/plugins/<plugin>/** for that same plugin. Flag any other modified file as a critical (P0) issue. PRs that only touch packages/<plugin>/plugin-docs.yaml and/or docs/plugins/<plugin>/** are documentation PRs, not plugin-code PRs; do not apply plugin demo/test/scope rules to them."
+        "rule": "A plugin PR must only modify files inside a single packages/<plugin>/ directory, plus packages/corsair/core/constants.ts, pnpm-lock.yaml, docs/plugins/<plugin>/** for that same plugin, and docs/docs.json. Flag any other modified file as a critical (P0) issue. PRs that only touch packages/<plugin>/plugin-docs.yaml, docs/plugins/<plugin>/**, and/or docs/docs.json are documentation PRs, not plugin-code PRs; do not apply plugin demo/test/scope rules to them."
       },
       {
         "scope": ["packages/**"],

--- a/greptile.json
+++ b/greptile.json
@@ -9,7 +9,7 @@
     "rules": [
       {
         "scope": ["packages/**"],
-        "rule": "A plugin PR must only modify files inside a single packages/<plugin>/ directory, plus packages/corsair/core/constants.ts and pnpm-lock.yaml. Flag any other modified file as a critical (P0) issue."
+        "rule": "A plugin PR must only modify files inside a single packages/<plugin>/ directory, plus packages/corsair/core/constants.ts, pnpm-lock.yaml, and docs/plugins/<plugin>/** for that same plugin. Flag any other modified file as a critical (P0) issue. PRs that only touch packages/<plugin>/plugin-docs.yaml and/or docs/plugins/<plugin>/** are documentation PRs, not plugin-code PRs; do not apply plugin demo/test/scope rules to them."
       },
       {
         "scope": ["packages/**"],

--- a/greptile.json
+++ b/greptile.json
@@ -13,11 +13,11 @@
       },
       {
         "scope": ["packages/**"],
-        "rule": "Plugin packages must include at least one *.test.ts file with real assertions against the plugin's endpoints. Flag missing, empty, or assertion-free tests as P1."
+        "rule": "Plugin packages must include at least one *.test.ts file with real assertions against the plugin's endpoints. Flag missing, empty, or assertion-free tests as P1. Skip this rule on documentation-only PRs (only packages/<plugin>/plugin-docs.yaml, docs/plugins/<that plugin>/**, and optional docs/docs.json)."
       },
       {
         "scope": ["packages/**"],
-        "rule": "Flag boilerplate residue from the plugin generator as P1: placeholder base URLs, commented-out Authorization headers, leftover endpoints/example.ts files, and TODO stubs."
+        "rule": "Flag boilerplate residue from the plugin generator as P1: placeholder base URLs, commented-out Authorization headers, leftover endpoints/example.ts files, and TODO stubs. Skip this rule on documentation-only PRs (only packages/<plugin>/plugin-docs.yaml, docs/plugins/<that plugin>/**, and optional docs/docs.json)."
       },
       {
         "scope": ["**"],
@@ -25,15 +25,15 @@
       },
       {
         "scope": ["packages/**"],
-        "rule": "Every endpoint must validate inputs and outputs with zod schemas, route errors through the plugin's error-handlers.ts including rate-limit (429) handling, and support pagination on list endpoints when the provider API offers it. Flag violations as P1."
+        "rule": "Every endpoint must validate inputs and outputs with zod schemas, route errors through the plugin's error-handlers.ts including rate-limit (429) handling, and support pagination on list endpoints when the provider API offers it. Flag violations as P1. Skip this rule on documentation-only PRs (only packages/<plugin>/plugin-docs.yaml, docs/plugins/<that plugin>/**, and optional docs/docs.json)."
       },
       {
         "scope": ["packages/**"],
-        "rule": "Verify the implementation matches the PR description: every endpoint the description claims must exist and work as described. Flag mismatches as P1."
+        "rule": "Verify the implementation matches the PR description: every endpoint the description claims must exist and work as described. Flag mismatches as P1. Skip this rule on documentation-only PRs (only packages/<plugin>/plugin-docs.yaml, docs/plugins/<that plugin>/**, and optional docs/docs.json)."
       },
       {
         "scope": ["packages/**"],
-        "rule": "Flag `any` types on exported or public surfaces as P2, and every implemented endpoint lacking a corresponding test as P1."
+        "rule": "Flag `any` types on exported or public surfaces as P2, and every implemented endpoint lacking a corresponding test as P1. Skip this rule on documentation-only PRs (only packages/<plugin>/plugin-docs.yaml, docs/plugins/<that plugin>/**, and optional docs/docs.json)."
       }
     ],
     "files": [

--- a/scripts/pr-review/gate.test.ts
+++ b/scripts/pr-review/gate.test.ts
@@ -90,6 +90,7 @@ test('plugin-docs.yaml + generated docs skip the plugin gate', () => {
 		changedFiles: [
 			'packages/airtable/plugin-docs.yaml',
 			'docs/plugins/airtable/overview.mdx',
+			'docs/docs.json',
 		],
 	});
 	assert.equal(r.isPluginPr, false);
@@ -111,6 +112,7 @@ test('R1: same-plugin generated docs pass', () => {
 			...goodFiles,
 			'packages/onepassword/plugin-docs.yaml',
 			'docs/plugins/onepassword/overview.mdx',
+			'docs/docs.json',
 		],
 	});
 	assert.ok(!r.failures.some((f) => f.rule === 'R1'));

--- a/scripts/pr-review/gate.test.ts
+++ b/scripts/pr-review/gate.test.ts
@@ -84,6 +84,46 @@ test('R1: two plugins in one PR fails', () => {
 	assert.ok(r.failures.some((f) => f.rule === 'R1'));
 });
 
+test('plugin-docs.yaml + generated docs skip the plugin gate', () => {
+	const r = runGate({
+		...goodInput,
+		changedFiles: [
+			'packages/airtable/plugin-docs.yaml',
+			'docs/plugins/airtable/overview.mdx',
+		],
+	});
+	assert.equal(r.isPluginPr, false);
+	assert.deepEqual(r.failures, []);
+});
+
+test('plugin-docs.yaml only skips the plugin gate', () => {
+	const r = runGate({
+		...goodInput,
+		changedFiles: ['packages/airtable/plugin-docs.yaml'],
+	});
+	assert.equal(r.isPluginPr, false);
+});
+
+test('R1: same-plugin generated docs pass', () => {
+	const r = runGate({
+		...goodInput,
+		changedFiles: [
+			...goodFiles,
+			'packages/onepassword/plugin-docs.yaml',
+			'docs/plugins/onepassword/overview.mdx',
+		],
+	});
+	assert.ok(!r.failures.some((f) => f.rule === 'R1'));
+});
+
+test('R1: other plugin docs fail', () => {
+	const r = runGate({
+		...goodInput,
+		changedFiles: [...goodFiles, 'docs/plugins/slack/overview.mdx'],
+	});
+	assert.ok(r.failures.some((f) => f.rule === 'R1'));
+});
+
 test('R2: plugin with no test files fails', () => {
 	const r = runGate({ ...goodInput, testFileCount: 0 });
 	assert.ok(r.failures.some((f) => f.rule === 'R2'));

--- a/scripts/pr-review/gate.ts
+++ b/scripts/pr-review/gate.ts
@@ -12,6 +12,39 @@ export const ALLOWED_EXTRA = [
 ];
 export const ASSERTION_WARN_FLOOR = 5;
 
+/** Generated plugin docs for the same plugin (plugin-docs.yaml PRs). */
+export function isSamePluginDocs(file: string, plugin: string): boolean {
+	const prefix = `docs/plugins/${plugin}/`;
+	return file.startsWith(prefix);
+}
+
+function pluginDocsYamlOf(file: string): string | null {
+	const name = file.match(/^packages\/([^/]+)\/plugin-docs\.yaml$/)?.[1];
+	if (!name) return null;
+	if (IGNORED_PACKAGES.includes(name) || name.startsWith('frpc-')) return null;
+	return name;
+}
+
+function pluginDocsDirOf(file: string): string | null {
+	const name = file.match(/^docs\/plugins\/([^/]+)\//)?.[1];
+	if (!name) return null;
+	if (IGNORED_PACKAGES.includes(name) || name.startsWith('frpc-')) return null;
+	return name;
+}
+
+/** yaml +/or generated docs for one plugin, nothing else. Not a plugin-code PR. */
+export function isPluginDocsManifestPr(changedFiles: string[]): boolean {
+	if (changedFiles.length === 0) return false;
+	let plugin: string | null = null;
+	for (const file of changedFiles) {
+		const id = pluginDocsYamlOf(file) ?? pluginDocsDirOf(file);
+		if (!id) return false;
+		if (plugin === null) plugin = id;
+		else if (plugin !== id) return false;
+	}
+	return plugin !== null;
+}
+
 export interface GateInput {
 	changedFiles: string[];
 	prBody: string;
@@ -78,7 +111,11 @@ export function runGate(input: GateInput): GateResult {
 	const plugins = new Set(
 		input.changedFiles.map(pluginOf).filter((p): p is string => p !== null),
 	);
-	if (plugins.size === 0 || input.isDraft) {
+	if (
+		isPluginDocsManifestPr(input.changedFiles) ||
+		plugins.size === 0 ||
+		input.isDraft
+	) {
 		return { isPluginPr: false, plugin: null, checks: [], failures: [] };
 	}
 
@@ -87,7 +124,10 @@ export function runGate(input: GateInput): GateResult {
 
 	// R1 — scope confinement
 	const outOfScope = input.changedFiles.filter(
-		(f) => pluginOf(f) === null && !ALLOWED_EXTRA.includes(f),
+		(f) =>
+			pluginOf(f) === null &&
+			!ALLOWED_EXTRA.includes(f) &&
+			!(plugin && isSamePluginDocs(f, plugin)),
 	);
 	if (plugins.size > 1) {
 		checks.push({

--- a/scripts/pr-review/gate.ts
+++ b/scripts/pr-review/gate.ts
@@ -12,6 +12,9 @@ export const ALLOWED_EXTRA = [
 ];
 export const ASSERTION_WARN_FLOOR = 5;
 
+/** Mintlify sidebar; `generate:docs` rewrites this with the plugin pages. */
+export const DOCS_NAV_FILE = 'docs/docs.json';
+
 /** Generated plugin docs for the same plugin (plugin-docs.yaml PRs). */
 export function isSamePluginDocs(file: string, plugin: string): boolean {
 	const prefix = `docs/plugins/${plugin}/`;
@@ -37,6 +40,7 @@ export function isPluginDocsManifestPr(changedFiles: string[]): boolean {
 	if (changedFiles.length === 0) return false;
 	let plugin: string | null = null;
 	for (const file of changedFiles) {
+		if (file === DOCS_NAV_FILE) continue;
 		const id = pluginDocsYamlOf(file) ?? pluginDocsDirOf(file);
 		if (!id) return false;
 		if (plugin === null) plugin = id;
@@ -127,6 +131,7 @@ export function runGate(input: GateInput): GateResult {
 		(f) =>
 			pluginOf(f) === null &&
 			!ALLOWED_EXTRA.includes(f) &&
+			f !== DOCS_NAV_FILE &&
 			!(plugin && isSamePluginDocs(f, plugin)),
 	);
 	if (plugins.size > 1) {

--- a/scripts/pr-review/pr-scope.test.ts
+++ b/scripts/pr-review/pr-scope.test.ts
@@ -53,6 +53,7 @@ test('skips heavy checks for plugin-docs.yaml and generated plugin docs', () => 
 		classifyPrScope([
 			'packages/airtable/plugin-docs.yaml',
 			'docs/plugins/airtable/overview.mdx',
+			'docs/docs.json',
 		]),
 		{ lane: 'skip-heavy' },
 	);

--- a/scripts/pr-review/pr-scope.test.ts
+++ b/scripts/pr-review/pr-scope.test.ts
@@ -17,6 +17,17 @@ test('uses the plugin lane for one plugin plus gate-approved extra files', () =>
 	);
 });
 
+test('keeps plugin-code PRs in the plugin lane when they regenerate that plugin docs', () => {
+	assert.deepEqual(
+		classifyPrScope([
+			'packages/airtable/index.ts',
+			'docs/plugins/airtable/overview.mdx',
+			'docs/docs.json',
+		]),
+		{ lane: 'plugin', plugin: 'airtable' },
+	);
+});
+
 test('uses the full lane when a plugin PR changes other corsair files', () => {
 	assert.deepEqual(
 		classifyPrScope([

--- a/scripts/pr-review/pr-scope.test.ts
+++ b/scripts/pr-review/pr-scope.test.ts
@@ -48,6 +48,16 @@ test('uses the full lane for lockfile-only changes', () => {
 	});
 });
 
+test('skips heavy checks for plugin-docs.yaml and generated plugin docs', () => {
+	assert.deepEqual(
+		classifyPrScope([
+			'packages/airtable/plugin-docs.yaml',
+			'docs/plugins/airtable/overview.mdx',
+		]),
+		{ lane: 'skip-heavy' },
+	);
+});
+
 test('skips heavy checks for explorer and documentation-only changes', () => {
 	assert.deepEqual(
 		classifyPrScope([

--- a/scripts/pr-review/pr-scope.ts
+++ b/scripts/pr-review/pr-scope.ts
@@ -2,8 +2,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import {
 	ALLOWED_EXTRA,
+	DOCS_NAV_FILE,
 	detectPlugin,
 	isPluginDocsManifestPr,
+	isSamePluginDocs,
 	pluginOf,
 } from './gate.ts';
 
@@ -50,7 +52,11 @@ export function classifyPrScope(changedFiles: string[]): PrScope {
 		plugin !== null &&
 		plugins.size === 1 &&
 		changedFiles.every(
-			(file) => pluginOf(file) === plugin || ALLOWED_EXTRA.includes(file),
+			(file) =>
+				pluginOf(file) === plugin ||
+				ALLOWED_EXTRA.includes(file) ||
+				file === DOCS_NAV_FILE ||
+				isSamePluginDocs(file, plugin),
 		)
 	) {
 		return { lane: 'plugin', plugin };

--- a/scripts/pr-review/pr-scope.ts
+++ b/scripts/pr-review/pr-scope.ts
@@ -1,6 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { ALLOWED_EXTRA, detectPlugin, pluginOf } from './gate.ts';
+import {
+	ALLOWED_EXTRA,
+	detectPlugin,
+	isPluginDocsManifestPr,
+	pluginOf,
+} from './gate.ts';
 
 export type PrScope =
 	| { lane: 'plugin'; plugin: string }
@@ -36,6 +41,10 @@ export function classifyPrScope(changedFiles: string[]): PrScope {
 			.filter((plugin): plugin is string => plugin !== null),
 	);
 	const plugin = detectPlugin(changedFiles);
+
+	if (isPluginDocsManifestPr(changedFiles)) {
+		return { lane: 'skip-heavy' };
+	}
 
 	if (
 		plugin !== null &&


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

`plugin-docs.yaml` PRs (yaml + generated `docs/plugins/<plugin>/**`) were getting treated as plugin-code PRs. R1 rejected the generated mdx, and R4 wanted a demo video. These are docs PRs.

This skips the plugin gate for that footprint and puts them on the skip-heavy CI lane. A real plugin-code PR can still include that same plugin's generated docs without failing R1.


## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [ ] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

Did not run a full monorepo `pnpm build`. This only changes the plugin gate / CI scope. Gate tests: `node --experimental-strip-types --test scripts/pr-review/gate.test.ts scripts/pr-review/pr-scope.test.ts`

## Screenshots / Demos (if applicable)

n/a

## Additional Notes

No breaking change, no new deps. After this lands, good-first-issue yaml PRs can include yaml + regenerated docs in one PR without the plugin gate failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added support for documentation-only plugin updates.
* Generated documentation for the corresponding plugin is now recognized as in scope.
* Documentation navigation updates are supported alongside generated documentation.
* Documentation-only changes use streamlined validation and skip plugin-specific demo and test requirements.

## Bug Fixes

* Documentation for other plugins is correctly identified as out of scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->