### PR TITLE
docs(resend): pin list/send on overview

### DIFF
--- a/docs/plugins/resend/overview.mdx
+++ b/docs/plugins/resend/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: "Resend plugin for Corsair"
+description: "Resend plugin for Corsair — transactional email send, list, and delivery events."
 ---
 
 Use **Resend** through Corsair: one client, typed API calls, local DB sync, and incoming webhooks.
@@ -92,19 +92,24 @@ const { connectUrl } = await corsair.manage.connect.createLink({
 
 ## Example API calls
 
-**`contacts.get`**
+**List emails**
 
 ```ts
 const tenant = corsair.withTenant('acme');
-await tenant.resend.api.contacts.get({});
+await tenant.resend.api.emails.list({});
 ```
 
 
-**`contacts.create`**
+**Send an email**
 
 ```ts
 const tenant = corsair.withTenant('acme');
-await tenant.resend.api.contacts.create({});
+await tenant.resend.api.emails.send({
+	from: 'corsair@example.com',
+	to: 'you@example.com',
+	subject: 'Hello from Corsair',
+	text: 'Hello from Corsair',
+});
 ```
 
 
@@ -112,15 +117,37 @@ See the full list on the [API](/plugins/resend/api) page.
 
 ## Query synced data
 
-Synced entities support `tenant.resend.db.<entity>.search()` and `.list()`: `contacts`, `domains`, `emails`.
+Search synced emails without hitting Resend.
 
-See [Database](/plugins/resend/database) for filters and operators.
+```ts
+const tenant = corsair.withTenant('acme');
+const rows = await tenant.resend.db.emails.search({
+	data: {},
+	limit: 50,
+});
+```
+
+Synced entities: `contacts`, `domains`, `emails`. See [Database](/plugins/resend/database) for filters and operators.
 
 ## Webhooks
 
-This plugin registers **16** webhook event types. Configure the provider to POST to your Corsair HTTP handler, then use `webhookHooks` on the plugin factory.
+Fires when Resend accepts an outbound email.
 
-See [Webhooks](/plugins/resend/webhooks) for every event path and payload shape, and [Webhooks concept](/concepts/webhooks) for routing.
+```ts
+resend({
+    webhookHooks: {
+        emails: {
+            sent: {
+                after: async (ctx, result) => {
+                    console.log('Email sent:', result.data);
+                }
+            },
+        },
+    },
+})
+```
+
+Mount your framework handler once (see [Frameworks](/frameworks/next)), then point the provider at that URL. Full event list: [Webhooks](/plugins/resend/webhooks). Concepts: [Webhooks](/concepts/webhooks), [Hooks](/concepts/hooks).
 
 ## What's next
 

--- a/packages/resend/plugin-docs.yaml
+++ b/packages/resend/plugin-docs.yaml
@@ -1,0 +1,29 @@
+# Overrides for scripts/generate-plugin-docs.ts
+# Plugin-specific examples; the generator owns Hub-shaped wiring and shared copy.
+
+displayName: Resend
+description: "Resend plugin for Corsair — transactional email send, list, and delivery events."
+
+examples:
+  read:
+    path: emails.list
+    title: List emails
+  write:
+    path: emails.send
+    title: Send an email
+    args:
+      from: corsair@example.com
+      to: you@example.com
+      subject: Hello from Corsair
+      text: Hello from Corsair
+
+dbExample:
+  entity: emails
+  note: "Search synced emails without hitting Resend."
+  limit: 50
+
+exampleWebhook:
+  path: emails.sent
+  note: "Fires when Resend accepts an outbound email."
+  after: |
+    console.log('Email sent:', result.data);


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

Adds Resend-specific documentation overrides so the generated Resend overview uses `emails.list` and `emails.send` as the primary API examples instead of the generator defaults.

Also configures the generated database and webhook examples for Resend.

Closes #1253

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

Not applicable — documentation-only change.

## Additional Notes

- Added `packages/resend/plugin-docs.yaml`.
- Regenerated `docs/plugins/resend/overview.mdx` using `pnpm generate:docs -- --plugin=resend`.
- No Resend plugin source code was changed.
- The documentation generator completed successfully with exit code 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Resend plugin guide to cover transactional email sending, email listing, and delivery events.
  - Added examples for sending and listing emails, searching synced email data, and configuring webhooks for accepted outbound messages.
  - Added plugin documentation metadata with read/write email examples, synced-data search guidance, and an `emails.sent` webhook example.
  - Clarified how to mount a webhook handler and configure Resend to send events to its URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->