### PR TITLE
docs(posthog): add familiar overview examples

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1478,7 +1478,7 @@
                 ]
               },
               {
-                "group": "Posthog",
+                "group": "PostHog",
                 "pages": [
                   "plugins/posthog/overview",
                   "plugins/posthog/get-credentials",

--- a/docs/plugins/posthog/api.mdx
+++ b/docs/plugins/posthog/api.mdx
@@ -1,6 +1,6 @@
 ---
 title: API
-description: "API reference for Posthog: every `posthog.api.*` operation with input and output types."
+description: "API reference for PostHog: every `posthog.api.*` operation with input and output types."
 ---
 
 Every `posthog.api.*` operation is listed below with parameter shapes and return types from the plugin Zod schemas.

--- a/docs/plugins/posthog/database.mdx
+++ b/docs/plugins/posthog/database.mdx
@@ -1,9 +1,9 @@
 ---
 title: Database
-description: "Posthog local sync: searchable entities, `.search()` filters, and operators."
+description: "PostHog local sync: searchable entities, `.search()` filters, and operators."
 ---
 
-The Posthog plugin syncs data locally. Use `corsair.posthog.db.<entity>.search({ data, limit?, offset? })` with the filters listed per entity.
+The PostHog plugin syncs data locally. Use `corsair.posthog.db.<entity>.search({ data, limit?, offset? })` with the filters listed per entity.
 
 <Info>
 **New to Corsair?** See [database operations](/concepts/database), [data synchronization](/concepts/integrations), and [multi-tenancy](/concepts/multi-tenancy).

--- a/docs/plugins/posthog/overview.mdx
+++ b/docs/plugins/posthog/overview.mdx
@@ -1,9 +1,9 @@
 ---
 title: Overview
-description: "Posthog plugin for Corsair"
+description: "PostHog plugin for Corsair — analytics events and event capture."
 ---
 
-Use **Posthog** through Corsair: one client, typed API calls, local DB sync, and incoming webhooks.
+Use **PostHog** through Corsair: one client, typed API calls, local DB sync, and incoming webhooks.
 
 **What you get:**
 
@@ -97,11 +97,11 @@ const { connectUrl } = await corsair.manage.connect.createLink({
 _No read-style endpoint inferred; pick any operation from the [API](/plugins/posthog/api) reference._
 
 
-**`events.aliasCreate`**
+**Capture an event**
 
 ```ts
 const tenant = corsair.withTenant('acme');
-await tenant.posthog.api.events.aliasCreate({});
+await tenant.posthog.api.events.eventCreate({ distinct_id: 'abc123', event: 'corsair_example' });
 ```
 
 
@@ -109,15 +109,37 @@ See the full list on the [API](/plugins/posthog/api) page.
 
 ## Query synced data
 
-Synced entities support `tenant.posthog.db.<entity>.search()` and `.list()`: `events`.
+Search synced events without hitting PostHog.
 
-See [Database](/plugins/posthog/database) for filters and operators.
+```ts
+const tenant = corsair.withTenant('acme');
+const rows = await tenant.posthog.db.events.search({
+	data: {},
+	limit: 50,
+});
+```
+
+Synced entities: `events`. See [Database](/plugins/posthog/database) for filters and operators.
 
 ## Webhooks
 
-This plugin registers **1** webhook event type. Configure the provider to POST to your Corsair HTTP handler, then use `webhookHooks` on the plugin factory.
+Fires when a PostHog event is captured.
 
-See [Webhooks](/plugins/posthog/webhooks) for every event path and payload shape, and [Webhooks concept](/concepts/webhooks) for routing.
+```ts
+posthog({
+    webhookHooks: {
+        events: {
+            captured: {
+                after: async (ctx, result) => {
+                    console.log('PostHog event captured:', result.data);
+                }
+            },
+        },
+    },
+})
+```
+
+Mount your framework handler once (see [Frameworks](/frameworks/next)), then point the provider at that URL. Full event list: [Webhooks](/plugins/posthog/webhooks). Concepts: [Webhooks](/concepts/webhooks), [Hooks](/concepts/hooks).
 
 ## What's next
 

--- a/docs/plugins/posthog/webhooks.mdx
+++ b/docs/plugins/posthog/webhooks.mdx
@@ -1,9 +1,9 @@
 ---
 title: Webhooks
-description: "Posthog incoming webhooks: event paths, payloads, and response data."
+description: "PostHog incoming webhooks: event paths, payloads, and response data."
 ---
 
-The Posthog plugin handles incoming webhooks. Point your provider’s subscription URL at your Corsair HTTP handler (see [Overview](/plugins/posthog/overview) for setup context and the exact URL shape).
+The PostHog plugin handles incoming webhooks. Point your provider’s subscription URL at your Corsair HTTP handler (see [Overview](/plugins/posthog/overview) for setup context and the exact URL shape).
 
 <Info>
 **New to Corsair?** See [webhooks](/concepts/webhooks) and [hooks](/concepts/hooks).

--- a/packages/posthog/plugin-docs.yaml
+++ b/packages/posthog/plugin-docs.yaml
@@ -1,0 +1,18 @@
+displayName: PostHog
+description: "PostHog plugin for Corsair — analytics events and event capture."
+examples:
+  write:
+    path: events.eventCreate
+    title: Capture an event
+    args:
+      distinct_id: abc123
+      event: corsair_example
+dbExample:
+  entity: events
+  note: "Search synced events without hitting PostHog."
+  limit: 50
+exampleWebhook:
+  path: events.captured
+  note: "Fires when a PostHog event is captured."
+  after: |
+    console.log('PostHog event captured:', result.data);


### PR DESCRIPTION
## Description

Adds PostHog-specific documentation overrides so the generated overview uses
`events.eventCreate` as the primary API example instead of the generator default.

Also configures the generated database and webhook examples for PostHog.

Closes #1246

## Checklist

- [x] I have added or updated necessary documentation

## Screenshots / Demos

Not applicable — documentation-only change.

## Additional Notes

- Added `packages/posthog/plugin-docs.yaml`.
- Regenerated `docs/plugins/posthog/*.mdx`.
- No PostHog plugin source code was changed.
- Documentation generation completed successfully with exit code 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected PostHog branding and capitalization across plugin documentation and navigation.
  * Added clearer examples for capturing events, querying synced data, and handling captured-event webhooks.
  * Added plugin metadata and usage examples for the documentation catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->