### PR TITLE
docs(resend): pin list/send on the overview

### DIFF
--- a/docs/plugins/resend/overview.mdx
+++ b/docs/plugins/resend/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: "Resend plugin for Corsair"
+description: "Resend plugin for Corsair — transactional email send, list, and delivery events."
 ---
 
 Use **Resend** through Corsair: one client, typed API calls, local DB sync, and incoming webhooks.
@@ -92,19 +92,24 @@ const { connectUrl } = await corsair.manage.connect.createLink({
 
 ## Example API calls
 
-**`contacts.get`**
+**List emails**
 
 ```ts
 const tenant = corsair.withTenant('acme');
-await tenant.resend.api.contacts.get({});
+await tenant.resend.api.emails.list({});
 ```
 
 
-**`contacts.create`**
+**Send an email**
 
 ```ts
 const tenant = corsair.withTenant('acme');
-await tenant.resend.api.contacts.create({});
+await tenant.resend.api.emails.send({
+	from: 'corsair@example.com',
+	to: 'you@example.com',
+	subject: 'Hello from Corsair',
+	text: 'Hello from Corsair',
+});
 ```
 
 
@@ -112,15 +117,37 @@ See the full list on the [API](/plugins/resend/api) page.
 
 ## Query synced data
 
-Synced entities support `tenant.resend.db.<entity>.search()` and `.list()`: `contacts`, `domains`, `emails`.
+Search synced emails without hitting Resend.
 
-See [Database](/plugins/resend/database) for filters and operators.
+```ts
+const tenant = corsair.withTenant('acme');
+const rows = await tenant.resend.db.emails.search({
+	data: {},
+	limit: 50,
+});
+```
+
+Synced entities: `contacts`, `domains`, `emails`. See [Database](/plugins/resend/database) for filters and operators.
 
 ## Webhooks
 
-This plugin registers **16** webhook event types. Configure the provider to POST to your Corsair HTTP handler, then use `webhookHooks` on the plugin factory.
+Fires when Resend accepts an outbound email.
 
-See [Webhooks](/plugins/resend/webhooks) for every event path and payload shape, and [Webhooks concept](/concepts/webhooks) for routing.
+```ts
+resend({
+    webhookHooks: {
+        emails: {
+            sent: {
+                after: async (ctx, result) => {
+                    console.log('Email sent:', result.data);
+                }
+            },
+        },
+    },
+})
+```
+
+Mount your framework handler once (see [Frameworks](/frameworks/next)), then point the provider at that URL. Full event list: [Webhooks](/plugins/resend/webhooks). Concepts: [Webhooks](/concepts/webhooks), [Hooks](/concepts/hooks).
 
 ## What's next
 

--- a/packages/resend/plugin-docs.yaml
+++ b/packages/resend/plugin-docs.yaml
@@ -1,0 +1,23 @@
+displayName: Resend
+description: "Resend plugin for Corsair — transactional email send, list, and delivery events."
+examples:
+  read:
+    path: emails.list
+    title: List emails
+  write:
+    path: emails.send
+    title: Send an email
+    args:
+      from: corsair@example.com
+      to: you@example.com
+      subject: Hello from Corsair
+      text: Hello from Corsair
+dbExample:
+  entity: emails
+  note: "Search synced emails without hitting Resend."
+  limit: 50
+exampleWebhook:
+  path: emails.sent
+  note: "Fires when Resend accepts an outbound email."
+  after: |
+    console.log('Email sent:', result.data);


### PR DESCRIPTION
## Description

Adds `packages/resend/plugin-docs.yaml` and regenerates `docs/plugins/resend/overview.mdx` so the overview demos `emails.list`/`emails.send` instead of the generator-default `domains.get`/`domains.create`. Also adds the DB search example (`emails`, limited to 50) and the `emails.sent` webhook example, following the same shape as `packages/slack/plugin-docs.yaml`.

Fixes #1253

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [ ] I have run `pnpm build` and all packages build successfully
- [ ] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable — not applicable, docs-only change, no source touched
- [x] I have added or updated necessary documentation

## Additional Notes

Docs-only PR: `packages/resend/plugin-docs.yaml` plus the `docs/plugins/resend/overview.mdx` output of `pnpm generate:docs -- --plugin=resend`. No plugin source changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Resend plugin overview with clearer coverage of transactional email sending, listing, and delivery events.
  - Added practical examples for listing and sending emails, searching synced email data, and handling sent-email webhooks.
  - Added plugin metadata with display information and representative API, database, and webhook examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->