### PR TITLE
docs(trello): pin list/create-card on the overview

### DIFF
--- a/docs/plugins/trello/overview.mdx
+++ b/docs/plugins/trello/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: "Trello plugin for Corsair"
+description: "Trello plugin for Corsair — cards, boards, and card events."
 ---
 
 Use **Trello** through Corsair: one client, typed API calls, local DB sync, and incoming webhooks.
@@ -92,19 +92,19 @@ const { connectUrl } = await corsair.manage.connect.createLink({
 
 ## Example API calls
 
-**`boards.get`**
+**List cards**
 
 ```ts
 const tenant = corsair.withTenant('acme');
-await tenant.trello.api.boards.get({});
+await tenant.trello.api.cards.list({ listId: '64a1b2c3d4e5f6a7b8c9d0e1' });
 ```
 
 
-**`boards.create`**
+**Create a card**
 
 ```ts
 const tenant = corsair.withTenant('acme');
-await tenant.trello.api.boards.create({});
+await tenant.trello.api.cards.create({ name: 'Follow up from Corsair', idList: '64a1b2c3d4e5f6a7b8c9d0e1' });
 ```
 
 
@@ -112,15 +112,37 @@ See the full list on the [API](/plugins/trello/api) page.
 
 ## Query synced data
 
-Synced entities support `tenant.trello.db.<entity>.search()` and `.list()`: `boards`, `cards`, `labels`, `lists`, `members`.
+Search synced cards without hitting Trello.
 
-See [Database](/plugins/trello/database) for filters and operators.
+```ts
+const tenant = corsair.withTenant('acme');
+const rows = await tenant.trello.db.cards.search({
+	data: { closed: false },
+	limit: 50,
+});
+```
+
+Synced entities: `boards`, `cards`, `labels`, `lists`, `members`. See [Database](/plugins/trello/database) for filters and operators.
 
 ## Webhooks
 
-This plugin registers **6** webhook event types. Configure the provider to POST to your Corsair HTTP handler, then use `webhookHooks` on the plugin factory.
+Fires when a Trello card is created.
 
-See [Webhooks](/plugins/trello/webhooks) for every event path and payload shape, and [Webhooks concept](/concepts/webhooks) for routing.
+```ts
+trello({
+    webhookHooks: {
+        cards: {
+            cardCreated: {
+                after: async (ctx, result) => {
+                    console.log('Trello card created:', result.data);
+                }
+            },
+        },
+    },
+})
+```
+
+Mount your framework handler once (see [Frameworks](/frameworks/next)), then point the provider at that URL. Full event list: [Webhooks](/plugins/trello/webhooks). Concepts: [Webhooks](/concepts/webhooks), [Hooks](/concepts/hooks).
 
 ## What's next
 

--- a/packages/trello/plugin-docs.yaml
+++ b/packages/trello/plugin-docs.yaml
@@ -1,0 +1,25 @@
+displayName: Trello
+description: "Trello plugin for Corsair — cards, boards, and card events."
+examples:
+  read:
+    path: cards.list
+    title: List cards
+    args:
+      listId: 64a1b2c3d4e5f6a7b8c9d0e1
+  write:
+    path: cards.create
+    title: Create a card
+    args:
+      name: Follow up from Corsair
+      idList: 64a1b2c3d4e5f6a7b8c9d0e1
+dbExample:
+  entity: cards
+  note: "Search synced cards without hitting Trello."
+  data:
+    closed: false
+  limit: 50
+exampleWebhook:
+  path: cards.cardCreated
+  note: "Fires when a Trello card is created."
+  after: |
+    console.log('Trello card created:', result.data);


### PR DESCRIPTION
## Description
Adds `packages/trello/plugin-docs.yaml` for the Trello plugin, following the shape used by `packages/slack/plugin-docs.yaml` (fields per `docs/plugins/README.md`). Regenerates the docs so `docs/plugins/trello/overview.mdx` now leads with `cards.list` (read) and `cards.create` (write) as the first examples instead of the `boards.get`/`boards.create` generator defaults, and includes the `dbExample` (synced-card search without hitting Trello) and `exampleWebhook` (`cards.cardCreated`) sections.

No plugin source code was changed — this is docs-generation config plus generated output only.

Fixes #1260

## Checklist
- [x] I have added or updated necessary documentation
- [x] Overview demos list cards and create a card, and generate exits 0

## Screenshots / Demos
<img width="1688" height="941" alt="Screenshot 2026-08-28 at 9 14 00 AM" src="https://github.com/user-attachments/assets/f53227e7-0ed2-4c78-8309-dd7d347e0b41" />


## Additional Notes
- `cards.list` requires `listId`; `cards.create` requires `name` and `idList`. All other example paths left as originally written 
- Command run: `pnpm install && pnpm generate:docs -- --plugin=trello`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Trello documentation to cover cards, boards, and card events.
  * Added examples for listing and creating cards, searching synced cards, and handling card-created webhooks.
  * Added plugin metadata and configuration examples for card operations, database queries, and webhooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->