### PR TITLE
docs(outlook): show mail examples in overview

### DIFF
--- a/docs/plugins/outlook/overview.mdx
+++ b/docs/plugins/outlook/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: "Outlook plugin for Corsair"
+description: "Outlook plugin for Corsair — mail, calendar, and message events."
 ---
 
 Use **Outlook** through Corsair: one client, typed API calls, local DB sync, and incoming webhooks.
@@ -109,19 +109,19 @@ const { connectUrl } = await corsair.manage.connect.createLink({
 
 ## Example API calls
 
-**`calendars.get`**
+**List messages**
 
 ```ts
 const tenant = corsair.withTenant('acme');
-await tenant.outlook.api.calendars.get({});
+await tenant.outlook.api.messages.list({});
 ```
 
 
-**`calendars.create`**
+**Send a message**
 
 ```ts
 const tenant = corsair.withTenant('acme');
-await tenant.outlook.api.calendars.create({});
+await tenant.outlook.api.messages.send({ to: 'you@example.com', subject: 'Hello from Corsair', body: 'Hello from Corsair' });
 ```
 
 
@@ -129,15 +129,37 @@ See the full list on the [API](/plugins/outlook/api) page.
 
 ## Query synced data
 
-Synced entities support `tenant.outlook.db.<entity>.search()` and `.list()`: `calendars`, `contacts`, `events`, `folders`, `messages`.
+Search synced mail without hitting Outlook.
 
-See [Database](/plugins/outlook/database) for filters and operators.
+```ts
+const tenant = corsair.withTenant('acme');
+const rows = await tenant.outlook.db.messages.search({
+	data: { isRead: false },
+	limit: 50,
+});
+```
+
+Synced entities: `calendars`, `contacts`, `events`, `folders`, `messages`. See [Database](/plugins/outlook/database) for filters and operators.
 
 ## Webhooks
 
-This plugin registers **6** webhook event types. Configure the provider to POST to your Corsair HTTP handler, then use `webhookHooks` on the plugin factory.
+Fires when a new Outlook message arrives.
 
-See [Webhooks](/plugins/outlook/webhooks) for every event path and payload shape, and [Webhooks concept](/concepts/webhooks) for routing.
+```ts
+outlook({
+    webhookHooks: {
+        messages: {
+            newMessage: {
+                after: async (ctx, result) => {
+                    console.log('Outlook message:', result.data);
+                }
+            },
+        },
+    },
+})
+```
+
+Mount your framework handler once (see [Frameworks](/frameworks/next)), then point the provider at that URL. Full event list: [Webhooks](/plugins/outlook/webhooks). Concepts: [Webhooks](/concepts/webhooks), [Hooks](/concepts/hooks).
 
 ## What's next
 

--- a/packages/outlook/plugin-docs.yaml
+++ b/packages/outlook/plugin-docs.yaml
@@ -1,0 +1,31 @@
+# Overrides for scripts/generate-plugin-docs.ts
+# Plugin-specific examples; the generator owns shared overview wiring.
+
+displayName: Outlook
+description: "Outlook plugin for Corsair — mail, calendar, and message events."
+recommendedAuth: managed
+
+examples:
+  read:
+    path: messages.list
+    title: List messages
+  write:
+    path: messages.send
+    title: Send a message
+    args:
+      to: you@example.com
+      subject: Hello from Corsair
+      body: Hello from Corsair
+
+dbExample:
+  entity: messages
+  note: "Search synced mail without hitting Outlook."
+  data:
+    isRead: false
+  limit: 50
+
+exampleWebhook:
+  path: messages.newMessage
+  note: "Fires when a new Outlook message arrives."
+  after: |
+    console.log('Outlook message:', result.data);


### PR DESCRIPTION
Closes #1258

## What

- Add Outlook plugin documentation overrides for the generated overview.
- Replace calendar examples with listing messages and sending a message.
- Add synced mail search and new-message webhook examples.

## Testing

Ran the Outlook documentation generator successfully.

Result: 37 API, 5 DB, and 6 webhook entries generated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Outlook plugin documentation to cover mail, calendar, and message events.
  - Added examples for listing and sending messages.
  - Added guidance for searching unread messages.
  - Added a webhook example for newly received messages and framework handler integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->