### PR TITLE
docs(outlook): pin list/send-mail on the overview

### DIFF
--- a/docs/plugins/outlook/overview.mdx
+++ b/docs/plugins/outlook/overview.mdx
@@ -129,15 +129,38 @@ See the full list on the [API](/plugins/outlook/api) page.
 
 ## Query synced data
 
-Synced entities support `tenant.outlook.db.<entity>.search()` and `.list()`: `calendars`, `contacts`, `events`, `folders`, `messages`.
+Search synced messages without hitting the Outlook API.
 
-See [Database](/plugins/outlook/database) for filters and operators.
+```ts
+const tenant = corsair.withTenant('acme');
+const rows = await tenant.outlook.db.messages.search({
+	data: { isRead: false },
+	limit: 50,
+});
+```
+
+Synced entities: `calendars`, `contacts`, `events`, `folders`, `messages`. See [Database](/plugins/outlook/database) for filters and operators.
 
 ## Webhooks
 
-This plugin registers **6** webhook event types. Configure the provider to POST to your Corsair HTTP handler, then use `webhookHooks` on the plugin factory.
+React when a new email is received.
 
-See [Webhooks](/plugins/outlook/webhooks) for every event path and payload shape, and [Webhooks concept](/concepts/webhooks) for routing.
+```ts
+outlook({
+    webhookHooks: {
+        messages: {
+            newMessage: {
+                after: async (ctx, result) => {
+                    const subject = result.data?.subject;
+                    console.log('New Outlook message:', subject);
+                }
+            },
+        },
+    },
+})
+```
+
+Mount your framework handler once (see [Frameworks](/frameworks/next)), then point the provider at that URL. Full event list: [Webhooks](/plugins/outlook/webhooks). Concepts: [Webhooks](/concepts/webhooks), [Hooks](/concepts/hooks).
 
 ## What's next
 

--- a/docs/plugins/outlook/overview.mdx
+++ b/docs/plugins/outlook/overview.mdx
@@ -109,19 +109,19 @@ const { connectUrl } = await corsair.manage.connect.createLink({
 
 ## Example API calls
 
-**`calendars.get`**
+**List messages**
 
 ```ts
 const tenant = corsair.withTenant('acme');
-await tenant.outlook.api.calendars.get({});
+await tenant.outlook.api.messages.list({});
 ```
 
 
-**`calendars.create`**
+**Send a message**
 
 ```ts
 const tenant = corsair.withTenant('acme');
-await tenant.outlook.api.calendars.create({});
+await tenant.outlook.api.messages.send({ subject: 'Hello from Corsair', body: 'This is a test email.', to: 'hello@example.com' });
 ```
 
 

--- a/packages/outlook/plugin-docs.yaml
+++ b/packages/outlook/plugin-docs.yaml
@@ -1,0 +1,15 @@
+displayName: Outlook
+description: "Outlook plugin for Corsair"
+recommendedAuth: managed
+
+examples:
+  read:
+    path: messages.list
+    title: List messages
+  write:
+    path: messages.send
+    title: Send a message
+    args:
+      subject: "Hello from Corsair"
+      body: "This is a test email."
+      to: "hello@example.com"

--- a/packages/outlook/plugin-docs.yaml
+++ b/packages/outlook/plugin-docs.yaml
@@ -13,3 +13,17 @@ examples:
       subject: "Hello from Corsair"
       body: "This is a test email."
       to: "hello@example.com"
+
+dbExample:
+  entity: messages
+  note: "Search synced messages without hitting the Outlook API."
+  data:
+    isRead: false
+  limit: 50
+
+exampleWebhook:
+  path: messages.newMessage
+  note: "React when a new email is received."
+  after: |
+    const subject = result.data?.subject;
+    console.log('New Outlook message:', subject);


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

This PR addresses issue #1258 by adding Outlook plugin documentation configuration and pinning the `messages.list` and `messages.send` examples on the Outlook overview.

Fixes #1258

## Checklist

Before submitting your PR, please verify the following:

- [ ] I have run `pnpm lint` and all checks pass
- [ ] I have run `pnpm typecheck` and there are no TypeScript errors
- [ ] I have run `pnpm build` and all packages build successfully
- [ ] I have run `pnpm test` and all tests pass
- [ ] I have added or updated tests where applicable
- [ ] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

<!-- If your changes affect the UI or CLI output, please include screenshots or terminal recordings. -->

## Additional Notes

<!-- Any other information that reviewers should know? (e.g. breaking changes, new dependencies) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Outlook plugin examples to demonstrate listing and sending messages.
  - Added guidance for searching synced messages without contacting Outlook.
  - Added webhook configuration examples for reacting to new messages.
  - Added Outlook plugin documentation metadata, including display information, authentication guidance, and read/write operation examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->