### PR TITLE
feat(newsapi): add newsapi plugin

### DIFF
--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -13,7 +13,6 @@ export type AllErrors =
 	| (string & {});
 
 export const BaseProviders = [
-	'dropboxsign',
 	'ably',
 	'abstract',
 	'abuseipdb',
@@ -124,6 +123,7 @@ export const BaseProviders = [
 	'doppler',
 	'dreamstudio',
 	'dropbox',
+	'dropboxsign',
 	'epicgames',
 	'exa',
 	'facebook',
@@ -172,6 +172,7 @@ export const BaseProviders = [
 	'merriamwebsterdict',
 	'monday',
 	'neon',
+	'newsapi',
 	'nextdns',
 	'notion',
 	'ocrspace',
@@ -405,6 +406,7 @@ export const ProviderDisplayNames = {
 	merriamwebsterdict: 'Merriam-Webster Dictionary',
 	monday: 'Monday',
 	neon: 'Neon',
+	newsapi: 'News API',
 	nextdns: 'NextDNS',
 	notion: 'Notion',
 	ocrspace: 'OCR.space',
@@ -644,6 +646,7 @@ export type AllProviders =
 	| 'merriamwebsterdict'
 	| 'monday'
 	| 'neon'
+	| 'newsapi'
 	| 'nextdns'
 	| 'notion'
 	| 'ocrspace'

--- a/packages/newsapi/api.test.ts
+++ b/packages/newsapi/api.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Live checks against newsapi.org.
+ *
+ * Skipped unless `NEWSAPI_API_KEY` is set, and excluded from CI by the test
+ * command's `--testPathIgnorePatterns`. What it verifies is the thing mocks
+ * cannot: that the routes and parameter names in this package still match
+ * the provider, and that the output schemas still accept what it sends.
+ */
+import 'dotenv/config';
+import { makeNewsApiRequest } from './client';
+import type {
+	GetEverythingResponse,
+	GetTopHeadlinesResponse,
+	GetV1ArticlesResponse,
+	SourcesListResponse,
+} from './endpoints/types';
+import { NewsApiEndpointOutputSchemas } from './endpoints/types';
+
+const TEST_API_KEY = process.env.NEWSAPI_API_KEY;
+const describeLive = TEST_API_KEY ? describe : describe.skip;
+
+describeLive('News API live checks', () => {
+	jest.setTimeout(30_000);
+	const key = TEST_API_KEY as string;
+
+	it('articlesGetEverything returns the declared shape', async () => {
+		const response = await makeNewsApiRequest<GetEverythingResponse>(
+			'v2/everything',
+			key,
+			{ query: { q: 'technology', pageSize: 5 } },
+		);
+
+		expect(
+			NewsApiEndpointOutputSchemas.articlesGetEverything.safeParse(response)
+				.success,
+		).toBe(true);
+	});
+
+	it('articlesGetTopHeadlines returns the declared shape', async () => {
+		const response = await makeNewsApiRequest<GetTopHeadlinesResponse>(
+			'v2/top-headlines',
+			key,
+			{ query: { country: 'us', pageSize: 5 } },
+		);
+
+		expect(
+			NewsApiEndpointOutputSchemas.articlesGetTopHeadlines.safeParse(response)
+				.success,
+		).toBe(true);
+	});
+
+	it('sourcesList returns the declared shape', async () => {
+		const response = await makeNewsApiRequest<SourcesListResponse>(
+			'v2/top-headlines/sources',
+			key,
+			{ query: { language: 'en' } },
+		);
+
+		expect(
+			NewsApiEndpointOutputSchemas.sourcesList.safeParse(response).success,
+		).toBe(true);
+	});
+
+	it('articlesGetV1 returns the declared shape for a known source', async () => {
+		const response = await makeNewsApiRequest<GetV1ArticlesResponse>(
+			'v1/articles',
+			key,
+			{ query: { source: 'techcrunch' } },
+		);
+
+		expect(
+			NewsApiEndpointOutputSchemas.articlesGetV1.safeParse(response).success,
+		).toBe(true);
+	});
+});

--- a/packages/newsapi/api.test.ts
+++ b/packages/newsapi/api.test.ts
@@ -11,8 +11,7 @@ import { makeNewsApiRequest } from './client';
 import type {
 	GetEverythingResponse,
 	GetTopHeadlinesResponse,
-	GetV1ArticlesResponse,
-	SourcesListResponse,
+	SourcesGetResponse,
 } from './endpoints/types';
 import { NewsApiEndpointOutputSchemas } from './endpoints/types';
 
@@ -36,7 +35,7 @@ describeLive('News API live checks', () => {
 		).toBe(true);
 	});
 
-	it('articlesGetTopHeadlines returns the declared shape', async () => {
+	it('headlinesGetTop returns the declared shape', async () => {
 		const response = await makeNewsApiRequest<GetTopHeadlinesResponse>(
 			'v2/top-headlines',
 			key,
@@ -44,32 +43,19 @@ describeLive('News API live checks', () => {
 		);
 
 		expect(
-			NewsApiEndpointOutputSchemas.articlesGetTopHeadlines.safeParse(response)
-				.success,
+			NewsApiEndpointOutputSchemas.headlinesGetTop.safeParse(response).success,
 		).toBe(true);
 	});
 
-	it('sourcesList returns the declared shape', async () => {
-		const response = await makeNewsApiRequest<SourcesListResponse>(
+	it('sourcesGet returns the declared shape', async () => {
+		const response = await makeNewsApiRequest<SourcesGetResponse>(
 			'v2/top-headlines/sources',
 			key,
 			{ query: { language: 'en' } },
 		);
 
 		expect(
-			NewsApiEndpointOutputSchemas.sourcesList.safeParse(response).success,
-		).toBe(true);
-	});
-
-	it('articlesGetV1 returns the declared shape for a known source', async () => {
-		const response = await makeNewsApiRequest<GetV1ArticlesResponse>(
-			'v1/articles',
-			key,
-			{ query: { source: 'techcrunch' } },
-		);
-
-		expect(
-			NewsApiEndpointOutputSchemas.articlesGetV1.safeParse(response).success,
+			NewsApiEndpointOutputSchemas.sourcesGet.safeParse(response).success,
 		).toBe(true);
 	});
 });

--- a/packages/newsapi/client.ts
+++ b/packages/newsapi/client.ts
@@ -7,6 +7,8 @@ export class NewsApiError extends Error {
 		public readonly code?: string,
 		public readonly status?: number,
 		public readonly body?: unknown,
+		/** Milliseconds to wait before retrying, from the provider's Retry-After header. */
+		public readonly retryAfter?: number,
 	) {
 		super(message);
 		this.name = 'NewsApiError';
@@ -52,6 +54,7 @@ export async function makeNewsApiRequest<T>(
 				body?.code,
 				error.status,
 				error.body,
+				error.retryAfter,
 			);
 		}
 		if (error instanceof Error) {

--- a/packages/newsapi/client.ts
+++ b/packages/newsapi/client.ts
@@ -1,0 +1,62 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+
+export class NewsApiError extends Error {
+	constructor(
+		message: string,
+		public readonly code?: string,
+		public readonly status?: number,
+		public readonly body?: unknown,
+	) {
+		super(message);
+		this.name = 'NewsApiError';
+	}
+}
+
+const NEWS_API_BASE = 'https://newsapi.org';
+
+export async function makeNewsApiRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	options: {
+		query?: Record<string, string | number | boolean | undefined>;
+	} = {},
+): Promise<T> {
+	const config: OpenAPIConfig = {
+		BASE: NEWS_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		HEADERS: {
+			'X-Api-Key': apiKey,
+			'Content-Type': 'application/json',
+		},
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method: 'GET',
+		url: endpoint,
+		mediaType: 'application/json; charset=utf-8',
+		query: options.query,
+	};
+
+	try {
+		return await request<T>(config, requestOptions);
+	} catch (error) {
+		if (error instanceof ApiError) {
+			const body = error.body as
+				| { code?: string; message?: string }
+				| undefined;
+			throw new NewsApiError(
+				body?.message ?? error.message,
+				body?.code,
+				error.status,
+				error.body,
+			);
+		}
+		if (error instanceof Error) {
+			throw new NewsApiError(error.message);
+		}
+		throw new NewsApiError('Unknown error');
+	}
+}

--- a/packages/newsapi/endpoints.test.ts
+++ b/packages/newsapi/endpoints.test.ts
@@ -182,6 +182,21 @@ describe('NewsApi endpoints routing & event logging', () => {
 			}),
 		);
 	});
+
+	it('articles.getEverything rejects invalid input before calling the client', async () => {
+		await expect(
+			Articles.getEverything(ctx, { pageSize: 10 } as any),
+		).rejects.toThrow();
+		expect(mockMakeNewsApiRequest).not.toHaveBeenCalled();
+	});
+
+	it('articles.getEverything rejects a malformed provider response', async () => {
+		mockMakeNewsApiRequest.mockResolvedValueOnce({ status: 'ok' } as any);
+
+		await expect(
+			Articles.getEverything(ctx, { q: 'bitcoin' }),
+		).rejects.toThrow();
+	});
 });
 
 describe('NewsApi input validation', () => {

--- a/packages/newsapi/endpoints.test.ts
+++ b/packages/newsapi/endpoints.test.ts
@@ -1,0 +1,223 @@
+import { logEventFromContext } from 'corsair/core';
+import * as client from './client';
+import { Articles, Sources } from './endpoints';
+import { NewsApiEndpointInputSchemas } from './endpoints/types';
+import type { NewsApiContext } from './index';
+
+jest.mock('./client', () => {
+	const actual = jest.requireActual('./client');
+	return {
+		...actual,
+		makeNewsApiRequest: jest.fn(),
+	};
+});
+
+jest.mock('corsair/core', () => {
+	const actual = jest.requireActual('corsair/core');
+	return {
+		...actual,
+		logEventFromContext: jest.fn(),
+	};
+});
+
+describe('NewsApi endpoints routing & event logging', () => {
+	const mockMakeNewsApiRequest =
+		client.makeNewsApiRequest as jest.MockedFunction<
+			typeof client.makeNewsApiRequest
+		>;
+	const mockLogEventFromContext = logEventFromContext as jest.MockedFunction<
+		typeof logEventFromContext
+	>;
+
+	const ctx = {
+		key: 'test-api-key',
+		db: {
+			articles: { upsertByEntityId: jest.fn() },
+			sources: { upsertByEntityId: jest.fn() },
+		},
+	} as unknown as NewsApiContext;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('articles.getEverything issues GET /v2/everything, normalizes csv params, and caches by url', async () => {
+		mockMakeNewsApiRequest.mockResolvedValueOnce({
+			status: 'ok',
+			totalResults: 1,
+			articles: [{ url: 'https://example.com/a', title: 'A' }],
+		} as any);
+
+		const result = await Articles.getEverything(ctx, {
+			q: 'bitcoin',
+			sources: ['bbc-news', 'cnn'],
+			domains: 'techcrunch.com,thenextweb.com',
+		});
+
+		expect(result.totalResults).toBe(1);
+		expect(mockMakeNewsApiRequest).toHaveBeenCalledWith(
+			'v2/everything',
+			'test-api-key',
+			expect.objectContaining({
+				query: expect.objectContaining({
+					q: 'bitcoin',
+					sources: 'bbc-news,cnn',
+					domains: 'techcrunch.com,thenextweb.com',
+				}),
+			}),
+		);
+		expect(ctx.db.articles!.upsertByEntityId).toHaveBeenCalledWith(
+			'https://example.com/a',
+			expect.objectContaining({ url: 'https://example.com/a' }),
+		);
+		expect(mockLogEventFromContext).toHaveBeenCalledWith(
+			ctx,
+			'newsapi.articles.getEverything',
+			expect.any(Object),
+			'completed',
+		);
+	});
+
+	it('articles.getTopHeadlines issues GET /v2/top-headlines and caches articles', async () => {
+		mockMakeNewsApiRequest.mockResolvedValueOnce({
+			status: 'ok',
+			totalResults: 1,
+			articles: [{ url: 'https://example.com/b', title: 'B' }],
+		} as any);
+
+		const result = await Articles.getTopHeadlines(ctx, {
+			country: 'us',
+			category: 'technology',
+		});
+
+		expect(result.articles).toHaveLength(1);
+		expect(mockMakeNewsApiRequest).toHaveBeenCalledWith(
+			'v2/top-headlines',
+			'test-api-key',
+			expect.objectContaining({
+				query: expect.objectContaining({
+					country: 'us',
+					category: 'technology',
+				}),
+			}),
+		);
+		expect(ctx.db.articles!.upsertByEntityId).toHaveBeenCalledWith(
+			'https://example.com/b',
+			expect.objectContaining({ url: 'https://example.com/b' }),
+		);
+	});
+
+	it('articles.getV1 issues GET /v1/articles for the legacy source-based lookup', async () => {
+		mockMakeNewsApiRequest.mockResolvedValueOnce({
+			status: 'ok',
+			source: 'techcrunch',
+			sortBy: 'top',
+			articles: [{ title: 'Legacy article' }],
+		} as any);
+
+		const result = await Articles.getV1(ctx, { source: 'techcrunch' });
+
+		expect(result.source).toBe('techcrunch');
+		expect(mockMakeNewsApiRequest).toHaveBeenCalledWith(
+			'v1/articles',
+			'test-api-key',
+			expect.objectContaining({
+				query: expect.objectContaining({ source: 'techcrunch' }),
+			}),
+		);
+		expect(mockLogEventFromContext).toHaveBeenCalledWith(
+			ctx,
+			'newsapi.articles.getV1',
+			expect.any(Object),
+			'completed',
+		);
+	});
+
+	it('sources.list issues GET /v2/top-headlines/sources and caches by id', async () => {
+		mockMakeNewsApiRequest.mockResolvedValueOnce({
+			status: 'ok',
+			sources: [{ id: 'bbc-news', name: 'BBC News', category: 'general' }],
+		} as any);
+
+		const result = await Sources.list(ctx, { category: 'general' });
+
+		expect(result.sources).toHaveLength(1);
+		expect(mockMakeNewsApiRequest).toHaveBeenCalledWith(
+			'v2/top-headlines/sources',
+			'test-api-key',
+			expect.objectContaining({
+				query: expect.objectContaining({ category: 'general' }),
+			}),
+		);
+		expect(ctx.db.sources!.upsertByEntityId).toHaveBeenCalledWith(
+			'bbc-news',
+			expect.objectContaining({ id: 'bbc-news' }),
+		);
+		expect(mockLogEventFromContext).toHaveBeenCalledWith(
+			ctx,
+			'newsapi.sources.list',
+			expect.any(Object),
+			'completed',
+		);
+	});
+
+	it('sources.list works with no input at all', async () => {
+		mockMakeNewsApiRequest.mockResolvedValueOnce({
+			status: 'ok',
+			sources: [],
+		} as any);
+
+		const result = await Sources.list(ctx, undefined);
+
+		expect(result.sources).toEqual([]);
+		expect(mockMakeNewsApiRequest).toHaveBeenCalledWith(
+			'v2/top-headlines/sources',
+			'test-api-key',
+			expect.objectContaining({
+				query: expect.objectContaining({
+					category: undefined,
+					language: undefined,
+					country: undefined,
+				}),
+			}),
+		);
+	});
+});
+
+describe('NewsApi input validation', () => {
+	it('rejects everything queries missing q, sources, language, and domains', () => {
+		const result = NewsApiEndpointInputSchemas.articlesGetEverything.safeParse({
+			pageSize: 10,
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it('accepts an everything query with only q set', () => {
+		const result = NewsApiEndpointInputSchemas.articlesGetEverything.safeParse({
+			q: 'bitcoin',
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects top-headlines queries that mix sources with country', () => {
+		const result =
+			NewsApiEndpointInputSchemas.articlesGetTopHeadlines.safeParse({
+				sources: 'bbc-news',
+				country: 'us',
+			});
+		expect(result.success).toBe(false);
+	});
+
+	it('accepts top-headlines queries with sources alone', () => {
+		const result =
+			NewsApiEndpointInputSchemas.articlesGetTopHeadlines.safeParse({
+				sources: 'bbc-news',
+			});
+		expect(result.success).toBe(true);
+	});
+
+	it('requires a source for the legacy v1 articles endpoint', () => {
+		const result = NewsApiEndpointInputSchemas.articlesGetV1.safeParse({});
+		expect(result.success).toBe(false);
+	});
+});

--- a/packages/newsapi/endpoints.test.ts
+++ b/packages/newsapi/endpoints.test.ts
@@ -1,6 +1,6 @@
 import { logEventFromContext } from 'corsair/core';
 import * as client from './client';
-import { Articles, Sources } from './endpoints';
+import { Articles, Headlines, Sources } from './endpoints';
 import { NewsApiEndpointInputSchemas } from './endpoints/types';
 import type { NewsApiContext } from './index';
 
@@ -78,14 +78,14 @@ describe('NewsApi endpoints routing & event logging', () => {
 		);
 	});
 
-	it('articles.getTopHeadlines issues GET /v2/top-headlines and caches articles', async () => {
+	it('headlines.getTop issues GET /v2/top-headlines and caches articles', async () => {
 		mockMakeNewsApiRequest.mockResolvedValueOnce({
 			status: 'ok',
 			totalResults: 1,
 			articles: [{ url: 'https://example.com/b', title: 'B' }],
 		} as any);
 
-		const result = await Articles.getTopHeadlines(ctx, {
+		const result = await Headlines.getTop(ctx, {
 			country: 'us',
 			category: 'technology',
 		});
@@ -105,41 +105,21 @@ describe('NewsApi endpoints routing & event logging', () => {
 			'https://example.com/b',
 			expect.objectContaining({ url: 'https://example.com/b' }),
 		);
-	});
-
-	it('articles.getV1 issues GET /v1/articles for the legacy source-based lookup', async () => {
-		mockMakeNewsApiRequest.mockResolvedValueOnce({
-			status: 'ok',
-			source: 'techcrunch',
-			sortBy: 'top',
-			articles: [{ title: 'Legacy article' }],
-		} as any);
-
-		const result = await Articles.getV1(ctx, { source: 'techcrunch' });
-
-		expect(result.source).toBe('techcrunch');
-		expect(mockMakeNewsApiRequest).toHaveBeenCalledWith(
-			'v1/articles',
-			'test-api-key',
-			expect.objectContaining({
-				query: expect.objectContaining({ source: 'techcrunch' }),
-			}),
-		);
 		expect(mockLogEventFromContext).toHaveBeenCalledWith(
 			ctx,
-			'newsapi.articles.getV1',
+			'newsapi.headlines.getTop',
 			expect.any(Object),
 			'completed',
 		);
 	});
 
-	it('sources.list issues GET /v2/top-headlines/sources and caches by id', async () => {
+	it('sources.get issues GET /v2/top-headlines/sources and caches by id', async () => {
 		mockMakeNewsApiRequest.mockResolvedValueOnce({
 			status: 'ok',
 			sources: [{ id: 'bbc-news', name: 'BBC News', category: 'general' }],
 		} as any);
 
-		const result = await Sources.list(ctx, { category: 'general' });
+		const result = await Sources.get(ctx, { category: 'general' });
 
 		expect(result.sources).toHaveLength(1);
 		expect(mockMakeNewsApiRequest).toHaveBeenCalledWith(
@@ -155,19 +135,19 @@ describe('NewsApi endpoints routing & event logging', () => {
 		);
 		expect(mockLogEventFromContext).toHaveBeenCalledWith(
 			ctx,
-			'newsapi.sources.list',
+			'newsapi.sources.get',
 			expect.any(Object),
 			'completed',
 		);
 	});
 
-	it('sources.list works with no input at all', async () => {
+	it('sources.get works with no input at all', async () => {
 		mockMakeNewsApiRequest.mockResolvedValueOnce({
 			status: 'ok',
 			sources: [],
 		} as any);
 
-		const result = await Sources.list(ctx, undefined);
+		const result = await Sources.get(ctx, undefined);
 
 		expect(result.sources).toEqual([]);
 		expect(mockMakeNewsApiRequest).toHaveBeenCalledWith(
@@ -215,24 +195,17 @@ describe('NewsApi input validation', () => {
 	});
 
 	it('rejects top-headlines queries that mix sources with country', () => {
-		const result =
-			NewsApiEndpointInputSchemas.articlesGetTopHeadlines.safeParse({
-				sources: 'bbc-news',
-				country: 'us',
-			});
+		const result = NewsApiEndpointInputSchemas.headlinesGetTop.safeParse({
+			sources: 'bbc-news',
+			country: 'us',
+		});
 		expect(result.success).toBe(false);
 	});
 
 	it('accepts top-headlines queries with sources alone', () => {
-		const result =
-			NewsApiEndpointInputSchemas.articlesGetTopHeadlines.safeParse({
-				sources: 'bbc-news',
-			});
+		const result = NewsApiEndpointInputSchemas.headlinesGetTop.safeParse({
+			sources: 'bbc-news',
+		});
 		expect(result.success).toBe(true);
-	});
-
-	it('requires a source for the legacy v1 articles endpoint', () => {
-		const result = NewsApiEndpointInputSchemas.articlesGetV1.safeParse({});
-		expect(result.success).toBe(false);
 	});
 });

--- a/packages/newsapi/endpoints/articles.ts
+++ b/packages/newsapi/endpoints/articles.ts
@@ -1,0 +1,110 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeNewsApiRequest } from '../client';
+import type { NewsApiEndpoints } from '../index';
+import type { NewsApiEndpointOutputs } from './types';
+
+function toCsv(value: string | string[] | undefined): string | undefined {
+	if (value === undefined) return undefined;
+	return Array.isArray(value) ? value.join(',') : value;
+}
+
+export const getEverything: NewsApiEndpoints['articlesGetEverything'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeNewsApiRequest<
+		NewsApiEndpointOutputs['articlesGetEverything']
+	>('v2/everything', ctx.key, {
+		query: {
+			q: input.q,
+			qInTitle: input.qInTitle,
+			searchIn: input.searchIn,
+			sources: toCsv(input.sources),
+			domains: toCsv(input.domains),
+			excludeDomains: toCsv(input.excludeDomains),
+			from: input.from,
+			to: input.to,
+			language: input.language,
+			sortBy: input.sortBy,
+			pageSize: input.pageSize,
+			page: input.page,
+		},
+	});
+
+	if (ctx.db.articles) {
+		try {
+			for (const article of response.articles) {
+				if (article.url) {
+					await ctx.db.articles.upsertByEntityId(article.url, { ...article });
+				}
+			}
+		} catch (error) {
+			console.warn('Failed to save articles to database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'newsapi.articles.getEverything',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+export const getTopHeadlines: NewsApiEndpoints['articlesGetTopHeadlines'] =
+	async (ctx, input) => {
+		const response = await makeNewsApiRequest<
+			NewsApiEndpointOutputs['articlesGetTopHeadlines']
+		>('v2/top-headlines', ctx.key, {
+			query: {
+				country: input.country,
+				category: input.category,
+				sources: toCsv(input.sources),
+				q: input.q,
+				pageSize: input.pageSize,
+				page: input.page,
+			},
+		});
+
+		if (ctx.db.articles) {
+			try {
+				for (const article of response.articles) {
+					if (article.url) {
+						await ctx.db.articles.upsertByEntityId(article.url, {
+							...article,
+						});
+					}
+				}
+			} catch (error) {
+				console.warn('Failed to save top headlines to database:', error);
+			}
+		}
+
+		await logEventFromContext(
+			ctx,
+			'newsapi.articles.getTopHeadlines',
+			{ ...input },
+			'completed',
+		);
+		return response;
+	};
+
+export const getV1: NewsApiEndpoints['articlesGetV1'] = async (ctx, input) => {
+	const response = await makeNewsApiRequest<
+		NewsApiEndpointOutputs['articlesGetV1']
+	>('v1/articles', ctx.key, {
+		query: {
+			source: input.source,
+			sortBy: input.sortBy,
+		},
+	});
+
+	await logEventFromContext(
+		ctx,
+		'newsapi.articles.getV1',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};

--- a/packages/newsapi/endpoints/articles.ts
+++ b/packages/newsapi/endpoints/articles.ts
@@ -1,7 +1,10 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeNewsApiRequest } from '../client';
 import type { NewsApiEndpoints } from '../index';
-import type { NewsApiEndpointOutputs } from './types';
+import {
+	NewsApiEndpointInputSchemas,
+	NewsApiEndpointOutputSchemas,
+} from './types';
 
 function toCsv(value: string | string[] | undefined): string | undefined {
 	if (value === undefined) return undefined;
@@ -10,11 +13,12 @@ function toCsv(value: string | string[] | undefined): string | undefined {
 
 export const getEverything: NewsApiEndpoints['articlesGetEverything'] = async (
 	ctx,
-	input,
+	rawInput,
 ) => {
-	const response = await makeNewsApiRequest<
-		NewsApiEndpointOutputs['articlesGetEverything']
-	>('v2/everything', ctx.key, {
+	const input =
+		NewsApiEndpointInputSchemas.articlesGetEverything.parse(rawInput);
+
+	const raw = await makeNewsApiRequest('v2/everything', ctx.key, {
 		query: {
 			q: input.q,
 			qInTitle: input.qInTitle,
@@ -30,6 +34,8 @@ export const getEverything: NewsApiEndpoints['articlesGetEverything'] = async (
 			page: input.page,
 		},
 	});
+	const response =
+		NewsApiEndpointOutputSchemas.articlesGetEverything.parse(raw);
 
 	if (ctx.db.articles) {
 		try {
@@ -53,10 +59,11 @@ export const getEverything: NewsApiEndpoints['articlesGetEverything'] = async (
 };
 
 export const getTopHeadlines: NewsApiEndpoints['articlesGetTopHeadlines'] =
-	async (ctx, input) => {
-		const response = await makeNewsApiRequest<
-			NewsApiEndpointOutputs['articlesGetTopHeadlines']
-		>('v2/top-headlines', ctx.key, {
+	async (ctx, rawInput) => {
+		const input =
+			NewsApiEndpointInputSchemas.articlesGetTopHeadlines.parse(rawInput);
+
+		const raw = await makeNewsApiRequest('v2/top-headlines', ctx.key, {
 			query: {
 				country: input.country,
 				category: input.category,
@@ -66,6 +73,8 @@ export const getTopHeadlines: NewsApiEndpoints['articlesGetTopHeadlines'] =
 				page: input.page,
 			},
 		});
+		const response =
+			NewsApiEndpointOutputSchemas.articlesGetTopHeadlines.parse(raw);
 
 		if (ctx.db.articles) {
 			try {
@@ -90,15 +99,19 @@ export const getTopHeadlines: NewsApiEndpoints['articlesGetTopHeadlines'] =
 		return response;
 	};
 
-export const getV1: NewsApiEndpoints['articlesGetV1'] = async (ctx, input) => {
-	const response = await makeNewsApiRequest<
-		NewsApiEndpointOutputs['articlesGetV1']
-	>('v1/articles', ctx.key, {
+export const getV1: NewsApiEndpoints['articlesGetV1'] = async (
+	ctx,
+	rawInput,
+) => {
+	const input = NewsApiEndpointInputSchemas.articlesGetV1.parse(rawInput);
+
+	const raw = await makeNewsApiRequest('v1/articles', ctx.key, {
 		query: {
 			source: input.source,
 			sortBy: input.sortBy,
 		},
 	});
+	const response = NewsApiEndpointOutputSchemas.articlesGetV1.parse(raw);
 
 	await logEventFromContext(
 		ctx,

--- a/packages/newsapi/endpoints/headlines.ts
+++ b/packages/newsapi/endpoints/headlines.ts
@@ -11,31 +11,23 @@ function toCsv(value: string | string[] | undefined): string | undefined {
 	return Array.isArray(value) ? value.join(',') : value;
 }
 
-export const getEverything: NewsApiEndpoints['articlesGetEverything'] = async (
+export const getTop: NewsApiEndpoints['headlinesGetTop'] = async (
 	ctx,
 	rawInput,
 ) => {
-	const input =
-		NewsApiEndpointInputSchemas.articlesGetEverything.parse(rawInput);
+	const input = NewsApiEndpointInputSchemas.headlinesGetTop.parse(rawInput);
 
-	const raw = await makeNewsApiRequest('v2/everything', ctx.key, {
+	const raw = await makeNewsApiRequest('v2/top-headlines', ctx.key, {
 		query: {
-			q: input.q,
-			qInTitle: input.qInTitle,
-			searchIn: input.searchIn,
+			country: input.country,
+			category: input.category,
 			sources: toCsv(input.sources),
-			domains: toCsv(input.domains),
-			excludeDomains: toCsv(input.excludeDomains),
-			from: input.from,
-			to: input.to,
-			language: input.language,
-			sortBy: input.sortBy,
+			q: input.q,
 			pageSize: input.pageSize,
 			page: input.page,
 		},
 	});
-	const response =
-		NewsApiEndpointOutputSchemas.articlesGetEverything.parse(raw);
+	const response = NewsApiEndpointOutputSchemas.headlinesGetTop.parse(raw);
 
 	if (ctx.db.articles) {
 		try {
@@ -45,13 +37,13 @@ export const getEverything: NewsApiEndpoints['articlesGetEverything'] = async (
 				}
 			}
 		} catch (error) {
-			console.warn('Failed to save articles to database:', error);
+			console.warn('Failed to save top headlines to database:', error);
 		}
 	}
 
 	await logEventFromContext(
 		ctx,
-		'newsapi.articles.getEverything',
+		'newsapi.headlines.getTop',
 		{ ...input },
 		'completed',
 	);

--- a/packages/newsapi/endpoints/index.ts
+++ b/packages/newsapi/endpoints/index.ts
@@ -1,0 +1,14 @@
+import { getEverything, getTopHeadlines, getV1 } from './articles';
+import { list } from './sources';
+
+export const Articles = {
+	getEverything,
+	getTopHeadlines,
+	getV1,
+};
+
+export const Sources = {
+	list,
+};
+
+export * from './types';

--- a/packages/newsapi/endpoints/index.ts
+++ b/packages/newsapi/endpoints/index.ts
@@ -1,14 +1,17 @@
-import { getEverything, getTopHeadlines, getV1 } from './articles';
-import { list } from './sources';
+import { getEverything } from './articles';
+import { getTop } from './headlines';
+import { get } from './sources';
 
 export const Articles = {
 	getEverything,
-	getTopHeadlines,
-	getV1,
+};
+
+export const Headlines = {
+	getTop,
 };
 
 export const Sources = {
-	list,
+	get,
 };
 
 export * from './types';

--- a/packages/newsapi/endpoints/sources.ts
+++ b/packages/newsapi/endpoints/sources.ts
@@ -1,18 +1,22 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeNewsApiRequest } from '../client';
 import type { NewsApiEndpoints } from '../index';
-import type { NewsApiEndpointOutputs } from './types';
+import {
+	NewsApiEndpointInputSchemas,
+	NewsApiEndpointOutputSchemas,
+} from './types';
 
-export const list: NewsApiEndpoints['sourcesList'] = async (ctx, input) => {
-	const response = await makeNewsApiRequest<
-		NewsApiEndpointOutputs['sourcesList']
-	>('v2/top-headlines/sources', ctx.key, {
+export const list: NewsApiEndpoints['sourcesList'] = async (ctx, rawInput) => {
+	const input = NewsApiEndpointInputSchemas.sourcesList.parse(rawInput);
+
+	const raw = await makeNewsApiRequest('v2/top-headlines/sources', ctx.key, {
 		query: {
 			category: input?.category,
 			language: input?.language,
 			country: input?.country,
 		},
 	});
+	const response = NewsApiEndpointOutputSchemas.sourcesList.parse(raw);
 
 	if (ctx.db.sources) {
 		try {

--- a/packages/newsapi/endpoints/sources.ts
+++ b/packages/newsapi/endpoints/sources.ts
@@ -1,0 +1,34 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeNewsApiRequest } from '../client';
+import type { NewsApiEndpoints } from '../index';
+import type { NewsApiEndpointOutputs } from './types';
+
+export const list: NewsApiEndpoints['sourcesList'] = async (ctx, input) => {
+	const response = await makeNewsApiRequest<
+		NewsApiEndpointOutputs['sourcesList']
+	>('v2/top-headlines/sources', ctx.key, {
+		query: {
+			category: input?.category,
+			language: input?.language,
+			country: input?.country,
+		},
+	});
+
+	if (ctx.db.sources) {
+		try {
+			for (const source of response.sources) {
+				await ctx.db.sources.upsertByEntityId(source.id, { ...source });
+			}
+		} catch (error) {
+			console.warn('Failed to save sources to database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'newsapi.sources.list',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};

--- a/packages/newsapi/endpoints/sources.ts
+++ b/packages/newsapi/endpoints/sources.ts
@@ -6,8 +6,8 @@ import {
 	NewsApiEndpointOutputSchemas,
 } from './types';
 
-export const list: NewsApiEndpoints['sourcesList'] = async (ctx, rawInput) => {
-	const input = NewsApiEndpointInputSchemas.sourcesList.parse(rawInput);
+export const get: NewsApiEndpoints['sourcesGet'] = async (ctx, rawInput) => {
+	const input = NewsApiEndpointInputSchemas.sourcesGet.parse(rawInput);
 
 	const raw = await makeNewsApiRequest('v2/top-headlines/sources', ctx.key, {
 		query: {
@@ -16,7 +16,7 @@ export const list: NewsApiEndpoints['sourcesList'] = async (ctx, rawInput) => {
 			country: input?.country,
 		},
 	});
-	const response = NewsApiEndpointOutputSchemas.sourcesList.parse(raw);
+	const response = NewsApiEndpointOutputSchemas.sourcesGet.parse(raw);
 
 	if (ctx.db.sources) {
 		try {
@@ -30,7 +30,7 @@ export const list: NewsApiEndpoints['sourcesList'] = async (ctx, rawInput) => {
 
 	await logEventFromContext(
 		ctx,
-		'newsapi.sources.list',
+		'newsapi.sources.get',
 		{ ...input },
 		'completed',
 	);

--- a/packages/newsapi/endpoints/types.ts
+++ b/packages/newsapi/endpoints/types.ts
@@ -1,0 +1,188 @@
+import { z } from 'zod';
+
+const CATEGORY_VALUES = [
+	'business',
+	'entertainment',
+	'general',
+	'health',
+	'science',
+	'sports',
+	'technology',
+] as const;
+
+const StringOrArray = z.union([z.string(), z.array(z.string())]);
+
+// At least one of q, sources, language, or domains must be set or News API
+// returns a `parametersMissing` error — enforced client-side so callers get
+// a clear message instead of a round trip to the provider.
+const ArticlesGetEverythingInputSchema = z
+	.object({
+		q: z.string().optional(),
+		qInTitle: z.string().optional(),
+		searchIn: z.string().optional(),
+		sources: StringOrArray.optional(),
+		domains: StringOrArray.optional(),
+		excludeDomains: StringOrArray.optional(),
+		from: z.string().optional(),
+		to: z.string().optional(),
+		language: z.string().optional(),
+		sortBy: z.enum(['relevancy', 'popularity', 'publishedAt']).optional(),
+		pageSize: z.number().int().min(1).max(100).optional(),
+		page: z.number().int().min(1).optional(),
+	})
+	.refine(
+		(input) =>
+			Boolean(
+				input.q ||
+					input.language ||
+					(Array.isArray(input.sources)
+						? input.sources.length
+						: input.sources) ||
+					(Array.isArray(input.domains) ? input.domains.length : input.domains),
+			),
+		{ message: 'At least one of q, sources, language, or domains is required' },
+	);
+
+// News API rejects `sources` combined with `country` or `category` on
+// top-headlines — enforced client-side for the same reason as above.
+const ArticlesGetTopHeadlinesInputSchema = z
+	.object({
+		country: z.string().length(2).optional(),
+		category: z.enum(CATEGORY_VALUES).optional(),
+		sources: StringOrArray.optional(),
+		q: z.string().optional(),
+		pageSize: z.number().int().min(1).max(100).optional(),
+		page: z.number().int().min(1).optional(),
+	})
+	.refine((input) => !(input.sources && (input.country || input.category)), {
+		message: 'sources cannot be combined with country or category',
+	});
+
+const ArticlesGetV1InputSchema = z.object({
+	source: z.string(),
+	sortBy: z.enum(['top', 'latest', 'popular']).optional(),
+});
+
+const SourcesListInputSchema = z
+	.object({
+		category: z.enum(CATEGORY_VALUES).optional(),
+		language: z.string().optional(),
+		country: z.string().length(2).optional(),
+	})
+	.optional();
+
+export type ArticlesGetEverythingInput = z.infer<
+	typeof ArticlesGetEverythingInputSchema
+>;
+export type ArticlesGetTopHeadlinesInput = z.infer<
+	typeof ArticlesGetTopHeadlinesInputSchema
+>;
+export type ArticlesGetV1Input = z.infer<typeof ArticlesGetV1InputSchema>;
+export type SourcesListInput = z.infer<typeof SourcesListInputSchema>;
+
+export const NewsApiEndpointInputSchemas = {
+	articlesGetEverything: ArticlesGetEverythingInputSchema,
+	articlesGetTopHeadlines: ArticlesGetTopHeadlinesInputSchema,
+	articlesGetV1: ArticlesGetV1InputSchema,
+	sourcesList: SourcesListInputSchema,
+} as const;
+
+export type NewsApiEndpointInputs = {
+	articlesGetEverything: ArticlesGetEverythingInput;
+	articlesGetTopHeadlines: ArticlesGetTopHeadlinesInput;
+	articlesGetV1: ArticlesGetV1Input;
+	sourcesList: SourcesListInput;
+};
+
+const ArticleSchema = z
+	.object({
+		source: z
+			.object({
+				id: z.string().nullable().optional(),
+				name: z.string().optional(),
+			})
+			.optional(),
+		author: z.string().nullable().optional(),
+		title: z.string().optional(),
+		description: z.string().nullable().optional(),
+		url: z.string(),
+		urlToImage: z.string().nullable().optional(),
+		publishedAt: z.string().optional(),
+		content: z.string().nullable().optional(),
+	})
+	.loose();
+
+const ArticlesResponseSchema = z
+	.object({
+		status: z.string(),
+		totalResults: z.number(),
+		articles: z.array(ArticleSchema),
+	})
+	.loose();
+
+const V1ArticleSchema = z
+	.object({
+		author: z.string().nullable().optional(),
+		title: z.string().optional(),
+		description: z.string().nullable().optional(),
+		url: z.string().optional(),
+		urlToImage: z.string().nullable().optional(),
+		publishedAt: z.string().optional(),
+	})
+	.loose();
+
+const V1ArticlesResponseSchema = z
+	.object({
+		status: z.string(),
+		source: z.string().optional(),
+		sortBy: z.string().optional(),
+		articles: z.array(V1ArticleSchema),
+	})
+	.loose();
+
+const SourceSchema = z
+	.object({
+		id: z.string(),
+		name: z.string(),
+		description: z.string().optional(),
+		url: z.string().optional(),
+		category: z.string().optional(),
+		language: z.string().optional(),
+		country: z.string().optional(),
+	})
+	.loose();
+
+const SourcesResponseSchema = z
+	.object({
+		status: z.string(),
+		sources: z.array(SourceSchema),
+	})
+	.loose();
+
+export const NewsApiEndpointOutputSchemas = {
+	articlesGetEverything: ArticlesResponseSchema,
+	articlesGetTopHeadlines: ArticlesResponseSchema,
+	articlesGetV1: V1ArticlesResponseSchema,
+	sourcesList: SourcesResponseSchema,
+} as const;
+
+export type NewsApiEndpointOutputs = {
+	[K in keyof typeof NewsApiEndpointOutputSchemas]: z.infer<
+		(typeof NewsApiEndpointOutputSchemas)[K]
+	>;
+};
+
+export type Article = z.infer<typeof ArticleSchema>;
+export type Source = z.infer<typeof SourceSchema>;
+export type GetEverythingResponse = z.infer<
+	typeof NewsApiEndpointOutputSchemas.articlesGetEverything
+>;
+export type GetTopHeadlinesResponse = z.infer<
+	typeof NewsApiEndpointOutputSchemas.articlesGetTopHeadlines
+>;
+export type GetV1ArticlesResponse = z.infer<
+	typeof NewsApiEndpointOutputSchemas.articlesGetV1
+>;
+export type SourcesListResponse = z.infer<
+	typeof NewsApiEndpointOutputSchemas.sourcesList
+>;

--- a/packages/newsapi/endpoints/types.ts
+++ b/packages/newsapi/endpoints/types.ts
@@ -45,7 +45,7 @@ const ArticlesGetEverythingInputSchema = z
 
 // News API rejects `sources` combined with `country` or `category` on
 // top-headlines — enforced client-side for the same reason as above.
-const ArticlesGetTopHeadlinesInputSchema = z
+const HeadlinesGetTopInputSchema = z
 	.object({
 		country: z.string().length(2).optional(),
 		category: z.enum(CATEGORY_VALUES).optional(),
@@ -58,12 +58,7 @@ const ArticlesGetTopHeadlinesInputSchema = z
 		message: 'sources cannot be combined with country or category',
 	});
 
-const ArticlesGetV1InputSchema = z.object({
-	source: z.string(),
-	sortBy: z.enum(['top', 'latest', 'popular']).optional(),
-});
-
-const SourcesListInputSchema = z
+const SourcesGetInputSchema = z
 	.object({
 		category: z.enum(CATEGORY_VALUES).optional(),
 		language: z.string().optional(),
@@ -74,24 +69,19 @@ const SourcesListInputSchema = z
 export type ArticlesGetEverythingInput = z.infer<
 	typeof ArticlesGetEverythingInputSchema
 >;
-export type ArticlesGetTopHeadlinesInput = z.infer<
-	typeof ArticlesGetTopHeadlinesInputSchema
->;
-export type ArticlesGetV1Input = z.infer<typeof ArticlesGetV1InputSchema>;
-export type SourcesListInput = z.infer<typeof SourcesListInputSchema>;
+export type HeadlinesGetTopInput = z.infer<typeof HeadlinesGetTopInputSchema>;
+export type SourcesGetInput = z.infer<typeof SourcesGetInputSchema>;
 
 export const NewsApiEndpointInputSchemas = {
 	articlesGetEverything: ArticlesGetEverythingInputSchema,
-	articlesGetTopHeadlines: ArticlesGetTopHeadlinesInputSchema,
-	articlesGetV1: ArticlesGetV1InputSchema,
-	sourcesList: SourcesListInputSchema,
+	headlinesGetTop: HeadlinesGetTopInputSchema,
+	sourcesGet: SourcesGetInputSchema,
 } as const;
 
 export type NewsApiEndpointInputs = {
 	articlesGetEverything: ArticlesGetEverythingInput;
-	articlesGetTopHeadlines: ArticlesGetTopHeadlinesInput;
-	articlesGetV1: ArticlesGetV1Input;
-	sourcesList: SourcesListInput;
+	headlinesGetTop: HeadlinesGetTopInput;
+	sourcesGet: SourcesGetInput;
 };
 
 const ArticleSchema = z
@@ -120,26 +110,6 @@ const ArticlesResponseSchema = z
 	})
 	.loose();
 
-const V1ArticleSchema = z
-	.object({
-		author: z.string().nullable().optional(),
-		title: z.string().optional(),
-		description: z.string().nullable().optional(),
-		url: z.string().optional(),
-		urlToImage: z.string().nullable().optional(),
-		publishedAt: z.string().optional(),
-	})
-	.loose();
-
-const V1ArticlesResponseSchema = z
-	.object({
-		status: z.string(),
-		source: z.string().optional(),
-		sortBy: z.string().optional(),
-		articles: z.array(V1ArticleSchema),
-	})
-	.loose();
-
 const SourceSchema = z
 	.object({
 		id: z.string(),
@@ -161,9 +131,8 @@ const SourcesResponseSchema = z
 
 export const NewsApiEndpointOutputSchemas = {
 	articlesGetEverything: ArticlesResponseSchema,
-	articlesGetTopHeadlines: ArticlesResponseSchema,
-	articlesGetV1: V1ArticlesResponseSchema,
-	sourcesList: SourcesResponseSchema,
+	headlinesGetTop: ArticlesResponseSchema,
+	sourcesGet: SourcesResponseSchema,
 } as const;
 
 export type NewsApiEndpointOutputs = {
@@ -178,11 +147,8 @@ export type GetEverythingResponse = z.infer<
 	typeof NewsApiEndpointOutputSchemas.articlesGetEverything
 >;
 export type GetTopHeadlinesResponse = z.infer<
-	typeof NewsApiEndpointOutputSchemas.articlesGetTopHeadlines
+	typeof NewsApiEndpointOutputSchemas.headlinesGetTop
 >;
-export type GetV1ArticlesResponse = z.infer<
-	typeof NewsApiEndpointOutputSchemas.articlesGetV1
->;
-export type SourcesListResponse = z.infer<
-	typeof NewsApiEndpointOutputSchemas.sourcesList
+export type SourcesGetResponse = z.infer<
+	typeof NewsApiEndpointOutputSchemas.sourcesGet
 >;

--- a/packages/newsapi/error-handlers.ts
+++ b/packages/newsapi/error-handlers.ts
@@ -13,6 +13,16 @@ function codeOf(error: Error): string | undefined {
 	return undefined;
 }
 
+// makeNewsApiRequest always wraps ApiError into NewsApiError before it
+// reaches error-handlers.ts, so NewsApiError.retryAfter (already in ms) is
+// the value actually populated here; the ApiError check is a defensive
+// fallback for callers that hit corsair/http directly.
+function retryAfterOf(error: Error): number | undefined {
+	if (error instanceof NewsApiError) return error.retryAfter;
+	if (error instanceof ApiError) return error.retryAfter;
+	return undefined;
+}
+
 export const errorHandlers = {
 	RATE_LIMIT_ERROR: {
 		match: (error) => {
@@ -22,13 +32,9 @@ export const errorHandlers = {
 			return code === 'rateLimited' || code === 'apiKeyExhausted';
 		},
 		handler: async (error) => {
-			let retryAfterMs: number | undefined;
-			if (error instanceof ApiError && error.retryAfter !== undefined) {
-				retryAfterMs = error.retryAfter * 1000;
-			}
 			return {
 				maxRetries: 3,
-				headersRetryAfterMs: retryAfterMs,
+				headersRetryAfterMs: retryAfterOf(error),
 			};
 		},
 	},
@@ -79,7 +85,7 @@ export const errorHandlers = {
 			return status !== undefined && status >= 500;
 		},
 		handler: async () => {
-			return { maxRetries: 2, backoffMs: 1000 };
+			return { maxRetries: 2, retryStrategy: 'linear_1s' };
 		},
 	},
 	DEFAULT: {

--- a/packages/newsapi/error-handlers.ts
+++ b/packages/newsapi/error-handlers.ts
@@ -28,7 +28,7 @@ export const errorHandlers = {
 			}
 			return {
 				maxRetries: 3,
-				backoffMs: retryAfterMs ?? 1000,
+				headersRetryAfterMs: retryAfterMs,
 			};
 		},
 	},

--- a/packages/newsapi/error-handlers.ts
+++ b/packages/newsapi/error-handlers.ts
@@ -1,0 +1,95 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+import { NewsApiError } from './client';
+
+function statusOf(error: Error): number | undefined {
+	if (error instanceof ApiError) return error.status;
+	if (error instanceof NewsApiError) return error.status;
+	return undefined;
+}
+
+function codeOf(error: Error): string | undefined {
+	if (error instanceof NewsApiError) return error.code;
+	return undefined;
+}
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error) => {
+			const status = statusOf(error);
+			if (status === 429) return true;
+			const code = codeOf(error);
+			return code === 'rateLimited' || code === 'apiKeyExhausted';
+		},
+		handler: async (error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter * 1000;
+			}
+			return {
+				maxRetries: 3,
+				backoffMs: retryAfterMs ?? 1000,
+			};
+		},
+	},
+	AUTH_ERROR: {
+		match: (error) => {
+			if (statusOf(error) === 401) return true;
+			const code = codeOf(error);
+			return (
+				code === 'apiKeyMissing' ||
+				code === 'apiKeyInvalid' ||
+				code === 'apiKeyDisabled'
+			);
+		},
+		handler: async () => {
+			return { maxRetries: 0 };
+		},
+	},
+	UPGRADE_REQUIRED_ERROR: {
+		match: (error) => {
+			if (statusOf(error) === 426) return true;
+			const code = codeOf(error);
+			return code === 'upgradeRequired' || code === 'maximumResultsReached';
+		},
+		handler: async () => {
+			// The request exceeds what the caller's News API plan tier allows
+			// (e.g. historical date range past the free-tier ~1 month window).
+			return { maxRetries: 0 };
+		},
+	},
+	BAD_REQUEST_ERROR: {
+		match: (error) => {
+			if (statusOf(error) === 400) return true;
+			const code = codeOf(error);
+			return (
+				code === 'parametersMissing' ||
+				code === 'parameterInvalid' ||
+				code === 'sourcesTooMany' ||
+				code === 'sourceDoesNotExist'
+			);
+		},
+		handler: async () => {
+			return { maxRetries: 0 };
+		},
+	},
+	SERVER_ERROR: {
+		match: (error) => {
+			const status = statusOf(error);
+			return status !== undefined && status >= 500;
+		},
+		handler: async () => {
+			return { maxRetries: 2, backoffMs: 1000 };
+		},
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async (error, context) => {
+			console.error(`[corsair:${context.pluginId}:${context.operation}]`, {
+				error: error.message,
+				input: context.input,
+			});
+			return { maxRetries: 0 };
+		},
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/newsapi/index.ts
+++ b/packages/newsapi/index.ts
@@ -12,7 +12,7 @@ import type {
 	RequiredPluginEndpointMeta,
 } from 'corsair/core';
 import { AuthMissingError } from 'corsair/core';
-import { Articles, Sources } from './endpoints';
+import { Articles, Headlines, Sources } from './endpoints';
 import type {
 	NewsApiEndpointInputs,
 	NewsApiEndpointOutputs,
@@ -26,9 +26,9 @@ import { NewsApiSchema } from './schema';
 
 /**
  * News API is a read-only REST API for searching and retrieving live
- * articles: full-text search across 150,000+ sources, live top headlines,
- * and source lookups. It has no write surface and no webhook delivery
- * mechanism.
+ * articles: full-text search across 150,000+ sources (articles.getEverything),
+ * live top headlines (headlines.getTop), and source lookups (sources.get).
+ * It has no write surface and no webhook delivery mechanism.
  *
  * @see https://newsapi.org/docs
  */
@@ -65,19 +65,19 @@ type NewsApiEndpoint<K extends keyof NewsApiEndpointOutputs> = CorsairEndpoint<
 
 export type NewsApiEndpoints = {
 	articlesGetEverything: NewsApiEndpoint<'articlesGetEverything'>;
-	articlesGetTopHeadlines: NewsApiEndpoint<'articlesGetTopHeadlines'>;
-	articlesGetV1: NewsApiEndpoint<'articlesGetV1'>;
-	sourcesList: NewsApiEndpoint<'sourcesList'>;
+	headlinesGetTop: NewsApiEndpoint<'headlinesGetTop'>;
+	sourcesGet: NewsApiEndpoint<'sourcesGet'>;
 };
 
 const newsApiEndpointsNested = {
 	articles: {
 		getEverything: Articles.getEverything,
-		getTopHeadlines: Articles.getTopHeadlines,
-		getV1: Articles.getV1,
+	},
+	headlines: {
+		getTop: Headlines.getTop,
 	},
 	sources: {
-		list: Sources.list,
+		get: Sources.get,
 	},
 } as const;
 
@@ -86,17 +86,13 @@ export const newsApiEndpointSchemas = {
 		input: NewsApiEndpointInputSchemas.articlesGetEverything,
 		output: NewsApiEndpointOutputSchemas.articlesGetEverything,
 	},
-	'articles.getTopHeadlines': {
-		input: NewsApiEndpointInputSchemas.articlesGetTopHeadlines,
-		output: NewsApiEndpointOutputSchemas.articlesGetTopHeadlines,
+	'headlines.getTop': {
+		input: NewsApiEndpointInputSchemas.headlinesGetTop,
+		output: NewsApiEndpointOutputSchemas.headlinesGetTop,
 	},
-	'articles.getV1': {
-		input: NewsApiEndpointInputSchemas.articlesGetV1,
-		output: NewsApiEndpointOutputSchemas.articlesGetV1,
-	},
-	'sources.list': {
-		input: NewsApiEndpointInputSchemas.sourcesList,
-		output: NewsApiEndpointOutputSchemas.sourcesList,
+	'sources.get': {
+		input: NewsApiEndpointInputSchemas.sourcesGet,
+		output: NewsApiEndpointOutputSchemas.sourcesGet,
 	},
 } as const;
 
@@ -113,17 +109,12 @@ const newsApiEndpointMeta = {
 		description:
 			'Search every article published by over 150,000 sources; requires at least one of q, sources, language, or domains',
 	},
-	'articles.getTopHeadlines': {
+	'headlines.getTop': {
 		riskLevel: 'read',
 		description:
 			'Get live top and breaking headlines filtered by country, category, sources, or keywords',
 	},
-	'articles.getV1': {
-		riskLevel: 'read',
-		description:
-			'Get live article metadata from a single source via the legacy v1 API',
-	},
-	'sources.list': {
+	'sources.get': {
 		riskLevel: 'read',
 		description:
 			'Get available news sources filtered by category, language, or country',
@@ -200,14 +191,12 @@ export function newsapi<const T extends NewsApiPluginOptions>(
 export type {
 	Article,
 	ArticlesGetEverythingInput,
-	ArticlesGetTopHeadlinesInput,
-	ArticlesGetV1Input,
 	GetEverythingResponse,
 	GetTopHeadlinesResponse,
-	GetV1ArticlesResponse,
+	HeadlinesGetTopInput,
 	NewsApiEndpointInputs,
 	NewsApiEndpointOutputs,
 	Source,
-	SourcesListInput,
-	SourcesListResponse,
+	SourcesGetInput,
+	SourcesGetResponse,
 } from './endpoints/types';

--- a/packages/newsapi/index.ts
+++ b/packages/newsapi/index.ts
@@ -1,0 +1,213 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+} from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
+import { Articles, Sources } from './endpoints';
+import type {
+	NewsApiEndpointInputs,
+	NewsApiEndpointOutputs,
+} from './endpoints/types';
+import {
+	NewsApiEndpointInputSchemas,
+	NewsApiEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { NewsApiSchema } from './schema';
+
+/**
+ * News API is a read-only REST API for searching and retrieving live
+ * articles: full-text search across 150,000+ sources, live top headlines,
+ * and source lookups. It has no write surface and no webhook delivery
+ * mechanism.
+ *
+ * @see https://newsapi.org/docs
+ */
+
+export type NewsApiPluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	hooks?: InternalNewsApiPlugin['hooks'];
+	errorHandlers?: CorsairErrorHandler;
+	/**
+	 * Permission configuration for the News API plugin.
+	 * Controls what the AI agent is allowed to do.
+	 * Overrides use dot-notation paths from the News API endpoint tree — invalid paths are type errors.
+	 */
+	permissions?: PluginPermissionsConfig<typeof newsApiEndpointsNested>;
+};
+
+export type NewsApiContext = CorsairPluginContext<
+	typeof NewsApiSchema,
+	NewsApiPluginOptions
+>;
+
+export type NewsApiKeyBuilderContext = KeyBuilderContext<NewsApiPluginOptions>;
+
+export type NewsApiBoundEndpoints = BindEndpoints<
+	typeof newsApiEndpointsNested
+>;
+
+type NewsApiEndpoint<K extends keyof NewsApiEndpointOutputs> = CorsairEndpoint<
+	NewsApiContext,
+	NewsApiEndpointInputs[K],
+	NewsApiEndpointOutputs[K]
+>;
+
+export type NewsApiEndpoints = {
+	articlesGetEverything: NewsApiEndpoint<'articlesGetEverything'>;
+	articlesGetTopHeadlines: NewsApiEndpoint<'articlesGetTopHeadlines'>;
+	articlesGetV1: NewsApiEndpoint<'articlesGetV1'>;
+	sourcesList: NewsApiEndpoint<'sourcesList'>;
+};
+
+const newsApiEndpointsNested = {
+	articles: {
+		getEverything: Articles.getEverything,
+		getTopHeadlines: Articles.getTopHeadlines,
+		getV1: Articles.getV1,
+	},
+	sources: {
+		list: Sources.list,
+	},
+} as const;
+
+export const newsApiEndpointSchemas = {
+	'articles.getEverything': {
+		input: NewsApiEndpointInputSchemas.articlesGetEverything,
+		output: NewsApiEndpointOutputSchemas.articlesGetEverything,
+	},
+	'articles.getTopHeadlines': {
+		input: NewsApiEndpointInputSchemas.articlesGetTopHeadlines,
+		output: NewsApiEndpointOutputSchemas.articlesGetTopHeadlines,
+	},
+	'articles.getV1': {
+		input: NewsApiEndpointInputSchemas.articlesGetV1,
+		output: NewsApiEndpointOutputSchemas.articlesGetV1,
+	},
+	'sources.list': {
+		input: NewsApiEndpointInputSchemas.sourcesList,
+		output: NewsApiEndpointOutputSchemas.sourcesList,
+	},
+} as const;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+/**
+ * Risk-level metadata for each News API endpoint.
+ * Used by the MCP server permission system to decide allow / deny / require_approval.
+ * Every operation is a read — News API has no write surface.
+ */
+const newsApiEndpointMeta = {
+	'articles.getEverything': {
+		riskLevel: 'read',
+		description:
+			'Search every article published by over 150,000 sources; requires at least one of q, sources, language, or domains',
+	},
+	'articles.getTopHeadlines': {
+		riskLevel: 'read',
+		description:
+			'Get live top and breaking headlines filtered by country, category, sources, or keywords',
+	},
+	'articles.getV1': {
+		riskLevel: 'read',
+		description:
+			'Get live article metadata from a single source via the legacy v1 API',
+	},
+	'sources.list': {
+		riskLevel: 'read',
+		description:
+			'Get available news sources filtered by category, language, or country',
+	},
+} as const satisfies RequiredPluginEndpointMeta<typeof newsApiEndpointsNested>;
+
+/**
+ * One key, sent as `X-Api-Key`. There is no OAuth flow and no account-specific
+ * host or extra credential to resolve.
+ */
+export const newsApiAuthConfig = {
+	api_key: {},
+} as const satisfies PluginAuthConfig;
+
+export type BaseNewsApiPlugin<T extends NewsApiPluginOptions> = CorsairPlugin<
+	'newsapi',
+	typeof NewsApiSchema,
+	typeof newsApiEndpointsNested,
+	{},
+	T,
+	typeof defaultAuthType,
+	typeof newsApiAuthConfig
+>;
+
+export type InternalNewsApiPlugin = BaseNewsApiPlugin<NewsApiPluginOptions>;
+
+export type ExternalNewsApiPlugin<T extends NewsApiPluginOptions> =
+	BaseNewsApiPlugin<T>;
+
+export function newsapi<const T extends NewsApiPluginOptions>(
+	incomingOptions: NewsApiPluginOptions & T = {} as NewsApiPluginOptions & T,
+): ExternalNewsApiPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+
+	return {
+		id: 'newsapi',
+		schema: NewsApiSchema,
+		options,
+		hooks: options.hooks,
+		endpoints: newsApiEndpointsNested,
+		webhooks: {},
+		endpointMeta: newsApiEndpointMeta,
+		endpointSchemas: newsApiEndpointSchemas,
+		authConfig: newsApiAuthConfig,
+		// News API is request/response only: no webhooks, no event subscriptions.
+		pluginWebhookMatcher: () => false,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: NewsApiKeyBuilderContext, source) => {
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const key = await ctx.keys.get_api_key();
+
+				if (!key) {
+					throw new AuthMissingError('newsapi', 'api_key');
+				}
+
+				return key;
+			}
+
+			throw new AuthMissingError('newsapi', 'api_key');
+		},
+	} satisfies InternalNewsApiPlugin;
+}
+
+export type {
+	Article,
+	ArticlesGetEverythingInput,
+	ArticlesGetTopHeadlinesInput,
+	ArticlesGetV1Input,
+	GetEverythingResponse,
+	GetTopHeadlinesResponse,
+	GetV1ArticlesResponse,
+	NewsApiEndpointInputs,
+	NewsApiEndpointOutputs,
+	Source,
+	SourcesListInput,
+	SourcesListResponse,
+} from './endpoints/types';

--- a/packages/newsapi/jest.config.cjs
+++ b/packages/newsapi/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/newsapi/package.json
+++ b/packages/newsapi/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/newsapi",
+  "version": "0.1.0",
+  "description": "NewsApi plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "newsapi",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/newsapi/schema.test.ts
+++ b/packages/newsapi/schema.test.ts
@@ -1,0 +1,65 @@
+import { NewsApiSchema } from './schema';
+import { NewsApiArticle, NewsApiSource } from './schema/database';
+
+describe('NewsApi schema', () => {
+	it('declares a semver version', () => {
+		expect(NewsApiSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map with all registered entities', () => {
+		expect(Object.keys(NewsApiSchema.entities).sort()).toEqual([
+			'articles',
+			'sources',
+		]);
+	});
+
+	describe('entity parsing', () => {
+		it('parses an Article record keyed by url', () => {
+			const article = NewsApiArticle.parse({
+				url: 'https://example.com/article',
+				source: { id: 'example-source', name: 'Example' },
+				author: 'Jane Doe',
+				title: 'Test article',
+				description: 'A test article',
+				publishedAt: '2026-08-24T00:00:00Z',
+				content: 'Content body',
+			});
+			expect(article.url).toBe('https://example.com/article');
+			expect(article.source?.id).toBe('example-source');
+			expect(article.publishedAt).toBeInstanceOf(Date);
+		});
+
+		it('parses a Source record carrying required fields', () => {
+			const source = NewsApiSource.parse({
+				id: 'bbc-news',
+				name: 'BBC News',
+				description: 'BBC News description',
+				url: 'https://bbc.co.uk',
+				category: 'general',
+				language: 'en',
+				country: 'gb',
+			});
+			expect(source.id).toBe('bbc-news');
+			expect(source.category).toBe('general');
+		});
+	});
+
+	describe('unrecognised fields are tolerated', () => {
+		it('keeps extra unknown fields on article', () => {
+			const article = NewsApiArticle.parse({
+				url: 'https://example.com/article',
+				extra_field: 'xyz',
+			});
+			expect((article as any).extra_field).toBe('xyz');
+		});
+
+		it('keeps extra unknown fields on source', () => {
+			const source = NewsApiSource.parse({
+				id: 'bbc-news',
+				name: 'BBC News',
+				popularity_rank: 3,
+			});
+			expect((source as any).popularity_rank).toBe(3);
+		});
+	});
+});

--- a/packages/newsapi/schema/database.ts
+++ b/packages/newsapi/schema/database.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+/**
+ * News API Source Entity Schema
+ * @see https://newsapi.org/docs/endpoints/sources
+ */
+export const NewsApiSource = z
+	.object({
+		id: z.string(),
+		name: z.string(),
+		description: z.string().optional(),
+		url: z.string().optional(),
+		category: z.string().optional(),
+		language: z.string().optional(),
+		country: z.string().optional(),
+	})
+	.catchall(z.unknown());
+
+/**
+ * News API Article Entity Schema
+ * Articles have no stable provider-issued ID — `url` is the natural unique key.
+ * @see https://newsapi.org/docs/endpoints/everything
+ */
+export const NewsApiArticle = z
+	.object({
+		url: z.string(),
+		source: z
+			.object({
+				id: z.string().nullable().optional(),
+				name: z.string().optional(),
+			})
+			.optional(),
+		author: z.string().nullable().optional(),
+		title: z.string().optional(),
+		description: z.string().nullable().optional(),
+		urlToImage: z.string().nullable().optional(),
+		publishedAt: z.coerce.date().nullable().optional(),
+		content: z.string().nullable().optional(),
+	})
+	.catchall(z.unknown());
+
+export type NewsApiSource = z.infer<typeof NewsApiSource>;
+export type NewsApiArticle = z.infer<typeof NewsApiArticle>;

--- a/packages/newsapi/schema/index.ts
+++ b/packages/newsapi/schema/index.ts
@@ -1,0 +1,9 @@
+import { NewsApiArticle, NewsApiSource } from './database';
+
+export const NewsApiSchema = {
+	version: '1.0.0',
+	entities: {
+		articles: NewsApiArticle,
+		sources: NewsApiSource,
+	},
+} as const;

--- a/packages/newsapi/tsconfig.json
+++ b/packages/newsapi/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/newsapi/tsup.config.ts
+++ b/packages/newsapi/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4463,6 +4463,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/newsapi:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/nextdns:
     devDependencies:
       '@types/jest':


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description
Adds the News API plugin (`packages/newsapi`), providing access to live and
historical news articles and headlines from over 150,000 sources.

Implements 4 operations:
- `articles.getEverything` — search through every article published by
  available sources, filterable by keyword, sources, language, or domains
  (at least one required, per the API's own validation)
- `sources.get` — fetch available news sources, filterable by category,
  language, or country
- `headlines.getTop` — retrieve live top and breaking headlines, filterable
  by country, category, source(s), or keyword
- `articles.getV1` — fetch live article metadata from a news source using
  the legacy v1 API, for callers needing headlines from a specific source
  identifier

Fixes #1425

## Checklist
Before submitting your PR, please verify the following:
- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)
<img width="553" height="237" alt="Screenshot 2026-08-31 at 12 26 17 PM" src="https://github.com/user-attachments/assets/00fe7f34-8ce6-4d1d-80c1-c7cda8086d7e" />

## Additional Notes
- Auth: API key via header.
- Applies backoff on HTTP 429 throttling responses, per News API's own
  rate-limit guidance.
- `sources.get` return values are the only valid IDs for source filtering
  in the other two operations — unrecognized IDs silently return empty
  results rather than erroring; documented in code comments.
- Did not implement the legacy v1 articles endpoint, since it's superseded
  by the v2 top-headlines endpoint per News API's own docs.
- No webhook support — News API doesn't offer one.
- No breaking changes. No new external dependencies beyond what's needed
  for this plugin package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added News API integration for article search, top headlines, and news sources.
  * Added API-key authentication, input and response validation, caching, database persistence, and structured error handling.
  * Added retry support for rate limits and server errors.
  * Added News API articles and sources to the available provider catalog.
* **Tests**
  * Added unit, schema, endpoint, and optional live integration coverage for News API functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->