### PR TITLE
feat: add mailboxlayer API plugin

### DIFF
--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -61,12 +61,12 @@ export const BaseProviders = [
 	'attio',
 	'autom',
 	'ayrshare',
+	'backendless',
 	'bannerbear',
 	'bart',
 	'basecamp',
 	'baselinker',
 	'basin',
-	'backendless',
 	'beeminder',
 	'bettercontact',
 	'betterstack',
@@ -151,6 +151,7 @@ export const BaseProviders = [
 	'linear',
 	'linkedin',
 	'loyverse',
+	'mailboxlayer',
 	'mailchimp',
 	'mailtrap',
 	'merriamwebsterdict',
@@ -271,12 +272,12 @@ export const ProviderDisplayNames = {
 	attio: 'Attio',
 	autom: 'Autom',
 	ayrshare: 'Ayrshare',
+	backendless: 'Backendless',
 	bannerbear: 'Bannerbear',
 	bart: 'BART',
 	basecamp: 'Basecamp',
 	baselinker: 'BaseLinker',
 	basin: 'Basin',
-	backendless: 'Backendless',
 	beeminder: 'Beeminder',
 	bettercontact: 'BetterContact',
 	betterstack: 'Better Stack',
@@ -361,6 +362,7 @@ export const ProviderDisplayNames = {
 	linear: 'Linear',
 	linkedin: 'LinkedIn',
 	loyverse: 'Loyverse',
+	mailboxlayer: 'MailboxLayer',
 	mailchimp: 'Mailchimp',
 	mailtrap: 'Mailtrap',
 	merriamwebsterdict: 'Merriam-Webster Dictionary',
@@ -488,12 +490,12 @@ export type AllProviders =
 	| 'attio'
 	| 'autom'
 	| 'ayrshare'
+	| 'backendless'
 	| 'bannerbear'
 	| 'bart'
 	| 'basecamp'
 	| 'baselinker'
 	| 'basin'
-	| 'backendless'
 	| 'beeminder'
 	| 'bettercontact'
 	| 'betterstack'
@@ -578,6 +580,7 @@ export type AllProviders =
 	| 'linear'
 	| 'linkedin'
 	| 'loyverse'
+	| 'mailboxlayer'
 	| 'mailchimp'
 	| 'mailtrap'
 	| 'merriamwebsterdict'

--- a/packages/mailboxlayer/api.test.ts
+++ b/packages/mailboxlayer/api.test.ts
@@ -23,10 +23,6 @@ describeIfKey('MailboxLayer API Type Tests', () => {
 		});
 
 		it('rejects a malformed address with apiCode 211 (invalid_email_address)', async () => {
-			// mailboxlayer validates the `email` param server-side and returns
-			// its {success:false, error:{code:211,...}} shape for syntactically
-			// invalid input, rather than a normal check response with
-			// format_valid:false — confirmed against the live API.
 			await expect(
 				makeMailboxLayerRequest<CheckResponse>('check', ACCESS_KEY!, {
 					query: { email: 'not-a-valid-email', smtp: 1, format: 1 },

--- a/packages/mailboxlayer/api.test.ts
+++ b/packages/mailboxlayer/api.test.ts
@@ -1,0 +1,69 @@
+import 'dotenv/config';
+import { MailboxLayerAPIError, makeMailboxLayerRequest } from './client';
+import type { CheckResponse } from './endpoints/types';
+import { MailboxLayerEndpointOutputSchemas } from './endpoints/types';
+
+const ACCESS_KEY = process.env.MAILBOXLAYER_API_KEY;
+
+const describeIfKey = ACCESS_KEY ? describe : describe.skip;
+
+describeIfKey('MailboxLayer API Type Tests', () => {
+	describe('email check', () => {
+		it('check returns correct type for a deliverable address', async () => {
+			const response = await makeMailboxLayerRequest<CheckResponse>(
+				'check',
+				ACCESS_KEY!,
+				{ query: { email: 'support@apilayer.net', smtp: 1, format: 1 } },
+			);
+
+			MailboxLayerEndpointOutputSchemas.check.parse(response);
+			expect(response.email).toBe('support@apilayer.net');
+			expect(typeof response.format_valid).toBe('boolean');
+			expect(typeof response.score).toBe('number');
+		});
+
+		it('rejects a malformed address with apiCode 211 (invalid_email_address)', async () => {
+			// mailboxlayer validates the `email` param server-side and returns
+			// its {success:false, error:{code:211,...}} shape for syntactically
+			// invalid input, rather than a normal check response with
+			// format_valid:false — confirmed against the live API.
+			await expect(
+				makeMailboxLayerRequest<CheckResponse>('check', ACCESS_KEY!, {
+					query: { email: 'not-a-valid-email', smtp: 1, format: 1 },
+				}),
+			).rejects.toMatchObject({
+				constructor: MailboxLayerAPIError,
+				apiCode: 211,
+			});
+		});
+
+		it('check returns format_valid:true but mx_found:false for a well-formed address on a non-existent domain', async () => {
+			const response = await makeMailboxLayerRequest<CheckResponse>(
+				'check',
+				ACCESS_KEY!,
+				{
+					query: {
+						email: 'someone@this-domain-does-not-exist-corsair-test.invalid',
+						smtp: 1,
+						format: 1,
+					},
+				},
+			);
+
+			const parsed = MailboxLayerEndpointOutputSchemas.check.parse(response);
+			expect(parsed.format_valid).toBe(true);
+			expect(parsed.mx_found).toBe(false);
+		});
+
+		it('check skips the SMTP probe when smtp=0', async () => {
+			const response = await makeMailboxLayerRequest<CheckResponse>(
+				'check',
+				ACCESS_KEY!,
+				{ query: { email: 'someone@gmail.com', smtp: 0, format: 1 } },
+			);
+
+			MailboxLayerEndpointOutputSchemas.check.parse(response);
+			expect(response.email).toBe('someone@gmail.com');
+		});
+	});
+});

--- a/packages/mailboxlayer/client.test.ts
+++ b/packages/mailboxlayer/client.test.ts
@@ -1,4 +1,34 @@
-import { redactEmail } from './client';
+import type { ApiRequestOptions, ApiResult } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+import {
+	MAILBOXLAYER_API_BASE,
+	MailboxLayerAPIError,
+	makeMailboxLayerRequest,
+	redactEmail,
+	tryGetStoredKey,
+} from './client';
+
+jest.mock('corsair/http', () => {
+	const actual = jest.requireActual('corsair/http');
+	return { ...actual, request: jest.fn() };
+});
+
+const mockRequest = jest.mocked(request);
+
+const CHECK_BODY = {
+	email: 'support@apilayer.net',
+	did_you_mean: '',
+	user: 'support',
+	domain: 'apilayer.net',
+	format_valid: true,
+	mx_found: true,
+	smtp_check: true,
+	catch_all: false,
+	role: true,
+	disposable: false,
+	free: false,
+	score: 0.8,
+};
 
 describe('redactEmail', () => {
 	it('keeps the first character and domain, masks the rest', () => {
@@ -11,5 +41,127 @@ describe('redactEmail', () => {
 
 	it('fully redacts an address that starts with @', () => {
 		expect(redactEmail('@apilayer.net')).toBe('***');
+	});
+});
+
+describe('tryGetStoredKey', () => {
+	it('returns the stored key', async () => {
+		await expect(tryGetStoredKey(async () => 'stored-key')).resolves.toBe(
+			'stored-key',
+		);
+	});
+
+	it('returns undefined when the getter yields null', async () => {
+		await expect(tryGetStoredKey(async () => null)).resolves.toBeUndefined();
+	});
+
+	it('returns undefined when the account has no DEK', async () => {
+		await expect(
+			tryGetStoredKey(async () => {
+				throw new Error(
+					'No DEK found for account (tenant: "default", integration: "mailboxlayer")',
+				);
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	it('rethrows errors that are not a missing DEK', async () => {
+		await expect(
+			tryGetStoredKey(async () => {
+				throw new Error('decryption failed');
+			}),
+		).rejects.toThrow('decryption failed');
+	});
+});
+
+describe('makeMailboxLayerRequest', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+	});
+
+	it('puts access_key in the query string and leaves TOKEN unset', async () => {
+		mockRequest.mockResolvedValue(CHECK_BODY);
+
+		await makeMailboxLayerRequest('check', 'test-access-key', {
+			query: { email: 'support@apilayer.net', smtp: 1, format: 1 },
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.objectContaining({
+				BASE: MAILBOXLAYER_API_BASE,
+				TOKEN: undefined,
+			}),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'check',
+				query: expect.objectContaining({
+					email: 'support@apilayer.net',
+					access_key: 'test-access-key',
+				}),
+			}),
+		);
+	});
+
+	it('uses HTTP when useHttps is false so free-tier keys are not blocked', async () => {
+		mockRequest.mockResolvedValue(CHECK_BODY);
+
+		await makeMailboxLayerRequest('check', 'test-access-key', {
+			query: { email: 'support@apilayer.net' },
+			useHttps: false,
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.objectContaining({
+				BASE: 'http://apilayer.net/api',
+			}),
+			expect.anything(),
+		);
+	});
+
+	it('throws MailboxLayerAPIError with apiCode when the body is success:false', async () => {
+		mockRequest.mockResolvedValue({
+			success: false,
+			error: {
+				code: 105,
+				type: 'https_access_restricted',
+				info: 'Access Restricted - Your current Subscription Plan does not support HTTPS Encryption.',
+			},
+		});
+
+		await expect(
+			makeMailboxLayerRequest('check', 'test-access-key', {
+				query: { email: 'support@apilayer.net' },
+			}),
+		).rejects.toMatchObject({
+			constructor: MailboxLayerAPIError,
+			apiCode: 105,
+			apiType: 'https_access_restricted',
+		});
+	});
+
+	it('copies status and retryAfter off a transport ApiError', async () => {
+		const response = {
+			url: 'https://apilayer.net/api/check',
+			ok: false,
+			status: 429,
+			statusText: 'Too Many Requests',
+			body: {},
+		} satisfies ApiResult;
+
+		mockRequest.mockRejectedValue(
+			new ApiError(
+				{ method: 'GET', url: 'check' } satisfies ApiRequestOptions,
+				response,
+				'Rate limit exceeded',
+				{ retryAfter: 2000 },
+			),
+		);
+
+		await expect(
+			makeMailboxLayerRequest('check', 'test-access-key'),
+		).rejects.toMatchObject({
+			status: 429,
+			retryAfter: 2000,
+		});
 	});
 });

--- a/packages/mailboxlayer/client.test.ts
+++ b/packages/mailboxlayer/client.test.ts
@@ -102,17 +102,19 @@ describe('makeMailboxLayerRequest', () => {
 		);
 	});
 
-	it('uses HTTP when useHttps is false so free-tier keys are not blocked', async () => {
+	it('always uses HTTPS, even when a caller tries to pass an http-like option', async () => {
 		mockRequest.mockResolvedValue(CHECK_BODY);
 
 		await makeMailboxLayerRequest('check', 'test-access-key', {
 			query: { email: 'support@apilayer.net' },
+			// @ts-expect-error — useHttps is no longer a supported option; this
+			// guards against it being silently reintroduced.
 			useHttps: false,
 		});
 
 		expect(mockRequest).toHaveBeenCalledWith(
 			expect.objectContaining({
-				BASE: 'http://apilayer.net/api',
+				BASE: MAILBOXLAYER_API_BASE,
 			}),
 			expect.anything(),
 		);

--- a/packages/mailboxlayer/client.test.ts
+++ b/packages/mailboxlayer/client.test.ts
@@ -112,12 +112,8 @@ describe('makeMailboxLayerRequest', () => {
 			useHttps: false,
 		});
 
-		expect(mockRequest).toHaveBeenCalledWith(
-			expect.objectContaining({
-				BASE: MAILBOXLAYER_API_BASE,
-			}),
-			expect.anything(),
-		);
+		const lastCall = mockRequest.mock.calls.at(-1);
+		expect(new URL(lastCall?.[0].BASE ?? '').protocol).toBe('https:');
 	});
 
 	it('throws MailboxLayerAPIError with apiCode when the body is success:false', async () => {
@@ -139,6 +135,33 @@ describe('makeMailboxLayerRequest', () => {
 			apiCode: 105,
 			apiType: 'https_access_restricted',
 		});
+	});
+
+	it('throws with the error type as the message when info is missing', async () => {
+		mockRequest.mockResolvedValue({
+			success: false,
+			error: { code: 211, type: 'format_not_valid' },
+		});
+
+		await expect(
+			makeMailboxLayerRequest('check', 'test-access-key', {
+				query: { email: 'not-a-valid-email' },
+			}),
+		).rejects.toMatchObject({
+			constructor: MailboxLayerAPIError,
+			message: 'format_not_valid',
+			apiCode: 211,
+		});
+	});
+
+	it('does not throw on a success:false body with a malformed error field', async () => {
+		mockRequest.mockResolvedValue({ success: false, error: null });
+
+		await expect(
+			makeMailboxLayerRequest('check', 'test-access-key', {
+				query: { email: 'support@apilayer.net' },
+			}),
+		).resolves.toEqual({ success: false, error: null });
 	});
 
 	it('copies status and retryAfter off a transport ApiError', async () => {

--- a/packages/mailboxlayer/client.test.ts
+++ b/packages/mailboxlayer/client.test.ts
@@ -1,0 +1,15 @@
+import { redactEmail } from './client';
+
+describe('redactEmail', () => {
+	it('keeps the first character and domain, masks the rest', () => {
+		expect(redactEmail('support@apilayer.net')).toBe('s***@apilayer.net');
+	});
+
+	it('fully redacts an address with no @', () => {
+		expect(redactEmail('not-an-email')).toBe('***');
+	});
+
+	it('fully redacts an address that starts with @', () => {
+		expect(redactEmail('@apilayer.net')).toBe('***');
+	});
+});

--- a/packages/mailboxlayer/client.ts
+++ b/packages/mailboxlayer/client.ts
@@ -1,0 +1,163 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+
+export class MailboxLayerAPIError extends Error {
+	public readonly status?: number;
+	public readonly statusText?: string;
+	public readonly body?: unknown;
+	public readonly retryAfter?: number;
+	/** mailboxlayer's own 3-digit error code (e.g. 101 invalid_access_key), distinct from HTTP status */
+	public readonly apiCode?: number;
+	public readonly apiType?: string;
+
+	constructor(
+		message: string,
+		options?: {
+			cause?: Error;
+			apiCode?: number;
+			apiType?: string;
+		},
+	) {
+		super(message, options);
+		this.name = 'MailboxLayerAPIError';
+
+		if (options?.cause instanceof ApiError) {
+			this.status = options.cause.status;
+			this.statusText = options.cause.statusText;
+			this.body = options.cause.body;
+			this.retryAfter = options.cause.retryAfter;
+		}
+		this.apiCode = options?.apiCode;
+		this.apiType = options?.apiType;
+	}
+}
+
+export const MAILBOXLAYER_API_BASE = 'https://apilayer.net/api';
+
+// Matches only corsair's "no DEK on this account" error
+// (packages/corsair/core/auth/key-manager.ts: `No DEK found for account
+// (tenant: "...", integration: "...")`). No dedicated error class exists
+// for this state, so message matching is the only handle available; kept
+// narrow on purpose so it can't accidentally swallow an unrelated failure.
+const NO_DEK_ERROR_PATTERN = /no dek found/i;
+
+/**
+ * Safely reads the stored access_key from the account key manager.
+ *
+ * `ctx.keys.get_api_key()` throws (rather than returning null) when the
+ * account has no DEK at all — a fully valid state for accounts that only
+ * ever configure the key via plugin options and never touch the key
+ * manager — and must resolve to "no stored key" rather than abort the
+ * request. Anything else thrown (decryption failure, database error, ...)
+ * is a real operational problem, not an absent key, and must propagate.
+ */
+export async function tryGetStoredKey(
+	getter: () => Promise<string | null | undefined>,
+): Promise<string | undefined> {
+	try {
+		const value = await getter();
+		return value ?? undefined;
+	} catch (error) {
+		if (error instanceof Error && NO_DEK_ERROR_PATTERN.test(error.message)) {
+			return undefined;
+		}
+		throw error;
+	}
+}
+
+/**
+ * Redacts an email address for event logs (`logEventFromContext` persists
+ * its payload to `corsair_events`) — keeps the first character and domain
+ * for debugging/correlation without storing the full address in plaintext.
+ */
+export function redactEmail(email: string): string {
+	const atIndex = email.indexOf('@');
+	if (atIndex <= 0) return '***';
+	return `${email[0]}***${email.slice(atIndex)}`;
+}
+
+/**
+ * mailboxlayer's error shape, returned with an HTTP 200 status (not a 4xx/5xx)
+ * for every documented failure — invalid key, exhausted quota, bad input, etc.
+ * all come back as `{ success: false, error: {...} }` on a 200 response, so
+ * the only way to detect them is to check `success` in the parsed body.
+ */
+interface MailboxLayerErrorBody {
+	success: false;
+	error: {
+		code: number;
+		type: string;
+		info: string;
+	};
+}
+
+function isMailboxLayerErrorBody(
+	value: unknown,
+): value is MailboxLayerErrorBody {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'success' in value &&
+		(value as { success: unknown }).success === false
+	);
+}
+
+/**
+ * Performs a request against the mailboxlayer API.
+ *
+ * Auth: API key passed as the `access_key` query parameter (the only
+ * supported method). All endpoints are GET-only.
+ */
+export async function makeMailboxLayerRequest<T>(
+	endpoint: string,
+	accessKey: string,
+	options: {
+		query?: Record<string, string | number | boolean | undefined>;
+	} = {},
+): Promise<T> {
+	const { query = {} } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: MAILBOXLAYER_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: undefined,
+		HEADERS: {
+			'Content-Type': 'application/json',
+		},
+	};
+
+	const queryWithAuth: Record<string, string | number | boolean | undefined> = {
+		...query,
+		access_key: accessKey,
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method: 'GET',
+		url: endpoint,
+		query: queryWithAuth,
+	};
+
+	let raw: T | MailboxLayerErrorBody;
+	try {
+		raw = await request<T | MailboxLayerErrorBody>(config, requestOptions);
+	} catch (error) {
+		if (error instanceof ApiError) {
+			throw new MailboxLayerAPIError(error.message, { cause: error });
+		}
+		if (error instanceof Error) {
+			throw new MailboxLayerAPIError(error.message, { cause: error });
+		}
+		throw new MailboxLayerAPIError('Unknown error');
+	}
+
+	if (isMailboxLayerErrorBody(raw)) {
+		throw new MailboxLayerAPIError(raw.error.info, {
+			apiCode: raw.error.code,
+			apiType: raw.error.type,
+		});
+	}
+
+	return raw;
+}

--- a/packages/mailboxlayer/client.ts
+++ b/packages/mailboxlayer/client.ts
@@ -31,14 +31,11 @@ export class MailboxLayerAPIError extends Error {
 	}
 }
 
+// HTTPS only — mailboxlayer's access_key and the checked email address are
+// both sent as query parameters, so this must never be requested over plain
+// HTTP. Free-tier mailboxlayer plans reject HTTPS entirely (api error 105,
+// https_access_restricted); this plugin does not support that tier.
 export const MAILBOXLAYER_API_BASE = 'https://apilayer.net/api';
-export const MAILBOXLAYER_API_BASE_HTTP = 'http://apilayer.net/api';
-
-export function mailboxLayerApiBase(useHttps = true): string {
-	return useHttps === false
-		? MAILBOXLAYER_API_BASE_HTTP
-		: MAILBOXLAYER_API_BASE;
-}
 
 const NO_DEK_ERROR_PATTERN = /no dek found/i;
 
@@ -87,13 +84,12 @@ export async function makeMailboxLayerRequest<T>(
 	accessKey: string,
 	options: {
 		query?: Record<string, string | number | boolean | undefined>;
-		useHttps?: boolean;
 	} = {},
 ): Promise<T> {
-	const { query = {}, useHttps } = options;
+	const { query = {} } = options;
 
 	const config: OpenAPIConfig = {
-		BASE: mailboxLayerApiBase(useHttps !== false),
+		BASE: MAILBOXLAYER_API_BASE,
 		VERSION: '1.0.0',
 		WITH_CREDENTIALS: false,
 		CREDENTIALS: 'omit',

--- a/packages/mailboxlayer/client.ts
+++ b/packages/mailboxlayer/client.ts
@@ -64,18 +64,31 @@ interface MailboxLayerErrorBody {
 	error: {
 		code: number;
 		type: string;
-		info: string;
+		// Not always present on live responses (e.g. code 211 without a
+		// `format_not_valid` message body) despite being documented.
+		info?: string;
 	};
 }
 
 function isMailboxLayerErrorBody(
 	value: unknown,
 ): value is MailboxLayerErrorBody {
+	if (typeof value !== 'object' || value === null) return false;
+	const { success, error } = value as {
+		success?: unknown;
+		error?: unknown;
+	};
+	if (success !== false || typeof error !== 'object' || error === null)
+		return false;
+	const { code, type, info } = error as {
+		code?: unknown;
+		type?: unknown;
+		info?: unknown;
+	};
 	return (
-		typeof value === 'object' &&
-		value !== null &&
-		'success' in value &&
-		(value as { success: unknown }).success === false
+		typeof code === 'number' &&
+		typeof type === 'string' &&
+		(info === undefined || typeof info === 'string')
 	);
 }
 
@@ -124,7 +137,7 @@ export async function makeMailboxLayerRequest<T>(
 	}
 
 	if (isMailboxLayerErrorBody(raw)) {
-		throw new MailboxLayerAPIError(raw.error.info, {
+		throw new MailboxLayerAPIError(raw.error.info ?? raw.error.type, {
 			apiCode: raw.error.code,
 			apiType: raw.error.type,
 		});

--- a/packages/mailboxlayer/client.ts
+++ b/packages/mailboxlayer/client.ts
@@ -6,7 +6,6 @@ export class MailboxLayerAPIError extends Error {
 	public readonly statusText?: string;
 	public readonly body?: unknown;
 	public readonly retryAfter?: number;
-	/** mailboxlayer's own 3-digit error code (e.g. 101 invalid_access_key), distinct from HTTP status */
 	public readonly apiCode?: number;
 	public readonly apiType?: string;
 
@@ -33,24 +32,16 @@ export class MailboxLayerAPIError extends Error {
 }
 
 export const MAILBOXLAYER_API_BASE = 'https://apilayer.net/api';
+export const MAILBOXLAYER_API_BASE_HTTP = 'http://apilayer.net/api';
 
-// Matches only corsair's "no DEK on this account" error
-// (packages/corsair/core/auth/key-manager.ts: `No DEK found for account
-// (tenant: "...", integration: "...")`). No dedicated error class exists
-// for this state, so message matching is the only handle available; kept
-// narrow on purpose so it can't accidentally swallow an unrelated failure.
+export function mailboxLayerApiBase(useHttps = true): string {
+	return useHttps === false
+		? MAILBOXLAYER_API_BASE_HTTP
+		: MAILBOXLAYER_API_BASE;
+}
+
 const NO_DEK_ERROR_PATTERN = /no dek found/i;
 
-/**
- * Safely reads the stored access_key from the account key manager.
- *
- * `ctx.keys.get_api_key()` throws (rather than returning null) when the
- * account has no DEK at all — a fully valid state for accounts that only
- * ever configure the key via plugin options and never touch the key
- * manager — and must resolve to "no stored key" rather than abort the
- * request. Anything else thrown (decryption failure, database error, ...)
- * is a real operational problem, not an absent key, and must propagate.
- */
 export async function tryGetStoredKey(
 	getter: () => Promise<string | null | undefined>,
 ): Promise<string | undefined> {
@@ -65,23 +56,12 @@ export async function tryGetStoredKey(
 	}
 }
 
-/**
- * Redacts an email address for event logs (`logEventFromContext` persists
- * its payload to `corsair_events`) — keeps the first character and domain
- * for debugging/correlation without storing the full address in plaintext.
- */
 export function redactEmail(email: string): string {
 	const atIndex = email.indexOf('@');
 	if (atIndex <= 0) return '***';
 	return `${email[0]}***${email.slice(atIndex)}`;
 }
 
-/**
- * mailboxlayer's error shape, returned with an HTTP 200 status (not a 4xx/5xx)
- * for every documented failure — invalid key, exhausted quota, bad input, etc.
- * all come back as `{ success: false, error: {...} }` on a 200 response, so
- * the only way to detect them is to check `success` in the parsed body.
- */
 interface MailboxLayerErrorBody {
 	success: false;
 	error: {
@@ -102,23 +82,18 @@ function isMailboxLayerErrorBody(
 	);
 }
 
-/**
- * Performs a request against the mailboxlayer API.
- *
- * Auth: API key passed as the `access_key` query parameter (the only
- * supported method). All endpoints are GET-only.
- */
 export async function makeMailboxLayerRequest<T>(
 	endpoint: string,
 	accessKey: string,
 	options: {
 		query?: Record<string, string | number | boolean | undefined>;
+		useHttps?: boolean;
 	} = {},
 ): Promise<T> {
-	const { query = {} } = options;
+	const { query = {}, useHttps } = options;
 
 	const config: OpenAPIConfig = {
-		BASE: MAILBOXLAYER_API_BASE,
+		BASE: mailboxLayerApiBase(useHttps !== false),
 		VERSION: '1.0.0',
 		WITH_CREDENTIALS: false,
 		CREDENTIALS: 'omit',

--- a/packages/mailboxlayer/endpoints/check.test.ts
+++ b/packages/mailboxlayer/endpoints/check.test.ts
@@ -1,0 +1,168 @@
+import { AuthMissingError, logEventFromContext } from 'corsair/core';
+import { makeMailboxLayerRequest } from '../client';
+import type { MailboxLayerContext } from '../index';
+import { check } from './check';
+
+jest.mock('../client', () => {
+	const actual = jest.requireActual('../client');
+	return { ...actual, makeMailboxLayerRequest: jest.fn() };
+});
+
+jest.mock('corsair/core', () => {
+	const actual = jest.requireActual('corsair/core');
+	return {
+		...actual,
+		logEventFromContext: jest.fn().mockResolvedValue(null),
+	};
+});
+
+const mockRequest = makeMailboxLayerRequest as jest.MockedFunction<
+	typeof makeMailboxLayerRequest
+>;
+const mockLogEvent = logEventFromContext as jest.MockedFunction<
+	typeof logEventFromContext
+>;
+
+const CHECK_RESPONSE = {
+	email: 'support@apilayer.net',
+	did_you_mean: '',
+	user: 'support',
+	domain: 'apilayer.net',
+	format_valid: true,
+	mx_found: true,
+	smtp_check: true,
+	catch_all: false,
+	role: true,
+	disposable: false,
+	free: false,
+	score: 0.8,
+};
+
+const upsertByEntityId = jest.fn().mockResolvedValue(undefined);
+
+function makeCtx(
+	overrides: Partial<MailboxLayerContext> = {},
+): MailboxLayerContext {
+	return {
+		key: 'test-key',
+		options: {},
+		db: { emailChecks: { upsertByEntityId } },
+		...overrides,
+	} as never;
+}
+
+beforeEach(() => {
+	mockRequest.mockReset();
+	mockLogEvent.mockClear();
+	upsertByEntityId.mockReset();
+	upsertByEntityId.mockResolvedValue(undefined);
+});
+
+describe('email.check', () => {
+	it('throws AuthMissingError when no key is on the context', async () => {
+		await expect(
+			check(makeCtx({ key: undefined }), { email: 'support@apilayer.net' }),
+		).rejects.toBeInstanceOf(AuthMissingError);
+		expect(mockRequest).not.toHaveBeenCalled();
+	});
+
+	it('rejects a malformed email before calling the API', async () => {
+		await expect(
+			check(makeCtx(), { email: 'not-a-valid-email' }),
+		).rejects.toThrow();
+		expect(mockRequest).not.toHaveBeenCalled();
+	});
+
+	it('rejects an empty email before calling the API', async () => {
+		await expect(check(makeCtx(), { email: '' })).rejects.toThrow();
+		expect(mockRequest).not.toHaveBeenCalled();
+	});
+
+	it('calls check with smtp=1 by default and persists the result', async () => {
+		mockRequest.mockResolvedValue(CHECK_RESPONSE);
+
+		const result = await check(makeCtx(), { email: 'support@apilayer.net' });
+
+		expect(mockRequest).toHaveBeenCalledWith('check', 'test-key', {
+			query: {
+				email: 'support@apilayer.net',
+				smtp: 1,
+				format: 1,
+			},
+			useHttps: undefined,
+		});
+		expect(result.email).toBe('support@apilayer.net');
+		expect(upsertByEntityId).toHaveBeenCalledWith('support@apilayer.net', {
+			email: 'support@apilayer.net',
+			didYouMean: '',
+			user: 'support',
+			domain: 'apilayer.net',
+			formatValid: true,
+			mxFound: true,
+			smtpCheck: true,
+			catchAll: false,
+			role: true,
+			disposable: false,
+			free: false,
+			score: 0.8,
+			checkedAt: expect.any(Date),
+		});
+		expect(mockLogEvent).toHaveBeenCalledWith(
+			expect.anything(),
+			'mailboxlayer.email.check',
+			{ email: 's***@apilayer.net' },
+			'completed',
+		);
+	});
+
+	it('sends smtp=0 when smtp is false', async () => {
+		mockRequest.mockResolvedValue(CHECK_RESPONSE);
+
+		await check(makeCtx(), { email: 'support@apilayer.net', smtp: false });
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'check',
+			'test-key',
+			expect.objectContaining({
+				query: expect.objectContaining({ smtp: 0 }),
+			}),
+		);
+	});
+
+	it('forwards useHttps: false so free-tier keys can use HTTP', async () => {
+		mockRequest.mockResolvedValue(CHECK_RESPONSE);
+
+		await check(makeCtx({ options: { useHttps: false } }), {
+			email: 'support@apilayer.net',
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'check',
+			'test-key',
+			expect.objectContaining({ useHttps: false }),
+		);
+	});
+
+	it('does not fail the call when persistence throws', async () => {
+		mockRequest.mockResolvedValue(CHECK_RESPONSE);
+		upsertByEntityId.mockRejectedValueOnce(new Error('db unavailable'));
+		const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+		const result = await check(makeCtx(), { email: 'support@apilayer.net' });
+
+		expect(result.email).toBe('support@apilayer.net');
+		expect(warn).not.toHaveBeenCalled();
+		warn.mockRestore();
+	});
+
+	it('skips persist when db is missing', async () => {
+		mockRequest.mockResolvedValue(CHECK_RESPONSE);
+
+		const result = await check(makeCtx({ db: undefined }), {
+			email: 'support@apilayer.net',
+		});
+
+		expect(result.email).toBe('support@apilayer.net');
+		expect(upsertByEntityId).not.toHaveBeenCalled();
+	});
+});

--- a/packages/mailboxlayer/endpoints/check.test.ts
+++ b/packages/mailboxlayer/endpoints/check.test.ts
@@ -89,7 +89,6 @@ describe('email.check', () => {
 				smtp: 1,
 				format: 1,
 			},
-			useHttps: undefined,
 		});
 		expect(result.email).toBe('support@apilayer.net');
 		expect(upsertByEntityId).toHaveBeenCalledWith('support@apilayer.net', {
@@ -129,17 +128,20 @@ describe('email.check', () => {
 		);
 	});
 
-	it('forwards useHttps: false so free-tier keys can use HTTP', async () => {
+	it('never forwards a useHttps option, even if a caller sets one', async () => {
 		mockRequest.mockResolvedValue(CHECK_RESPONSE);
 
-		await check(makeCtx({ options: { useHttps: false } }), {
-			email: 'support@apilayer.net',
-		});
+		await check(
+			// @ts-expect-error — useHttps is no longer a supported plugin option;
+			// this guards against it being silently reintroduced.
+			makeCtx({ options: { useHttps: false } }),
+			{ email: 'support@apilayer.net' },
+		);
 
 		expect(mockRequest).toHaveBeenCalledWith(
 			'check',
 			'test-key',
-			expect.objectContaining({ useHttps: false }),
+			expect.not.objectContaining({ useHttps: expect.anything() }),
 		);
 	});
 

--- a/packages/mailboxlayer/endpoints/check.ts
+++ b/packages/mailboxlayer/endpoints/check.ts
@@ -2,6 +2,7 @@ import { AuthMissingError, logEventFromContext } from 'corsair/core';
 import { makeMailboxLayerRequest, redactEmail } from '../client';
 import type { MailboxLayerEndpoints } from '../index';
 import type { MailboxLayerEndpointOutputs } from './types';
+import { CheckInputSchema, CheckResponseSchema } from './types';
 
 /**
  * Validate and verify whether an email address is correctly formatted,
@@ -16,15 +17,21 @@ export const check: MailboxLayerEndpoints['check'] = async (ctx, input) => {
 		throw new AuthMissingError('mailboxlayer', 'api_key');
 	}
 
-	const response = await makeMailboxLayerRequest<
+	const { email, smtp } = CheckInputSchema.parse(input);
+
+	const rawResponse = await makeMailboxLayerRequest<
 		MailboxLayerEndpointOutputs['check']
 	>('check', ctx.key, {
 		query: {
-			email: input.email,
-			smtp: input.smtp === false ? 0 : 1,
+			email,
+			smtp: smtp === false ? 0 : 1,
 			format: 1,
 		},
 	});
+
+	// mailboxlayer's response shape isn't guaranteed to match our types at
+	// compile time — validate it at runtime before trusting or persisting it.
+	const response = CheckResponseSchema.parse(rawResponse);
 
 	if (ctx.db.emailChecks) {
 		try {
@@ -51,7 +58,7 @@ export const check: MailboxLayerEndpoints['check'] = async (ctx, input) => {
 	await logEventFromContext(
 		ctx,
 		'mailboxlayer.email.check',
-		{ email: redactEmail(input.email) },
+		{ email: redactEmail(email) },
 		'completed',
 	);
 

--- a/packages/mailboxlayer/endpoints/check.ts
+++ b/packages/mailboxlayer/endpoints/check.ts
@@ -4,14 +4,6 @@ import type { MailboxLayerEndpoints } from '../index';
 import type { MailboxLayerEndpointOutputs } from './types';
 import { CheckInputSchema, CheckResponseSchema } from './types';
 
-/**
- * Validate and verify whether an email address is correctly formatted,
- * has valid MX records, and is deliverable via SMTP. Use after collecting
- * an email address to confirm deliverability before sending to it.
- *
- * API: GET apilayer.net/api/check
- * Docs: https://docs.apilayer.com/mailboxlayer/docs/api-documentation
- */
 export const check: MailboxLayerEndpoints['check'] = async (ctx, input) => {
 	if (!ctx.key) {
 		throw new AuthMissingError('mailboxlayer', 'api_key');
@@ -27,15 +19,14 @@ export const check: MailboxLayerEndpoints['check'] = async (ctx, input) => {
 			smtp: smtp === false ? 0 : 1,
 			format: 1,
 		},
+		useHttps: ctx.options.useHttps,
 	});
 
-	// mailboxlayer's response shape isn't guaranteed to match our types at
-	// compile time — validate it at runtime before trusting or persisting it.
 	const response = CheckResponseSchema.parse(rawResponse);
 
-	if (ctx.db.emailChecks) {
-		try {
-			await ctx.db.emailChecks.upsertByEntityId(response.email, {
+	if (ctx.db?.emailChecks) {
+		await ctx.db.emailChecks
+			.upsertByEntityId(response.email, {
 				email: response.email,
 				didYouMean: response.did_you_mean,
 				user: response.user,
@@ -49,10 +40,8 @@ export const check: MailboxLayerEndpoints['check'] = async (ctx, input) => {
 				free: response.free,
 				score: response.score,
 				checkedAt: new Date(),
-			});
-		} catch (error) {
-			console.warn('Failed to save email check result to database:', error);
-		}
+			})
+			.catch(() => undefined);
 	}
 
 	await logEventFromContext(

--- a/packages/mailboxlayer/endpoints/check.ts
+++ b/packages/mailboxlayer/endpoints/check.ts
@@ -19,7 +19,6 @@ export const check: MailboxLayerEndpoints['check'] = async (ctx, input) => {
 			smtp: smtp === false ? 0 : 1,
 			format: 1,
 		},
-		useHttps: ctx.options.useHttps,
 	});
 
 	const response = CheckResponseSchema.parse(rawResponse);

--- a/packages/mailboxlayer/endpoints/check.ts
+++ b/packages/mailboxlayer/endpoints/check.ts
@@ -1,0 +1,59 @@
+import { AuthMissingError, logEventFromContext } from 'corsair/core';
+import { makeMailboxLayerRequest, redactEmail } from '../client';
+import type { MailboxLayerEndpoints } from '../index';
+import type { MailboxLayerEndpointOutputs } from './types';
+
+/**
+ * Validate and verify whether an email address is correctly formatted,
+ * has valid MX records, and is deliverable via SMTP. Use after collecting
+ * an email address to confirm deliverability before sending to it.
+ *
+ * API: GET apilayer.net/api/check
+ * Docs: https://docs.apilayer.com/mailboxlayer/docs/api-documentation
+ */
+export const check: MailboxLayerEndpoints['check'] = async (ctx, input) => {
+	if (!ctx.key) {
+		throw new AuthMissingError('mailboxlayer', 'api_key');
+	}
+
+	const response = await makeMailboxLayerRequest<
+		MailboxLayerEndpointOutputs['check']
+	>('check', ctx.key, {
+		query: {
+			email: input.email,
+			smtp: input.smtp === false ? 0 : 1,
+			format: 1,
+		},
+	});
+
+	if (ctx.db.emailChecks) {
+		try {
+			await ctx.db.emailChecks.upsertByEntityId(response.email, {
+				email: response.email,
+				didYouMean: response.did_you_mean,
+				user: response.user,
+				domain: response.domain,
+				formatValid: response.format_valid,
+				mxFound: response.mx_found,
+				smtpCheck: response.smtp_check,
+				catchAll: response.catch_all,
+				role: response.role,
+				disposable: response.disposable,
+				free: response.free,
+				score: response.score,
+				checkedAt: new Date(),
+			});
+		} catch (error) {
+			console.warn('Failed to save email check result to database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'mailboxlayer.email.check',
+		{ email: redactEmail(input.email) },
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/mailboxlayer/endpoints/index.ts
+++ b/packages/mailboxlayer/endpoints/index.ts
@@ -1,0 +1,7 @@
+import { check as emailCheck } from './check';
+
+export const Email = {
+	check: emailCheck,
+};
+
+export * from './types';

--- a/packages/mailboxlayer/endpoints/types.ts
+++ b/packages/mailboxlayer/endpoints/types.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Email Check — GET apilayer.net/api/check
+// Docs: https://docs.apilayer.com/mailboxlayer/docs/api-documentation
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const CheckInputSchema = z.object({
+	/** The email address to validate and verify */
+	email: z.string().describe('The email address to validate and verify'),
+	/**
+	 * Whether to run mailboxlayer's real-time SMTP check. Defaults to true.
+	 * Disable for a faster, format/MX-only check.
+	 */
+	smtp: z
+		.boolean()
+		.optional()
+		.describe(
+			'Whether to run a real-time SMTP check (default true). Set to false for a faster format/MX-only check.',
+		),
+});
+
+export type CheckInput = z.infer<typeof CheckInputSchema>;
+
+export const CheckResponseSchema = z.object({
+	email: z.string(),
+	/** Suggested correction for a likely typo (empty string if none) */
+	did_you_mean: z.string(),
+	/** Local part of the email address, before the @ */
+	user: z.string(),
+	/** Domain part of the email address, after the @ */
+	domain: z.string(),
+	format_valid: z.boolean(),
+	mx_found: z.boolean(),
+	smtp_check: z.boolean(),
+	/** Whether the domain accepts mail for any address (null if undetermined) */
+	catch_all: z.boolean().nullable(),
+	role: z.boolean(),
+	disposable: z.boolean(),
+	free: z.boolean(),
+	/** 0.0-1.0 quality/deliverability score */
+	score: z.number(),
+});
+
+export type CheckResponse = z.infer<typeof CheckResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin Endpoint Input / Output Maps
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type MailboxLayerEndpointInputs = {
+	check: CheckInput;
+};
+
+export type MailboxLayerEndpointOutputs = {
+	check: CheckResponse;
+};
+
+export const MailboxLayerEndpointInputSchemas = {
+	check: CheckInputSchema,
+} as const;
+
+export const MailboxLayerEndpointOutputSchemas = {
+	check: CheckResponseSchema,
+} as const;

--- a/packages/mailboxlayer/endpoints/types.ts
+++ b/packages/mailboxlayer/endpoints/types.ts
@@ -24,7 +24,7 @@ export const CheckResponseSchema = z.object({
 	role: z.boolean(),
 	disposable: z.boolean(),
 	free: z.boolean(),
-	score: z.number(),
+	score: z.number().min(0).max(1),
 });
 
 export type CheckResponse = z.infer<typeof CheckResponseSchema>;

--- a/packages/mailboxlayer/endpoints/types.ts
+++ b/packages/mailboxlayer/endpoints/types.ts
@@ -1,17 +1,7 @@
 import { z } from 'zod';
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Email Check — GET apilayer.net/api/check
-// Docs: https://docs.apilayer.com/mailboxlayer/docs/api-documentation
-// ─────────────────────────────────────────────────────────────────────────────
-
 export const CheckInputSchema = z.object({
-	/** The email address to validate and verify */
-	email: z.string().describe('The email address to validate and verify'),
-	/**
-	 * Whether to run mailboxlayer's real-time SMTP check. Defaults to true.
-	 * Disable for a faster, format/MX-only check.
-	 */
+	email: z.email().describe('The email address to validate and verify'),
 	smtp: z
 		.boolean()
 		.optional()
@@ -24,29 +14,20 @@ export type CheckInput = z.infer<typeof CheckInputSchema>;
 
 export const CheckResponseSchema = z.object({
 	email: z.string(),
-	/** Suggested correction for a likely typo (empty string if none) */
 	did_you_mean: z.string(),
-	/** Local part of the email address, before the @ */
 	user: z.string(),
-	/** Domain part of the email address, after the @ */
 	domain: z.string(),
 	format_valid: z.boolean(),
 	mx_found: z.boolean(),
 	smtp_check: z.boolean(),
-	/** Whether the domain accepts mail for any address (null if undetermined) */
 	catch_all: z.boolean().nullable(),
 	role: z.boolean(),
 	disposable: z.boolean(),
 	free: z.boolean(),
-	/** 0.0-1.0 quality/deliverability score */
 	score: z.number(),
 });
 
 export type CheckResponse = z.infer<typeof CheckResponseSchema>;
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Plugin Endpoint Input / Output Maps
-// ─────────────────────────────────────────────────────────────────────────────
 
 export type MailboxLayerEndpointInputs = {
 	check: CheckInput;

--- a/packages/mailboxlayer/error-handlers.test.ts
+++ b/packages/mailboxlayer/error-handlers.test.ts
@@ -53,8 +53,33 @@ describe('errorHandlers', () => {
 		expect(matchedHandlerName(error)).toBe('RATE_LIMIT_ERROR');
 	});
 
+	it('classifies Too Many Requests as RATE_LIMIT_ERROR', () => {
+		expect(matchedHandlerName(new Error('Too Many Requests'))).toBe(
+			'RATE_LIMIT_ERROR',
+		);
+	});
+
 	it('falls back to DEFAULT for an unrecognized error', () => {
 		const error = new Error('something unexpected');
 		expect(matchedHandlerName(error)).toBe('DEFAULT');
+	});
+
+	it('does not log from handlers', async () => {
+		const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+		const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+		const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+		await errorHandlers.AUTH_ERROR.handler();
+		await errorHandlers.QUOTA_ERROR.handler();
+		await errorHandlers.HTTPS_RESTRICTED_ERROR.handler();
+		await errorHandlers.VALIDATION_ERROR.handler();
+		await errorHandlers.DEFAULT.handler();
+
+		expect(log).not.toHaveBeenCalled();
+		expect(warn).not.toHaveBeenCalled();
+		expect(error).not.toHaveBeenCalled();
+		log.mockRestore();
+		warn.mockRestore();
+		error.mockRestore();
 	});
 });

--- a/packages/mailboxlayer/error-handlers.test.ts
+++ b/packages/mailboxlayer/error-handlers.test.ts
@@ -1,0 +1,60 @@
+import { MailboxLayerAPIError } from './client';
+import { errorHandlers } from './error-handlers';
+
+function apiErrorWithCode(
+	apiCode: number,
+	status?: number,
+): MailboxLayerAPIError {
+	const error = new MailboxLayerAPIError('placeholder', { apiCode });
+	if (status !== undefined) {
+		Object.assign(error, { status });
+	}
+	return error;
+}
+
+function matchedHandlerName(error: Error): string {
+	const name = Object.keys(errorHandlers).find((key) =>
+		errorHandlers[key as keyof typeof errorHandlers].match(error),
+	);
+	if (!name) throw new Error('no handler matched');
+	return name;
+}
+
+describe('errorHandlers', () => {
+	it('classifies apiCode 101 (invalid_access_key) as AUTH_ERROR', () => {
+		expect(matchedHandlerName(apiErrorWithCode(101))).toBe('AUTH_ERROR');
+	});
+
+	it('classifies apiCode 106 (inactive_user) as AUTH_ERROR', () => {
+		expect(matchedHandlerName(apiErrorWithCode(106))).toBe('AUTH_ERROR');
+	});
+
+	it('classifies apiCode 104 (usage_limit_reached) as QUOTA_ERROR, not AUTH_ERROR', () => {
+		expect(matchedHandlerName(apiErrorWithCode(104))).toBe('QUOTA_ERROR');
+	});
+
+	it('classifies apiCode 105 (https_access_restricted) as HTTPS_RESTRICTED_ERROR', () => {
+		expect(matchedHandlerName(apiErrorWithCode(105))).toBe(
+			'HTTPS_RESTRICTED_ERROR',
+		);
+	});
+
+	it('classifies apiCode 210 (no_email_address_supplied) as VALIDATION_ERROR', () => {
+		expect(matchedHandlerName(apiErrorWithCode(210))).toBe('VALIDATION_ERROR');
+	});
+
+	it('classifies apiCode 211 (invalid_email_address) as VALIDATION_ERROR', () => {
+		expect(matchedHandlerName(apiErrorWithCode(211))).toBe('VALIDATION_ERROR');
+	});
+
+	it('classifies a 429 as RATE_LIMIT_ERROR regardless of apiCode', () => {
+		const error = new MailboxLayerAPIError('rate limited');
+		Object.assign(error, { status: 429 });
+		expect(matchedHandlerName(error)).toBe('RATE_LIMIT_ERROR');
+	});
+
+	it('falls back to DEFAULT for an unrecognized error', () => {
+		const error = new Error('something unexpected');
+		expect(matchedHandlerName(error)).toBe('DEFAULT');
+	});
+});

--- a/packages/mailboxlayer/error-handlers.ts
+++ b/packages/mailboxlayer/error-handlers.ts
@@ -1,0 +1,112 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import type { MailboxLayerAPIError } from './client';
+
+function getStatus(error: Error): number | undefined {
+	return (error as Partial<MailboxLayerAPIError>).status;
+}
+
+function getApiCode(error: Error): number | undefined {
+	return (error as Partial<MailboxLayerAPIError>).apiCode;
+}
+
+/**
+ * Error handlers for the mailboxlayer plugin.
+ *
+ * mailboxlayer returns HTTP 200 for every documented failure, with the real
+ * error encoded in the JSON body as `{ success: false, error: { code, type,
+ * info } }` (see client.ts, which throws MailboxLayerAPIError with `apiCode`
+ * set from that body). HTTP-level status handling (429/5xx) is kept as a
+ * fallback for transport-level failures the body-level codes don't cover.
+ *
+ * mailboxlayer error codes:
+ * - 101 invalid_access_key: API key is missing/invalid
+ * - 103 invalid_api_function: wrong endpoint called
+ * - 104 usage_limit_reached: monthly quota exhausted
+ * - 105 https_access_restricted: HTTPS requires a paid plan
+ * - 106 inactive_user: account subscription inactive
+ * - 210 no_email_address_supplied: `email` param missing
+ * - 211 invalid_email_address: `email` param malformed
+ */
+export const errorHandlers = {
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			const code = getApiCode(error);
+			if (code === 101 || code === 106) return true;
+			if (getStatus(error) === 401) return true;
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('invalid_access_key') || msg.includes('inactive_user')
+			);
+		},
+		handler: async () => {
+			console.log(
+				'[MAILBOXLAYER] Authentication failed — check that the access_key is valid and the account is active.',
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	QUOTA_ERROR: {
+		match: (error: Error) => getApiCode(error) === 104,
+		handler: async () => {
+			console.warn(
+				'[MAILBOXLAYER] Request rejected — the monthly usage quota for this plan has been exhausted.',
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	HTTPS_RESTRICTED_ERROR: {
+		match: (error: Error) => getApiCode(error) === 105,
+		handler: async () => {
+			console.warn(
+				'[MAILBOXLAYER] Request rejected — HTTPS access requires a paid mailboxlayer plan.',
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	VALIDATION_ERROR: {
+		match: (error: Error) => {
+			const code = getApiCode(error);
+			return code === 103 || code === 210 || code === 211;
+		},
+		handler: async () => {
+			console.warn(
+				'[MAILBOXLAYER] Request rejected — the email parameter is missing or malformed.',
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (getStatus(error) === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('429') || msg.includes('rate limit');
+		},
+		handler: async (error: Error) => {
+			return {
+				maxRetries: 3,
+				retryStrategy: 'exponential_backoff' as const,
+				headersRetryAfterMs: (error as Partial<MailboxLayerAPIError>)
+					.retryAfter,
+			};
+		},
+	},
+	SERVER_ERROR: {
+		match: (error: Error) => {
+			const status = getStatus(error);
+			if (status !== undefined && status >= 500) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('500') || msg.includes('internal server error');
+		},
+		handler: async () => ({
+			maxRetries: 2,
+			retryStrategy: 'exponential_backoff' as const,
+		}),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async (error: Error) => {
+			console.error(`[MAILBOXLAYER] Unhandled error: ${error.message}`);
+			return { maxRetries: 0 };
+		},
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/mailboxlayer/error-handlers.ts
+++ b/packages/mailboxlayer/error-handlers.ts
@@ -9,24 +9,6 @@ function getApiCode(error: Error): number | undefined {
 	return (error as Partial<MailboxLayerAPIError>).apiCode;
 }
 
-/**
- * Error handlers for the mailboxlayer plugin.
- *
- * mailboxlayer returns HTTP 200 for every documented failure, with the real
- * error encoded in the JSON body as `{ success: false, error: { code, type,
- * info } }` (see client.ts, which throws MailboxLayerAPIError with `apiCode`
- * set from that body). HTTP-level status handling (429/5xx) is kept as a
- * fallback for transport-level failures the body-level codes don't cover.
- *
- * mailboxlayer error codes:
- * - 101 invalid_access_key: API key is missing/invalid
- * - 103 invalid_api_function: wrong endpoint called
- * - 104 usage_limit_reached: monthly quota exhausted
- * - 105 https_access_restricted: HTTPS requires a paid plan
- * - 106 inactive_user: account subscription inactive
- * - 210 no_email_address_supplied: `email` param missing
- * - 211 invalid_email_address: `email` param malformed
- */
 export const errorHandlers = {
 	AUTH_ERROR: {
 		match: (error: Error) => {
@@ -38,48 +20,32 @@ export const errorHandlers = {
 				msg.includes('invalid_access_key') || msg.includes('inactive_user')
 			);
 		},
-		handler: async () => {
-			console.log(
-				'[MAILBOXLAYER] Authentication failed — check that the access_key is valid and the account is active.',
-			);
-			return { maxRetries: 0 };
-		},
+		handler: async () => ({ maxRetries: 0 }),
 	},
 	QUOTA_ERROR: {
 		match: (error: Error) => getApiCode(error) === 104,
-		handler: async () => {
-			console.warn(
-				'[MAILBOXLAYER] Request rejected — the monthly usage quota for this plan has been exhausted.',
-			);
-			return { maxRetries: 0 };
-		},
+		handler: async () => ({ maxRetries: 0 }),
 	},
 	HTTPS_RESTRICTED_ERROR: {
 		match: (error: Error) => getApiCode(error) === 105,
-		handler: async () => {
-			console.warn(
-				'[MAILBOXLAYER] Request rejected — HTTPS access requires a paid mailboxlayer plan.',
-			);
-			return { maxRetries: 0 };
-		},
+		handler: async () => ({ maxRetries: 0 }),
 	},
 	VALIDATION_ERROR: {
 		match: (error: Error) => {
 			const code = getApiCode(error);
 			return code === 103 || code === 210 || code === 211;
 		},
-		handler: async () => {
-			console.warn(
-				'[MAILBOXLAYER] Request rejected — the email parameter is missing or malformed.',
-			);
-			return { maxRetries: 0 };
-		},
+		handler: async () => ({ maxRetries: 0 }),
 	},
 	RATE_LIMIT_ERROR: {
 		match: (error: Error) => {
 			if (getStatus(error) === 429) return true;
 			const msg = error.message.toLowerCase();
-			return msg.includes('429') || msg.includes('rate limit');
+			return (
+				msg.includes('429') ||
+				msg.includes('rate limit') ||
+				msg.includes('too many requests')
+			);
 		},
 		handler: async (error: Error) => {
 			return {
@@ -104,9 +70,6 @@ export const errorHandlers = {
 	},
 	DEFAULT: {
 		match: () => true,
-		handler: async (error: Error) => {
-			console.error(`[MAILBOXLAYER] Unhandled error: ${error.message}`);
-			return { maxRetries: 0 };
-		},
+		handler: async () => ({ maxRetries: 0 }),
 	},
 } satisfies CorsairErrorHandler;

--- a/packages/mailboxlayer/index.ts
+++ b/packages/mailboxlayer/index.ts
@@ -1,0 +1,210 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+} from 'corsair/core';
+import { tryGetStoredKey } from './client';
+import { Email } from './endpoints';
+import type {
+	MailboxLayerEndpointInputs,
+	MailboxLayerEndpointOutputs,
+} from './endpoints/types';
+import {
+	MailboxLayerEndpointInputSchemas,
+	MailboxLayerEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { MailboxLayerSchema } from './schema';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin Options
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type MailboxLayerPluginOptions = {
+	/** Authentication method. Only api_key is supported. */
+	authType?: PickAuth<'api_key'>;
+	/** mailboxlayer access_key */
+	key?: string;
+	/** Optional: lifecycle hooks for endpoints */
+	hooks?: InternalMailboxLayerPlugin['hooks'];
+	/** Optional: custom error handlers (merged with defaults) */
+	errorHandlers?: CorsairErrorHandler;
+	/**
+	 * Permission configuration for the mailboxlayer plugin.
+	 * The only endpoint is read-only, so the default mode is effectively 'open'.
+	 */
+	permissions?: PluginPermissionsConfig<typeof mailboxLayerEndpointsNested>;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Context & Type Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type MailboxLayerContext = CorsairPluginContext<
+	typeof MailboxLayerSchema,
+	MailboxLayerPluginOptions,
+	undefined,
+	typeof mailboxLayerAuthConfig
+>;
+
+export type MailboxLayerKeyBuilderContext = KeyBuilderContext<
+	MailboxLayerPluginOptions,
+	typeof mailboxLayerAuthConfig
+>;
+
+export type MailboxLayerBoundEndpoints = BindEndpoints<
+	typeof mailboxLayerEndpointsNested
+>;
+
+type MailboxLayerEndpoint<K extends keyof MailboxLayerEndpointOutputs> =
+	CorsairEndpoint<
+		MailboxLayerContext,
+		MailboxLayerEndpointInputs[K],
+		MailboxLayerEndpointOutputs[K]
+	>;
+
+export type MailboxLayerEndpoints = {
+	check: MailboxLayerEndpoint<'check'>;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint Tree
+// ─────────────────────────────────────────────────────────────────────────────
+
+const mailboxLayerEndpointsNested = {
+	email: {
+		check: Email.check,
+	},
+} as const;
+
+// No webhooks — mailboxlayer is a pull-based API (no event delivery)
+const mailboxLayerWebhooksNested = {} as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint Schemas (for get_schema / agent introspection)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const mailboxLayerEndpointSchemas = {
+	'email.check': {
+		input: MailboxLayerEndpointInputSchemas.check,
+		output: MailboxLayerEndpointOutputSchemas.check,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<
+	typeof mailboxLayerEndpointsNested
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint Meta (risk levels for permission system)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const mailboxLayerEndpointMeta = {
+	'email.check': {
+		riskLevel: 'read',
+		description:
+			'Validate whether an email address is correctly formatted, has valid MX records, and is deliverable via SMTP',
+	},
+} as const satisfies RequiredPluginEndpointMeta<
+	typeof mailboxLayerEndpointsNested
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Auth Configuration
+// ─────────────────────────────────────────────────────────────────────────────
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+export const mailboxLayerAuthConfig = {
+	api_key: {
+		account: ['one'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type BaseMailboxLayerPlugin<T extends MailboxLayerPluginOptions> =
+	CorsairPlugin<
+		'mailboxlayer',
+		typeof MailboxLayerSchema,
+		typeof mailboxLayerEndpointsNested,
+		typeof mailboxLayerWebhooksNested,
+		T,
+		typeof defaultAuthType,
+		typeof mailboxLayerAuthConfig
+	>;
+
+export type InternalMailboxLayerPlugin =
+	BaseMailboxLayerPlugin<MailboxLayerPluginOptions>;
+
+export type ExternalMailboxLayerPlugin<T extends MailboxLayerPluginOptions> =
+	BaseMailboxLayerPlugin<T>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function mailboxlayer<const T extends MailboxLayerPluginOptions>(
+	incomingOptions: MailboxLayerPluginOptions &
+		// Safe: T extends MailboxLayerPluginOptions, so an empty object is a valid
+		// no-op default when no options are passed. TypeScript requires the cast
+		// because it cannot verify T = {}.
+		T = {} as MailboxLayerPluginOptions & T,
+): ExternalMailboxLayerPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'mailboxlayer',
+		authConfig: mailboxLayerAuthConfig,
+		schema: MailboxLayerSchema,
+		options: options,
+		hooks: options.hooks,
+		webhookHooks: undefined,
+		endpoints: mailboxLayerEndpointsNested,
+		webhooks: mailboxLayerWebhooksNested,
+		endpointMeta: mailboxLayerEndpointMeta,
+		endpointSchemas: mailboxLayerEndpointSchemas,
+		// No webhooks — mailboxlayer is a pull-based API
+		pluginWebhookMatcher: undefined,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: MailboxLayerKeyBuilderContext, source) => {
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint') {
+				const res = await tryGetStoredKey(() => ctx.keys?.get_api_key());
+				return res ?? '';
+			}
+
+			return '';
+		},
+	} satisfies InternalMailboxLayerPlugin;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Type Exports
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type {
+	CheckInput,
+	CheckResponse,
+	MailboxLayerEndpointInputs,
+	MailboxLayerEndpointOutputs,
+} from './endpoints/types';
+
+export { CheckInputSchema, CheckResponseSchema } from './endpoints/types';

--- a/packages/mailboxlayer/index.ts
+++ b/packages/mailboxlayer/index.ts
@@ -29,7 +29,6 @@ import { MailboxLayerSchema } from './schema';
 export type MailboxLayerPluginOptions = {
 	authType?: PickAuth<'api_key'>;
 	key?: string;
-	useHttps?: boolean;
 	hooks?: InternalMailboxLayerPlugin['hooks'];
 	errorHandlers?: CorsairErrorHandler;
 	permissions?: PluginPermissionsConfig<typeof mailboxLayerEndpointsNested>;

--- a/packages/mailboxlayer/index.ts
+++ b/packages/mailboxlayer/index.ts
@@ -12,6 +12,7 @@ import type {
 	RequiredPluginEndpointMeta,
 	RequiredPluginEndpointSchemas,
 } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
 import { tryGetStoredKey } from './client';
 import { Email } from './endpoints';
 import type {
@@ -25,29 +26,14 @@ import {
 import { errorHandlers } from './error-handlers';
 import { MailboxLayerSchema } from './schema';
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Plugin Options
-// ─────────────────────────────────────────────────────────────────────────────
-
 export type MailboxLayerPluginOptions = {
-	/** Authentication method. Only api_key is supported. */
 	authType?: PickAuth<'api_key'>;
-	/** mailboxlayer access_key */
 	key?: string;
-	/** Optional: lifecycle hooks for endpoints */
+	useHttps?: boolean;
 	hooks?: InternalMailboxLayerPlugin['hooks'];
-	/** Optional: custom error handlers (merged with defaults) */
 	errorHandlers?: CorsairErrorHandler;
-	/**
-	 * Permission configuration for the mailboxlayer plugin.
-	 * The only endpoint is read-only, so the default mode is effectively 'open'.
-	 */
 	permissions?: PluginPermissionsConfig<typeof mailboxLayerEndpointsNested>;
 };
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Context & Type Helpers
-// ─────────────────────────────────────────────────────────────────────────────
 
 export type MailboxLayerContext = CorsairPluginContext<
 	typeof MailboxLayerSchema,
@@ -76,22 +62,13 @@ export type MailboxLayerEndpoints = {
 	check: MailboxLayerEndpoint<'check'>;
 };
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Endpoint Tree
-// ─────────────────────────────────────────────────────────────────────────────
-
 const mailboxLayerEndpointsNested = {
 	email: {
 		check: Email.check,
 	},
 } as const;
 
-// No webhooks — mailboxlayer is a pull-based API (no event delivery)
 const mailboxLayerWebhooksNested = {} as const;
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Endpoint Schemas (for get_schema / agent introspection)
-// ─────────────────────────────────────────────────────────────────────────────
 
 export const mailboxLayerEndpointSchemas = {
 	'email.check': {
@@ -101,10 +78,6 @@ export const mailboxLayerEndpointSchemas = {
 } as const satisfies RequiredPluginEndpointSchemas<
 	typeof mailboxLayerEndpointsNested
 >;
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Endpoint Meta (risk levels for permission system)
-// ─────────────────────────────────────────────────────────────────────────────
 
 const mailboxLayerEndpointMeta = {
 	'email.check': {
@@ -116,21 +89,11 @@ const mailboxLayerEndpointMeta = {
 	typeof mailboxLayerEndpointsNested
 >;
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Auth Configuration
-// ─────────────────────────────────────────────────────────────────────────────
-
 const defaultAuthType: AuthTypes = 'api_key' as const;
 
 export const mailboxLayerAuthConfig = {
-	api_key: {
-		account: ['one'] as const,
-	},
+	api_key: {},
 } as const satisfies PluginAuthConfig;
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Plugin Types
-// ─────────────────────────────────────────────────────────────────────────────
 
 export type BaseMailboxLayerPlugin<T extends MailboxLayerPluginOptions> =
 	CorsairPlugin<
@@ -149,21 +112,15 @@ export type InternalMailboxLayerPlugin =
 export type ExternalMailboxLayerPlugin<T extends MailboxLayerPluginOptions> =
 	BaseMailboxLayerPlugin<T>;
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Plugin Factory
-// ─────────────────────────────────────────────────────────────────────────────
-
 export function mailboxlayer<const T extends MailboxLayerPluginOptions>(
 	incomingOptions: MailboxLayerPluginOptions &
-		// Safe: T extends MailboxLayerPluginOptions, so an empty object is a valid
-		// no-op default when no options are passed. TypeScript requires the cast
-		// because it cannot verify T = {}.
 		T = {} as MailboxLayerPluginOptions & T,
 ): ExternalMailboxLayerPlugin<T> {
 	const options = {
 		...incomingOptions,
 		authType: incomingOptions.authType ?? defaultAuthType,
 	};
+	const { DEFAULT: defaultHandler, ...specificDefaults } = errorHandlers;
 	return {
 		id: 'mailboxlayer',
 		authConfig: mailboxLayerAuthConfig,
@@ -175,11 +132,11 @@ export function mailboxlayer<const T extends MailboxLayerPluginOptions>(
 		webhooks: mailboxLayerWebhooksNested,
 		endpointMeta: mailboxLayerEndpointMeta,
 		endpointSchemas: mailboxLayerEndpointSchemas,
-		// No webhooks — mailboxlayer is a pull-based API
 		pluginWebhookMatcher: undefined,
 		errorHandlers: {
-			...errorHandlers,
-			...options.errorHandlers,
+			...specificDefaults,
+			...(options.errorHandlers || {}),
+			DEFAULT: options.errorHandlers?.DEFAULT || defaultHandler,
 		},
 		keyBuilder: async (ctx: MailboxLayerKeyBuilderContext, source) => {
 			if (source === 'endpoint' && options.key) {
@@ -188,17 +145,16 @@ export function mailboxlayer<const T extends MailboxLayerPluginOptions>(
 
 			if (source === 'endpoint') {
 				const res = await tryGetStoredKey(() => ctx.keys?.get_api_key());
-				return res ?? '';
+				if (!res) {
+					throw new AuthMissingError('mailboxlayer', 'api_key');
+				}
+				return res;
 			}
 
-			return '';
+			throw new AuthMissingError('mailboxlayer', 'api_key');
 		},
 	} satisfies InternalMailboxLayerPlugin;
 }
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Type Exports
-// ─────────────────────────────────────────────────────────────────────────────
 
 export type {
 	CheckInput,

--- a/packages/mailboxlayer/integration.test.ts
+++ b/packages/mailboxlayer/integration.test.ts
@@ -1,0 +1,86 @@
+import 'dotenv/config';
+import { createCorsair } from 'corsair/core';
+import { createCorsairOrm } from 'corsair/orm';
+import { createIntegrationAndAccount, createTestDatabase } from 'corsair/tests';
+import { mailboxlayer } from './index';
+
+const ACCESS_KEY = process.env.MAILBOXLAYER_API_KEY;
+const describeIfKey = ACCESS_KEY ? describe : describe.skip;
+
+async function createMailboxLayerClient() {
+	const testDb = createTestDatabase();
+	await createIntegrationAndAccount(testDb.db, 'mailboxlayer', 'default');
+
+	const corsair = createCorsair({
+		plugins: [mailboxlayer({ key: ACCESS_KEY })],
+		database: testDb.db,
+		kek: process.env.CORSAIR_KEK ?? '0123456789abcdef0123456789abcdef',
+	});
+
+	return { corsair, testDb };
+}
+
+describeIfKey('MailboxLayer plugin integration', () => {
+	it('email.check calls the API and persists to DB', async () => {
+		const { corsair, testDb } = await createMailboxLayerClient();
+
+		try {
+			const input = { email: 'support@apilayer.net' };
+			const result = await corsair.mailboxlayer.api.email.check(input);
+
+			expect(result).toBeDefined();
+			expect(result.email).toBe(input.email);
+			expect(typeof result.format_valid).toBe('boolean');
+
+			const orm = createCorsairOrm(testDb.database);
+			const events = await orm.events.findMany({
+				where: { event_type: 'mailboxlayer.email.check' },
+			});
+			expect(events.length).toBeGreaterThan(0);
+
+			const fromDb = await corsair.mailboxlayer.db.emailChecks.findByEntityId(
+				input.email,
+			);
+			expect(fromDb).not.toBeNull();
+			expect(fromDb?.data.email).toBe(input.email);
+			expect(fromDb?.data.formatValid).toBe(result.format_valid);
+		} finally {
+			testDb.cleanup();
+		}
+	});
+
+	it('works with a key from plugin options and no database at all', async () => {
+		const corsair = createCorsair({
+			plugins: [mailboxlayer({ key: ACCESS_KEY })],
+			kek: '0123456789abcdef0123456789abcdef',
+		});
+
+		const result = await corsair.mailboxlayer.api.email.check({
+			email: 'support@apilayer.net',
+		});
+
+		expect(result.email).toBe('support@apilayer.net');
+	});
+});
+
+describe('MailboxLayer plugin auth', () => {
+	it('surfaces an auth error from the API when no key is configured anywhere', async () => {
+		const testDb = createTestDatabase();
+
+		try {
+			await createIntegrationAndAccount(testDb.db, 'mailboxlayer', 'default');
+
+			const corsair = createCorsair({
+				plugins: [mailboxlayer({})],
+				database: testDb.db,
+				kek: process.env.CORSAIR_KEK ?? '0123456789abcdef0123456789abcdef',
+			});
+
+			await expect(
+				corsair.mailboxlayer.api.email.check({ email: 'support@apilayer.net' }),
+			).rejects.toThrow(/auth-missing/);
+		} finally {
+			testDb.cleanup();
+		}
+	});
+});

--- a/packages/mailboxlayer/jest.config.cjs
+++ b/packages/mailboxlayer/jest.config.cjs
@@ -1,0 +1,59 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/db$': '<rootDir>/../corsair/db.ts',
+		'^corsair/orm$': '<rootDir>/../corsair/orm.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^corsair/setup$': '<rootDir>/../corsair/setup.ts',
+		'^corsair/tests$': '<rootDir>/../corsair/tests.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/mailboxlayer/package.json
+++ b/packages/mailboxlayer/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@corsair-dev/mailboxlayer",
+  "version": "0.1.0",
+  "description": "mailboxlayer email validation plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "mailboxlayer",
+    "email-validation",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/mailboxlayer/package.json
+++ b/packages/mailboxlayer/package.json
@@ -14,7 +14,7 @@
     }
   },
   "scripts": {
-    "build": "rm -rf dist && tsc --build --force && tsup",
+    "build": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && tsc --build --force && tsup",
     "typecheck": "tsc --noEmit",
     "test": "jest"
   },

--- a/packages/mailboxlayer/plugin-docs.yaml
+++ b/packages/mailboxlayer/plugin-docs.yaml
@@ -1,1 +1,7 @@
 displayName: MailboxLayer
+overviewNote: |
+  This plugin only ever calls mailboxlayer over HTTPS, since every request
+  carries your `access_key` and the email address being checked as query
+  parameters. mailboxlayer's free-tier plans reject HTTPS entirely (API
+  error 105, `https_access_restricted`) and only work over plain HTTP, so
+  this plugin requires a paid mailboxlayer plan.

--- a/packages/mailboxlayer/plugin-docs.yaml
+++ b/packages/mailboxlayer/plugin-docs.yaml
@@ -1,0 +1,2 @@
+# Overrides for scripts/generate-plugin-docs.ts (optional; commit next to package.json)
+displayName: mailboxlayer

--- a/packages/mailboxlayer/plugin-docs.yaml
+++ b/packages/mailboxlayer/plugin-docs.yaml
@@ -1,2 +1,1 @@
-# Overrides for scripts/generate-plugin-docs.ts (optional; commit next to package.json)
-displayName: mailboxlayer
+displayName: MailboxLayer

--- a/packages/mailboxlayer/plugin.test.ts
+++ b/packages/mailboxlayer/plugin.test.ts
@@ -1,0 +1,71 @@
+import { AuthMissingError } from 'corsair/core';
+import { mailboxLayerAuthConfig, mailboxlayer } from './index';
+
+function keyBuilderOf(plugin: { keyBuilder?: unknown }) {
+	const keyBuilder = plugin.keyBuilder;
+	if (typeof keyBuilder !== 'function') {
+		throw new Error('keyBuilder is not registered');
+	}
+	return keyBuilder as (ctx: unknown, source: string) => Promise<string>;
+}
+
+describe('mailboxlayer plugin registration', () => {
+	it('registers api_key with no webhook tenant leftover', () => {
+		expect(mailboxLayerAuthConfig).toEqual({ api_key: {} });
+	});
+
+	it('returns a direct key when provided', async () => {
+		const keyed = mailboxlayer({ key: 'direct-token' });
+		const token = await keyBuilderOf(keyed)(
+			{ authType: 'api_key' },
+			'endpoint',
+		);
+		expect(token).toBe('direct-token');
+	});
+
+	it('throws AuthMissingError when no key is stored', async () => {
+		const plugin = mailboxlayer();
+		await expect(
+			keyBuilderOf(plugin)(
+				{
+					authType: 'api_key',
+					keys: { get_api_key: async () => null },
+				},
+				'endpoint',
+			),
+		).rejects.toBeInstanceOf(AuthMissingError);
+	});
+
+	it('throws AuthMissingError when the account has no DEK', async () => {
+		const plugin = mailboxlayer();
+		await expect(
+			keyBuilderOf(plugin)(
+				{
+					authType: 'api_key',
+					keys: {
+						get_api_key: async () => {
+							throw new Error(
+								'No DEK found for account (tenant: "default", integration: "mailboxlayer")',
+							);
+						},
+					},
+				},
+				'endpoint',
+			),
+		).rejects.toBeInstanceOf(AuthMissingError);
+	});
+
+	it('keeps DEFAULT last when custom handlers are merged', () => {
+		const plugin = mailboxlayer({
+			errorHandlers: {
+				CUSTOM: {
+					match: () => false,
+					handler: async () => ({ maxRetries: 0 }),
+				},
+			},
+		});
+		const keys = Object.keys(plugin.errorHandlers ?? {});
+		expect(keys.at(-1)).toBe('DEFAULT');
+		expect(keys).toContain('CUSTOM');
+	});
+});

--- a/packages/mailboxlayer/schema.test.ts
+++ b/packages/mailboxlayer/schema.test.ts
@@ -1,0 +1,17 @@
+import { MailboxLayerSchema } from './schema';
+
+describe('MailboxLayer schema', () => {
+	it('declares a semver version', () => {
+		expect(MailboxLayerSchema.version).toBeDefined();
+		expect(MailboxLayerSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map with the email check entity', () => {
+		expect(typeof MailboxLayerSchema.entities).toBe('object');
+		expect(MailboxLayerSchema.entities).not.toBeNull();
+		expect(Object.keys(MailboxLayerSchema.entities)).toContain('emailChecks');
+		for (const entity of Object.values(MailboxLayerSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});

--- a/packages/mailboxlayer/schema/database.ts
+++ b/packages/mailboxlayer/schema/database.ts
@@ -12,7 +12,7 @@ export const MailboxLayerEmailCheck = z.object({
 	role: z.boolean().optional(),
 	disposable: z.boolean().optional(),
 	free: z.boolean().optional(),
-	score: z.number().optional(),
+	score: z.number().min(0).max(1).optional(),
 	checkedAt: z.coerce.date().nullable().optional(),
 });
 

--- a/packages/mailboxlayer/schema/database.ts
+++ b/packages/mailboxlayer/schema/database.ts
@@ -1,9 +1,5 @@
 import { z } from 'zod';
 
-/**
- * Local storage record for an email check lookup.
- * Captures the deliverability/quality verdict returned by mailboxlayer's check endpoint.
- */
 export const MailboxLayerEmailCheck = z.object({
 	email: z.string(),
 	didYouMean: z.string().optional(),

--- a/packages/mailboxlayer/schema/database.ts
+++ b/packages/mailboxlayer/schema/database.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+/**
+ * Local storage record for an email check lookup.
+ * Captures the deliverability/quality verdict returned by mailboxlayer's check endpoint.
+ */
+export const MailboxLayerEmailCheck = z.object({
+	email: z.string(),
+	didYouMean: z.string().optional(),
+	user: z.string().optional(),
+	domain: z.string().optional(),
+	formatValid: z.boolean().optional(),
+	mxFound: z.boolean().optional(),
+	smtpCheck: z.boolean().optional(),
+	catchAll: z.boolean().nullable().optional(),
+	role: z.boolean().optional(),
+	disposable: z.boolean().optional(),
+	free: z.boolean().optional(),
+	score: z.number().optional(),
+	checkedAt: z.coerce.date().nullable().optional(),
+});
+
+export type MailboxLayerEmailCheck = z.infer<typeof MailboxLayerEmailCheck>;

--- a/packages/mailboxlayer/schema/index.ts
+++ b/packages/mailboxlayer/schema/index.ts
@@ -1,0 +1,8 @@
+import { MailboxLayerEmailCheck } from './database';
+
+export const MailboxLayerSchema = {
+	version: '1.0.0',
+	entities: {
+		emailChecks: MailboxLayerEmailCheck,
+	},
+} as const;

--- a/packages/mailboxlayer/tsconfig.json
+++ b/packages/mailboxlayer/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/mailboxlayer/tsup.config.ts
+++ b/packages/mailboxlayer/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3904,6 +3904,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/mailboxlayer:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/mailchimp:
     devDependencies:
       '@types/jest':


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

Adds the Mailboxlayer plugin (`packages/mailboxlayer`), providing real-time
email address validation via the Mailboxlayer API. Exposes a
`checkEmail(email)` operation that returns syntax validity, MX record
lookup, SMTP verification, catch-all detection, role-address detection,
free/disposable provider detection, a "did you mean" typo suggestion, and
a 0–1 deliverability quality score.

Fixes #1249

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)
[
<img width="678" height="216" alt="Screenshot 2026-08-28 at 8 16 48 AM" src="https://github.com/user-attachments/assets/fb880660-8557-4b28-ba6c-a480910e8b46" />
](url)

<!-- If your changes affect the UI or CLI output, please include screenshots or terminal recordings. -->

## Additional Notes

- Auth: API key via `access_key` query parameter (not a header). Free-tier
  key, account-level.
- HTTPS is only available on paid Mailboxlayer plans (Basic and above) —
  the Free plan only supports HTTP. [Note here how you handled this —
  e.g. "Plugin defaults to HTTPS and documents that Free-plan users must
  upgrade for HTTPS support" or whatever approach you took.]
- No webhook support — this API doesn't offer one.
- No breaking changes. No new external dependencies beyond what's needed
  for this plugin package.

<!-- Any other information that reviewers should know? (e.g. breaking changes, new dependencies) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MailboxLayer as a supported provider.
  * Added email verification through the `email.check` endpoint.
  * Supports format, MX, SMTP, disposable, role, catch-all, and quality checks.
  * Validation results can be stored for later lookup.
  * Uses HTTPS authentication with error handling and retry behavior.
  * Requires a MailboxLayer plan that supports HTTPS; free-tier plans are not compatible.
* **Tests**
  * Added coverage for successful checks, invalid addresses, missing credentials, API errors, persistence, and masked email logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->