### PR TITLE
fix: keep the hero headline readable in dark mode

### DIFF
--- a/www/src/components/landing/hero/landing-hero.tsx
+++ b/www/src/components/landing/hero/landing-hero.tsx
@@ -27,7 +27,7 @@ export function LandingHero({ starCount }: { starCount?: number | null }) {
 				<div className="flex w-full flex-col items-center gap-4 sm:max-w-[360px] sm:gap-5 md:max-w-[720px]">
 					{/* High-Fidelity Typography Headline */}
 					<h1 className="animate-hero-fade-up delay-[100ms] w-full text-[clamp(2.25rem,6vw,4.5rem)] font-light leading-[1.05] tracking-tight text-[#1c1c1c]">
-						<span className="font-[family-name:var(--landing-font-serif)] italic text-transparent bg-clip-text bg-gradient-to-br from-[#1c1c1c] to-[#555] pr-1.5">
+						<span className="font-[family-name:var(--landing-font-serif)] italic pr-1.5">
 							Add any integration
 						</span>{' '}
 						<br className="hidden sm:block" />

--- a/www/src/components/landing/theme.css
+++ b/www/src/components/landing/theme.css
@@ -18,6 +18,7 @@
 		0 14px 80px 0 rgba(0, 0, 0, 0.26), 0 4px 12px 0 rgba(0, 0, 0, 0.08);
 	color: var(--landing-black);
 	font-family: var(--landing-font-sans);
+	color-scheme: only light;
 }
 
 .landing *,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the landing page hero headline for improved readability and consistent text coloring.
  * Ensured the landing page remains in light mode for a consistent visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->