### PR TITLE
docs: framework Connect guides, reachable SDK nav, "Start the server"

### DIFF
--- a/docs/adapters/corsair-connect.mdx
+++ b/docs/adapters/corsair-connect.mdx
@@ -1,0 +1,120 @@
+---
+title: Corsair Connect
+description: An in-app connect dialog for your end users. Wrap the app in <CorsairProvider>; a Corsair call that fails because a tenant hasn't connected a plugin opens the dialog and resumes the work once they're done.
+---
+
+Your users connect their own accounts. Someone signs into your app, hits a feature that needs their GitHub, and a dialog opens right there to connect it. They never leave the page, and once they're back the action they tried finishes on its own.
+
+That's Corsair Connect. It's the same OAuth flow as the [hosted connect link](/management/connect), moved inside your app: a React provider owns a connect dialog, and any Corsair call that fails for a missing credential opens it. The [React hooks](/adapters/react) give you the raw pieces (read status, mint a link, route the user); Corsair Connect wires them together so you write no per-call code.
+
+<Note>
+Corsair Connect is React-only. The provider and dialog are client components. A non-React frontend still gets the server half: a failed call records a connect-request you read at `/api/corsair/connect/request`, so you can build your own prompt or redirect to the link. See the [vanilla client](/adapters/client).
+</Note>
+
+## When to reach for it
+
+Use the plain [connect link](/management/connect) when *you* are wiring up a tenant ahead of time, from a settings screen or an onboarding step, and can redirect the browser to Hub's page.
+
+Use Corsair Connect when your end users connect their own accounts, on demand, mid-task, without leaving your app. It shines when a credential can go missing at any point: a token gets revoked, a new user hasn't connected yet, a feature touches a plugin they've never used. Instead of guarding every call site, you wrap the app once and let the failure drive the prompt.
+
+## Wrap the app
+
+Put `<CorsairProvider>` at the root, once. Point `onConnected` at your framework's refresh so a server read that failed with a missing credential re-runs against the now-connected account.
+
+```tsx app/providers.tsx
+"use client";
+import { CorsairProvider } from "corsair/client/react";
+import { useRouter } from "next/navigation";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  return (
+    <CorsairProvider onConnected={() => router.refresh()}>
+      {children}
+    </CorsairProvider>
+  );
+}
+```
+
+### Props
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `baseURL` | `string` | `/api/corsair` | Where your Corsair handler is mounted. Set it if the handler lives on another path or origin. |
+| `appearance` | `"light" \| "dark" \| "auto"` | `"auto"` | Dialog theme. `"auto"` follows the OS color scheme. Also accepts `{ theme }`. |
+| `onConnected` | `() => void` | — | Runs once after a successful connect. Wire it to `router.refresh()` (Next), `revalidate()` (Remix), or `router.invalidate()` (TanStack) so failed server reads re-run. Mutations resume on their own. |
+| `captureUnhandled` | `boolean` | `true` | Open the dialog when any unwrapped client call rejects with a missing-credential error, no `call` wrapper needed. Set `false` to drive the dialog only through `connect`, `call`, and the error boundary. |
+
+With `captureUnhandled` on (the default), a client call that fails because the tenant isn't connected opens the dialog by itself. It can't resume the original work, though, so reach for `call` when you want the failed action to re-run.
+
+## The hook
+
+`useConnections()` reads this user's connection status and drives the flow. It must be called under `<CorsairProvider>`, or it throws.
+
+```tsx
+import { useConnections } from "corsair/client/react";
+
+const { connections, isConnected, loading, connect, call } = useConnections();
+```
+
+| Field | Type | What it does |
+| --- | --- | --- |
+| `connections` | `Record<string, 'connected' \| 'missing_credentials' \| 'not_connected'> \| null` | Per-plugin status, `null` until the first fetch lands. Refreshes itself after every successful connect. |
+| `isConnected` | `(plugin: string) => boolean` | `connections?.[plugin] === 'connected'`, and `false` while status is loading. |
+| `loading` | `boolean` | `true` while the first status fetch is in flight. Render a placeholder rather than flash a "Connect" button that may already be done. |
+| `connect` | `(plugin, opts?) => Promise<boolean>` | Open the dialog for a plugin proactively. Resolves `true` once connected. |
+| `call` | `<T>(fn: () => Promise<T>) => Promise<T \| null>` | Run a mutation; if it fails while a connect-request is pending, open the dialog and re-run once connected. |
+
+### A "Connect X" button
+
+For a button the user clicks before anything has failed, `connect(plugin)` mints a fresh link and opens the dialog. Gate the label on `isConnected` so it doesn't flash while status loads.
+
+```tsx connect-slack.tsx
+"use client";
+import { useConnections } from "corsair/client/react";
+
+export function ConnectSlack() {
+  const { connect, isConnected, loading } = useConnections();
+
+  if (loading) return null;
+  if (isConnected("slack")) return <span>Slack connected</span>;
+
+  return <button onClick={() => connect("slack")}>Connect Slack</button>;
+}
+```
+
+### Wrap a mutation
+
+`call` runs the action, and if it fails while a connect-request is pending it opens the dialog and re-runs the action once connected. It resolves `null` when the user closes the dialog, and rethrows any error that isn't a pending connect. Wrap only connect-gated or retry-safe mutations, since it may run `fn` twice.
+
+```tsx send.tsx
+"use client";
+import { useConnections } from "corsair/client/react";
+
+export function SendButton() {
+  const { call } = useConnections();
+  return <button onClick={() => call(() => sendEmail())}>Send</button>;
+}
+```
+
+## Server reads (Next.js)
+
+A Server Component that reads Corsair data can't be wrapped in a client component, so when its render throws for a missing credential, Next routes the error to the segment's `error.tsx`. `CorsairErrorBoundary` is a drop-in for that file: it asks the provider whether a connect-request is pending, opens the dialog if so, and calls Next's `reset()` once connected to re-run the read. A genuine error is rethrown so your own handling still sees it.
+
+```tsx app/inbox/error.tsx
+"use client";
+export { CorsairErrorBoundary as default } from "corsair/client/react";
+```
+
+It renders under the provider, so keep `<CorsairProvider>` in your root layout where it wraps every segment's `error.tsx`. If the user closes the dialog without connecting, the boundary shows a "Try again" button that re-runs the read.
+
+Remix and TanStack read in loaders, not Server Components, so this boundary is Next-only. There, a failed loader read surfaces the same typed error; open the dialog from your route's error element with `connect(plugin)`.
+
+## What the user sees
+
+1. A call fails because the tenant has no usable credential for the plugin. Corsair throws a typed error carrying a scoped connect link (see [error handling](/concepts/error-handling)).
+2. The provider opens the dialog and, on click, opens Hub's connect page in a popup.
+3. The user signs in and grants access. Hub runs the OAuth handshake and writes the encrypted tokens to your own database. Neither you nor Hub sees them in the clear.
+4. The popup closes, the provider confirms the connection, fires `onConnected`, and resumes any `call` that was waiting.
+
+A stale connection, like a revoked refresh token, throws `ReconnectRequiredError` instead. The provider treats it the same way: same dialog, same reconnect, same resume.

--- a/docs/adapters/handlers.mdx
+++ b/docs/adapters/handlers.mdx
@@ -17,7 +17,7 @@ Corsair mounts **one** route. It serves Hub delivery, meaning OAuth callbacks, c
 
 <MountHandlerTabs />
 
-## Run and go green
+## Start the server
 
 Start your dev server and make one request to `/api/corsair`. On that first request your app self-registers its delivery URL with Hub and the dashboard header dot turns green. See [Delivery URLs](/hub/delivery-urls).
 

--- a/docs/adapters/react.mdx
+++ b/docs/adapters/react.mdx
@@ -1,6 +1,6 @@
 ---
 title: React hooks
-description: createCorsairReactClient returns typed React hooks over the management API, including useTenants, useConnectionStatus, and useOAuthCallback.
+description: Typed React hooks over the management API (useTenants, useConnectionStatus, …), plus Corsair Connect — <CorsairProvider> opens a connect dialog and resumes the failed work when a tenant isn't connected.
 ---
 
 `createCorsairReactClient({ baseURL })` returns a set of typed React hooks built on top of [`createCorsairClient`](/adapters/client). One factory call per app, then use the returned hooks anywhere in your component tree.
@@ -20,6 +20,75 @@ export const {
 ```
 
 React 18+ is a peer dependency. If you aren't on React, use the [vanilla client](/adapters/client).
+
+## Corsair Connect
+
+The hooks in this client give you the pieces — read status, mint a link, route the user. **Corsair Connect** wires them together: wrap your app once, and any Corsair call that fails because the tenant hasn't connected a plugin opens a connect dialog and resumes the work once they're done. No per-call code at the call sites.
+
+Wrap the app at the root and point `onConnected` at a refresh so reads that failed re-run against the now-connected account:
+
+```tsx app/providers.tsx
+"use client";
+import { CorsairProvider } from "corsair/client/react";
+import { useRouter } from "next/navigation";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  return (
+    <CorsairProvider onConnected={() => router.refresh()}>
+      {children}
+    </CorsairProvider>
+  );
+}
+```
+
+`baseURL` defaults to `/api/corsair` — set it if your handler is mounted elsewhere. `appearance` is `"light"`, `"dark"`, or `"auto"` (the default, which follows the OS color scheme).
+
+### Read regions
+
+Wrap a server-rendered region that reads Corsair data in `<CorsairBoundary>`. When the render fails because the tenant must connect, the boundary opens the dialog and — once connected — retries the region instead of crashing the tree:
+
+```tsx inbox.tsx
+import { CorsairBoundary } from "corsair/client/react";
+
+<CorsairBoundary fallback={<p>Couldn't load Gmail.</p>}>
+  <Inbox />   {/* a Server Component that reads Gmail */}
+</CorsairBoundary>
+```
+
+`fallback` renders only for a genuine error or when the user dismisses the dialog; it defaults to `null`.
+
+### Mutations
+
+Wrap a mutation in `call` so it re-runs after connect. It resolves `null` if the user dismisses the dialog, and rethrows any error that isn't a pending connect:
+
+```tsx send.tsx
+"use client";
+import { useConnect } from "corsair/client/react";
+
+function SendButton() {
+  const { call } = useConnect();
+  return <button onClick={() => call(() => sendEmail())}>Send</button>;
+}
+```
+
+### Proactive connect
+
+For a plain "Connect X" button, before anything has failed, `connect(plugin)` mints a fresh link and opens the same dialog. It resolves `true` once connected:
+
+```tsx connect-slack.tsx
+"use client";
+import { useConnect } from "corsair/client/react";
+
+function ConnectSlack() {
+  const { connect } = useConnect();
+  return <button onClick={() => connect("slack")}>Connect Slack</button>;
+}
+```
+
+<Note>
+Corsair Connect is React-only — the provider, boundary, and dialog are client components. A non-React frontend still gets the server side: the failed call records a connect-request that you read at `/api/corsair/connect/request`, so you can build your own prompt or redirect to the connect link. See the [vanilla client](/adapters/client).
+</Note>
 
 ## Read hooks
 

--- a/docs/adapters/react.mdx
+++ b/docs/adapters/react.mdx
@@ -44,19 +44,16 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
 `baseURL` defaults to `/api/corsair` — set it if your handler is mounted elsewhere. `appearance` is `"light"`, `"dark"`, or `"auto"` (the default, which follows the OS color scheme).
 
-### Read regions
+### Read regions (Next.js)
 
-Wrap a server-rendered region that reads Corsair data in `<CorsairBoundary>`. When the render fails because the tenant must connect, the boundary opens the dialog and — once connected — retries the region instead of crashing the tree:
+A Server Component that reads Corsair data can't sit inside a client wrapper, so when its render fails for a missing credential, Next routes the error to the segment's `error.tsx`. `CorsairErrorBoundary` is a drop-in for that file: it opens the dialog and, once connected, re-runs the read.
 
-```tsx inbox.tsx
-import { CorsairBoundary } from "corsair/client/react";
-
-<CorsairBoundary fallback={<p>Couldn't load Gmail.</p>}>
-  <Inbox />   {/* a Server Component that reads Gmail */}
-</CorsairBoundary>
+```tsx app/inbox/error.tsx
+"use client";
+export { CorsairErrorBoundary as default } from "corsair/client/react";
 ```
 
-`fallback` renders only for a genuine error or when the user dismisses the dialog; it defaults to `null`. Like `useConnect`, `<CorsairBoundary>` reads the provider context — it must sit inside the `<CorsairProvider>` from the step above, or it throws.
+It reads the provider context, so keep `<CorsairProvider>` in your root layout where it wraps every segment's `error.tsx`. A genuine error is rethrown to the next boundary up; if the user closes the dialog without connecting, it shows a "Try again" button.
 
 ### Mutations
 
@@ -64,10 +61,10 @@ Wrap a mutation in `call` so it re-runs after connect. It resolves `null` if the
 
 ```tsx send.tsx
 "use client";
-import { useConnect } from "corsair/client/react";
+import { useConnections } from "corsair/client/react";
 
 function SendButton() {
-  const { call } = useConnect();
+  const { call } = useConnections();
   return <button onClick={() => call(() => sendEmail())}>Send</button>;
 }
 ```
@@ -78,10 +75,10 @@ For a plain "Connect X" button, before anything has failed, `connect(plugin)` mi
 
 ```tsx connect-slack.tsx
 "use client";
-import { useConnect } from "corsair/client/react";
+import { useConnections } from "corsair/client/react";
 
 function ConnectSlack() {
-  const { connect } = useConnect();
+  const { connect } = useConnections();
   return <button onClick={() => connect("slack")}>Connect Slack</button>;
 }
 ```
@@ -89,6 +86,8 @@ function ConnectSlack() {
 <Note>
 Corsair Connect is React-only — the provider, boundary, and dialog are client components. A non-React frontend still gets the server side: the failed call records a connect-request that you read at `/api/corsair/connect/request`, so you can build your own prompt or redirect to the connect link. See the [vanilla client](/adapters/client).
 </Note>
+
+The full walkthrough, props, and hook shape are on the [Corsair Connect](/adapters/corsair-connect) page.
 
 ## Read hooks
 

--- a/docs/adapters/react.mdx
+++ b/docs/adapters/react.mdx
@@ -56,7 +56,7 @@ import { CorsairBoundary } from "corsair/client/react";
 </CorsairBoundary>
 ```
 
-`fallback` renders only for a genuine error or when the user dismisses the dialog; it defaults to `null`.
+`fallback` renders only for a genuine error or when the user dismisses the dialog; it defaults to `null`. Like `useConnect`, `<CorsairBoundary>` reads the provider context — it must sit inside the `<CorsairProvider>` from the step above, or it throws.
 
 ### Mutations
 

--- a/docs/concepts/database.mdx
+++ b/docs/concepts/database.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database
-description: Five tables, always-fresh integration data, tenant-scoped by default.
+description: Six tables, always-fresh integration data, tenant-scoped by default.
 ---
 
 import { WindowsMigrationNote } from '/snippets/windows-shell.mdx';
@@ -145,6 +145,13 @@ CREATE TABLE IF NOT EXISTS corsair_permissions (
     expires_at TEXT NOT NULL,
     error TEXT
 );
+
+CREATE TABLE IF NOT EXISTS corsair_connect_requests (
+    tenant_id TEXT PRIMARY KEY,
+    plugin TEXT NOT NULL,
+    connect_url TEXT NOT NULL,
+    requested_at TEXT NOT NULL
+);
 ```
 
 </Accordion>
@@ -232,6 +239,13 @@ CREATE TABLE IF NOT EXISTS corsair_permissions (
     expires_at TEXT NOT NULL,
     error TEXT
 );
+
+CREATE TABLE IF NOT EXISTS corsair_connect_requests (
+    tenant_id TEXT PRIMARY KEY,
+    plugin TEXT NOT NULL,
+    connect_url TEXT NOT NULL,
+    requested_at TEXT NOT NULL
+);
 ```
 
 </Accordion>
@@ -317,6 +331,13 @@ export const corsairPermissions = pgTable('corsair_permissions', {
     status: text('status').notNull().default('pending'),
     expiresAt: text('expires_at').notNull(),
     error: text('error'),
+});
+
+export const corsairConnectRequests = pgTable('corsair_connect_requests', {
+    tenantId: text('tenant_id').primaryKey(),
+    plugin: text('plugin').notNull(),
+    connectUrl: text('connect_url').notNull(),
+    requestedAt: text('requested_at').notNull(),
 });
 ```
 
@@ -405,6 +426,15 @@ model CorsairPermission {
 
   @@map("corsair_permissions")
 }
+
+model CorsairConnectRequest {
+  tenantId    String @id @map("tenant_id")
+  plugin      String
+  connectUrl  String @map("connect_url")
+  requestedAt String @map("requested_at")
+
+  @@map("corsair_connect_requests")
+}
 ```
 
 </Accordion>
@@ -449,7 +479,7 @@ Use `*.api.*` to write or force a fresh read. Use `*.db.*` for lists, search, an
 
 ## Core tables
 
-Five tables for every integration. Slack, GitHub, Linear, and the rest all share the same schema.
+Six tables. The first five are shared by every integration — Slack, GitHub, Linear, and the rest use the same schema. `corsair_connect_requests` records a tenant's pending connect prompt.
 
 | Table | Purpose |
 |-------|---------|
@@ -458,6 +488,7 @@ Five tables for every integration. Slack, GitHub, Linear, and the rest all share
 | `corsair_entities` | Synced resources like messages, channels, issues, repos (`entity_id`, `entity_type`, `data`) |
 | `corsair_events` | Audit log of API calls and webhooks |
 | `corsair_permissions` | Approval queue for gated [permissions](/concepts/permissions) (`token`, `tenant_id`, `endpoint`, `args`, `status`) |
+| `corsair_connect_requests` | A tenant's pending connect prompt, written when a call needs auth and read by the client to open the connect dialog (`tenant_id`, `plugin`, `connect_url`) |
 
 ```sql
 -- corsair_entities example (a Slack message)
@@ -569,7 +600,7 @@ export const corsair = createCorsair({
 </Tab>
 <Tab title="Drizzle / Prisma">
 
-Define the five Corsair tables in your ORM schema (see migration tabs above), run your normal migrations, and pass the **underlying connection** to Corsair, not the ORM client:
+Define the six Corsair tables in your ORM schema (see migration tabs above), run your normal migrations, and pass the **underlying connection** to Corsair, not the ORM client:
 
 ```ts
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });

--- a/docs/concepts/error-handling.mdx
+++ b/docs/concepts/error-handling.mdx
@@ -130,3 +130,12 @@ handler: async (error, context) => ({
 })
 ```
 
+## Reconnect and auth-missing
+
+The handlers above cover errors from a *connected* integration. When a tenant hasn't connected a plugin yet, or a stored token can no longer be refreshed, Corsair throws a typed error carrying the connect link instead:
+
+- `AuthMissingError` — no usable credential for the tenant. Send them through a connect flow.
+- `ReconnectRequiredError` — a stored connection went stale (for example, a revoked refresh token). Same fix: reconnect.
+
+In a React app, [Corsair Connect](/adapters/react#corsair-connect) turns both into a connect dialog and resumes the failed work automatically — you don't catch them by hand. Anywhere else, read `error.connectUrl` and route the user there.
+

--- a/docs/concepts/error-handling.mdx
+++ b/docs/concepts/error-handling.mdx
@@ -137,5 +137,5 @@ The handlers above cover errors from a *connected* integration. When a tenant ha
 - `AuthMissingError` — no usable credential for the tenant. Send them through a connect flow.
 - `ReconnectRequiredError` — a stored connection went stale (for example, a revoked refresh token). Same fix: reconnect.
 
-In a React app, [Corsair Connect](/adapters/react#corsair-connect) turns both into a connect dialog and resumes the failed work automatically — you don't catch them by hand. Anywhere else, read `error.connectUrl` and route the user there.
+In a React app, [Corsair Connect](/adapters/corsair-connect) turns both into a connect dialog and resumes the failed work automatically, so you don't catch them by hand. Anywhere else, read `error.connectUrl` and route the user there.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -117,6 +117,14 @@
           {
             "group": "Reference",
             "pages": [
+              {
+                "group": "SDK",
+                "pages": [
+                  "adapters/handlers",
+                  "adapters/client",
+                  "adapters/react"
+                ]
+              },
               "concepts/api",
               "concepts/auth",
               "concepts/provisioning",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -122,7 +122,8 @@
                 "pages": [
                   "adapters/handlers",
                   "adapters/client",
-                  "adapters/react"
+                  "adapters/react",
+                  "adapters/corsair-connect"
                 ]
               },
               "concepts/api",

--- a/docs/frameworks/astro.mdx
+++ b/docs/frameworks/astro.mdx
@@ -81,7 +81,7 @@ Connecting is interactive, but it doesn't need a UI framework. Use the framework
 
 <ClientVanilla />
 
-## Go green
+## Start the server
 
 ```bash
 npm run dev

--- a/docs/frameworks/express.mdx
+++ b/docs/frameworks/express.mdx
@@ -89,7 +89,7 @@ Express is a backend, so use the vanilla client from your frontend, a worker, or
 
 <ClientVanilla />
 
-## Go green
+## Start the server
 
 Start the server:
 

--- a/docs/frameworks/fastify.mdx
+++ b/docs/frameworks/fastify.mdx
@@ -99,7 +99,7 @@ Fastify is a backend, so use the vanilla client from your frontend, a worker, or
 
 <ClientVanilla />
 
-## Go green
+## Start the server
 
 Start the server:
 

--- a/docs/frameworks/hono.mdx
+++ b/docs/frameworks/hono.mdx
@@ -80,7 +80,7 @@ Hono is a backend, so use the vanilla client from your frontend, a worker, or a 
 
 <ClientVanilla />
 
-## Go green
+## Start the server
 
 Start the app on your runtime of choice: `npm run dev` with `@hono/node-server`, `bun run index.ts`, or `wrangler dev` on Workers. The first request to `/api/corsair` registers your delivery URL with Hub and turns the **App sync** dot in the dashboard header green.
 

--- a/docs/frameworks/nestjs.mdx
+++ b/docs/frameworks/nestjs.mdx
@@ -108,7 +108,7 @@ Nest is a backend, so use the vanilla client from your frontend, a worker, or a 
 
 <ClientVanilla />
 
-## Go green
+## Start the server
 
 Start the app:
 

--- a/docs/frameworks/next.mdx
+++ b/docs/frameworks/next.mdx
@@ -121,7 +121,28 @@ The read and write paths above assume a tenant has already connected GitHub. Tha
 
 <ClientReact />
 
-## Go green
+### Or let Corsair Connect drive it
+
+The hooks above are the manual flow. **Corsair Connect** is the batteries-included version — wrap the app once and a failed call opens the connect dialog and resumes. Wrap your root layout:
+
+```tsx app/providers.tsx
+"use client";
+import { CorsairProvider } from "corsair/client/react";
+import { useRouter } from "next/navigation";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  return (
+    <CorsairProvider onConnected={() => router.refresh()}>
+      {children}
+    </CorsairProvider>
+  );
+}
+```
+
+Use `<Providers>` in `app/layout.tsx`. Then a `<CorsairBoundary>` around a Server Component read, `useConnect().call` around a mutation, or `useConnect().connect` for a button each open the dialog on their own. Full API: [React hooks → Corsair Connect](/adapters/react#corsair-connect).
+
+## Start the server
 
 ```bash
 npm run dev

--- a/docs/frameworks/next.mdx
+++ b/docs/frameworks/next.mdx
@@ -140,7 +140,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
 }
 ```
 
-Use `<Providers>` in `app/layout.tsx`. Then a `<CorsairBoundary>` around a Server Component read, `useConnect().call` around a mutation, or `useConnect().connect` for a button each open the dialog on their own. Full API: [React hooks → Corsair Connect](/adapters/react#corsair-connect).
+Use `<Providers>` in `app/layout.tsx`. Then a `CorsairErrorBoundary` in a segment's `error.tsx` for a Server Component read, `useConnections().call` around a mutation, or `useConnections().connect` for a button each open the dialog on their own. Full API: [Corsair Connect](/adapters/corsair-connect).
 
 ## Start the server
 

--- a/docs/frameworks/node.mdx
+++ b/docs/frameworks/node.mdx
@@ -69,7 +69,7 @@ There's no React here, so use the vanilla client from a script, a worker, or a n
 
 <ClientVanilla />
 
-## Go green
+## Start the server
 
 Start the server:
 

--- a/docs/frameworks/nuxt.mdx
+++ b/docs/frameworks/nuxt.mdx
@@ -103,7 +103,7 @@ Nuxt renders Vue, and Corsair's typed hooks client is React-only, so use the fra
 
 <ClientVanilla />
 
-## Go green
+## Start the server
 
 ```bash
 npm run dev

--- a/docs/frameworks/remix.mdx
+++ b/docs/frameworks/remix.mdx
@@ -104,7 +104,27 @@ A tenant has to connect GitHub before the loader has anything to read. That flow
 
 <ClientReact />
 
-## Go green
+### Or let Corsair Connect drive it
+
+**Corsair Connect** wraps the app once so a failed call opens the connect dialog and resumes. Mount the provider in `app/root.tsx`; Remix re-runs loaders through `useRevalidator`, so wire that into `onConnected`:
+
+```tsx app/root.tsx
+import { CorsairProvider } from "corsair/client/react";
+import { Outlet, useRevalidator } from "@remix-run/react";
+
+export default function App() {
+  const { revalidate } = useRevalidator();
+  return (
+    <CorsairProvider onConnected={() => revalidate()}>
+      <Outlet />
+    </CorsairProvider>
+  );
+}
+```
+
+Then `useConnect().call` around a mutation and `useConnect().connect` for a button open the dialog on their own. (The `<CorsairBoundary>` read helper is specific to Next's Server Components; in Remix, reads live in loaders.) Full API: [React hooks → Corsair Connect](/adapters/react#corsair-connect).
+
+## Start the server
 
 ```bash
 npm run dev

--- a/docs/frameworks/remix.mdx
+++ b/docs/frameworks/remix.mdx
@@ -122,7 +122,7 @@ export default function App() {
 }
 ```
 
-Then `useConnect().call` around a mutation and `useConnect().connect` for a button open the dialog on their own. (The `<CorsairBoundary>` read helper is specific to Next's Server Components; in Remix, reads live in loaders.) Full API: [React hooks → Corsair Connect](/adapters/react#corsair-connect).
+Then `useConnections().call` around a mutation and `useConnections().connect` for a button open the dialog on their own. (`CorsairErrorBoundary` is specific to Next's Server Components; in Remix, reads live in loaders.) Full API: [Corsair Connect](/adapters/corsair-connect).
 
 ## Start the server
 

--- a/docs/frameworks/sveltekit.mdx
+++ b/docs/frameworks/sveltekit.mdx
@@ -120,7 +120,7 @@ A tenant connects GitHub before `load` has anything to read. Svelte isn't React,
 
 <ClientVanilla />
 
-## Go green
+## Start the server
 
 ```bash
 npm run dev

--- a/docs/frameworks/tanstack.mdx
+++ b/docs/frameworks/tanstack.mdx
@@ -89,7 +89,27 @@ The connect UI is plain React, so use the typed [React hooks](/adapters/react) c
 
 <ClientReact />
 
-## Go green
+### Or let Corsair Connect drive it
+
+**Corsair Connect** wraps the app once so a failed call opens the connect dialog and resumes. Mount the provider in your root route; TanStack re-runs loaders through `router.invalidate()`:
+
+```tsx routes/__root.tsx
+import { CorsairProvider } from "corsair/client/react";
+import { Outlet, useRouter } from "@tanstack/react-router";
+
+function RootComponent() {
+  const router = useRouter();
+  return (
+    <CorsairProvider onConnected={() => router.invalidate()}>
+      <Outlet />
+    </CorsairProvider>
+  );
+}
+```
+
+Then `useConnect().call` around a mutation and `useConnect().connect` for a button open the dialog on their own. (The `<CorsairBoundary>` read helper is specific to Next's Server Components; in TanStack, reads live in loaders.) Full API: [React hooks → Corsair Connect](/adapters/react#corsair-connect).
+
+## Start the server
 
 ```bash
 npm run dev

--- a/docs/frameworks/tanstack.mdx
+++ b/docs/frameworks/tanstack.mdx
@@ -107,7 +107,7 @@ function RootComponent() {
 }
 ```
 
-Then `useConnect().call` around a mutation and `useConnect().connect` for a button open the dialog on their own. (The `<CorsairBoundary>` read helper is specific to Next's Server Components; in TanStack, reads live in loaders.) Full API: [React hooks → Corsair Connect](/adapters/react#corsair-connect).
+Then `useConnections().call` around a mutation and `useConnections().connect` for a button open the dialog on their own. (`CorsairErrorBoundary` is specific to Next's Server Components; in TanStack, reads live in loaders.) Full API: [Corsair Connect](/adapters/corsair-connect).
 
 ## Start the server
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -34,7 +34,8 @@
 
 - [Handlers](https://docs.corsair.dev/adapters/handlers.md): Mount the /api/corsair route — Next.js, Express, Hono, or any Web-standard runtime.
 - [Vanilla client](https://docs.corsair.dev/adapters/client.md): createCorsairClient — typed fetch wrapper for the management API, any JS runtime.
-- [React hooks & Corsair Connect](https://docs.corsair.dev/adapters/react.md): createCorsairReactClient hooks (useTenants, useConnectionStatus, …) plus `<CorsairProvider>` / `<CorsairBoundary>` / useConnect, which open a connect dialog and resume the failed work when a tenant isn't connected.
+- [React hooks](https://docs.corsair.dev/adapters/react.md): createCorsairReactClient hooks (useTenants, useConnectionStatus, …) over the management API.
+- [Corsair Connect](https://docs.corsair.dev/adapters/corsair-connect.md): `<CorsairProvider>` + `useConnections` + `CorsairErrorBoundary` — an in-app connect dialog for end users that opens on a missing credential and resumes the failed work once connected.
 
 ## Core concepts
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5,88 +5,119 @@
 ## Get started
 
 - [Introduction](https://docs.corsair.dev/introduction.md): What Corsair is, how the SDK works, and when to use it.
-- [Quick start](https://docs.corsair.dev/quick-start.md): Get a local Corsair instance running with Hub.
-- [Set up with your agent](https://docs.corsair.dev/getting-started/set-up-with-your-agent.md): One prompt that wires Corsair Hub into your app end to end.
+- [Quick start](https://docs.corsair.dev/quick-start.md): A working integration in five steps, powered by Hub.
+- [Set up with your agent](https://docs.corsair.dev/getting-started/set-up-with-your-agent.md): One prompt that takes your app from empty to a working, connected integration.
 
-## Adapters
+## Use cases
 
-- [Handlers](https://docs.corsair.dev/adapters/handlers.md): Mount the /api/corsair route — Next.js, Express, Hono, or any Web-standard runtime (SvelteKit, Remix, Astro, Nuxt, Workers, Bun, Deno).
+- [Overview](https://docs.corsair.dev/use-cases/overview.md): The four shapes an app built on Corsair takes, and how to pick between them.
+- [Dashboard](https://docs.corsair.dev/use-cases/dashboards.md): Render synced integration data from your own database, and act on it with live API calls.
+- [Agent](https://docs.corsair.dev/use-cases/agents.md): Expose every integration as tools over MCP so an LLM can pick the operation from a plain-English instruction.
+- [Knowledge base](https://docs.corsair.dev/use-cases/knowledge-base.md): Treat everything you've synced as one searchable corpus and answer questions from it.
+- [Workflow](https://docs.corsair.dev/use-cases/workflows.md): An event in one service triggers actions in another, chained in TypeScript.
+
+## Frameworks
+
+- [Next.js](https://docs.corsair.dev/frameworks/next.md): Mount Corsair as one catch-all route, read synced data in Server Components, and mutate with Server Actions.
+- [Nuxt](https://docs.corsair.dev/frameworks/nuxt.md): Mount as a Nitro server route, read synced data with useFetch, and connect tenants with the vanilla client.
+- [SvelteKit](https://docs.corsair.dev/frameworks/sveltekit.md): Read synced data in a load function, render it in +page.svelte, and mutate through form actions.
+- [Remix](https://docs.corsair.dev/frameworks/remix.md): Loaders read from .db, actions write through .api — Corsair's read/write split on Remix's data model.
+- [Astro](https://docs.corsair.dev/frameworks/astro.md): Mount as an Astro API route, then read synced data straight from .astro frontmatter, server-rendered per request.
+- [TanStack Start](https://docs.corsair.dev/frameworks/tanstack.md): Mount as a server route, read synced data in a server function or loader, and connect tenants with React hooks.
+- [Node.js](https://docs.corsair.dev/frameworks/node.md): Mount on a bare node:http server with toNodeHandler — you own the plumbing, the adapter handles the body.
+- [Express](https://docs.corsair.dev/frameworks/express.md): Drop Corsair into the Express API you already run — one line of middleware, then your own routes.
+- [Fastify](https://docs.corsair.dev/frameworks/fastify.md): Mount as a wildcard route in a Fastify plugin, then read synced data from your database.
+- [Hono](https://docs.corsair.dev/frameworks/hono.md): One wildcard route mounts Corsair in Hono, and it runs unchanged on Workers, Bun, Deno, and Node.
+- [Nest.js](https://docs.corsair.dev/frameworks/nestjs.md): Mount on Nest's Express instance, then provide it and inject it into your controllers.
+
+## SDK adapters
+
+- [Handlers](https://docs.corsair.dev/adapters/handlers.md): Mount the /api/corsair route — Next.js, Express, Hono, or any Web-standard runtime.
 - [Vanilla client](https://docs.corsair.dev/adapters/client.md): createCorsairClient — typed fetch wrapper for the management API, any JS runtime.
-- [React hooks](https://docs.corsair.dev/adapters/react.md): createCorsairReactClient — typed useTenants, useConnectionStatus, and friends.
+- [React hooks & Corsair Connect](https://docs.corsair.dev/adapters/react.md): createCorsairReactClient hooks (useTenants, useConnectionStatus, …) plus `<CorsairProvider>` / `<CorsairBoundary>` / useConnect, which open a connect dialog and resume the failed work when a tenant isn't connected.
 
 ## Core concepts
 
 - [Integrations](https://docs.corsair.dev/concepts/integrations.md): Instances, plugins, permissions, and root credentials.
-- [Auth](https://docs.corsair.dev/concepts/auth.md): How Corsair authenticates to third-party services.
-- [Permissions](https://docs.corsair.dev/concepts/permissions.md): Scope what each instance and tenant can do.
-- [Multi-tenancy](https://docs.corsair.dev/concepts/multi-tenancy.md): Tenants, connect links, and per-customer credentials.
-- [Database](https://docs.corsair.dev/concepts/database.md): Synced cache, schemas, and reading data.
-- [Webhooks](https://docs.corsair.dev/concepts/webhooks.md): Receive and route provider webhooks.
-- [Hooks](https://docs.corsair.dev/concepts/hooks.md): Run logic on Corsair events.
+- [Auth](https://docs.corsair.dev/concepts/auth.md): OAuth, API keys, and bot tokens, handled automatically.
+- [Permissions](https://docs.corsair.dev/concepts/permissions.md): Gate destructive agent actions behind human approval before they execute.
+- [Multi-tenancy](https://docs.corsair.dev/concepts/multi-tenancy.md): One flag, and every user gets their own credentials and data.
+- [Database](https://docs.corsair.dev/concepts/database.md): Six tables, always-fresh integration data, tenant-scoped by default.
+- [Triggers](https://docs.corsair.dev/concepts/webhooks.md): One endpoint for every incoming webhook, automatically routed and verified.
+- [Hooks](https://docs.corsair.dev/concepts/hooks.md): Hook into API calls and webhooks to customize behavior.
 - [API](https://docs.corsair.dev/concepts/api.md): Call plugin operations directly with `tenant.run()`.
-- [Error handling](https://docs.corsair.dev/concepts/error-handling.md): `CorsairApiError` and failure modes.
-- [TypeScript](https://docs.corsair.dev/concepts/typescript.md): Generated types and Zod schemas.
+- [Error handling](https://docs.corsair.dev/concepts/error-handling.md): Error handlers and retry strategies, plus the typed AuthMissingError / ReconnectRequiredError.
+- [TypeScript](https://docs.corsair.dev/concepts/typescript.md): End-to-end type safety with zero configuration.
+- [Provisioning](https://docs.corsair.dev/concepts/provisioning.md): Initialize integrations, accounts, and tenants with `setupCorsair` or the corsair CLI.
 
 ## Authentication
 
-- [API key](https://docs.corsair.dev/concepts/api-key.md): API-key based auth for providers.
-- [OAuth](https://docs.corsair.dev/concepts/oauth.md): OAuth-based auth for providers.
-- [OAuth process](https://docs.corsair.dev/concepts/oauth-process.md): Manual-mode production OAuth flow and connect links.
-
-## Provisioning
-
-- [Provisioning](https://docs.corsair.dev/concepts/provisioning.md): Initialize integrations, accounts, and tenants with `setupCorsair` or the corsair CLI.
+- [API key](https://docs.corsair.dev/concepts/api-key.md): Use static API keys and tokens with Corsair plugins.
+- [OAuth 2.0](https://docs.corsair.dev/concepts/oauth.md): Connect user accounts with OAuth 2.0 flows.
+- [OAuth process](https://docs.corsair.dev/concepts/oauth-process.md): A production OAuth implementation with security best practices.
 
 ## Hub
 
-Optional hosted relay for the parts of Corsair that need a public URL — OAuth callbacks, connect pages, approvals. Stores none of your credentials.
+Optional hosted relay for the parts of Corsair that need a public URL — OAuth callbacks, connect pages, approvals. Your users' API tokens land in your database, not Hub.
 
-- [Overview](https://docs.corsair.dev/hub/overview.md): What Hub is and why it stores no credentials.
-- [Setup](https://docs.corsair.dev/hub/setup.md): Wire the SDK into your app — install, /api/corsair route, keys, self-registration.
-- [Environments](https://docs.corsair.dev/hub/environments.md): Development vs production keys.
-- [Delivery URLs](https://docs.corsair.dev/hub/delivery-urls.md): How Hub delivers results; dev self-registration and production POST.
-- [Dashboard](https://docs.corsair.dev/hub/dashboard.md): Manage keys, connections, and delivery URLs.
-- [Manual or Hub](https://docs.corsair.dev/hub/manual-vs-hub.md): What you build in each mode.
-- [Permissions](https://docs.corsair.dev/hub/permissions.md): Scope what each environment can do.
-- [Hub REST API](https://docs.corsair.dev/hub/rest-api.md): Language-agnostic HTTP contract for non-JS backends.
+- [Overview](https://docs.corsair.dev/hub/overview.md): What Hub is and why it stores none of your credentials.
+- [Setup](https://docs.corsair.dev/hub/setup.md): Install, add the /api/corsair route, add your keys, and start — your app self-registers on first run.
+- [Environments](https://docs.corsair.dev/hub/environments.md): Development and Production environments for different stages of your workflow.
+- [Delivery URLs](https://docs.corsair.dev/hub/delivery-urls.md): How Hub delivers OAuth results, credentials, and approvals — signed POST over a tunnel in dev, to your public URL in prod.
+- [Dashboard](https://docs.corsair.dev/hub/dashboard.md): Manage project keys, connection status, sign-in links, and production delivery.
+- [Manual or Hub](https://docs.corsair.dev/hub/manual-vs-hub.md): The same instance, two ways to handle the surfaces that need a public URL.
+- [Approvals on Hub](https://docs.corsair.dev/hub/permissions.md): Let Hub host the approve/deny UI for gated permissions.
+- [Hub REST API](https://docs.corsair.dev/hub/rest-api.md): Integrate Hub from any language over plain HTTP, no SDK required.
+
+## Management API
+
+- [Overview](https://docs.corsair.dev/management/overview.md): Mount Corsair's management API in your own app — the same routes app.corsair.dev uses.
+- [Handler](https://docs.corsair.dev/management/handler.md): `managementHandler()` turns a Corsair instance into a framework-agnostic fetch handler.
+- [Connect / OAuth](https://docs.corsair.dev/management/connect.md): Connect users to Slack, GitHub, and other plugins with one `createLink` API.
 
 ## Use with AI
 
 Expose Corsair tools to agents over MCP, or wire them into agent SDKs and coding agents.
 
-- [MCP adapters](https://docs.corsair.dev/mcp-adapters/mcp-adapters.md): Local stdio MCP for agents and clients.
-- [Anthropic SDK](https://docs.corsair.dev/mcp-adapters/anthropic-sdk.md): Use Corsair tools with the Anthropic SDK.
-- [Claude Agent SDK](https://docs.corsair.dev/mcp-adapters/claude-sdk.md): `claudeMcpServerConfig` and `query()`.
-- [OpenAI Agents](https://docs.corsair.dev/mcp-adapters/openai-agents.md): Corsair tools in the OpenAI Agents SDK.
-- [Vercel AI SDK](https://docs.corsair.dev/mcp-adapters/vercel-ai.md): `streamText` / `generateText` with Corsair MCP tools.
-- [Mastra](https://docs.corsair.dev/mcp-adapters/mastra.md): Corsair tools in Mastra.
-- [OpenAI](https://docs.corsair.dev/mcp-adapters/openai.md): Responses API with Corsair MCP.
-- [Coding agents](https://docs.corsair.dev/mcp-adapters/coding-agents.md): Give Cursor, Claude Code, and other clients a local MCP server.
-- [Claude Code](https://docs.corsair.dev/mcp-adapters/claude-code.md): `.mcp.json` or `claude mcp add`.
-- [Cursor](https://docs.corsair.dev/mcp-adapters/cursor.md): `.cursor/mcp.json` configuration.
-
-## Management API
-
-- [Overview](https://docs.corsair.dev/management/overview.md): Manage instances, tenants, and connections programmatically.
-- [Handler](https://docs.corsair.dev/management/handler.md): The 9 management routes, options, and error shapes. Mounting lives under [Adapters](https://docs.corsair.dev/adapters/handlers.md).
-- [Connect](https://docs.corsair.dev/management/connect.md): Connect link flow.
+- [MCP adapters](https://docs.corsair.dev/mcp-adapters/mcp-adapters.md): Connect Corsair to any AI framework or agent runtime using MCP adapters.
+- [Anthropic SDK](https://docs.corsair.dev/mcp-adapters/anthropic-sdk.md): Use Corsair tools with the Anthropic SDK via tool use.
+- [Claude Agent SDK](https://docs.corsair.dev/mcp-adapters/claude-sdk.md): Use Corsair with the Claude Agent SDK via an in-process MCP server.
+- [Vercel AI SDK](https://docs.corsair.dev/mcp-adapters/vercel-ai.md): Connect Corsair to the Vercel AI SDK over HTTP.
+- [Mastra](https://docs.corsair.dev/mcp-adapters/mastra.md): Connect Corsair to the Mastra agent framework.
+- [OpenAI](https://docs.corsair.dev/mcp-adapters/openai.md): Connect Corsair to OpenAI via the Agents SDK or the Responses API over HTTP.
+- [Coding agents](https://docs.corsair.dev/mcp-adapters/coding-agents.md): Use Corsair's CLI discovery commands with Claude Code, Cursor, and Copilot.
+- [Claude Code](https://docs.corsair.dev/mcp-adapters/claude-code.md): Connect Corsair to Claude Code via MCP or use the CLI directly.
+- [Cursor](https://docs.corsair.dev/mcp-adapters/cursor.md): Connect Corsair to Cursor via MCP or the CLI.
+- [Codex](https://docs.corsair.dev/mcp-adapters/codex.md): Connect Corsair to OpenAI's Codex CLI via MCP, or the CLI.
+- [OpenCode](https://docs.corsair.dev/mcp-adapters/opencode.md): Connect Corsair to OpenCode via MCP, or the CLI.
+- [Hermes](https://docs.corsair.dev/mcp-adapters/hermes.md): Connect Corsair to the Hermes agent via MCP, or the CLI.
 
 ## Workflow engines
 
-- [Inngest](https://docs.corsair.dev/guides/inngest.md): Run Corsair operations from Inngest functions.
-- [Temporal](https://docs.corsair.dev/guides/temporal.md): Use Corsair in Temporal workflows.
-- [Trigger.dev](https://docs.corsair.dev/guides/trigger-dev.md): Use Corsair in Trigger.dev tasks.
-- [Hatchet](https://docs.corsair.dev/guides/hatchet.md): Use Corsair in Hatchet workflows.
+- [Inngest](https://docs.corsair.dev/guides/inngest.md): Trigger durable Inngest functions from Corsair webhook events.
+- [Temporal](https://docs.corsair.dev/guides/temporal.md): Start Temporal workflows from Corsair webhook events.
+- [Trigger.dev](https://docs.corsair.dev/guides/trigger-dev.md): Run Trigger.dev background tasks from Corsair webhook events.
+- [Hatchet](https://docs.corsair.dev/guides/hatchet.md): Push Hatchet workflow events from Corsair webhook hooks.
+
+## Workflows (beta)
+
+- [Overview](https://docs.corsair.dev/workflows/overview.md): Durable, multi-step workflows that run inside your app against your integrations, no external engine.
+- [Triggering](https://docs.corsair.dev/workflows/triggering.md): Start and list workflow runs, plus webhook and schedule triggers.
+- [Execution & steps](https://docs.corsair.dev/workflows/execution.md): Turn on execution, and how `step()` and `step.sleep()` make a run durable.
 
 ## Plugins
 
-- [Plugins guide](https://docs.corsair.dev/guides/plugins.md): The Corsair plugin catalog and how to use plugins.
-- [Create your own plugin](https://docs.corsair.dev/guides/create-your-own-plugin.md): Build a custom plugin.
-- [Plugin credentials](https://docs.corsair.dev/guides/plugin-credentials.md): Configure credentials for plugins.
+- [Plugins guide](https://docs.corsair.dev/guides/plugins.md): Install an integration package, register it, and browse reference docs for each provider.
+- [Create your own plugin](https://docs.corsair.dev/guides/create-your-own-plugin.md): Scaffold a new Corsair plugin with the generator.
+- [Plugin credentials](https://docs.corsair.dev/guides/plugin-credentials.md): How to obtain API keys, tokens, client IDs, secrets, and webhook credentials for every plugin.
 - [Integrations catalog](https://api.corsair.dev/md/integrations): Complete Corsair integration catalog (Markdown).
 
 ## Guides
 
-- [Webhooks](https://docs.corsair.dev/guides/webhooks.md): End-to-end webhook setup.
-- [Workflows](https://docs.corsair.dev/guides/workflows.md): Build workflows with Corsair.
-- [Dashboard](https://docs.corsair.dev/guides/dashboard.md): Use the Corsair dashboard.
+- [Vibe code your dashboard](https://docs.corsair.dev/guides/dashboard.md): Scaffold a T3 app, wire in Google Calendar, and let an agent build the whole dashboard from one prompt.
+- [Webhooks](https://docs.corsair.dev/guides/webhooks.md): Receive real-time events from any plugin in three steps.
+- [Workflows](https://docs.corsair.dev/guides/workflows.md): Chain webhook events into multi-step automations across any plugin.
+
+## LLM gateway
+
+- [LLM gateway](https://docs.corsair.dev/llm-gateway.md): Use llm.corsair.dev as an OpenAI-compatible API with per-developer keys and budgets.

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -60,7 +60,7 @@ Keep your KEK safe. Lose it and you lose access to every stored credential. Trea
 
 ## Create the database
 
-Corsair stores data in five tables. SQLite is the fastest way to start:
+Corsair stores data in six tables. SQLite is the fastest way to start:
 
 <CodeGroup>
 ```bash npm
@@ -135,6 +135,13 @@ CREATE TABLE IF NOT EXISTS corsair_permissions (
     status TEXT NOT NULL DEFAULT 'pending',
     expires_at TEXT NOT NULL,
     error TEXT
+);
+
+CREATE TABLE IF NOT EXISTS corsair_connect_requests (
+    tenant_id TEXT PRIMARY KEY,
+    plugin TEXT NOT NULL,
+    connect_url TEXT NOT NULL,
+    requested_at TEXT NOT NULL
 );
 ```
 
@@ -254,7 +261,7 @@ Load your app so the mounted route gets its first hit. That request registers yo
     Building a product? Flip one flag and every user gets their own data and credentials.
   </Card>
   <Card title="Database options" href="/concepts/database">
-    Postgres, Drizzle, Prisma, and the five tables Corsair uses.
+    Postgres, Drizzle, Prisma, and the six tables Corsair uses.
   </Card>
   <Card title="Provisioning" href="/concepts/provisioning">
     Seed credentials and provision tenants from the `corsair` CLI or `setupCorsair`.

--- a/docs/snippets/framework-verify.mdx
+++ b/docs/snippets/framework-verify.mdx
@@ -1,4 +1,4 @@
-## Go green
+## Start the server
 
 Start your dev server. The first time your app talks to `/api/corsair`, which happens as soon as a dashboard that calls the client loads, it self-registers its delivery URL with Hub and the dashboard header dot turns green. See [Delivery URLs](/hub/delivery-urls).
 

--- a/packages/corsair/client/index.ts
+++ b/packages/corsair/client/index.ts
@@ -1,6 +1,7 @@
 import type {
 	ConnectionStatus,
 	ConnectLink,
+	ConnectRequest,
 	ManagementOk,
 	OAuthCallbackResult,
 	PermissionRecord,
@@ -108,6 +109,18 @@ export function createCorsairClient(
 				getJson<ResolvedConnectLink>('/connect/resolve', { state }),
 			oauthCallback: (input) =>
 				postJson<OAuthCallbackResult>('/connect/oauth/callback', input),
+		},
+		connectRequest: {
+			get: (q) => {
+				const query: Record<string, string> = {};
+				if (q?.tenantId) query.tenantId = q.tenantId;
+				return getJson<{ request: ConnectRequest | null }>(
+					'/connect/request',
+					query,
+				);
+			},
+			clear: (input) =>
+				postJson<{ ok: true }>('/connect/request/clear', input ?? {}),
 		},
 	};
 }

--- a/packages/corsair/client/react/boundary.tsx
+++ b/packages/corsair/client/react/boundary.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { Component } from 'react';
+import type { RequireConnectOutcome } from './provider';
+import { useCorsair } from './provider';
+
+type InnerProps = {
+	requireConnect: () => Promise<RequireConnectOutcome>;
+	// The provider's connectNonce — bumps on each successful connect so we can
+	// reset and re-render the (now-refreshed) children.
+	resetKey: number;
+	fallback: ReactNode;
+	children: ReactNode;
+};
+
+type InnerState = { errored: boolean; showFallback: boolean };
+
+class ConnectErrorBoundary extends Component<InnerProps, InnerState> {
+	state: InnerState = { errored: false, showFallback: false };
+
+	static getDerivedStateFromError(): Partial<InnerState> {
+		return { errored: true, showFallback: false };
+	}
+
+	componentDidCatch(): void {
+		// A caught error reaches the browser redacted, so we can't tell a connect
+		// failure from a real one here. Ask the provider: if a connect-request is
+		// pending it opens the dialog (and resetKey bumps on connect → we retry);
+		// otherwise it's a genuine error → show the fallback.
+		this.props
+			.requireConnect()
+			.then((outcome) => {
+				if (outcome !== 'connected') this.setState({ showFallback: true });
+			})
+			.catch(() => this.setState({ showFallback: true }));
+	}
+
+	componentDidUpdate(prev: InnerProps): void {
+		if (prev.resetKey !== this.props.resetKey && this.state.errored) {
+			this.setState({ errored: false, showFallback: false });
+		}
+	}
+
+	render(): ReactNode {
+		if (this.state.errored) {
+			return this.state.showFallback ? this.props.fallback : null;
+		}
+		return this.props.children;
+	}
+}
+
+/** Props for {@link CorsairBoundary}. */
+export type CorsairBoundaryProps = {
+	/**
+	 * Rendered when the region fails for a reason that isn't a pending connect,
+	 * or when the user dismisses the dialog without connecting. Defaults to
+	 * `null` (render nothing).
+	 */
+	fallback?: ReactNode;
+	children: ReactNode;
+};
+
+/**
+ * Wrap a server-rendered read region so an auth-missing failure inside it opens
+ * the connect dialog and, once connected, retries — instead of crashing the
+ * tree. This is the read-side counterpart to {@link useConnect}'s `call` (which
+ * covers mutations). Pair with
+ * `<CorsairProvider onConnected={() => router.refresh()}>` so the refreshed read
+ * re-runs on connect.
+ */
+export function CorsairBoundary({
+	fallback = null,
+	children,
+}: CorsairBoundaryProps): ReactNode {
+	const { requireConnect, connectNonce } = useCorsair();
+	return (
+		<ConnectErrorBoundary
+			requireConnect={requireConnect}
+			resetKey={connectNonce}
+			fallback={fallback}
+		>
+			{children}
+		</ConnectErrorBoundary>
+	);
+}

--- a/packages/corsair/client/react/connect-controller.ts
+++ b/packages/corsair/client/react/connect-controller.ts
@@ -54,3 +54,30 @@ export function isPluginConnected(
 ): boolean {
 	return status?.[plugin] === 'connected';
 }
+
+export const CONNECTED_MESSAGE_TYPE = 'corsair:connected';
+
+// Instant "done" signal the managed connect page posts to its opener. Trusted
+// only from the connect link's own origin — a self-hosted or custom page that
+// never posts it simply falls back to status polling, so nothing breaks.
+export function isConnectedMessage(
+	data: unknown,
+	origin: string,
+	trustedOrigin: string,
+): boolean {
+	return (
+		trustedOrigin.length > 0 &&
+		origin === trustedOrigin &&
+		typeof data === 'object' &&
+		data !== null &&
+		(data as { type?: unknown }).type === CONNECTED_MESSAGE_TYPE
+	);
+}
+
+export function originOf(url: string): string | null {
+	try {
+		return new URL(url).origin;
+	} catch {
+		return null;
+	}
+}

--- a/packages/corsair/client/react/connect-controller.ts
+++ b/packages/corsair/client/react/connect-controller.ts
@@ -1,0 +1,56 @@
+import type { ConnectionStatus } from '../../core/management/types';
+
+// State machine behind the connect overlay. Kept pure (no React) so the
+// open → poll → resolve flow is testable without a DOM.
+
+export type ConnectPhase = 'idle' | 'connecting' | 'success';
+
+export type ConnectState = {
+	phase: ConnectPhase;
+	plugin: string | null;
+	tenantId: string | null;
+	connectUrl: string | null;
+};
+
+export type ConnectAction =
+	| {
+			type: 'OPEN';
+			plugin: string;
+			tenantId: string | null;
+			connectUrl: string;
+	  }
+	| { type: 'SUCCESS' }
+	| { type: 'CLOSE' };
+
+export const initialConnectState: ConnectState = {
+	phase: 'idle',
+	plugin: null,
+	tenantId: null,
+	connectUrl: null,
+};
+
+export function connectReducer(
+	state: ConnectState,
+	action: ConnectAction,
+): ConnectState {
+	switch (action.type) {
+		case 'OPEN':
+			return {
+				phase: 'connecting',
+				plugin: action.plugin,
+				tenantId: action.tenantId,
+				connectUrl: action.connectUrl,
+			};
+		case 'SUCCESS':
+			return { ...state, phase: 'success' };
+		case 'CLOSE':
+			return initialConnectState;
+	}
+}
+
+export function isPluginConnected(
+	status: ConnectionStatus | null | undefined,
+	plugin: string,
+): boolean {
+	return status?.[plugin] === 'connected';
+}

--- a/packages/corsair/client/react/connect-controller.ts
+++ b/packages/corsair/client/react/connect-controller.ts
@@ -55,29 +55,18 @@ export function isPluginConnected(
 	return status?.[plugin] === 'connected';
 }
 
-export const CONNECTED_MESSAGE_TYPE = 'corsair:connected';
-
-// Instant "done" signal the managed connect page posts to its opener. Trusted
-// only from the connect link's own origin — a self-hosted or custom page that
-// never posts it simply falls back to status polling, so nothing breaks.
-export function isConnectedMessage(
-	data: unknown,
-	origin: string,
-	trustedOrigin: string,
-): boolean {
+// A status poll is async: it can resolve after its overlay was closed or a new
+// connection attempt began. Settle only when the poll still belongs to the
+// current attempt and the plugin actually connected — otherwise a stale poll
+// would resolve the wrong promise.
+export function shouldSettleConnected(input: {
+	capturedAttempt: number;
+	currentAttempt: number;
+	status: ConnectionStatus | null | undefined;
+	plugin: string;
+}): boolean {
 	return (
-		trustedOrigin.length > 0 &&
-		origin === trustedOrigin &&
-		typeof data === 'object' &&
-		data !== null &&
-		(data as { type?: unknown }).type === CONNECTED_MESSAGE_TYPE
+		input.capturedAttempt === input.currentAttempt &&
+		isPluginConnected(input.status, input.plugin)
 	);
-}
-
-export function originOf(url: string): string | null {
-	try {
-		return new URL(url).origin;
-	} catch {
-		return null;
-	}
 }

--- a/packages/corsair/client/react/connect-controller.ts
+++ b/packages/corsair/client/react/connect-controller.ts
@@ -9,10 +9,17 @@ export type ConnectState = {
 	phase: ConnectPhase;
 	plugin: string | null;
 	connectUrl: string | null;
+	// Explicit tenant for a proactive connect; null means the handler resolves it.
+	tenantId: string | null;
 };
 
 export type ConnectAction =
-	| { type: 'OPEN'; plugin: string; connectUrl: string }
+	| {
+			type: 'OPEN';
+			plugin: string;
+			connectUrl: string;
+			tenantId: string | null;
+	  }
 	| { type: 'SUCCESS' }
 	| { type: 'CLOSE' };
 
@@ -20,6 +27,7 @@ export const initialConnectState: ConnectState = {
 	phase: 'idle',
 	plugin: null,
 	connectUrl: null,
+	tenantId: null,
 };
 
 export function connectReducer(
@@ -32,6 +40,7 @@ export function connectReducer(
 				phase: 'connecting',
 				plugin: action.plugin,
 				connectUrl: action.connectUrl,
+				tenantId: action.tenantId,
 			};
 		case 'SUCCESS':
 			return { ...state, phase: 'success' };

--- a/packages/corsair/client/react/connect-controller.ts
+++ b/packages/corsair/client/react/connect-controller.ts
@@ -1,31 +1,24 @@
 import type { ConnectionStatus } from '../../core/management/types';
 
 // State machine behind the connect overlay. Kept pure (no React) so the
-// open → poll → resolve flow is testable without a DOM.
+// open → watch → settle flow is testable without a DOM.
 
 export type ConnectPhase = 'idle' | 'connecting' | 'success';
 
 export type ConnectState = {
 	phase: ConnectPhase;
 	plugin: string | null;
-	tenantId: string | null;
 	connectUrl: string | null;
 };
 
 export type ConnectAction =
-	| {
-			type: 'OPEN';
-			plugin: string;
-			tenantId: string | null;
-			connectUrl: string;
-	  }
+	| { type: 'OPEN'; plugin: string; connectUrl: string }
 	| { type: 'SUCCESS' }
 	| { type: 'CLOSE' };
 
 export const initialConnectState: ConnectState = {
 	phase: 'idle',
 	plugin: null,
-	tenantId: null,
 	connectUrl: null,
 };
 
@@ -38,7 +31,6 @@ export function connectReducer(
 			return {
 				phase: 'connecting',
 				plugin: action.plugin,
-				tenantId: action.tenantId,
 				connectUrl: action.connectUrl,
 			};
 		case 'SUCCESS':
@@ -55,10 +47,9 @@ export function isPluginConnected(
 	return status?.[plugin] === 'connected';
 }
 
-// A status poll is async: it can resolve after its overlay was closed or a new
-// connection attempt began. Settle only when the poll still belongs to the
-// current attempt and the plugin actually connected — otherwise a stale poll
-// would resolve the wrong promise.
+// A status poll can resolve after its overlay closed or a new attempt began.
+// Settle only when the poll still belongs to the current attempt and the plugin
+// actually connected — otherwise a stale poll would resolve the wrong promise.
 export function shouldSettleConnected(input: {
 	capturedAttempt: number;
 	currentAttempt: number;

--- a/packages/corsair/client/react/connect-overlay.tsx
+++ b/packages/corsair/client/react/connect-overlay.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import type { ReactElement } from 'react';
+import type { ConnectState } from './connect-controller';
+
+export type ConnectAppearance = {
+	theme?: 'light' | 'dark';
+};
+
+// Full-screen overlay (max z-index, not an iframe) shown while a connect flow is
+// active. The user clicks through to Hub's connect page in a popup — opening it
+// from the click keeps the browser's popup blocker happy.
+export function ConnectOverlay({
+	state,
+	appearance,
+	onOpen,
+	onClose,
+}: {
+	state: ConnectState;
+	appearance?: ConnectAppearance;
+	onOpen: () => void;
+	onClose: () => void;
+}): ReactElement {
+	const dark = appearance?.theme === 'dark';
+	const fg = dark ? '#f5f5f5' : '#111';
+	const bg = dark ? '#1b1b1b' : '#fff';
+	const accent = '#4f46e5';
+	const plugin = state.plugin ?? 'this integration';
+	const connected = state.phase === 'success';
+
+	return (
+		<div
+			role="dialog"
+			aria-modal="true"
+			style={{
+				position: 'fixed',
+				inset: 0,
+				zIndex: 2147483647,
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				background: 'rgba(0,0,0,0.5)',
+			}}
+		>
+			<div
+				style={{
+					width: 'min(92vw, 380px)',
+					borderRadius: 12,
+					background: bg,
+					color: fg,
+					padding: 24,
+					boxShadow: '0 10px 40px rgba(0,0,0,0.35)',
+					fontFamily: 'system-ui, sans-serif',
+				}}
+			>
+				<button
+					type="button"
+					onClick={onClose}
+					aria-label="Close"
+					style={{
+						float: 'right',
+						border: 'none',
+						background: 'transparent',
+						color: fg,
+						fontSize: 20,
+						cursor: 'pointer',
+					}}
+				>
+					×
+				</button>
+				{connected ? (
+					<>
+						<h2 style={{ margin: '0 0 8px', fontSize: 18 }}>Connected</h2>
+						<p style={{ margin: 0, opacity: 0.8 }}>
+							{plugin} is connected — you can continue.
+						</p>
+					</>
+				) : (
+					<>
+						<h2 style={{ margin: '0 0 8px', fontSize: 18 }}>
+							Connect {plugin}
+						</h2>
+						<p style={{ margin: '0 0 20px', opacity: 0.8 }}>
+							Sign in to {plugin} to continue where you left off.
+						</p>
+						<button
+							type="button"
+							onClick={onOpen}
+							style={{
+								width: '100%',
+								padding: '10px 16px',
+								borderRadius: 8,
+								border: 'none',
+								background: accent,
+								color: '#fff',
+								fontSize: 15,
+								fontWeight: 600,
+								cursor: 'pointer',
+							}}
+						>
+							Connect {plugin}
+						</button>
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/packages/corsair/client/react/connect-overlay.tsx
+++ b/packages/corsair/client/react/connect-overlay.tsx
@@ -1,37 +1,327 @@
 'use client';
 
-import type { ReactElement } from 'react';
+import type { CSSProperties, ReactElement } from 'react';
+import { useEffect, useState } from 'react';
+import type {
+	ConnectionStatus,
+	PluginConnectionState,
+} from '../../core/management/types';
+import type { CorsairManagementClient } from '../types';
 import type { ConnectState } from './connect-controller';
+import { PluginIcon, pluginToDomain, titleCasePlugin } from './plugin-icon';
 
-export type ConnectAppearance = {
-	theme?: 'light' | 'dark';
-};
+export type ConnectTheme = 'light' | 'dark' | 'auto';
 
-// Full-screen overlay (max z-index, not an iframe) shown while a connect flow is
-// active. The user clicks through to Hub's connect page in a popup — opening it
-// from the click keeps the browser's popup blocker happy.
+/**
+ * How the connect dialog looks. Pass the shorthand string (`appearance="dark"`)
+ * or the object form (`appearance={{ theme: 'dark' }}`) — both are accepted.
+ * Defaults to `'auto'`, which follows the host's `prefers-color-scheme`.
+ */
+export type ConnectAppearance = ConnectTheme | { theme?: ConnectTheme };
+
+function resolveTheme(
+	a: ConnectAppearance | undefined,
+): ConnectTheme | undefined {
+	return typeof a === 'string' ? a : a?.theme;
+}
+
+// Resolve the effective dark flag: an explicit light/dark wins; otherwise follow
+// the host app's color scheme and react to changes.
+function useDark(theme: ConnectTheme | undefined): boolean {
+	const [dark, setDark] = useState(theme === 'dark');
+	useEffect(() => {
+		if (theme === 'dark' || theme === 'light') {
+			setDark(theme === 'dark');
+			return;
+		}
+		const mq = window.matchMedia('(prefers-color-scheme: dark)');
+		setDark(mq.matches);
+		const onChange = (e: MediaQueryListEvent) => setDark(e.matches);
+		mq.addEventListener('change', onChange);
+		return () => mq.removeEventListener('change', onChange);
+	}, [theme]);
+	return dark;
+}
+
+const ACCENT = '#4a38f5';
+const INK = '#1c1c1c';
+const SUCCESS = '#1a7f4b';
+const MONO = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+const SANS =
+	'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, system-ui, sans-serif';
+
+const STYLES = `
+@keyframes corsair-fade { from { opacity: 0 } to { opacity: 1 } }
+@keyframes corsair-rise {
+	from { opacity: 0; transform: translateY(8px) scale(0.985) }
+	to { opacity: 1; transform: none }
+}
+.corsair-scrim { animation: corsair-fade 150ms ease-out }
+.corsair-card { animation: corsair-rise 240ms cubic-bezier(0.2,0.8,0.2,1) }
+.corsair-primary { transition: background 120ms ease, transform 90ms ease }
+.corsair-primary:hover { background: var(--corsair-primary-hover, #000) }
+.corsair-primary:active { transform: translateY(1px) }
+.corsair-ghost { transition: color 120ms ease }
+.corsair-roster { transition: background 120ms ease }
+.corsair-roster:hover { background: #1c1c1c05 }
+.corsair-primary:focus-visible, .corsair-ghost:focus-visible, .corsair-roster:focus-visible {
+	outline: 2px solid ${ACCENT}; outline-offset: 2px;
+}
+@media (prefers-reduced-motion: reduce) { .corsair-scrim, .corsair-card { animation: none } }
+`;
+
+// Blueprint dot-grid behind the hero — the same mark as the Hub connect canvas,
+// so the card reads as pinned onto Corsair's surface. Faint accent, radial-faded
+// so it never competes with the type.
+function heroGrid(dark: boolean): CSSProperties {
+	const dot = dark ? 'rgba(129,116,248,0.16)' : 'rgba(74,56,245,0.10)';
+	return {
+		position: 'absolute',
+		inset: 0,
+		backgroundImage: `radial-gradient(circle at 1px 1px, ${dot} 1px, transparent 0)`,
+		backgroundSize: '13px 13px',
+		maskImage:
+			'radial-gradient(ellipse 78% 70% at 50% 32%, #000 0%, transparent 78%)',
+		WebkitMaskImage:
+			'radial-gradient(ellipse 78% 70% at 50% 32%, #000 0%, transparent 78%)',
+		pointerEvents: 'none',
+	};
+}
+
+// Corner crop-marks framing the card.
+function PlusCorner({ style }: { style: CSSProperties }): ReactElement {
+	return (
+		<svg
+			width="16"
+			height="16"
+			viewBox="0 0 16 16"
+			fill="none"
+			aria-hidden
+			style={{ position: 'absolute', ...style }}
+		>
+			<path d="M8 0v16M0 8h16" stroke={ACCENT} strokeWidth="1.5" />
+		</svg>
+	);
+}
+
+function isConnected(state: PluginConnectionState): boolean {
+	return state === 'connected';
+}
+
+// The tenant's other integrations — read-only, collapsed by default.
+function ConnectionsRoster({
+	client,
+	activePlugin,
+	ink,
+	muted,
+	faint,
+	border,
+	hair,
+}: {
+	client: CorsairManagementClient;
+	activePlugin: string | null;
+	ink: string;
+	muted: string;
+	faint: string;
+	border: string;
+	hair: string;
+}): ReactElement | null {
+	const [statuses, setStatuses] = useState<ConnectionStatus | null>(null);
+	const [open, setOpen] = useState(false);
+
+	useEffect(() => {
+		let live = true;
+		client.connectionStatus
+			.get()
+			.then((s) => {
+				if (live) setStatuses(s);
+			})
+			.catch(() => {});
+		return () => {
+			live = false;
+		};
+	}, [client]);
+
+	const others = statuses
+		? Object.entries(statuses).filter(([id]) => id !== activePlugin)
+		: [];
+	if (others.length === 0) return null;
+
+	const connectedCount = others.filter(([, s]) => isConnected(s)).length;
+
+	return (
+		<div
+			style={{ marginTop: 12, borderTop: `1px solid ${hair}`, paddingTop: 12 }}
+		>
+			<button
+				type="button"
+				onClick={() => setOpen((v) => !v)}
+				aria-expanded={open}
+				className="corsair-roster"
+				style={{
+					display: 'flex',
+					width: '100%',
+					alignItems: 'center',
+					justifyContent: 'space-between',
+					gap: 8,
+					padding: '7px 8px',
+					borderRadius: 8,
+					border: 'none',
+					background: 'transparent',
+					cursor: 'pointer',
+				}}
+			>
+				<span
+					style={{
+						fontFamily: MONO,
+						fontSize: 10.5,
+						letterSpacing: '0.06em',
+						textTransform: 'uppercase',
+						color: faint,
+					}}
+				>
+					Your connections
+				</span>
+				<span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+					<span style={{ fontSize: 12, color: muted }}>
+						{connectedCount}/{others.length}
+					</span>
+					<svg
+						width="12"
+						height="12"
+						viewBox="0 0 12 12"
+						fill="none"
+						aria-hidden
+						style={{
+							transform: open ? 'rotate(180deg)' : 'none',
+							transition: 'transform 160ms ease',
+						}}
+					>
+						<path
+							d="M3 4.5L6 7.5L9 4.5"
+							stroke={faint}
+							strokeWidth="1.3"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+						/>
+					</svg>
+				</span>
+			</button>
+
+			{open ? (
+				<ul style={{ listStyle: 'none', margin: '4px 0 0', padding: 0 }}>
+					{others.map(([id, state]) => {
+						const name = titleCasePlugin(id);
+						const connected = isConnected(state);
+						return (
+							<li
+								key={id}
+								style={{
+									display: 'flex',
+									alignItems: 'center',
+									gap: 10,
+									padding: '7px 8px',
+									borderRadius: 8,
+								}}
+							>
+								<PluginIcon
+									domain={pluginToDomain(id)}
+									label={name}
+									size={20}
+								/>
+								<span style={{ flex: 1, fontSize: 13, color: ink }}>
+									{name}
+								</span>
+								<span
+									style={{
+										display: 'flex',
+										alignItems: 'center',
+										gap: 6,
+										fontSize: 11.5,
+										color: connected ? SUCCESS : faint,
+									}}
+								>
+									<span
+										style={{
+											width: 6,
+											height: 6,
+											borderRadius: 999,
+											background: connected ? SUCCESS : border,
+										}}
+									/>
+									{connected ? 'Connected' : 'Not connected'}
+								</span>
+							</li>
+						);
+					})}
+				</ul>
+			) : null}
+		</div>
+	);
+}
+
+/**
+ * Centered dialog shown while a connect flow is active. Deliberately minimal —
+ * the provider mark, the action, and a trust line. The full consent screen (org,
+ * scopes, credential fields) lives on the Hub connect page the button opens; this
+ * overlay only gets the user there. Opening the popup from the click keeps the
+ * popup blocker happy; the provider polls and resolves once connected.
+ */
 export function ConnectOverlay({
 	state,
+	client,
 	appearance,
 	onOpen,
 	onClose,
 }: {
 	state: ConnectState;
+	client: CorsairManagementClient;
 	appearance?: ConnectAppearance;
 	onOpen: () => void;
 	onClose: () => void;
 }): ReactElement {
-	const dark = appearance?.theme === 'dark';
-	const fg = dark ? '#f5f5f5' : '#111';
-	const bg = dark ? '#1b1b1b' : '#fff';
-	const accent = '#4f46e5';
-	const plugin = state.plugin ?? 'this integration';
 	const connected = state.phase === 'success';
+
+	useEffect(() => {
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') onClose();
+		};
+		window.addEventListener('keydown', onKey);
+		return () => window.removeEventListener('keydown', onKey);
+	}, [onClose]);
+
+	const dark = useDark(resolveTheme(appearance));
+	const surface = dark ? '#141414' : '#fff';
+	const ink = dark ? '#f5f5f5' : INK;
+	const muted = dark ? '#f5f5f599' : `${INK}66`;
+	const faint = dark ? '#f5f5f566' : `${INK}40`;
+	const border = dark ? '#ffffff1f' : `${INK}1a`;
+	const hair = dark ? '#ffffff12' : `${INK}0d`;
+	// CTA inverts with the theme so it reads against the surface: dark button on
+	// a light card, light button on a dark card.
+	const primaryBg = dark ? '#f5f5f5' : INK;
+	const primaryFg = dark ? INK : '#fff';
+	const primaryHover = dark ? '#ffffff' : '#000';
+
+	const pluginId = state.plugin ?? '';
+	const name = pluginId ? titleCasePlugin(pluginId) : 'your account';
+	const domain = pluginToDomain(pluginId);
+	// Faint violet wash behind the provider mark — the accent earning interior
+	// presence instead of living only in the corners.
+	const glow = dark ? 'rgba(129,116,248,0.22)' : 'rgba(74,56,245,0.14)';
+	const iconShadow = dark
+		? 'drop-shadow(0 8px 18px rgba(0,0,0,0.55))'
+		: 'drop-shadow(0 8px 16px rgba(20,18,40,0.22))';
 
 	return (
 		<div
 			role="dialog"
 			aria-modal="true"
+			aria-labelledby="corsair-connect-title"
+			className="corsair-scrim"
+			onMouseDown={(e) => {
+				if (e.target === e.currentTarget) onClose();
+			}}
 			style={{
 				position: 'fixed',
 				inset: 0,
@@ -39,69 +329,207 @@ export function ConnectOverlay({
 				display: 'flex',
 				alignItems: 'center',
 				justifyContent: 'center',
-				background: 'rgba(0,0,0,0.5)',
+				padding: 16,
+				background: 'rgba(20,20,22,0.5)',
+				backdropFilter: 'blur(3px)',
+				fontFamily: SANS,
 			}}
 		>
-			<div
-				style={{
-					width: 'min(92vw, 380px)',
-					borderRadius: 12,
-					background: bg,
-					color: fg,
-					padding: 24,
-					boxShadow: '0 10px 40px rgba(0,0,0,0.35)',
-					fontFamily: 'system-ui, sans-serif',
-				}}
-			>
-				<button
-					type="button"
-					onClick={onClose}
-					aria-label="Close"
-					style={{
-						float: 'right',
-						border: 'none',
-						background: 'transparent',
-						color: fg,
-						fontSize: 20,
-						cursor: 'pointer',
-					}}
+			<style>{STYLES}</style>
+			<div style={{ position: 'relative', width: 'min(94vw, 380px)' }}>
+				<PlusCorner style={{ left: -8, top: -8 }} />
+				<PlusCorner style={{ right: -8, top: -8 }} />
+				<PlusCorner style={{ left: -8, bottom: -8 }} />
+				<PlusCorner style={{ right: -8, bottom: -8 }} />
+
+				<div
+					className="corsair-card"
+					style={
+						{
+							overflow: 'hidden',
+							borderRadius: 0,
+							border: `1px solid ${border}`,
+							background: surface,
+							boxShadow:
+								'0 1px 0 0 rgba(255,255,255,0.04) inset, 0 24px 80px -12px rgba(20,18,40,0.34), 0 6px 18px -6px rgba(20,18,40,0.16)',
+							'--corsair-primary-hover': primaryHover,
+						} as CSSProperties
+					}
 				>
-					×
-				</button>
-				{connected ? (
-					<>
-						<h2 style={{ margin: '0 0 8px', fontSize: 18 }}>Connected</h2>
-						<p style={{ margin: 0, opacity: 0.8 }}>
-							{plugin} is connected — you can continue.
-						</p>
-					</>
-				) : (
-					<>
-						<h2 style={{ margin: '0 0 8px', fontSize: 18 }}>
-							Connect {plugin}
-						</h2>
-						<p style={{ margin: '0 0 20px', opacity: 0.8 }}>
-							Sign in to {plugin} to continue where you left off.
-						</p>
-						<button
-							type="button"
-							onClick={onOpen}
-							style={{
-								width: '100%',
-								padding: '10px 16px',
-								borderRadius: 8,
-								border: 'none',
-								background: accent,
-								color: '#fff',
-								fontSize: 15,
-								fontWeight: 600,
-								cursor: 'pointer',
-							}}
-						>
-							Connect {plugin}
-						</button>
-					</>
-				)}
+					{connected ? (
+						<div style={{ padding: '40px 24px', textAlign: 'center' }}>
+							<div
+								style={{
+									width: 48,
+									height: 48,
+									margin: '0 auto 14px',
+									borderRadius: 999,
+									display: 'flex',
+									alignItems: 'center',
+									justifyContent: 'center',
+									background: dark ? '#0f3d26' : '#eafaf0',
+								}}
+							>
+								<svg
+									width="24"
+									height="24"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke={SUCCESS}
+									strokeWidth="2.5"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									aria-hidden
+								>
+									<path d="M20 6L9 17l-5-5" />
+								</svg>
+							</div>
+							<p
+								id="corsair-connect-title"
+								style={{
+									margin: 0,
+									fontSize: 15.5,
+									fontWeight: 700,
+									color: ink,
+								}}
+							>
+								{name} connected
+							</p>
+							<p style={{ margin: '5px 0 0', fontSize: 13, color: muted }}>
+								Taking you back.
+							</p>
+						</div>
+					) : (
+						<div style={{ padding: '32px 22px 18px' }}>
+							{/* Provider hero — a single mark on the blueprint grid */}
+							<div
+								style={{
+									position: 'relative',
+									textAlign: 'center',
+								}}
+							>
+								<div style={heroGrid(dark)} />
+								<div
+									style={{
+										position: 'relative',
+										display: 'flex',
+										justifyContent: 'center',
+									}}
+								>
+									<span
+										aria-hidden
+										style={{
+											position: 'absolute',
+											left: '50%',
+											bottom: -8,
+											width: 62,
+											height: 22,
+											transform: 'translateX(-50%)',
+											borderRadius: 999,
+											background: glow,
+											filter: 'blur(12px)',
+										}}
+									/>
+									<span style={{ position: 'relative', filter: iconShadow }}>
+										<PluginIcon
+											domain={domain}
+											label={name}
+											size={52}
+											radius={14}
+										/>
+									</span>
+								</div>
+								<h2
+									id="corsair-connect-title"
+									style={{
+										position: 'relative',
+										margin: '18px 0 0',
+										fontSize: 18.5,
+										fontWeight: 700,
+										letterSpacing: '-0.02em',
+										color: ink,
+									}}
+								>
+									Connect {name}
+								</h2>
+							</div>
+
+							<div
+								style={{
+									margin: '20px 0 0',
+								}}
+							>
+								<button
+									type="button"
+									onClick={onOpen}
+									className="corsair-primary"
+									autoFocus
+									style={{
+										display: 'flex',
+										width: '100%',
+										alignItems: 'center',
+										justifyContent: 'center',
+										gap: 9,
+										padding: '12px 16px',
+										borderRadius: 11,
+										border: 'none',
+										background: primaryBg,
+										color: primaryFg,
+										fontSize: 13.5,
+										fontWeight: 700,
+										cursor: 'pointer',
+									}}
+								>
+									Continue
+								</button>
+
+								<button
+									type="button"
+									onClick={onClose}
+									className="corsair-ghost"
+									style={{
+										display: 'block',
+										margin: '10px auto 0',
+										padding: '4px 10px',
+										border: 'none',
+										background: 'transparent',
+										color: faint,
+										fontSize: 12.5,
+										fontWeight: 500,
+										cursor: 'pointer',
+									}}
+								>
+									Not now
+								</button>
+							</div>
+
+							<ConnectionsRoster
+								client={client}
+								activePlugin={state.plugin}
+								ink={ink}
+								muted={muted}
+								faint={faint}
+								border={border}
+								hair={hair}
+							/>
+						</div>
+					)}
+
+					<div
+						style={{
+							padding: '11px 18px',
+							borderTop: `1px solid ${hair}`,
+							fontFamily: MONO,
+							fontSize: 10,
+							letterSpacing: '0.06em',
+							textTransform: 'uppercase',
+							color: faint,
+							textAlign: 'center',
+						}}
+					>
+						Secured by Corsair
+					</div>
+				</div>
 			</div>
 		</div>
 	);

--- a/packages/corsair/client/react/index.ts
+++ b/packages/corsair/client/react/index.ts
@@ -303,6 +303,22 @@ export function createCorsairReactClient(opts: CorsairReactClientOptions) {
 	};
 }
 
+export type {
+	ConnectPhase,
+	ConnectState,
+} from './connect-controller';
+export type { ConnectAppearance } from './connect-overlay';
+// ─────────────────────────────────────────────────────────────────────────────
+// Corsair Connect — <CorsairProvider> + useConnect: on a reconnect/auth-missing
+// failure, pop an overlay with the scoped connect link and resume once connected.
+// ─────────────────────────────────────────────────────────────────────────────
+export {
+	type CorsairContextValue,
+	CorsairProvider,
+	useConnect,
+	useCorsair,
+} from './provider';
+
 // Re-export types that hook consumers need
 export type {
 	AsyncState,

--- a/packages/corsair/client/react/index.ts
+++ b/packages/corsair/client/react/index.ts
@@ -303,18 +303,23 @@ export function createCorsairReactClient(opts: CorsairReactClientOptions) {
 	};
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Corsair Connect — wrap the app in <CorsairProvider> (and data regions in
+// <CorsairBoundary>): an auth-missing failure anywhere opens the connect dialog
+// and resumes once connected, with no per-call code. useConnect exposes the
+// opt-in escape hatches (proactive `connect`, mutation `call`).
+// ─────────────────────────────────────────────────────────────────────────────
+export { CorsairBoundary, type CorsairBoundaryProps } from './boundary';
 export type {
 	ConnectPhase,
 	ConnectState,
 } from './connect-controller';
-export type { ConnectAppearance } from './connect-overlay';
-// ─────────────────────────────────────────────────────────────────────────────
-// Corsair Connect — <CorsairProvider> + useConnect: on a reconnect/auth-missing
-// failure, pop an overlay with the scoped connect link and resume once connected.
-// ─────────────────────────────────────────────────────────────────────────────
+export type { ConnectAppearance, ConnectTheme } from './connect-overlay';
 export {
 	type CorsairContextValue,
 	CorsairProvider,
+	type CorsairProviderProps,
+	type UseConnectResult,
 	useConnect,
 	useCorsair,
 } from './provider';

--- a/packages/corsair/client/react/plugin-icon.tsx
+++ b/packages/corsair/client/react/plugin-icon.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import type { CSSProperties, ReactElement } from 'react';
+import { useEffect, useState } from 'react';
+
+// Brand icons for the connect overlay. Mirrors the Hub connect page's
+// favicon-logo so the SDK dialog and the Hub page render the same marks: one
+// maintained domain table, svgl SVGs for products whose favicons are generic,
+// and a monogram fallback when an icon can't load.
+
+const DOMAIN_OVERRIDES: Record<string, string> = {
+	github: 'github.com',
+	gitlab: 'gitlab.com',
+	slack: 'slack.com',
+	notion: 'notion.so',
+	airtable: 'airtable.com',
+	linear: 'linear.app',
+	jira: 'atlassian.com',
+	confluence: 'atlassian.com',
+	google: 'google.com',
+	gmail: 'gmail.com',
+	gdrive: 'drive.google.com',
+	gcalendar: 'calendar.google.com',
+	hubspot: 'hubspot.com',
+	salesforce: 'salesforce.com',
+	stripe: 'stripe.com',
+	discord: 'discord.com',
+	intercom: 'intercom.com',
+	zendesk: 'zendesk.com',
+	figma: 'figma.com',
+	dropbox: 'dropbox.com',
+	asana: 'asana.com',
+	trello: 'trello.com',
+	clickup: 'clickup.com',
+	monday: 'monday.com',
+	twilio: 'twilio.com',
+	sendgrid: 'sendgrid.com',
+	shopify: 'shopify.com',
+	agentql: 'agentql.com',
+	ahrefs: 'ahrefs.com',
+	amplitude: 'amplitude.com',
+	bitwarden: 'bitwarden.com',
+	bluesky: 'bsky.app',
+	box: 'box.com',
+	cal: 'cal.com',
+	calendly: 'calendly.com',
+	cloudflare: 'cloudflare.com',
+	cursor: 'cursor.com',
+	dodopayments: 'dodopayments.com',
+	exa: 'exa.ai',
+	firecrawl: 'firecrawl.dev',
+	fireflies: 'fireflies.ai',
+	googlecalendar: 'calendar.google.com',
+	googledrive: 'drive.google.com',
+	googlemeet: 'meet.google.com',
+	googlesheets: 'docs.google.com',
+	grafana: 'grafana.com',
+	hackernews: 'news.ycombinator.com',
+	instagram: 'instagram.com',
+	onedrive: 'onedrive.live.com',
+	openweathermap: 'openweathermap.org',
+	oura: 'ouraring.com',
+	outlook: 'outlook.live.com',
+	pagerduty: 'pagerduty.com',
+	posthog: 'posthog.com',
+	razorpay: 'razorpay.com',
+	reddit: 'reddit.com',
+	resend: 'resend.com',
+	sentry: 'sentry.io',
+	sharepoint: 'sharepoint.com',
+	spotify: 'spotify.com',
+	strava: 'strava.com',
+	supabase: 'supabase.com',
+	tally: 'tally.so',
+	tavily: 'tavily.com',
+	teams: 'teams.microsoft.com',
+	telegram: 'telegram.org',
+	todoist: 'todoist.com',
+	twitter: 'x.com',
+	twitterapiio: 'twitter.com',
+	typeform: 'typeform.com',
+	vapi: 'vapi.ai',
+	vercel: 'vercel.com',
+	youtube: 'youtube.com',
+	zohomail: 'zoho.com',
+	zoom: 'zoom.us',
+};
+
+// Products whose public favicon is generic (Microsoft serves the same squares
+// for every M365 product) — served from svgl's brand-SVG CDN instead.
+const LOGO_OVERRIDES: Record<string, string> = {
+	'outlook.live.com': 'https://svgl.app/library/microsoft-outlook.svg',
+	'onedrive.live.com': 'https://svgl.app/library/microsoft-onedrive.svg',
+	'sharepoint.com': 'https://svgl.app/library/microsoft-sharepoint.svg',
+	'teams.microsoft.com': 'https://svgl.app/library/microsoft-teams.svg',
+	'gmail.com': 'https://svgl.app/library/gmail.svg',
+	'drive.google.com': 'https://svgl.app/library/drive.svg',
+	'calendar.google.com': 'https://svgl.app/library/google-calendar.svg',
+	'meet.google.com': 'https://svgl.app/library/google-meet.svg',
+	'docs.google.com': 'https://svgl.app/library/google-sheets.svg',
+};
+
+/** Resolve a plugin id to a brand domain. */
+export function pluginToDomain(pluginId: string): string {
+	const id = pluginId.toLowerCase().replace(/_/g, '');
+	return DOMAIN_OVERRIDES[id] ?? `${id}.com`;
+}
+
+/** The icon URL for a brand domain — an svgl override when the favicon is generic. */
+export function resolveIconUrl(domain: string): string {
+	const clean = domain
+		.replace(/^(https?:\/\/)|(www\.)/g, '')
+		.replace(/\/$/, '');
+	return LOGO_OVERRIDES[clean] ?? `https://twenty-icons.com/${clean}`;
+}
+
+/** Title-case a plugin id for display: `google_sheets` → `Google Sheets`. */
+export function titleCasePlugin(pluginId: string): string {
+	return pluginId
+		.replace(/[_-]+/g, ' ')
+		.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/**
+ * Brand mark for a plugin. Renders a monogram first and swaps to the loaded
+ * icon only once it decodes, so a blocked or missing icon shows a clean initial
+ * rather than a broken-image glyph.
+ */
+export function PluginIcon({
+	domain,
+	label,
+	size = 24,
+	radius,
+}: {
+	domain: string;
+	label: string;
+	size?: number;
+	radius?: number;
+}): ReactElement {
+	const [src, setSrc] = useState<string | null>(null);
+	useEffect(() => {
+		let live = true;
+		const img = new Image();
+		img.referrerPolicy = 'no-referrer';
+		img.onload = () => {
+			if (live && img.naturalWidth > 0) setSrc(img.src);
+		};
+		img.src = resolveIconUrl(domain);
+		return () => {
+			live = false;
+		};
+	}, [domain]);
+
+	const box: CSSProperties = {
+		width: size,
+		height: size,
+		borderRadius: radius ?? Math.round(size * 0.28),
+		flexShrink: 0,
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+		overflow: 'hidden',
+		background: src ? '#fff' : '#f1f1f1',
+		border: '1px solid #1c1c1c12',
+	};
+	return (
+		<span style={box}>
+			{src ? (
+				<img
+					src={src}
+					alt=""
+					width={Math.round(size * 0.62)}
+					height={Math.round(size * 0.62)}
+					referrerPolicy="no-referrer"
+					style={{ objectFit: 'contain' }}
+				/>
+			) : (
+				<span
+					style={{
+						fontSize: Math.round(size * 0.4),
+						fontWeight: 600,
+						color: '#7a7a7a',
+					}}
+				>
+					{(label[0] ?? '?').toUpperCase()}
+				</span>
+			)}
+		</span>
+	);
+}

--- a/packages/corsair/client/react/plugin-icon.tsx
+++ b/packages/corsair/client/react/plugin-icon.tsx
@@ -140,6 +140,9 @@ export function PluginIcon({
 	const [src, setSrc] = useState<string | null>(null);
 	useEffect(() => {
 		let live = true;
+		// Drop the prior brand mark so a reused icon shows the monogram, not the
+		// last plugin's logo, while the new one loads (or if it fails).
+		setSrc(null);
 		const img = new Image();
 		img.referrerPolicy = 'no-referrer';
 		img.onload = () => {

--- a/packages/corsair/client/react/provider.tsx
+++ b/packages/corsair/client/react/provider.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import type { ReactElement, ReactNode } from 'react';
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useReducer,
+	useRef,
+} from 'react';
+import { ReconnectRequiredError } from '../../core/auth/errors/reconnect-required';
+import { createCorsairClient } from '../index';
+import type { CorsairManagementClient } from '../types';
+import type { ConnectState } from './connect-controller';
+import {
+	connectReducer,
+	initialConnectState,
+	isPluginConnected,
+} from './connect-controller';
+import type { ConnectAppearance } from './connect-overlay';
+import { ConnectOverlay } from './connect-overlay';
+
+const POLL_MS = 2000;
+
+export type CorsairContextValue = {
+	client: CorsairManagementClient;
+	/** Mint a fresh link and open the overlay. Resolves true once connected. */
+	connect: (plugin: string, opts?: { tenantId?: string }) => Promise<boolean>;
+	/** Open the overlay from a caught ReconnectRequiredError (reuses its link). */
+	connectFromError: (error: unknown) => Promise<boolean>;
+	connectState: ConnectState;
+};
+
+const CorsairContext = createContext<CorsairContextValue | null>(null);
+
+export function CorsairProvider({
+	baseURL,
+	appearance,
+	children,
+}: {
+	baseURL: string;
+	appearance?: ConnectAppearance;
+	children: ReactNode;
+}): ReactElement {
+	const clientRef = useRef<CorsairManagementClient | null>(null);
+	if (!clientRef.current) {
+		clientRef.current = createCorsairClient({ baseURL });
+	}
+	const client = clientRef.current;
+
+	const [connectState, dispatch] = useReducer(
+		connectReducer,
+		initialConnectState,
+	);
+
+	const resolveRef = useRef<((ok: boolean) => void) | null>(null);
+	const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+	const stopPoll = useCallback(() => {
+		if (pollRef.current) {
+			clearInterval(pollRef.current);
+			pollRef.current = null;
+		}
+	}, []);
+
+	const settle = useCallback(
+		(ok: boolean) => {
+			stopPoll();
+			resolveRef.current?.(ok);
+			resolveRef.current = null;
+		},
+		[stopPoll],
+	);
+
+	// Poll the app's own connection-status route until the plugin flips to
+	// connected — the browser-safe way to learn the popup finished.
+	const beginPoll = useCallback(
+		(plugin: string, tenantId: string | null) => {
+			stopPoll();
+			pollRef.current = setInterval(() => {
+				client.connectionStatus
+					.get(tenantId ? { tenantId } : undefined)
+					.then((status) => {
+						if (isPluginConnected(status, plugin)) {
+							dispatch({ type: 'SUCCESS' });
+							settle(true);
+						}
+					})
+					.catch(() => {});
+			}, POLL_MS);
+		},
+		[client, settle, stopPoll],
+	);
+
+	const openOverlay = useCallback(
+		(plugin: string, tenantId: string | null, connectUrl: string) => {
+			resolveRef.current?.(false);
+			dispatch({ type: 'OPEN', plugin, tenantId, connectUrl });
+			return new Promise<boolean>((resolve) => {
+				resolveRef.current = resolve;
+			});
+		},
+		[],
+	);
+
+	const connect = useCallback(
+		async (plugin: string, opts?: { tenantId?: string }): Promise<boolean> => {
+			const tenantId = opts?.tenantId ?? null;
+			const { connectUrl } = await client.connect.createLink({
+				plugin,
+				tenantId: tenantId ?? undefined,
+			});
+			return openOverlay(plugin, tenantId, connectUrl);
+		},
+		[client, openOverlay],
+	);
+
+	const connectFromError = useCallback(
+		(error: unknown): Promise<boolean> => {
+			if (
+				!(error instanceof ReconnectRequiredError) ||
+				!error.plugin ||
+				!error.connectUrl
+			) {
+				return Promise.resolve(false);
+			}
+			return openOverlay(error.plugin, error.tenantId, error.connectUrl);
+		},
+		[openOverlay],
+	);
+
+	// User clicked "Connect" — open Hub's page in a popup and start watching.
+	const handleOpen = useCallback(() => {
+		if (!connectState.connectUrl || !connectState.plugin) return;
+		window.open(
+			connectState.connectUrl,
+			'corsair-connect',
+			'width=520,height=720',
+		);
+		beginPoll(connectState.plugin, connectState.tenantId);
+	}, [beginPoll, connectState]);
+
+	const handleClose = useCallback(() => {
+		settle(false);
+		dispatch({ type: 'CLOSE' });
+	}, [settle]);
+
+	useEffect(() => stopPoll, [stopPoll]);
+
+	const value = useMemo<CorsairContextValue>(
+		() => ({ client, connect, connectFromError, connectState }),
+		[client, connect, connectFromError, connectState],
+	);
+
+	const overlayOpen =
+		connectState.phase === 'connecting' || connectState.phase === 'success';
+
+	return (
+		<CorsairContext.Provider value={value}>
+			{children}
+			{overlayOpen ? (
+				<ConnectOverlay
+					state={connectState}
+					appearance={appearance}
+					onOpen={handleOpen}
+					onClose={handleClose}
+				/>
+			) : null}
+		</CorsairContext.Provider>
+	);
+}
+
+export function useCorsair(): CorsairContextValue {
+	const ctx = useContext(CorsairContext);
+	if (!ctx) {
+		throw new Error('useCorsair must be used within <CorsairProvider>');
+	}
+	return ctx;
+}
+
+/** Open the connect overlay imperatively, or from a caught ReconnectRequiredError. */
+export function useConnect(): {
+	connect: (plugin: string, opts?: { tenantId?: string }) => Promise<boolean>;
+	connectFromError: (error: unknown) => Promise<boolean>;
+	state: ConnectState;
+} {
+	const { connect, connectFromError, connectState } = useCorsair();
+	return { connect, connectFromError, state: connectState };
+}

--- a/packages/corsair/client/react/provider.tsx
+++ b/packages/corsair/client/react/provider.tsx
@@ -17,12 +17,14 @@ import type { ConnectState } from './connect-controller';
 import {
 	connectReducer,
 	initialConnectState,
+	isConnectedMessage,
 	isPluginConnected,
+	originOf,
 } from './connect-controller';
 import type { ConnectAppearance } from './connect-overlay';
 import { ConnectOverlay } from './connect-overlay';
 
-const POLL_MS = 2000;
+const WATCH_INTERVAL_MS = 2000;
 
 export type CorsairContextValue = {
 	client: CorsairManagementClient;
@@ -56,42 +58,62 @@ export function CorsairProvider({
 	);
 
 	const resolveRef = useRef<((ok: boolean) => void) | null>(null);
-	const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+	const popupRef = useRef<Window | null>(null);
+	const watchRef = useRef<ReturnType<typeof setInterval> | null>(null);
+	const messageHandlerRef = useRef<((e: MessageEvent) => void) | null>(null);
 
-	const stopPoll = useCallback(() => {
-		if (pollRef.current) {
-			clearInterval(pollRef.current);
-			pollRef.current = null;
+	const stopWatch = useCallback(() => {
+		if (watchRef.current) {
+			clearInterval(watchRef.current);
+			watchRef.current = null;
+		}
+		if (messageHandlerRef.current) {
+			window.removeEventListener('message', messageHandlerRef.current);
+			messageHandlerRef.current = null;
 		}
 	}, []);
 
 	const settle = useCallback(
 		(ok: boolean) => {
-			stopPoll();
+			stopWatch();
 			resolveRef.current?.(ok);
 			resolveRef.current = null;
 		},
-		[stopPoll],
+		[stopWatch],
 	);
 
-	// Poll the app's own connection-status route until the plugin flips to
-	// connected — the browser-safe way to learn the popup finished.
-	const beginPoll = useCallback(
-		(plugin: string, tenantId: string | null) => {
-			stopPoll();
-			pollRef.current = setInterval(() => {
+	// Learn when the connection lands. Status polling against the app's own
+	// backend is the universal signal — it works self-hosted and for custom
+	// connect pages. The popup closing triggers an immediate check; a postMessage
+	// from the managed connect page is an instant fast-path. All converge here.
+	const beginWatch = useCallback(
+		(plugin: string, tenantId: string | null, trustedOrigin: string) => {
+			stopWatch();
+			const check = () => {
 				client.connectionStatus
 					.get(tenantId ? { tenantId } : undefined)
 					.then((status) => {
 						if (isPluginConnected(status, plugin)) {
+							popupRef.current?.close();
+							popupRef.current = null;
 							dispatch({ type: 'SUCCESS' });
 							settle(true);
 						}
 					})
 					.catch(() => {});
-			}, POLL_MS);
+			};
+			const onMessage = (e: MessageEvent) => {
+				if (isConnectedMessage(e.data, e.origin, trustedOrigin)) check();
+			};
+			window.addEventListener('message', onMessage);
+			messageHandlerRef.current = onMessage;
+			watchRef.current = setInterval(() => {
+				check();
+				// Popup gone without connecting → stop; the modal stays for a retry.
+				if (popupRef.current?.closed) stopWatch();
+			}, WATCH_INTERVAL_MS);
 		},
-		[client, settle, stopPoll],
+		[client, settle, stopWatch],
 	);
 
 	const openOverlay = useCallback(
@@ -133,21 +155,24 @@ export function CorsairProvider({
 
 	// User clicked "Connect" — open Hub's page in a popup and start watching.
 	const handleOpen = useCallback(() => {
-		if (!connectState.connectUrl || !connectState.plugin) return;
-		window.open(
-			connectState.connectUrl,
+		const { connectUrl, plugin, tenantId } = connectState;
+		if (!connectUrl || !plugin) return;
+		popupRef.current = window.open(
+			connectUrl,
 			'corsair-connect',
 			'width=520,height=720',
 		);
-		beginPoll(connectState.plugin, connectState.tenantId);
-	}, [beginPoll, connectState]);
+		beginWatch(plugin, tenantId, originOf(connectUrl) ?? '');
+	}, [beginWatch, connectState]);
 
 	const handleClose = useCallback(() => {
+		popupRef.current?.close();
+		popupRef.current = null;
 		settle(false);
 		dispatch({ type: 'CLOSE' });
 	}, [settle]);
 
-	useEffect(() => stopPoll, [stopPoll]);
+	useEffect(() => stopWatch, [stopWatch]);
 
 	const value = useMemo<CorsairContextValue>(
 		() => ({ client, connect, connectFromError, connectState }),

--- a/packages/corsair/client/react/provider.tsx
+++ b/packages/corsair/client/react/provider.tsx
@@ -17,9 +17,7 @@ import type { ConnectState } from './connect-controller';
 import {
 	connectReducer,
 	initialConnectState,
-	isConnectedMessage,
-	isPluginConnected,
-	originOf,
+	shouldSettleConnected,
 } from './connect-controller';
 import type { ConnectAppearance } from './connect-overlay';
 import { ConnectOverlay } from './connect-overlay';
@@ -60,16 +58,14 @@ export function CorsairProvider({
 	const resolveRef = useRef<((ok: boolean) => void) | null>(null);
 	const popupRef = useRef<Window | null>(null);
 	const watchRef = useRef<ReturnType<typeof setInterval> | null>(null);
-	const messageHandlerRef = useRef<((e: MessageEvent) => void) | null>(null);
+	// Bumped on every open and close so an in-flight poll from a superseded or
+	// closed attempt can't settle the current one.
+	const attemptRef = useRef(0);
 
 	const stopWatch = useCallback(() => {
 		if (watchRef.current) {
 			clearInterval(watchRef.current);
 			watchRef.current = null;
-		}
-		if (messageHandlerRef.current) {
-			window.removeEventListener('message', messageHandlerRef.current);
-			messageHandlerRef.current = null;
 		}
 	}, []);
 
@@ -82,18 +78,25 @@ export function CorsairProvider({
 		[stopWatch],
 	);
 
-	// Learn when the connection lands. Status polling against the app's own
-	// backend is the universal signal — it works self-hosted and for custom
-	// connect pages. The popup closing triggers an immediate check; a postMessage
-	// from the managed connect page is an instant fast-path. All converge here.
+	// Learn when the connection lands. Polling the app's own backend is the
+	// universal signal — it works self-hosted and for custom connect pages. The
+	// popup closing stops the watch once the user is done either way.
 	const beginWatch = useCallback(
-		(plugin: string, tenantId: string | null, trustedOrigin: string) => {
+		(plugin: string, tenantId: string | null) => {
 			stopWatch();
+			const attempt = attemptRef.current;
 			const check = () => {
 				client.connectionStatus
 					.get(tenantId ? { tenantId } : undefined)
 					.then((status) => {
-						if (isPluginConnected(status, plugin)) {
+						if (
+							shouldSettleConnected({
+								capturedAttempt: attempt,
+								currentAttempt: attemptRef.current,
+								status,
+								plugin,
+							})
+						) {
 							popupRef.current?.close();
 							popupRef.current = null;
 							dispatch({ type: 'SUCCESS' });
@@ -102,11 +105,6 @@ export function CorsairProvider({
 					})
 					.catch(() => {});
 			};
-			const onMessage = (e: MessageEvent) => {
-				if (isConnectedMessage(e.data, e.origin, trustedOrigin)) check();
-			};
-			window.addEventListener('message', onMessage);
-			messageHandlerRef.current = onMessage;
 			watchRef.current = setInterval(() => {
 				check();
 				// Popup gone without connecting → stop; the modal stays for a retry.
@@ -118,6 +116,7 @@ export function CorsairProvider({
 
 	const openOverlay = useCallback(
 		(plugin: string, tenantId: string | null, connectUrl: string) => {
+			attemptRef.current += 1;
 			resolveRef.current?.(false);
 			dispatch({ type: 'OPEN', plugin, tenantId, connectUrl });
 			return new Promise<boolean>((resolve) => {
@@ -162,10 +161,11 @@ export function CorsairProvider({
 			'corsair-connect',
 			'width=520,height=720',
 		);
-		beginWatch(plugin, tenantId, originOf(connectUrl) ?? '');
+		beginWatch(plugin, tenantId);
 	}, [beginWatch, connectState]);
 
 	const handleClose = useCallback(() => {
+		attemptRef.current += 1;
 		popupRef.current?.close();
 		popupRef.current = null;
 		settle(false);

--- a/packages/corsair/client/react/provider.tsx
+++ b/packages/corsair/client/react/provider.tsx
@@ -98,6 +98,7 @@ export function CorsairProvider({
 	const resolveRef = useRef<((ok: boolean) => void) | null>(null);
 	const popupRef = useRef<Window | null>(null);
 	const watchRef = useRef<ReturnType<typeof setInterval> | null>(null);
+	const graceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	// Bumped on every open and close so an in-flight poll from a superseded or
 	// closed attempt can't settle the current one.
 	const attemptRef = useRef(0);
@@ -124,12 +125,13 @@ export function CorsairProvider({
 	// completion signal (works self-hosted and for custom connect pages). On
 	// connect: clear the request, let the host refresh, resume any waiter.
 	const beginWatch = useCallback(
-		(plugin: string) => {
+		(plugin: string, tenantId: string | null) => {
 			stopWatch();
 			const attempt = attemptRef.current;
+			const scope = tenantId ? { tenantId } : undefined;
 			const check = () => {
 				client.connectionStatus
-					.get()
+					.get(scope)
 					.then((status) => {
 						if (
 							shouldSettleConnected({
@@ -139,10 +141,13 @@ export function CorsairProvider({
 								plugin,
 							})
 						) {
+							// Bump first so a slower poll from this same attempt (a request
+							// still in flight past the interval) can't repeat these effects.
+							attemptRef.current += 1;
 							popupRef.current?.close();
 							popupRef.current = null;
 							dispatch({ type: 'SUCCESS' });
-							client.connectRequest.clear().catch(() => {});
+							client.connectRequest.clear(scope).catch(() => {});
 							onConnectedRef.current?.();
 							setConnectNonce((n) => n + 1);
 							settle(true);
@@ -157,11 +162,11 @@ export function CorsairProvider({
 				// within the grace window, the closed popup means the user backed out.
 				if (popupRef.current?.closed) {
 					stopWatch();
-					window.setTimeout(() => {
+					graceRef.current = setTimeout(() => {
 						if (attempt !== attemptRef.current || !resolveRef.current) return;
 						attemptRef.current += 1;
 						popupRef.current = null;
-						client.connectRequest.clear().catch(() => {});
+						client.connectRequest.clear(scope).catch(() => {});
 						dispatch({ type: 'CLOSE' });
 						settle(false);
 					}, POPUP_CLOSE_GRACE_MS);
@@ -172,10 +177,14 @@ export function CorsairProvider({
 	);
 
 	const openDialog = useCallback(
-		(plugin: string, connectUrl: string): Promise<boolean> => {
+		(
+			plugin: string,
+			connectUrl: string,
+			tenantId: string | null,
+		): Promise<boolean> => {
 			attemptRef.current += 1;
 			resolveRef.current?.(false);
-			dispatch({ type: 'OPEN', plugin, connectUrl });
+			dispatch({ type: 'OPEN', plugin, connectUrl, tenantId });
 			return new Promise<boolean>((resolve) => {
 				resolveRef.current = resolve;
 			});
@@ -189,16 +198,18 @@ export function CorsairProvider({
 				plugin,
 				tenantId: opts?.tenantId,
 			});
-			return openDialog(plugin, connectUrl);
+			return openDialog(plugin, connectUrl, opts?.tenantId ?? null);
 		},
 		[client, openDialog],
 	);
 
+	// Reactive path: the handler recorded the request under the resolved tenant,
+	// so leave scoping to it (null) rather than guess a tenant here.
 	const requireConnect =
 		useCallback(async (): Promise<RequireConnectOutcome> => {
 			const { request } = await client.connectRequest.get();
 			if (!request) return 'none';
-			const ok = await openDialog(request.plugin, request.connectUrl);
+			const ok = await openDialog(request.plugin, request.connectUrl, null);
 			return ok ? 'connected' : 'cancelled';
 		}, [client, openDialog]);
 
@@ -220,26 +231,42 @@ export function CorsairProvider({
 
 	// User clicked "Connect" — open Hub's page in a popup and start watching.
 	const handleOpen = useCallback(() => {
-		const { connectUrl, plugin } = connectState;
+		const { connectUrl, plugin, tenantId } = connectState;
 		if (!connectUrl || !plugin) return;
 		popupRef.current = window.open(
 			connectUrl,
 			'corsair-connect',
 			'width=520,height=720',
 		);
-		beginWatch(plugin);
+		beginWatch(plugin, tenantId);
 	}, [beginWatch, connectState]);
 
 	const handleClose = useCallback(() => {
 		attemptRef.current += 1;
 		popupRef.current?.close();
 		popupRef.current = null;
-		client.connectRequest.clear().catch(() => {});
+		const scope = connectState.tenantId
+			? { tenantId: connectState.tenantId }
+			: undefined;
+		client.connectRequest.clear(scope).catch(() => {});
 		settle(false);
 		dispatch({ type: 'CLOSE' });
-	}, [client, settle]);
+	}, [client, settle, connectState.tenantId]);
 
-	useEffect(() => stopWatch, [stopWatch]);
+	// Unmount mid-flow: stop the timers, invalidate any in-flight poll, close the
+	// popup, and resolve a waiting caller so its promise can't hang forever.
+	useEffect(
+		() => () => {
+			stopWatch();
+			if (graceRef.current) clearTimeout(graceRef.current);
+			attemptRef.current += 1;
+			popupRef.current?.close();
+			popupRef.current = null;
+			resolveRef.current?.(false);
+			resolveRef.current = null;
+		},
+		[stopWatch],
+	);
 
 	// Hold the "connected" check briefly, then dismiss — the resolved call has
 	// already resumed, so the success card is just a confirmation.

--- a/packages/corsair/client/react/provider.tsx
+++ b/packages/corsair/client/react/provider.tsx
@@ -17,6 +17,7 @@ import type { ConnectState } from './connect-controller';
 import {
 	connectReducer,
 	initialConnectState,
+	isPluginConnected,
 	shouldSettleConnected,
 } from './connect-controller';
 import type { ConnectAppearance } from './connect-overlay';
@@ -129,11 +130,34 @@ export function CorsairProvider({
 			stopWatch();
 			const attempt = attemptRef.current;
 			const scope = tenantId ? { tenantId } : undefined;
+			// Guard every settle: the poll must still belong to this attempt and a
+			// caller must still be waiting. Bumping the attempt makes it single-shot.
+			const isCurrent = () =>
+				attempt === attemptRef.current && !!resolveRef.current;
+			const finishConnected = () => {
+				attemptRef.current += 1;
+				popupRef.current?.close();
+				popupRef.current = null;
+				dispatch({ type: 'SUCCESS' });
+				client.connectRequest.clear(scope).catch(() => {});
+				onConnectedRef.current?.();
+				setConnectNonce((n) => n + 1);
+				settle(true);
+			};
+			const finishCancelled = () => {
+				attemptRef.current += 1;
+				popupRef.current?.close();
+				popupRef.current = null;
+				client.connectRequest.clear(scope).catch(() => {});
+				dispatch({ type: 'CLOSE' });
+				settle(false);
+			};
 			const check = () => {
 				client.connectionStatus
 					.get(scope)
 					.then((status) => {
 						if (
+							isCurrent() &&
 							shouldSettleConnected({
 								capturedAttempt: attempt,
 								currentAttempt: attemptRef.current,
@@ -141,16 +165,7 @@ export function CorsairProvider({
 								plugin,
 							})
 						) {
-							// Bump first so a slower poll from this same attempt (a request
-							// still in flight past the interval) can't repeat these effects.
-							attemptRef.current += 1;
-							popupRef.current?.close();
-							popupRef.current = null;
-							dispatch({ type: 'SUCCESS' });
-							client.connectRequest.clear(scope).catch(() => {});
-							onConnectedRef.current?.();
-							setConnectNonce((n) => n + 1);
-							settle(true);
+							finishConnected();
 						}
 					})
 					.catch(() => {});
@@ -158,17 +173,23 @@ export function CorsairProvider({
 			watchRef.current = setInterval(() => {
 				check();
 				// Popup gone — the user closed it, or the success page self-closed.
-				// The check() just fired settles a completed connect; if it hasn't
-				// within the grace window, the closed popup means the user backed out.
+				// After the grace window, decide with one authoritative check rather
+				// than assume a cancel: the success page closes the popup only once the
+				// connection persisted, so a slow final poll must not discard success.
 				if (popupRef.current?.closed) {
 					stopWatch();
 					graceRef.current = setTimeout(() => {
-						if (attempt !== attemptRef.current || !resolveRef.current) return;
-						attemptRef.current += 1;
-						popupRef.current = null;
-						client.connectRequest.clear(scope).catch(() => {});
-						dispatch({ type: 'CLOSE' });
-						settle(false);
+						if (!isCurrent()) return;
+						client.connectionStatus
+							.get(scope)
+							.then((status) => {
+								if (!isCurrent()) return;
+								if (isPluginConnected(status, plugin)) finishConnected();
+								else finishCancelled();
+							})
+							.catch(() => {
+								if (isCurrent()) finishCancelled();
+							});
 					}, POPUP_CLOSE_GRACE_MS);
 				}
 			}, WATCH_INTERVAL_MS);

--- a/packages/corsair/client/react/provider.tsx
+++ b/packages/corsair/client/react/provider.tsx
@@ -213,8 +213,11 @@ export function CorsairProvider({
 			return ok ? 'connected' : 'cancelled';
 		}, [client, openDialog]);
 
-	// Opt-in mutation wrapper: run the action; if it failed because the tenant
-	// must connect, open the dialog and re-run. A non-connect error rethrows.
+	// Opt-in mutation wrapper: run the action; on failure, if a connect-request is
+	// pending, open the dialog and re-run once connected — otherwise rethrow. The
+	// server records that request across the RSC boundary where the typed error is
+	// lost, so this can't classify the error itself; wrap only connect-gated or
+	// retry-safe mutations.
 	const call = useCallback(
 		async <T,>(fn: () => Promise<T>): Promise<T | null> => {
 			try {
@@ -233,13 +236,23 @@ export function CorsairProvider({
 	const handleOpen = useCallback(() => {
 		const { connectUrl, plugin, tenantId } = connectState;
 		if (!connectUrl || !plugin) return;
-		popupRef.current = window.open(
+		const popup = window.open(
 			connectUrl,
 			'corsair-connect',
 			'width=520,height=720',
 		);
+		if (!popup) {
+			// Popup blocked — there's no window to watch, so end the attempt instead
+			// of leaving connect() pending forever. The caller can retry once the
+			// user allows popups.
+			attemptRef.current += 1;
+			settle(false);
+			dispatch({ type: 'CLOSE' });
+			return;
+		}
+		popupRef.current = popup;
 		beginWatch(plugin, tenantId);
-	}, [beginWatch, connectState]);
+	}, [beginWatch, connectState, settle]);
 
 	const handleClose = useCallback(() => {
 		attemptRef.current += 1;
@@ -326,9 +339,10 @@ export type UseConnectResult = {
 	/** Proactively open the dialog for a plugin (e.g. a "Connect GitHub" button),
 	 * before any call has failed. Resolves `true` once connected. */
 	connect: (plugin: string, opts?: { tenantId?: string }) => Promise<boolean>;
-	/** Run a mutation; if it fails because the tenant must connect, open the
-	 * dialog and re-run once connected. Resolves `null` if the user cancels, and
-	 * rethrows any error that isn't auth-missing. */
+	/** Run a connect-gated mutation; if it fails while a connect-request is
+	 * pending, open the dialog and re-run once connected. Resolves `null` if the
+	 * user cancels, and rethrows the original error when nothing is pending. Wrap
+	 * only connect-gated or retry-safe mutations. */
 	call: <T>(fn: () => Promise<T>) => Promise<T | null>;
 	/** Current dialog state, for driving your own connect UI if needed. */
 	status: ConnectState;

--- a/packages/corsair/client/react/provider.tsx
+++ b/packages/corsair/client/react/provider.tsx
@@ -9,8 +9,8 @@ import {
 	useMemo,
 	useReducer,
 	useRef,
+	useState,
 } from 'react';
-import { ReconnectRequiredError } from '../../core/auth/errors/reconnect-required';
 import { createCorsairClient } from '../index';
 import type { CorsairManagementClient } from '../types';
 import type { ConnectState } from './connect-controller';
@@ -23,30 +23,69 @@ import type { ConnectAppearance } from './connect-overlay';
 import { ConnectOverlay } from './connect-overlay';
 
 const WATCH_INTERVAL_MS = 2000;
+// Grace after the popup closes for the final status poll to confirm a completed
+// connect before a closed popup is read as the user backing out.
+const POPUP_CLOSE_GRACE_MS = 1500;
+
+/** Whether a failed call needs a connect, and how the user answered. */
+export type RequireConnectOutcome = 'connected' | 'cancelled' | 'none';
 
 export type CorsairContextValue = {
 	client: CorsairManagementClient;
-	/** Mint a fresh link and open the overlay. Resolves true once connected. */
+	/** Mint a fresh link and open the overlay (proactive "Connect X" button). */
 	connect: (plugin: string, opts?: { tenantId?: string }) => Promise<boolean>;
-	/** Open the overlay from a caught ReconnectRequiredError (reuses its link). */
-	connectFromError: (error: unknown) => Promise<boolean>;
-	connectState: ConnectState;
+	/** Wrap a mutation so it auto-resumes after connect (opt-in, no re-click). */
+	call: <T>(fn: () => Promise<T>) => Promise<T | null>;
+	/** Read the pending connect-request and open the overlay. Used by the boundary
+	 * and by `call` — returns 'none' when there's nothing to connect. */
+	requireConnect: () => Promise<RequireConnectOutcome>;
+	/** Bumped on each successful connect so boundaries can reset and retry. */
+	connectNonce: number;
+	status: ConnectState;
 };
 
 const CorsairContext = createContext<CorsairContextValue | null>(null);
 
+/** Props for {@link CorsairProvider}. */
+export type CorsairProviderProps = {
+	/**
+	 * Base URL of your Corsair management handler — the route that runs
+	 * `createCorsairHandler`. Defaults to `/api/corsair`. Override it when the
+	 * handler is mounted elsewhere or on a separate origin.
+	 */
+	baseURL?: string;
+	/** Dialog theme: `'light'`, `'dark'`, or `'auto'` (the default, which follows
+	 * the OS color scheme). Also accepts the object form `{ theme }`. */
+	appearance?: ConnectAppearance;
+	/**
+	 * Called once after a successful connect. Wire this to `router.refresh()` in
+	 * Next.js so server reads that failed with auth-missing re-run against the
+	 * now-connected account. Mutations resume on their own via `call`.
+	 */
+	onConnected?: () => void;
+	children: ReactNode;
+};
+
+/**
+ * App-wide provider for Corsair Connect — wrap your app once at the root. When a
+ * server-side Corsair call fails because the tenant hasn't connected a plugin,
+ * the provider surfaces a connect dialog, waits for the user to finish, then
+ * lets the failed work resume — no per-call code at any of the call sites.
+ *
+ * Pair it with {@link CorsairBoundary} around server-rendered read regions, and
+ * with {@link useConnect}'s `call` to wrap mutations that should auto-resume.
+ */
 export function CorsairProvider({
 	baseURL,
 	appearance,
+	onConnected,
 	children,
-}: {
-	baseURL: string;
-	appearance?: ConnectAppearance;
-	children: ReactNode;
-}): ReactElement {
+}: CorsairProviderProps): ReactElement {
 	const clientRef = useRef<CorsairManagementClient | null>(null);
 	if (!clientRef.current) {
-		clientRef.current = createCorsairClient({ baseURL });
+		clientRef.current = createCorsairClient({
+			baseURL: baseURL ?? '/api/corsair',
+		});
 	}
 	const client = clientRef.current;
 
@@ -54,6 +93,7 @@ export function CorsairProvider({
 		connectReducer,
 		initialConnectState,
 	);
+	const [connectNonce, setConnectNonce] = useState(0);
 
 	const resolveRef = useRef<((ok: boolean) => void) | null>(null);
 	const popupRef = useRef<Window | null>(null);
@@ -61,6 +101,8 @@ export function CorsairProvider({
 	// Bumped on every open and close so an in-flight poll from a superseded or
 	// closed attempt can't settle the current one.
 	const attemptRef = useRef(0);
+	const onConnectedRef = useRef(onConnected);
+	onConnectedRef.current = onConnected;
 
 	const stopWatch = useCallback(() => {
 		if (watchRef.current) {
@@ -78,16 +120,16 @@ export function CorsairProvider({
 		[stopWatch],
 	);
 
-	// Learn when the connection lands. Polling the app's own backend is the
-	// universal signal — it works self-hosted and for custom connect pages. The
-	// popup closing stops the watch once the user is done either way.
+	// Poll the app's own backend while the popup is open — the universal
+	// completion signal (works self-hosted and for custom connect pages). On
+	// connect: clear the request, let the host refresh, resume any waiter.
 	const beginWatch = useCallback(
-		(plugin: string, tenantId: string | null) => {
+		(plugin: string) => {
 			stopWatch();
 			const attempt = attemptRef.current;
 			const check = () => {
 				client.connectionStatus
-					.get(tenantId ? { tenantId } : undefined)
+					.get()
 					.then((status) => {
 						if (
 							shouldSettleConnected({
@@ -100,6 +142,9 @@ export function CorsairProvider({
 							popupRef.current?.close();
 							popupRef.current = null;
 							dispatch({ type: 'SUCCESS' });
+							client.connectRequest.clear().catch(() => {});
+							onConnectedRef.current?.();
+							setConnectNonce((n) => n + 1);
 							settle(true);
 						}
 					})
@@ -107,18 +152,30 @@ export function CorsairProvider({
 			};
 			watchRef.current = setInterval(() => {
 				check();
-				// Popup gone without connecting → stop; the modal stays for a retry.
-				if (popupRef.current?.closed) stopWatch();
+				// Popup gone — the user closed it, or the success page self-closed.
+				// The check() just fired settles a completed connect; if it hasn't
+				// within the grace window, the closed popup means the user backed out.
+				if (popupRef.current?.closed) {
+					stopWatch();
+					window.setTimeout(() => {
+						if (attempt !== attemptRef.current || !resolveRef.current) return;
+						attemptRef.current += 1;
+						popupRef.current = null;
+						client.connectRequest.clear().catch(() => {});
+						dispatch({ type: 'CLOSE' });
+						settle(false);
+					}, POPUP_CLOSE_GRACE_MS);
+				}
 			}, WATCH_INTERVAL_MS);
 		},
 		[client, settle, stopWatch],
 	);
 
-	const openOverlay = useCallback(
-		(plugin: string, tenantId: string | null, connectUrl: string) => {
+	const openDialog = useCallback(
+		(plugin: string, connectUrl: string): Promise<boolean> => {
 			attemptRef.current += 1;
 			resolveRef.current?.(false);
-			dispatch({ type: 'OPEN', plugin, tenantId, connectUrl });
+			dispatch({ type: 'OPEN', plugin, connectUrl });
 			return new Promise<boolean>((resolve) => {
 				resolveRef.current = resolve;
 			});
@@ -128,55 +185,80 @@ export function CorsairProvider({
 
 	const connect = useCallback(
 		async (plugin: string, opts?: { tenantId?: string }): Promise<boolean> => {
-			const tenantId = opts?.tenantId ?? null;
 			const { connectUrl } = await client.connect.createLink({
 				plugin,
-				tenantId: tenantId ?? undefined,
+				tenantId: opts?.tenantId,
 			});
-			return openOverlay(plugin, tenantId, connectUrl);
+			return openDialog(plugin, connectUrl);
 		},
-		[client, openOverlay],
+		[client, openDialog],
 	);
 
-	const connectFromError = useCallback(
-		(error: unknown): Promise<boolean> => {
-			if (
-				!(error instanceof ReconnectRequiredError) ||
-				!error.plugin ||
-				!error.connectUrl
-			) {
-				return Promise.resolve(false);
+	const requireConnect =
+		useCallback(async (): Promise<RequireConnectOutcome> => {
+			const { request } = await client.connectRequest.get();
+			if (!request) return 'none';
+			const ok = await openDialog(request.plugin, request.connectUrl);
+			return ok ? 'connected' : 'cancelled';
+		}, [client, openDialog]);
+
+	// Opt-in mutation wrapper: run the action; if it failed because the tenant
+	// must connect, open the dialog and re-run. A non-connect error rethrows.
+	const call = useCallback(
+		async <T,>(fn: () => Promise<T>): Promise<T | null> => {
+			try {
+				return await fn();
+			} catch (err) {
+				const outcome = await requireConnect();
+				if (outcome === 'none') throw err;
+				if (outcome === 'cancelled') return null;
+				return await fn();
 			}
-			return openOverlay(error.plugin, error.tenantId, error.connectUrl);
 		},
-		[openOverlay],
+		[requireConnect],
 	);
 
 	// User clicked "Connect" — open Hub's page in a popup and start watching.
 	const handleOpen = useCallback(() => {
-		const { connectUrl, plugin, tenantId } = connectState;
+		const { connectUrl, plugin } = connectState;
 		if (!connectUrl || !plugin) return;
 		popupRef.current = window.open(
 			connectUrl,
 			'corsair-connect',
 			'width=520,height=720',
 		);
-		beginWatch(plugin, tenantId);
+		beginWatch(plugin);
 	}, [beginWatch, connectState]);
 
 	const handleClose = useCallback(() => {
 		attemptRef.current += 1;
 		popupRef.current?.close();
 		popupRef.current = null;
+		client.connectRequest.clear().catch(() => {});
 		settle(false);
 		dispatch({ type: 'CLOSE' });
-	}, [settle]);
+	}, [client, settle]);
 
 	useEffect(() => stopWatch, [stopWatch]);
 
+	// Hold the "connected" check briefly, then dismiss — the resolved call has
+	// already resumed, so the success card is just a confirmation.
+	useEffect(() => {
+		if (connectState.phase !== 'success') return;
+		const t = setTimeout(() => dispatch({ type: 'CLOSE' }), 1100);
+		return () => clearTimeout(t);
+	}, [connectState.phase]);
+
 	const value = useMemo<CorsairContextValue>(
-		() => ({ client, connect, connectFromError, connectState }),
-		[client, connect, connectFromError, connectState],
+		() => ({
+			client,
+			connect,
+			call,
+			requireConnect,
+			connectNonce,
+			status: connectState,
+		}),
+		[client, connect, call, requireConnect, connectNonce, connectState],
 	);
 
 	const overlayOpen =
@@ -188,6 +270,7 @@ export function CorsairProvider({
 			{overlayOpen ? (
 				<ConnectOverlay
 					state={connectState}
+					client={client}
 					appearance={appearance}
 					onOpen={handleOpen}
 					onClose={handleClose}
@@ -197,6 +280,12 @@ export function CorsairProvider({
 	);
 }
 
+/**
+ * Access the full Corsair Connect context — the management client plus the
+ * connect/call/status API and the internals {@link CorsairBoundary} relies on.
+ * Most components want {@link useConnect} instead; reach for this only when you
+ * need the raw `client`. Throws if used outside {@link CorsairProvider}.
+ */
 export function useCorsair(): CorsairContextValue {
 	const ctx = useContext(CorsairContext);
 	if (!ctx) {
@@ -205,12 +294,25 @@ export function useCorsair(): CorsairContextValue {
 	return ctx;
 }
 
-/** Open the connect overlay imperatively, or from a caught ReconnectRequiredError. */
-export function useConnect(): {
+/** Return value of {@link useConnect}. */
+export type UseConnectResult = {
+	/** Proactively open the dialog for a plugin (e.g. a "Connect GitHub" button),
+	 * before any call has failed. Resolves `true` once connected. */
 	connect: (plugin: string, opts?: { tenantId?: string }) => Promise<boolean>;
-	connectFromError: (error: unknown) => Promise<boolean>;
-	state: ConnectState;
-} {
-	const { connect, connectFromError, connectState } = useCorsair();
-	return { connect, connectFromError, state: connectState };
+	/** Run a mutation; if it fails because the tenant must connect, open the
+	 * dialog and re-run once connected. Resolves `null` if the user cancels, and
+	 * rethrows any error that isn't auth-missing. */
+	call: <T>(fn: () => Promise<T>) => Promise<T | null>;
+	/** Current dialog state, for driving your own connect UI if needed. */
+	status: ConnectState;
+};
+
+/**
+ * The everyday hook into Corsair Connect. Use `connect` for a proactive connect
+ * button and `call` to wrap a mutation so it auto-resumes after connect. Server
+ * read regions don't need this — wrap them in {@link CorsairBoundary} instead.
+ */
+export function useConnect(): UseConnectResult {
+	const { connect, call, status } = useCorsair();
+	return { connect, call, status };
 }

--- a/packages/corsair/client/types.ts
+++ b/packages/corsair/client/types.ts
@@ -1,6 +1,7 @@
 import type {
 	ConnectionStatus,
 	ConnectLink,
+	ConnectRequest,
 	CreateConnectLinkInput,
 	CreateTenantInput,
 	ManagementOk,
@@ -47,6 +48,12 @@ export type CorsairManagementClient = {
 		createLink: (input: CreateConnectLinkInput) => Promise<ConnectLink>;
 		resolve: (state: string) => Promise<ResolvedConnectLink>;
 		oauthCallback: (input: OAuthCallbackInput) => Promise<OAuthCallbackResult>;
+	};
+	connectRequest: {
+		get: (query?: {
+			tenantId?: string;
+		}) => Promise<{ request: ConnectRequest | null }>;
+		clear: (input?: { tenantId?: string }) => Promise<{ ok: true }>;
 	};
 };
 

--- a/packages/corsair/core/auth/auth-missing-message.ts
+++ b/packages/corsair/core/auth/auth-missing-message.ts
@@ -20,51 +20,12 @@ export function formatDefaultAuthMissingMessage(
 	return `[auth-missing:${pluginId}] Authentication required. Direct the user to connect their account: ${connectUrl}`;
 }
 
-type AuthMissingRoutingConfig = {
-	manual?: EndpointManualConfig;
-	hub?: HubConfig;
+/** The agent-facing message plus the connect link that produced it (null when
+ * no link could be minted), so the error can carry both. */
+export type ResolvedAuthMissingMessage = {
+	message: string;
+	connectUrl: string | null;
 };
-
-/**
- * Resolves a Hub connect URL for a plugin when auth credentials are missing.
- *
- * Mirrors {@link resolveApprovalUrl} for permissions: only needs `hub` from
- * `createCorsair({ hub })` plus explicit plugin/tenant/database/kek inputs.
- * Returns `null` when hub is not configured, database/kek are missing, or
- * session creation fails.
- *
- * @returns The hosted connect URL, or `null` if one could not be created.
- */
-export async function resolveAuthMissingConnectUrl(
-	routing: AuthMissingRoutingConfig,
-	input: {
-		plugin: CorsairPlugin;
-		tenantId: string;
-		database?: CorsairDatabase;
-		kek?: string;
-		plugins: readonly CorsairPlugin[];
-		multiTenancy?: boolean;
-	},
-): Promise<string | null> {
-	const hub = routing.hub;
-	if (!hub || !input.database || !input.kek) {
-		return null;
-	}
-
-	try {
-		const session = await createHubConnectSessionForPlugin(hub, {
-			tenantId: input.tenantId,
-			plugin: input.plugin,
-			database: input.database,
-			kek: input.kek,
-			plugins: input.plugins,
-			multiTenancy: input.multiTenancy,
-		});
-		return session.connectUrl;
-	} catch {
-		return null;
-	}
-}
 
 /**
  * Builds the agent-facing message returned when a keyBuilder raises AuthMissingError.
@@ -88,7 +49,7 @@ export async function resolveAuthMissingConnectMessage(input: {
 	kek?: string;
 	plugins: readonly CorsairPlugin[];
 	multiTenancy?: boolean;
-}): Promise<string> {
+}): Promise<ResolvedAuthMissingMessage> {
 	const hub = input.hub;
 	if (hub && input.database && input.kek) {
 		try {
@@ -101,40 +62,28 @@ export async function resolveAuthMissingConnectMessage(input: {
 				multiTenancy: input.multiTenancy,
 			});
 
-			if (input.manual?.onAuthMissing) {
-				return input.manual.onAuthMissing({
-					plugin: input.pluginId,
-					connectUrl: session.connectUrl,
-					state: session.token,
-				});
-			}
-
-			return formatDefaultAuthMissingMessage(
-				input.pluginId,
-				session.connectUrl,
-			);
+			const message = input.manual?.onAuthMissing
+				? input.manual.onAuthMissing({
+						plugin: input.pluginId,
+						connectUrl: session.connectUrl,
+						state: session.token,
+					})
+				: formatDefaultAuthMissingMessage(input.pluginId, session.connectUrl);
+			return { message, connectUrl: session.connectUrl };
 		} catch {
-			return `[auth-missing:${input.pluginId}:${input.authType}] Authentication required. Could not create connect link. Check hub configuration and server logs.`;
+			return {
+				message: `[auth-missing:${input.pluginId}:${input.authType}] Authentication required. Could not create connect link. Check hub configuration and server logs.`,
+				connectUrl: null,
+			};
 		}
 	}
 
-	const connectUrl = await resolveAuthMissingConnectUrl(
-		{ manual: input.manual, hub: input.hub },
-		{
-			plugin: input.plugin,
-			tenantId: input.tenantId,
-			database: input.database,
-			kek: input.kek,
-			plugins: input.plugins,
-			multiTenancy: input.multiTenancy,
-		},
-	);
-
-	if (connectUrl) {
-		return formatDefaultAuthMissingMessage(input.pluginId, connectUrl);
-	}
-
-	return `[auth-missing:${input.pluginId}:${input.authType}]`;
+	// hub/database/kek were all required above; reaching here means one is
+	// missing, so no link can be minted.
+	return {
+		message: `[auth-missing:${input.pluginId}:${input.authType}]`,
+		connectUrl: null,
+	};
 }
 
 /**
@@ -150,7 +99,7 @@ export function buildManualConnectMessage(
 		kek: string;
 	},
 	fallbackTenantId: string | undefined,
-): string {
+): ResolvedAuthMissingMessage {
 	const state = signState(
 		encodeOAuthState(
 			pluginId,
@@ -162,11 +111,10 @@ export function buildManualConnectMessage(
 	url.searchParams.set('state', state);
 	const connectUrl = url.toString();
 
-	if (manualConfig.onAuthMissing) {
-		return manualConfig.onAuthMissing({ plugin: pluginId, connectUrl, state });
-	}
-
-	return formatDefaultAuthMissingMessage(pluginId, connectUrl);
+	const message = manualConfig.onAuthMissing
+		? manualConfig.onAuthMissing({ plugin: pluginId, connectUrl, state })
+		: formatDefaultAuthMissingMessage(pluginId, connectUrl);
+	return { message, connectUrl };
 }
 
 /**
@@ -182,7 +130,7 @@ export async function resolveAuthMissingEndpointMessage(input: {
 	kek?: string;
 	plugins?: readonly CorsairPlugin[];
 	multiTenancy?: boolean;
-}): Promise<string> {
+}): Promise<ResolvedAuthMissingMessage> {
 	const tenantId = input.tenantId ?? 'default';
 	const pluginId = input.error.pluginId;
 
@@ -225,7 +173,7 @@ export async function resolveAuthMissingEndpointMessage(input: {
 		});
 	}
 
-	return input.error.message;
+	return { message: input.error.message, connectUrl: null };
 }
 
 /**
@@ -242,10 +190,15 @@ export async function throwAuthMissingEndpointError(input: {
 	plugins?: readonly CorsairPlugin[];
 	multiTenancy?: boolean;
 }): Promise<never> {
-	const message = await resolveAuthMissingEndpointMessage(input);
+	const { message, connectUrl } =
+		await resolveAuthMissingEndpointMessage(input);
 	throw new AuthMissingError(
 		input.error.pluginId,
 		input.error.authType,
 		message,
+		{
+			connectUrl,
+			tenantId: input.tenantId ?? 'default',
+		},
 	);
 }

--- a/packages/corsair/core/auth/errors/auth-missing.ts
+++ b/packages/corsair/core/auth/errors/auth-missing.ts
@@ -1,17 +1,27 @@
 /**
- * Error thrown when a plugin endpoint is called but the required auth credentials
- * are missing. Endpoint binding enriches the message with a connect link when hub
- * or manual config is available, then rethrows this error for callers to handle.
+ * Error thrown when a plugin endpoint is called but the required auth
+ * credentials are missing.
  */
 export class AuthMissingError extends Error {
 	pluginId: string;
 	authType: string;
+	/** Scoped connect link when one could be minted — lets a UI open Connect
+	 * without parsing the message. Null when no link was available. */
+	connectUrl: string | null;
+	tenantId: string | null;
 
-	constructor(pluginId: string, authType: string, message?: string) {
+	constructor(
+		pluginId: string,
+		authType: string,
+		message?: string,
+		link?: { connectUrl: string | null; tenantId: string | null },
+	) {
 		super(message ?? `[auth-missing:${pluginId}:${authType}]`);
 		Object.setPrototypeOf(this, new.target.prototype);
 		this.name = 'AuthMissingError';
 		this.pluginId = pluginId;
 		this.authType = authType;
+		this.connectUrl = link?.connectUrl ?? null;
+		this.tenantId = link?.tenantId ?? null;
 	}
 }

--- a/packages/corsair/core/auth/errors/index.ts
+++ b/packages/corsair/core/auth/errors/index.ts
@@ -1,2 +1,3 @@
 export { AuthMissingError } from './auth-missing';
 export { createMissingConfigProxy } from './missing-config';
+export { ReconnectRequiredError } from './reconnect-required';

--- a/packages/corsair/core/auth/errors/reconnect-required.ts
+++ b/packages/corsair/core/auth/errors/reconnect-required.ts
@@ -1,0 +1,28 @@
+/**
+ * Thrown when Hub reports that a connection needs to be (re)established — a
+ * refresh token was rejected, or there's no usable connection for the tenant.
+ * Carries the scoped connect link Hub minted (null when it couldn't, e.g. no
+ * OAuth app is configured) so a UI can send the user straight to it.
+ */
+export class ReconnectRequiredError extends Error {
+	connectUrl: string | null;
+	plugin: string | null;
+	tenantId: string | null;
+	reason?: string;
+
+	constructor(input: {
+		message?: string;
+		connectUrl: string | null;
+		plugin: string | null;
+		tenantId: string | null;
+		reason?: string;
+	}) {
+		super(input.message ?? 'Reconnect required');
+		Object.setPrototypeOf(this, new.target.prototype);
+		this.name = 'ReconnectRequiredError';
+		this.connectUrl = input.connectUrl;
+		this.plugin = input.plugin;
+		this.tenantId = input.tenantId;
+		this.reason = input.reason;
+	}
+}

--- a/packages/corsair/core/auth/index.ts
+++ b/packages/corsair/core/auth/index.ts
@@ -10,7 +10,11 @@ export {
 	reEncryptConfig,
 } from './encryption';
 // Auth error utilities
-export { AuthMissingError, createMissingConfigProxy } from './errors';
+export {
+	AuthMissingError,
+	createMissingConfigProxy,
+	ReconnectRequiredError,
+} from './errors';
 export type { TokenResponse } from './exchange';
 // Token exchange utility
 export { exchangeCodeForTokens } from './exchange';

--- a/packages/corsair/core/auth/oauth-token-cache.ts
+++ b/packages/corsair/core/auth/oauth-token-cache.ts
@@ -11,7 +11,11 @@ export function isAccessTokenFresh(input: {
 	forceRefresh?: boolean;
 }): boolean {
 	if (input.forceRefresh) return false;
-	if (!input.accessToken || !input.expiresAt) return false;
+	if (!input.accessToken) return false;
+	// A non-expiring token (Notion et al.) carries no expires_at — a present access
+	// token is fresh. If a provider that really does expire ever omits it, the call
+	// gets a 401 and the endpoint's 401-retry forces a refresh.
+	if (!input.expiresAt) return true;
 	const now = input.now ?? Math.floor(Date.now() / 1000);
 	return Number(input.expiresAt) > now + TOKEN_REFRESH_BUFFER_SECONDS;
 }

--- a/packages/corsair/core/connect-request/store.ts
+++ b/packages/corsair/core/connect-request/store.ts
@@ -1,0 +1,94 @@
+import type { CorsairConnectRequest } from '../../db';
+import type { CorsairDatabase } from '../../db/kysely/database';
+import type { ConnectRequest } from '../management/types';
+
+// A connect-request is the bridge between a server-side auth-missing failure and
+// the browser dialog: when any tool call raises auth-missing, the binding
+// records one here; the client reads it on-demand when a failure surfaces (a
+// read boundary catching, or `call` catching a mutation) to show the dialog.
+// One row per tenant — the latest failure wins.
+
+/** How long a recorded request stays live before it's treated as stale. */
+export const CONNECT_REQUEST_TTL_MS = 10 * 60 * 1000;
+
+export type RecordConnectRequestInput = {
+	tenantId: string;
+	plugin: string;
+	connectUrl: string;
+};
+
+export async function recordConnectRequest(
+	database: CorsairDatabase,
+	input: RecordConnectRequestInput,
+	now: number = Date.now(),
+): Promise<void> {
+	await database.db
+		.insertInto('corsair_connect_requests')
+		.values({
+			tenant_id: input.tenantId,
+			plugin: input.plugin,
+			connect_url: input.connectUrl,
+			requested_at: new Date(now).toISOString(),
+		})
+		.onConflict((oc) =>
+			oc.column('tenant_id').doUpdateSet({
+				plugin: input.plugin,
+				connect_url: input.connectUrl,
+				requested_at: new Date(now).toISOString(),
+			}),
+		)
+		.execute();
+}
+
+/** The tenant's live connect-request, or null when there is none or it expired. */
+export async function readConnectRequest(
+	database: CorsairDatabase,
+	tenantId: string,
+	now: number = Date.now(),
+	ttlMs: number = CONNECT_REQUEST_TTL_MS,
+): Promise<ConnectRequest | null> {
+	const row = (await database.db
+		.selectFrom('corsair_connect_requests')
+		.selectAll()
+		.where('tenant_id', '=', tenantId)
+		.executeTakeFirst()) as CorsairConnectRequest | undefined;
+
+	if (!row) return null;
+	if (now - Date.parse(row.requested_at) > ttlMs) return null;
+	return {
+		plugin: row.plugin,
+		connectUrl: row.connect_url,
+		requestedAt: row.requested_at,
+	};
+}
+
+export async function clearConnectRequest(
+	database: CorsairDatabase,
+	tenantId: string,
+): Promise<void> {
+	await database.db
+		.deleteFrom('corsair_connect_requests')
+		.where('tenant_id', '=', tenantId)
+		.execute();
+}
+
+// Called from the failing tool-call path, so it must never throw or block: a
+// missing db/plugin/url just means no dialog is pre-armed, and a write error is
+// swallowed.
+export async function recordConnectRequestBestEffort(
+	database: CorsairDatabase | undefined,
+	input: {
+		tenantId: string | undefined;
+		plugin: string | null | undefined;
+		connectUrl: string | null | undefined;
+	},
+): Promise<void> {
+	if (!database || !input.plugin || !input.connectUrl) return;
+	try {
+		await recordConnectRequest(database, {
+			tenantId: input.tenantId ?? 'default',
+			plugin: input.plugin,
+			connectUrl: input.connectUrl,
+		});
+	} catch {}
+}

--- a/packages/corsair/core/endpoints/bind.ts
+++ b/packages/corsair/core/endpoints/bind.ts
@@ -3,6 +3,7 @@ import type { HubConfig } from '../../hub';
 import { reportPluginConnectionStatusFromBinding } from '../../hub/report-connection-status';
 import { throwAuthMissingEndpointError } from '../auth/auth-missing-message';
 import { AuthMissingError } from '../auth/errors/auth-missing';
+import { ReconnectRequiredError } from '../auth/errors/reconnect-required';
 import type { EndpointManualConfig } from '../config/manual-connect';
 import type { CorsairErrorHandler } from '../errors';
 import { handleCorsairError } from '../errors/handler';
@@ -253,6 +254,22 @@ export function bindEndpointsRecursively({
 				try {
 					key = keyBuilder ? await keyBuilder(ctx, 'endpoint') : undefined;
 				} catch (err) {
+					// Hub already minted a scoped connect link and put it on the typed
+					// error — report the connection unverified and rethrow it intact.
+					if (err instanceof ReconnectRequiredError) {
+						if (plugin && hubConfig) {
+							reportPluginConnectionStatusFromBinding({
+								hub: hubConfig,
+								database,
+								kek,
+								plugins: allPlugins ?? [],
+								plugin,
+								tenantId,
+								verified: false,
+							});
+						}
+						throw err;
+					}
 					if (err instanceof AuthMissingError) {
 						if (plugin && hubConfig) {
 							reportPluginConnectionStatusFromBinding({

--- a/packages/corsair/core/endpoints/bind.ts
+++ b/packages/corsair/core/endpoints/bind.ts
@@ -5,6 +5,7 @@ import { throwAuthMissingEndpointError } from '../auth/auth-missing-message';
 import { AuthMissingError } from '../auth/errors/auth-missing';
 import { ReconnectRequiredError } from '../auth/errors/reconnect-required';
 import type { EndpointManualConfig } from '../config/manual-connect';
+import { recordConnectRequestBestEffort } from '../connect-request/store';
 import type { CorsairErrorHandler } from '../errors';
 import { handleCorsairError } from '../errors/handler';
 import {
@@ -268,6 +269,11 @@ export function bindEndpointsRecursively({
 								verified: false,
 							});
 						}
+						await recordConnectRequestBestEffort(database, {
+							tenantId,
+							plugin: err.plugin,
+							connectUrl: err.connectUrl,
+						});
 						throw err;
 					}
 					if (err instanceof AuthMissingError) {
@@ -282,17 +288,30 @@ export function bindEndpointsRecursively({
 								verified: false,
 							});
 						}
-						await throwAuthMissingEndpointError({
-							error: err,
-							manual: manualConfig,
-							hub: hubConfig,
-							plugin,
-							tenantId,
-							database,
-							kek,
-							plugins: allPlugins,
-							multiTenancy,
-						});
+						// throwAuthMissingEndpointError mints the scoped link and rethrows
+						// the enriched error; capture that link for the connect dialog.
+						try {
+							await throwAuthMissingEndpointError({
+								error: err,
+								manual: manualConfig,
+								hub: hubConfig,
+								plugin,
+								tenantId,
+								database,
+								kek,
+								plugins: allPlugins,
+								multiTenancy,
+							});
+						} catch (enriched) {
+							if (enriched instanceof AuthMissingError) {
+								await recordConnectRequestBestEffort(database, {
+									tenantId,
+									plugin: enriched.pluginId,
+									connectUrl: enriched.connectUrl,
+								});
+							}
+							throw enriched;
+						}
 					}
 					throw err;
 				}

--- a/packages/corsair/core/endpoints/bind.ts
+++ b/packages/corsair/core/endpoints/bind.ts
@@ -270,7 +270,7 @@ export function bindEndpointsRecursively({
 							});
 						}
 						await recordConnectRequestBestEffort(database, {
-							tenantId,
+							tenantId: err.tenantId ?? tenantId,
 							plugin: err.plugin,
 							connectUrl: err.connectUrl,
 						});
@@ -305,7 +305,7 @@ export function bindEndpointsRecursively({
 						} catch (enriched) {
 							if (enriched instanceof AuthMissingError) {
 								await recordConnectRequestBestEffort(database, {
-									tenantId,
+									tenantId: enriched.tenantId ?? tenantId,
 									plugin: enriched.pluginId,
 									connectUrl: enriched.connectUrl,
 								});

--- a/packages/corsair/core/index.ts
+++ b/packages/corsair/core/index.ts
@@ -260,6 +260,7 @@ export {
 	getOAuthAccessToken,
 	initializeAccountDEK,
 	initializeIntegrationDEK,
+	ReconnectRequiredError,
 	reEncryptConfig,
 } from './auth';
 // Agent chats namespace

--- a/packages/corsair/core/management/errors.ts
+++ b/packages/corsair/core/management/errors.ts
@@ -23,10 +23,14 @@ export class ManagementApiError extends Error {
 	}
 }
 
-export function json(status: number, body: unknown): Response {
+export function json(
+	status: number,
+	body: unknown,
+	headers?: Record<string, string>,
+): Response {
 	return new Response(JSON.stringify(body), {
 		status,
-		headers: { 'content-type': 'application/json' },
+		headers: { 'content-type': 'application/json', ...headers },
 	});
 }
 

--- a/packages/corsair/core/management/handler.ts
+++ b/packages/corsair/core/management/handler.ts
@@ -1,5 +1,9 @@
 import { respondToHubDeliveryFromRequest } from '../../hub/delivery';
 import type { CorsairInternalConfig } from '..';
+import {
+	clearConnectRequest,
+	readConnectRequest,
+} from '../connect-request/store';
 import { getCorsairInternal } from '../utils/corsair-instance';
 import type { CappedReadOptions } from './body-limit';
 import {
@@ -60,6 +64,15 @@ export type ManagementHandlerOptions = {
 		err: unknown,
 		req: Request,
 	) => Response | Promise<Response> | undefined;
+	/**
+	 * Resolve the tenant for an incoming request from your own auth (cookies /
+	 * session). When set, the tenant-scoped routes (/connect/links and
+	 * /connection-status) use the returned id and IGNORE any client-sent
+	 * tenantId — so a browser can't act for another tenant. Return null to reject
+	 * the request as unauthenticated. Omit in single-tenant apps, or when your own
+	 * backend already scopes the tenant server-side.
+	 */
+	resolveTenant?: (req: Request) => string | null | Promise<string | null>;
 };
 
 type RouteCtx = {
@@ -69,7 +82,43 @@ type RouteCtx = {
 	params: Record<string, string>;
 	query: Record<string, string>;
 	body: unknown;
+	// The resolved tenant — see resolveScopedTenant for the tri-state.
+	scopedTenant: string | null | undefined;
 };
+
+// The resolver's result is authoritative for the two routes that take a raw
+// tenantId. A string scopes the request; null means the caller isn't
+// authenticated for any tenant; undefined means no resolver, so trust the
+// client value (single-tenant, or a server-fronted handler).
+export function resolveScopedTenant(
+	scoped: string | null | undefined,
+	fromClient: string | undefined,
+): string | undefined {
+	if (scoped === undefined) return fromClient;
+	if (scoped === null) {
+		throw new ManagementApiError(
+			401,
+			'unauthenticated',
+			'Could not determine the tenant for this request. Sign in and retry.',
+		);
+	}
+	return scoped;
+}
+
+// End-user mode (resolveTenant configured): the cross-tenant admin routes are
+// off so a user can't enumerate tenants or read another's records. `undefined`
+// means no resolver, i.e. admin/server mode.
+export function assertAdminRouteAllowed(
+	scoped: string | null | undefined,
+): void {
+	if (scoped !== undefined) {
+		throw new ManagementApiError(
+			403,
+			'forbidden',
+			'This route is disabled when resolveTenant is configured (end-user mode). Use a handler without resolveTenant, behind your own admin auth.',
+		);
+	}
+}
 
 type Route = {
 	method: 'GET' | 'POST';
@@ -90,19 +139,26 @@ const ROUTES: Route[] = [
 	{
 		method: 'GET',
 		pattern: '/tenants',
-		handler: async ({ internal }) => json(200, await listTenants(internal)),
+		handler: async ({ internal, scopedTenant }) => {
+			assertAdminRouteAllowed(scopedTenant);
+			return json(200, await listTenants(internal));
+		},
 	},
 	{
 		method: 'POST',
 		pattern: '/tenants',
-		handler: async ({ internal, body }) =>
-			json(201, await createTenant(internal, body as { id: string })),
+		handler: async ({ internal, body, scopedTenant }) => {
+			assertAdminRouteAllowed(scopedTenant);
+			return json(201, await createTenant(internal, body as { id: string }));
+		},
 	},
 	{
 		method: 'GET',
 		pattern: '/tenants/:id',
-		handler: async ({ internal, params }) =>
-			json(200, await getTenant(internal, params.id!)),
+		handler: async ({ internal, params, scopedTenant }) => {
+			assertAdminRouteAllowed(scopedTenant);
+			return json(200, await getTenant(internal, params.id!));
+		},
 	},
 	{
 		method: 'GET',
@@ -118,14 +174,22 @@ const ROUTES: Route[] = [
 	{
 		method: 'GET',
 		pattern: '/connection-status',
-		handler: async ({ internal, query }) =>
-			json(200, await getConnectionStatus(internal, query.tenantId)),
+		handler: async ({ internal, query, scopedTenant }) =>
+			json(
+				200,
+				await getConnectionStatus(
+					internal,
+					resolveScopedTenant(scopedTenant, query.tenantId),
+				),
+			),
 	},
 	{
 		method: 'GET',
 		pattern: '/permissions/:id',
-		handler: async ({ internal, params }) =>
-			json(200, await getPermission(internal, params.id!)),
+		handler: async ({ internal, params, scopedTenant }) => {
+			assertAdminRouteAllowed(scopedTenant);
+			return json(200, await getPermission(internal, params.id!));
+		},
 	},
 	{
 		// POST + body, not GET + path. Tokens are short-lived authorization
@@ -148,15 +212,14 @@ const ROUTES: Route[] = [
 	{
 		method: 'POST',
 		pattern: '/connect/links',
-		handler: async ({ corsair, internal, body }) =>
-			json(
+		handler: async ({ corsair, internal, body, scopedTenant }) => {
+			const input = body as CreateConnectLinkInput;
+			const tenantId = resolveScopedTenant(scopedTenant, input.tenantId);
+			return json(
 				200,
-				await createConnectLink(
-					corsair,
-					internal,
-					body as CreateConnectLinkInput,
-				),
-			),
+				await createConnectLink(corsair, internal, { ...input, tenantId }),
+			);
+		},
 	},
 	{
 		method: 'GET',
@@ -176,6 +239,34 @@ const ROUTES: Route[] = [
 					body as OAuthCallbackInput,
 				),
 			),
+	},
+	{
+		// Read on-demand when a failure surfaces (read boundary / `call`), not polled.
+		method: 'GET',
+		pattern: '/connect/request',
+		handler: async ({ internal, query, scopedTenant }) => {
+			const tenantId =
+				resolveScopedTenant(scopedTenant, query.tenantId) ?? 'default';
+			const request = internal.database
+				? await readConnectRequest(internal.database, tenantId)
+				: null;
+			return json(200, { request });
+		},
+	},
+	{
+		method: 'POST',
+		pattern: '/connect/request/clear',
+		handler: async ({ internal, body, scopedTenant }) => {
+			const tenantId =
+				resolveScopedTenant(
+					scopedTenant,
+					(body as { tenantId?: string } | undefined)?.tenantId,
+				) ?? 'default';
+			if (internal.database) {
+				await clearConnectRequest(internal.database, tenantId);
+			}
+			return json(200, { ok: true });
+		},
 	},
 ];
 
@@ -318,6 +409,9 @@ export function managementHandler(
 				const params = matchPattern(route.pattern, pathname);
 				if (!params) continue;
 				const body = await parseBody(req, bodyLimits);
+				const scopedTenant = opts.resolveTenant
+					? await opts.resolveTenant(req)
+					: undefined;
 				return await route.handler({
 					corsair,
 					internal,
@@ -325,6 +419,7 @@ export function managementHandler(
 					params,
 					query,
 					body,
+					scopedTenant,
 				});
 			}
 

--- a/packages/corsair/core/management/handler.ts
+++ b/packages/corsair/core/management/handler.ts
@@ -250,7 +250,8 @@ const ROUTES: Route[] = [
 			const request = internal.database
 				? await readConnectRequest(internal.database, tenantId)
 				: null;
-			return json(200, { request });
+			// Tenant-scoped connect link — never let a shared cache reuse it.
+			return json(200, { request }, { 'cache-control': 'no-store' });
 		},
 	},
 	{

--- a/packages/corsair/core/management/types.ts
+++ b/packages/corsair/core/management/types.ts
@@ -37,6 +37,13 @@ export type PluginConnectionState =
 
 export type ConnectionStatus = Record<string, PluginConnectionState>;
 
+/** A live connect-request — the client reads this on-demand to drive the dialog. */
+export type ConnectRequest = {
+	plugin: string;
+	connectUrl: string;
+	requestedAt: string;
+};
+
 export type ManagementOk = { ok: true };
 
 export type PermissionRecord = CorsairPermission & {

--- a/packages/corsair/db/index.ts
+++ b/packages/corsair/db/index.ts
@@ -157,6 +157,33 @@ export type CorsairPermissionInsert = {
 	error?: string | null;
 };
 
+// A short-lived record that a tenant hit a wall and must connect a plugin —
+// written when a tool call raises auth-missing, read on-demand by the client to
+// drive the connect dialog. One row per tenant (latest wins).
+export type CorsairConnectRequest = {
+	tenant_id: string;
+	plugin: string;
+	connect_url: string;
+	/** ISO8601 timestamp the request was recorded; the store enforces the TTL on read. */
+	requested_at: string;
+};
+
+export type CorsairConnectRequestInsert = {
+	tenant_id: string;
+	plugin: string;
+	connect_url: string;
+	requested_at: string;
+};
+
+// Registered in setup's REQUIRED_TABLES so a deploy missing this table gets a
+// clear "run your migrations" warning instead of a 500 on the first connect.
+export const CorsairConnectRequestsSchema = z.object({
+	tenant_id: z.string(),
+	plugin: z.string(),
+	connect_url: z.string(),
+	requested_at: z.string(),
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Table Names
 // ─────────────────────────────────────────────────────────────────────────────
@@ -167,6 +194,7 @@ export type CorsairTableName =
 	| 'corsair_entities'
 	| 'corsair_events'
 	| 'corsair_permissions'
+	| 'corsair_connect_requests'
 	| (string & {});
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -178,6 +206,7 @@ export type CorsairTableRow = {
 	corsair_accounts: CorsairAccount;
 	corsair_entities: CorsairEntity;
 	corsair_events: CorsairEvent;
+	corsair_connect_requests: CorsairConnectRequest;
 };
 
 export type TableRowType<T extends CorsairTableName> =
@@ -234,6 +263,7 @@ export type CorsairTableInsert = {
 	corsair_accounts: CorsairAccountInsert;
 	corsair_entities: CorsairEntityInsert;
 	corsair_events: CorsairEventInsert;
+	corsair_connect_requests: CorsairConnectRequestInsert;
 };
 
 export type TableInsertType<T extends CorsairTableName> =

--- a/packages/corsair/db/kysely/database.ts
+++ b/packages/corsair/db/kysely/database.ts
@@ -5,6 +5,7 @@ import type { Pool } from 'pg';
 import type { ReservedSql, Sql, UnsafeQueryOptions } from 'postgres';
 import type {
 	CorsairAccount,
+	CorsairConnectRequest,
 	CorsairEntity,
 	CorsairEvent,
 	CorsairIntegration,
@@ -18,6 +19,7 @@ export type CorsairKyselyDatabase = {
 	corsair_entities: CorsairEntity;
 	corsair_events: CorsairEvent;
 	corsair_permissions: CorsairPermission;
+	corsair_connect_requests: CorsairConnectRequest;
 };
 
 export type CorsairDatabase = {

--- a/packages/corsair/hub/client/http.ts
+++ b/packages/corsair/hub/client/http.ts
@@ -1,4 +1,8 @@
-import { parseHubApiErrorBody } from '../contracts/connect-api';
+import { ReconnectRequiredError } from '../../core/auth/errors/reconnect-required';
+import {
+	parseHubApiErrorBody,
+	parseHubReconnectBody,
+} from '../contracts/connect-api';
 import { resolveHubDeliveryUrl } from '../resolve-delivery-url';
 import type { HubConfig } from '../types';
 
@@ -77,6 +81,26 @@ export function parseHubApiError(
 	return `Hub API returned HTTP ${status}`;
 }
 
+// A `reconnect_required` body becomes a typed error carrying Hub's scoped connect
+// link, so callers (and the client UI) can act on it instead of parsing a string.
+function throwHubApiError(
+	payload: unknown,
+	status: number,
+	notFoundMessage?: string,
+): never {
+	const reconnect = parseHubReconnectBody(payload);
+	if (reconnect) {
+		throw new ReconnectRequiredError({
+			message: reconnect.message ?? undefined,
+			connectUrl: reconnect.connectUrl,
+			plugin: reconnect.plugin,
+			tenantId: reconnect.tenantId,
+			reason: reconnect.reason ?? undefined,
+		});
+	}
+	throw new Error(parseHubApiError(payload, status, notFoundMessage));
+}
+
 export async function hubApiPost<T>(input: {
 	hub: HubConfig;
 	path: string;
@@ -98,9 +122,7 @@ export async function hubApiPost<T>(input: {
 	const payload = await readHubJsonResponse(response);
 
 	if (!response.ok) {
-		throw new Error(
-			parseHubApiError(payload, response.status, input.notFoundMessage),
-		);
+		throwHubApiError(payload, response.status, input.notFoundMessage);
 	}
 
 	return input.parseResponse(payload);
@@ -124,9 +146,7 @@ export async function hubApiGet<T>(input: {
 	const payload = await readHubJsonResponse(response);
 
 	if (!response.ok) {
-		throw new Error(
-			parseHubApiError(payload, response.status, input.notFoundMessage),
-		);
+		throwHubApiError(payload, response.status, input.notFoundMessage);
 	}
 
 	return input.parseResponse(payload);

--- a/packages/corsair/hub/contracts/connect-api.ts
+++ b/packages/corsair/hub/contracts/connect-api.ts
@@ -416,3 +416,35 @@ export function parseHubApiErrorBody(payload: unknown): string | null {
 	const body = payload as HubApiErrorBody;
 	return body.error ?? body.message ?? null;
 }
+
+export type HubReconnectBody = {
+	message: string | null;
+	connectUrl: string | null;
+	plugin: string | null;
+	tenantId: string | null;
+	reason: string | null;
+};
+
+// Recognizes Hub's `reconnect_required` error body and pulls out the scoped
+// connect link + identity. Returns null for any other error shape, so callers
+// fall back to their generic handling.
+export function parseHubReconnectBody(
+	payload: unknown,
+): HubReconnectBody | null {
+	if (!payload || typeof payload !== 'object') {
+		return null;
+	}
+	const body = payload as Record<string, unknown>;
+	if (body.errorType !== 'reconnect_required') {
+		return null;
+	}
+	const str = (v: unknown) =>
+		typeof v === 'string' && v.length > 0 ? v : null;
+	return {
+		message: str(body.error),
+		connectUrl: str(body.connectUrl),
+		plugin: str(body.plugin),
+		tenantId: str(body.tenantId),
+		reason: str(body.reason),
+	};
+}

--- a/packages/corsair/index.ts
+++ b/packages/corsair/index.ts
@@ -9,6 +9,7 @@ export {
 	createCorsair,
 	PermissionRequiredError,
 	ReadonlyForbiddenError,
+	ReconnectRequiredError,
 	resolveConnectLink,
 	runReadonly,
 } from './core';

--- a/packages/corsair/inspect.ts
+++ b/packages/corsair/inspect.ts
@@ -1,11 +1,12 @@
+import type { CorsairInternalConfig } from './core';
+import { CORSAIR_INTERNAL } from './core';
+// Import these directly from their source modules (not the ./core barrel) so
+// inspect.ts and core/index.ts don't form a circular chunk dependency.
 import type {
 	CorsairClient,
-	CorsairInternalConfig,
-	CorsairPlugin,
 	CorsairSingleTenantClient,
 	CorsairTenantWrapper,
-} from './core';
-import { CORSAIR_INTERNAL } from './core';
+} from './core/client';
 import type { FormFieldSchema, ListOperationsOptions } from './core/inspect';
 import {
 	formatDocSchemaShape,
@@ -13,6 +14,7 @@ import {
 	getStructuredSchema as getStructuredSchemaCore,
 	listOperations as listOperationsCore,
 } from './core/inspect';
+import type { CorsairPlugin } from './core/plugins';
 
 export type { ListOperationsOptions, FormFieldSchema };
 export { formatDocSchemaShape };

--- a/packages/corsair/package.json
+++ b/packages/corsair/package.json
@@ -81,7 +81,7 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:api": "jest --testPathPattern=api\\.test\\.ts",
-    "build": "tsup",
+    "build": "rm -rf dist && tsup",
     "build:watch": "tsup --watch",
     "postinstall": "node scripts/postinstall-frpc.mjs",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",

--- a/packages/corsair/package.json
+++ b/packages/corsair/package.json
@@ -81,7 +81,7 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:api": "jest --testPathPattern=api\\.test\\.ts",
-    "build": "rm -rf dist && tsup",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsup",
     "build:watch": "tsup --watch",
     "postinstall": "node scripts/postinstall-frpc.mjs",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",

--- a/packages/corsair/package.json
+++ b/packages/corsair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corsair",
-  "version": "0.1.122",
+  "version": "0.1.123",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/corsair/setup/index.ts
+++ b/packages/corsair/setup/index.ts
@@ -12,20 +12,20 @@ import {
 	ZodString,
 	ZodType,
 } from 'zod';
-import type {
-	AuthTypes,
-	BaseKeyManager,
-	CorsairInternalConfig,
-	CorsairPlugin,
-	CorsairSingleTenantClient,
-	CorsairTenantWrapper,
-} from '../core';
+import type { AuthTypes, BaseKeyManager, CorsairInternalConfig } from '../core';
 import {
 	BASE_AUTH_FIELDS,
 	createAccountKeyManager,
 	createCorsair,
 	createIntegrationKeyManager,
 } from '../core';
+// Direct source-module imports (not the ./core barrel) to avoid a circular
+// chunk dependency between setup and core/index.
+import type {
+	CorsairSingleTenantClient,
+	CorsairTenantWrapper,
+} from '../core/client';
+import type { CorsairPlugin } from '../core/plugins';
 import {
 	getCallableProperty,
 	isMultiTenantInstance,
@@ -33,6 +33,7 @@ import {
 	tryGetCorsairInternal,
 } from '../core/utils';
 import { getPluginAuthType } from '../core/utils/plugin-auth';
+import { CorsairConnectRequestsSchema } from '../db';
 import type {
 	CorsairDatabase,
 	CorsairKyselyDatabase,
@@ -315,6 +316,7 @@ function isBackfillYaml(value: unknown): value is BackfillYaml {
 
 const REQUIRED_TABLES = {
 	...TABLE_SCHEMAS,
+	corsair_connect_requests: CorsairConnectRequestsSchema,
 };
 
 function describeZodSchema(schema: ZodTypeAny): unknown {

--- a/packages/corsair/tests/auth-missing-message.test.ts
+++ b/packages/corsair/tests/auth-missing-message.test.ts
@@ -1,7 +1,6 @@
 import {
 	formatDefaultAuthMissingMessage,
 	resolveAuthMissingConnectMessage,
-	resolveAuthMissingConnectUrl,
 } from '../core/auth/auth-missing-message';
 import type { CorsairPlugin } from '../core/plugins';
 import type { HubConfig } from '../hub/types';
@@ -44,55 +43,13 @@ describe('formatDefaultAuthMissingMessage', () => {
 	});
 });
 
-describe('resolveAuthMissingConnectUrl', () => {
-	beforeEach(() => {
-		createHubConnectSessionForPlugin.mockClear();
-	});
-
-	it('creates a hub connect session scoped to tenant and plugin', async () => {
-		const url = await resolveAuthMissingConnectUrl(
-			{ hub },
-			{
-				plugin: slackPlugin,
-				tenantId: 'tenant-1',
-				database: {} as never,
-				kek: 'test-kek',
-				plugins: [slackPlugin],
-			},
-		);
-
-		expect(createHubConnectSessionForPlugin).toHaveBeenCalledWith(hub, {
-			tenantId: 'tenant-1',
-			plugin: slackPlugin,
-			database: {},
-			kek: 'test-kek',
-			plugins: [slackPlugin],
-		});
-		expect(url).toBe('https://hub.example/connect/sess-1');
-	});
-
-	it('returns null when hub is not configured', async () => {
-		const url = await resolveAuthMissingConnectUrl(
-			{},
-			{
-				plugin: slackPlugin,
-				tenantId: 'tenant-1',
-				database: {} as never,
-				kek: 'test-kek',
-				plugins: [slackPlugin],
-			},
-		);
-		expect(url).toBeNull();
-	});
-});
-
 describe('resolveAuthMissingConnectMessage', () => {
 	beforeEach(() => {
 		createHubConnectSessionForPlugin.mockClear();
 	});
 
 	it('returns a connect link message when hub is configured', async () => {
-		const msg = await resolveAuthMissingConnectMessage({
+		const result = await resolveAuthMissingConnectMessage({
 			hub,
 			plugin: slackPlugin,
 			pluginId: 'slack',
@@ -103,8 +60,9 @@ describe('resolveAuthMissingConnectMessage', () => {
 			plugins: [slackPlugin],
 		});
 
-		expect(msg).toContain('[auth-missing:slack]');
-		expect(msg).toContain('https://hub.example/connect/sess-1');
+		expect(result.message).toContain('[auth-missing:slack]');
+		expect(result.message).toContain('https://hub.example/connect/sess-1');
+		expect(result.connectUrl).toBe('https://hub.example/connect/sess-1');
 	});
 
 	it('calls manual.onAuthMissing when configured', async () => {
@@ -112,7 +70,7 @@ describe('resolveAuthMissingConnectMessage', () => {
 			({ connectUrl }: { connectUrl: string }) => `Connect here: ${connectUrl}`,
 		);
 
-		const msg = await resolveAuthMissingConnectMessage({
+		const result = await resolveAuthMissingConnectMessage({
 			hub,
 			manual: { onAuthMissing },
 			plugin: slackPlugin,
@@ -129,7 +87,10 @@ describe('resolveAuthMissingConnectMessage', () => {
 			connectUrl: 'https://hub.example/connect/sess-1',
 			state: 'hub-connect-token',
 		});
-		expect(msg).toBe('Connect here: https://hub.example/connect/sess-1');
+		expect(result.message).toBe(
+			'Connect here: https://hub.example/connect/sess-1',
+		);
+		expect(result.connectUrl).toBe('https://hub.example/connect/sess-1');
 	});
 
 	it('returns fallback message when hub session creation fails', async () => {
@@ -137,7 +98,7 @@ describe('resolveAuthMissingConnectMessage', () => {
 			new Error('hub down'),
 		);
 
-		const msg = await resolveAuthMissingConnectMessage({
+		const result = await resolveAuthMissingConnectMessage({
 			hub,
 			plugin: slackPlugin,
 			pluginId: 'slack',
@@ -148,8 +109,9 @@ describe('resolveAuthMissingConnectMessage', () => {
 			plugins: [slackPlugin],
 		});
 
-		expect(msg).toBe(
+		expect(result.message).toBe(
 			'[auth-missing:slack:oauth_2] Authentication required. Could not create connect link. Check hub configuration and server logs.',
 		);
+		expect(result.connectUrl).toBeNull();
 	});
 });

--- a/packages/corsair/tests/connect-controller.test.ts
+++ b/packages/corsair/tests/connect-controller.test.ts
@@ -1,7 +1,10 @@
 import {
+	CONNECTED_MESSAGE_TYPE,
 	connectReducer,
 	initialConnectState,
+	isConnectedMessage,
 	isPluginConnected,
+	originOf,
 } from '../client/react/connect-controller';
 
 describe('connectReducer', () => {
@@ -55,5 +58,39 @@ describe('isPluginConnected', () => {
 		);
 		expect(isPluginConnected({}, 'gmail')).toBe(false);
 		expect(isPluginConnected(null, 'gmail')).toBe(false);
+	});
+});
+
+describe('isConnectedMessage', () => {
+	const hub = 'https://hub.corsair.dev';
+	it('accepts the connected message from the trusted origin', () => {
+		expect(isConnectedMessage({ type: CONNECTED_MESSAGE_TYPE }, hub, hub)).toBe(
+			true,
+		);
+	});
+	it('rejects a message from any other origin', () => {
+		expect(
+			isConnectedMessage(
+				{ type: CONNECTED_MESSAGE_TYPE },
+				'https://evil.com',
+				hub,
+			),
+		).toBe(false);
+	});
+	it('rejects the wrong message type, non-objects, and an empty trusted origin', () => {
+		expect(isConnectedMessage({ type: 'other' }, hub, hub)).toBe(false);
+		expect(isConnectedMessage('corsair:connected', hub, hub)).toBe(false);
+		expect(isConnectedMessage({ type: CONNECTED_MESSAGE_TYPE }, '', '')).toBe(
+			false,
+		);
+	});
+});
+
+describe('originOf', () => {
+	it('returns the origin of a valid url, null otherwise', () => {
+		expect(originOf('https://hub.corsair.dev/connect/tok')).toBe(
+			'https://hub.corsair.dev',
+		);
+		expect(originOf('not a url')).toBeNull();
 	});
 });

--- a/packages/corsair/tests/connect-controller.test.ts
+++ b/packages/corsair/tests/connect-controller.test.ts
@@ -1,0 +1,59 @@
+import {
+	connectReducer,
+	initialConnectState,
+	isPluginConnected,
+} from '../client/react/connect-controller';
+
+describe('connectReducer', () => {
+	it('OPEN moves to connecting and holds the plugin + link', () => {
+		const s = connectReducer(initialConnectState, {
+			type: 'OPEN',
+			plugin: 'gmail',
+			tenantId: 'acme',
+			connectUrl: 'https://hub/connect/tok',
+		});
+		expect(s).toEqual({
+			phase: 'connecting',
+			plugin: 'gmail',
+			tenantId: 'acme',
+			connectUrl: 'https://hub/connect/tok',
+		});
+	});
+
+	it('SUCCESS marks success but keeps the plugin for the caller', () => {
+		const open = connectReducer(initialConnectState, {
+			type: 'OPEN',
+			plugin: 'gmail',
+			tenantId: null,
+			connectUrl: 'https://hub/connect/tok',
+		});
+		expect(connectReducer(open, { type: 'SUCCESS' })).toMatchObject({
+			phase: 'success',
+			plugin: 'gmail',
+		});
+	});
+
+	it('CLOSE returns to idle', () => {
+		const open = connectReducer(initialConnectState, {
+			type: 'OPEN',
+			plugin: 'gmail',
+			tenantId: null,
+			connectUrl: 'https://hub/connect/tok',
+		});
+		expect(connectReducer(open, { type: 'CLOSE' })).toEqual(
+			initialConnectState,
+		);
+	});
+});
+
+describe('isPluginConnected', () => {
+	it('is true only when the plugin reads connected', () => {
+		expect(isPluginConnected({ gmail: 'connected' }, 'gmail')).toBe(true);
+		expect(isPluginConnected({ gmail: 'not_connected' }, 'gmail')).toBe(false);
+		expect(isPluginConnected({ gmail: 'missing_credentials' }, 'gmail')).toBe(
+			false,
+		);
+		expect(isPluginConnected({}, 'gmail')).toBe(false);
+		expect(isPluginConnected(null, 'gmail')).toBe(false);
+	});
+});

--- a/packages/corsair/tests/connect-controller.test.ts
+++ b/packages/corsair/tests/connect-controller.test.ts
@@ -1,10 +1,8 @@
 import {
-	CONNECTED_MESSAGE_TYPE,
 	connectReducer,
 	initialConnectState,
-	isConnectedMessage,
 	isPluginConnected,
-	originOf,
+	shouldSettleConnected,
 } from '../client/react/connect-controller';
 
 describe('connectReducer', () => {
@@ -61,36 +59,39 @@ describe('isPluginConnected', () => {
 	});
 });
 
-describe('isConnectedMessage', () => {
-	const hub = 'https://hub.corsair.dev';
-	it('accepts the connected message from the trusted origin', () => {
-		expect(isConnectedMessage({ type: CONNECTED_MESSAGE_TYPE }, hub, hub)).toBe(
-			true,
-		);
-	});
-	it('rejects a message from any other origin', () => {
+describe('shouldSettleConnected', () => {
+	const connected = { gmail: 'connected' } as const;
+
+	it('settles when the poll is current and the plugin is connected', () => {
 		expect(
-			isConnectedMessage(
-				{ type: CONNECTED_MESSAGE_TYPE },
-				'https://evil.com',
-				hub,
-			),
+			shouldSettleConnected({
+				capturedAttempt: 3,
+				currentAttempt: 3,
+				status: connected,
+				plugin: 'gmail',
+			}),
+		).toBe(true);
+	});
+
+	it('ignores a poll from a superseded or closed attempt', () => {
+		expect(
+			shouldSettleConnected({
+				capturedAttempt: 2,
+				currentAttempt: 3,
+				status: connected,
+				plugin: 'gmail',
+			}),
 		).toBe(false);
 	});
-	it('rejects the wrong message type, non-objects, and an empty trusted origin', () => {
-		expect(isConnectedMessage({ type: 'other' }, hub, hub)).toBe(false);
-		expect(isConnectedMessage('corsair:connected', hub, hub)).toBe(false);
-		expect(isConnectedMessage({ type: CONNECTED_MESSAGE_TYPE }, '', '')).toBe(
-			false,
-		);
-	});
-});
 
-describe('originOf', () => {
-	it('returns the origin of a valid url, null otherwise', () => {
-		expect(originOf('https://hub.corsair.dev/connect/tok')).toBe(
-			'https://hub.corsair.dev',
-		);
-		expect(originOf('not a url')).toBeNull();
+	it('does not settle when the plugin is not yet connected', () => {
+		expect(
+			shouldSettleConnected({
+				capturedAttempt: 3,
+				currentAttempt: 3,
+				status: { gmail: 'not_connected' },
+				plugin: 'gmail',
+			}),
+		).toBe(false);
 	});
 });

--- a/packages/corsair/tests/connect-controller.test.ts
+++ b/packages/corsair/tests/connect-controller.test.ts
@@ -10,13 +10,11 @@ describe('connectReducer', () => {
 		const s = connectReducer(initialConnectState, {
 			type: 'OPEN',
 			plugin: 'gmail',
-			tenantId: 'acme',
 			connectUrl: 'https://hub/connect/tok',
 		});
 		expect(s).toEqual({
 			phase: 'connecting',
 			plugin: 'gmail',
-			tenantId: 'acme',
 			connectUrl: 'https://hub/connect/tok',
 		});
 	});
@@ -25,7 +23,6 @@ describe('connectReducer', () => {
 		const open = connectReducer(initialConnectState, {
 			type: 'OPEN',
 			plugin: 'gmail',
-			tenantId: null,
 			connectUrl: 'https://hub/connect/tok',
 		});
 		expect(connectReducer(open, { type: 'SUCCESS' })).toMatchObject({
@@ -38,7 +35,6 @@ describe('connectReducer', () => {
 		const open = connectReducer(initialConnectState, {
 			type: 'OPEN',
 			plugin: 'gmail',
-			tenantId: null,
 			connectUrl: 'https://hub/connect/tok',
 		});
 		expect(connectReducer(open, { type: 'CLOSE' })).toEqual(

--- a/packages/corsair/tests/connect-controller.test.ts
+++ b/packages/corsair/tests/connect-controller.test.ts
@@ -6,16 +6,18 @@ import {
 } from '../client/react/connect-controller';
 
 describe('connectReducer', () => {
-	it('OPEN moves to connecting and holds the plugin + link', () => {
+	it('OPEN moves to connecting and holds the plugin, link, and tenant', () => {
 		const s = connectReducer(initialConnectState, {
 			type: 'OPEN',
 			plugin: 'gmail',
 			connectUrl: 'https://hub/connect/tok',
+			tenantId: 'acme',
 		});
 		expect(s).toEqual({
 			phase: 'connecting',
 			plugin: 'gmail',
 			connectUrl: 'https://hub/connect/tok',
+			tenantId: 'acme',
 		});
 	});
 
@@ -24,6 +26,7 @@ describe('connectReducer', () => {
 			type: 'OPEN',
 			plugin: 'gmail',
 			connectUrl: 'https://hub/connect/tok',
+			tenantId: null,
 		});
 		expect(connectReducer(open, { type: 'SUCCESS' })).toMatchObject({
 			phase: 'success',
@@ -36,6 +39,7 @@ describe('connectReducer', () => {
 			type: 'OPEN',
 			plugin: 'gmail',
 			connectUrl: 'https://hub/connect/tok',
+			tenantId: null,
 		});
 		expect(connectReducer(open, { type: 'CLOSE' })).toEqual(
 			initialConnectState,

--- a/packages/corsair/tests/connect-request-store.test.ts
+++ b/packages/corsair/tests/connect-request-store.test.ts
@@ -1,0 +1,158 @@
+import {
+	CONNECT_REQUEST_TTL_MS,
+	clearConnectRequest,
+	readConnectRequest,
+	recordConnectRequest,
+	recordConnectRequestBestEffort,
+} from '../core/connect-request/store';
+import { createTestDatabase } from './setup-db';
+
+describe('connect-request store', () => {
+	it('records a request and reads it back for the tenant', async () => {
+		const { database, cleanup } = createTestDatabase();
+		try {
+			await recordConnectRequest(database, {
+				tenantId: 'acme',
+				plugin: 'linear',
+				connectUrl: 'https://hub.corsair.dev/connect/abc',
+			});
+			const req = await readConnectRequest(database, 'acme');
+			expect(req).toEqual({
+				plugin: 'linear',
+				connectUrl: 'https://hub.corsair.dev/connect/abc',
+				requestedAt: expect.any(String),
+			});
+		} finally {
+			cleanup();
+		}
+	});
+
+	it('keeps one row per tenant — the latest failure wins', async () => {
+		const { database, cleanup } = createTestDatabase();
+		try {
+			await recordConnectRequest(database, {
+				tenantId: 'acme',
+				plugin: 'linear',
+				connectUrl: 'https://hub.corsair.dev/connect/one',
+			});
+			await recordConnectRequest(database, {
+				tenantId: 'acme',
+				plugin: 'github',
+				connectUrl: 'https://hub.corsair.dev/connect/two',
+			});
+			const req = await readConnectRequest(database, 'acme');
+			expect(req?.plugin).toBe('github');
+			expect(req?.connectUrl).toBe('https://hub.corsair.dev/connect/two');
+		} finally {
+			cleanup();
+		}
+	});
+
+	it('scopes by tenant — another tenant sees nothing', async () => {
+		const { database, cleanup } = createTestDatabase();
+		try {
+			await recordConnectRequest(database, {
+				tenantId: 'acme',
+				plugin: 'linear',
+				connectUrl: 'https://hub.corsair.dev/connect/abc',
+			});
+			expect(await readConnectRequest(database, 'other')).toBeNull();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it('treats an expired request as gone', async () => {
+		const { database, cleanup } = createTestDatabase();
+		try {
+			const t0 = 1_000_000_000_000;
+			await recordConnectRequest(
+				database,
+				{
+					tenantId: 'acme',
+					plugin: 'linear',
+					connectUrl: 'https://hub.corsair.dev/connect/abc',
+				},
+				t0,
+			);
+			// still live just before the TTL, gone just after
+			expect(
+				await readConnectRequest(
+					database,
+					'acme',
+					t0 + CONNECT_REQUEST_TTL_MS - 1,
+				),
+			).not.toBeNull();
+			expect(
+				await readConnectRequest(
+					database,
+					'acme',
+					t0 + CONNECT_REQUEST_TTL_MS + 1,
+				),
+			).toBeNull();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it('clears a request', async () => {
+		const { database, cleanup } = createTestDatabase();
+		try {
+			await recordConnectRequest(database, {
+				tenantId: 'acme',
+				plugin: 'linear',
+				connectUrl: 'https://hub.corsair.dev/connect/abc',
+			});
+			await clearConnectRequest(database, 'acme');
+			expect(await readConnectRequest(database, 'acme')).toBeNull();
+		} finally {
+			cleanup();
+		}
+	});
+});
+
+describe('recordConnectRequestBestEffort', () => {
+	it('no-ops without a database, plugin, or connectUrl — never throws', async () => {
+		await expect(
+			recordConnectRequestBestEffort(undefined, {
+				tenantId: 'acme',
+				plugin: 'linear',
+				connectUrl: 'x',
+			}),
+		).resolves.toBeUndefined();
+
+		const { database, cleanup } = createTestDatabase();
+		try {
+			await recordConnectRequestBestEffort(database, {
+				tenantId: 'acme',
+				plugin: null,
+				connectUrl: 'x',
+			});
+			await recordConnectRequestBestEffort(database, {
+				tenantId: 'acme',
+				plugin: 'linear',
+				connectUrl: null,
+			});
+			expect(await readConnectRequest(database, 'acme')).toBeNull();
+		} finally {
+			cleanup();
+		}
+	});
+
+	it('records when everything is present, defaulting a missing tenant', async () => {
+		const { database, cleanup } = createTestDatabase();
+		try {
+			await recordConnectRequestBestEffort(database, {
+				tenantId: undefined,
+				plugin: 'linear',
+				connectUrl: 'https://hub.corsair.dev/connect/abc',
+			});
+			expect(await readConnectRequest(database, 'default')).toMatchObject({
+				plugin: 'linear',
+				connectUrl: 'https://hub.corsair.dev/connect/abc',
+			});
+		} finally {
+			cleanup();
+		}
+	});
+});

--- a/packages/corsair/tests/hub-reconnect.test.ts
+++ b/packages/corsair/tests/hub-reconnect.test.ts
@@ -1,0 +1,55 @@
+import { ReconnectRequiredError } from '../core/auth/errors/reconnect-required';
+import { parseHubReconnectBody } from '../hub/contracts/connect-api';
+
+describe('parseHubReconnectBody', () => {
+	it('extracts the scoped link + identity from a reconnect_required body', () => {
+		expect(
+			parseHubReconnectBody({
+				error: 'refresh token rejected',
+				errorType: 'reconnect_required',
+				connectUrl: 'https://hub/connect/tok',
+				plugin: 'notion',
+				tenantId: 't1',
+			}),
+		).toEqual({
+			message: 'refresh token rejected',
+			connectUrl: 'https://hub/connect/tok',
+			plugin: 'notion',
+			tenantId: 't1',
+			reason: null,
+		});
+	});
+
+	it('keeps a null connectUrl and carries the reason when Hub cannot mint', () => {
+		expect(
+			parseHubReconnectBody({
+				error: 'reconnect required: no OAuth app credentials',
+				errorType: 'reconnect_required',
+				connectUrl: null,
+				plugin: 'notion',
+				tenantId: 't1',
+				reason: 'no_credentials',
+			}),
+		).toMatchObject({ connectUrl: null, reason: 'no_credentials' });
+	});
+
+	it('returns null for a non-reconnect error body', () => {
+		expect(parseHubReconnectBody({ error: 'Token refresh failed' })).toBeNull();
+		expect(parseHubReconnectBody(null)).toBeNull();
+	});
+});
+
+describe('ReconnectRequiredError', () => {
+	it('carries the connect link and identity, defaults a message', () => {
+		const e = new ReconnectRequiredError({
+			connectUrl: 'https://hub/connect/tok',
+			plugin: 'notion',
+			tenantId: 't1',
+		});
+		expect(e).toBeInstanceOf(Error);
+		expect(e.name).toBe('ReconnectRequiredError');
+		expect(e.connectUrl).toBe('https://hub/connect/tok');
+		expect(e.plugin).toBe('notion');
+		expect(e.message).toBe('Reconnect required');
+	});
+});

--- a/packages/corsair/tests/oauth-token-cache.test.ts
+++ b/packages/corsair/tests/oauth-token-cache.test.ts
@@ -24,6 +24,38 @@ function collectingKeys() {
 	};
 }
 
+describe('isAccessTokenFresh', () => {
+	it('treats a non-expiring token (access token, no expiry) as fresh', () => {
+		expect(
+			isAccessTokenFresh({ accessToken: 'notion-token', expiresAt: null }),
+		).toBe(true);
+	});
+	it('forceRefresh overrides a non-expiring token', () => {
+		expect(
+			isAccessTokenFresh({
+				accessToken: 'notion-token',
+				expiresAt: null,
+				forceRefresh: true,
+			}),
+		).toBe(false);
+	});
+	it('a missing access token is never fresh', () => {
+		expect(isAccessTokenFresh({ accessToken: null, expiresAt: null })).toBe(
+			false,
+		);
+	});
+	it('an expired token with a known expiry is stale', () => {
+		const now = Math.floor(Date.now() / 1000);
+		expect(
+			isAccessTokenFresh({
+				accessToken: 'x',
+				expiresAt: String(now - 10),
+				now,
+			}),
+		).toBe(false);
+	});
+});
+
 describe('cacheRefreshedTokens expiry fallback', () => {
 	it('a refresh with no expires_in yields a future expiry, not the stale previous one', async () => {
 		const { store, keys } = collectingKeys();

--- a/packages/corsair/tests/plugin-icon.test.ts
+++ b/packages/corsair/tests/plugin-icon.test.ts
@@ -1,0 +1,45 @@
+import {
+	pluginToDomain,
+	resolveIconUrl,
+	titleCasePlugin,
+} from '../client/react/plugin-icon';
+
+describe('pluginToDomain', () => {
+	it('maps known plugin ids to their brand domain', () => {
+		expect(pluginToDomain('github')).toBe('github.com');
+		expect(pluginToDomain('linear')).toBe('linear.app');
+		expect(pluginToDomain('gdrive')).toBe('drive.google.com');
+	});
+
+	it('normalizes underscores and case in the id', () => {
+		expect(pluginToDomain('google_sheets')).toBe('docs.google.com');
+	});
+
+	it('falls back to <id>.com when nothing matches', () => {
+		expect(pluginToDomain('madeupplugin')).toBe('madeupplugin.com');
+	});
+});
+
+describe('resolveIconUrl', () => {
+	it('uses the svgl override for generic-favicon products', () => {
+		expect(resolveIconUrl('outlook.live.com')).toBe(
+			'https://svgl.app/library/microsoft-outlook.svg',
+		);
+	});
+
+	it('uses twenty-icons for everything else, stripping scheme/www/trailing slash', () => {
+		expect(resolveIconUrl('github.com')).toBe(
+			'https://twenty-icons.com/github.com',
+		);
+		expect(resolveIconUrl('https://www.linear.app/')).toBe(
+			'https://twenty-icons.com/linear.app',
+		);
+	});
+});
+
+describe('titleCasePlugin', () => {
+	it('humanizes an id', () => {
+		expect(titleCasePlugin('google_sheets')).toBe('Google Sheets');
+		expect(titleCasePlugin('github')).toBe('Github');
+	});
+});

--- a/packages/corsair/tests/resolve-scoped-tenant.test.ts
+++ b/packages/corsair/tests/resolve-scoped-tenant.test.ts
@@ -1,0 +1,45 @@
+import { ManagementApiError } from '../core/management/errors';
+import {
+	assertAdminRouteAllowed,
+	resolveScopedTenant,
+} from '../core/management/handler';
+
+describe('resolveScopedTenant', () => {
+	it('falls back to the client value when no resolver is configured', () => {
+		expect(resolveScopedTenant(undefined, 'acme')).toBe('acme');
+		expect(resolveScopedTenant(undefined, undefined)).toBeUndefined();
+	});
+
+	it('uses the resolved tenant and ignores the client value', () => {
+		// even if the client asks for another tenant, the resolver wins
+		expect(resolveScopedTenant('real-tenant', 'attacker-tenant')).toBe(
+			'real-tenant',
+		);
+	});
+
+	it('rejects as unauthenticated when the resolver returns null', () => {
+		expect(() => resolveScopedTenant(null, 'acme')).toThrow(ManagementApiError);
+		try {
+			resolveScopedTenant(null, 'acme');
+		} catch (err) {
+			expect((err as ManagementApiError).status).toBe(401);
+		}
+	});
+});
+
+describe('assertAdminRouteAllowed', () => {
+	it('allows admin routes only when no resolver is configured', () => {
+		expect(() => assertAdminRouteAllowed(undefined)).not.toThrow();
+	});
+
+	it('forbids admin routes in end-user mode (resolver configured)', () => {
+		for (const scoped of ['acme', null] as const) {
+			expect(() => assertAdminRouteAllowed(scoped)).toThrow(ManagementApiError);
+			try {
+				assertAdminRouteAllowed(scoped);
+			} catch (err) {
+				expect((err as ManagementApiError).status).toBe(403);
+			}
+		}
+	});
+});

--- a/packages/corsair/tests/setup-db.ts
+++ b/packages/corsair/tests/setup-db.ts
@@ -55,6 +55,13 @@ export function createTestDatabase(): {
 			payload TEXT NOT NULL,
 			status TEXT
 		);
+
+		CREATE TABLE IF NOT EXISTS corsair_connect_requests (
+			tenant_id TEXT PRIMARY KEY,
+			plugin TEXT NOT NULL,
+			connect_url TEXT NOT NULL,
+			requested_at TEXT NOT NULL
+		);
 	`);
 
 	const db = new Kysely<CorsairKyselyDatabase>({

--- a/packages/corsair/tsup.config.ts
+++ b/packages/corsair/tsup.config.ts
@@ -18,45 +18,69 @@ const yamlPlugin = {
 	},
 };
 
-export default defineConfig({
-	clean: true,
-	dts: { compilerOptions: { composite: false, incremental: false } },
-	// Injects the __filename/__dirname shim into the ESM output so frpc-binary.ts's
-	// createRequire(__filename) resolves. __filename (not import.meta.url) keeps that
-	// file parseable by ts-jest, which transpiles it to CJS.
-	shims: true,
-	format: ['esm'],
-	target: 'esnext',
-	platform: 'node',
-	bundle: true,
-	splitting: true,
-	minify: true,
-	outDir: 'dist',
-	external: [
-		'kysely',
-		'zod',
-		'dotenv',
-		'react',
-		'@modelcontextprotocol/sdk',
-		'@ngrok/ngrok',
-		'jiti',
-		'better-sqlite3',
-		/^@corsair-dev\//,
-	],
-	esbuildPlugins: [yamlPlugin],
-	entry: [
-		'index.ts',
-		'core.ts',
-		'db.ts',
-		'mcp.ts',
-		'oauth.ts',
-		'tunnel.ts',
-		'hub.ts',
-		'hub/tunnel/run-tunnel.ts',
-		'orm.ts',
-		'setup.ts',
-		'http.ts',
-		'tests.ts',
-		'client/react/index.ts',
-	],
-});
+export default defineConfig([
+	// Node build — the server SDK. Ships the __filename/__dirname shim so
+	// frpc-binary.ts's createRequire(__filename) resolves. Neither build cleans:
+	// they run concurrently, so a clean here would race and wipe the other's
+	// output. The build script clears dist once up front.
+	{
+		clean: false,
+		dts: { compilerOptions: { composite: false, incremental: false } },
+		shims: true,
+		format: ['esm'],
+		target: 'esnext',
+		platform: 'node',
+		bundle: true,
+		splitting: true,
+		minify: true,
+		outDir: 'dist',
+		external: [
+			'kysely',
+			'zod',
+			'dotenv',
+			'react',
+			'@modelcontextprotocol/sdk',
+			'@ngrok/ngrok',
+			'jiti',
+			'better-sqlite3',
+			/^@corsair-dev\//,
+		],
+		esbuildPlugins: [yamlPlugin],
+		entry: [
+			'index.ts',
+			'core.ts',
+			'db.ts',
+			'mcp.ts',
+			'oauth.ts',
+			'tunnel.ts',
+			'hub.ts',
+			'hub/tunnel/run-tunnel.ts',
+			'orm.ts',
+			'setup.ts',
+			'http.ts',
+			'tests.ts',
+		],
+	},
+	// Browser build — the React client. Built on its own so it never shares a
+	// chunk with the Node shim (fileURLToPath(import.meta.url) crashes in the
+	// browser). shims:false + platform:browser keep the bundle Node-free; the
+	// banner restores the 'use client' directive tsup would otherwise strip.
+	{
+		clean: false,
+		dts: { compilerOptions: { composite: false, incremental: false } },
+		shims: false,
+		format: ['esm'],
+		target: 'esnext',
+		platform: 'browser',
+		bundle: true,
+		splitting: false,
+		minify: true,
+		// Single entry → tsup flattens to <outDir>/index.js, so target the nested
+		// dir directly to land dist/client/react/index.js (matches package exports).
+		outDir: 'dist/client/react',
+		banner: { js: '"use client";' },
+		external: ['react', 'react/jsx-runtime', 'react/jsx-dev-runtime'],
+		esbuildPlugins: [yamlPlugin],
+		entry: ['client/react/index.ts'],
+	},
+]);

--- a/www/public/llms.txt
+++ b/www/public/llms.txt
@@ -16,21 +16,32 @@ Corsair acts as a secure intermediary between your AI agents and external APIs. 
 
 ## Documentation Index
 
-### Getting Started
-- [Introduction](/docs/introduction): Introduction to Corsair.
-- [Quickstart](/docs/getting-started/quickstart): Set up Corsair in minutes.
+The full agent index lives at [docs.corsair.dev/llms.txt](https://docs.corsair.dev/llms.txt).
 
-### Core Concepts
-- [API Keys](/docs/concepts/api-key): Managing API key integrations.
-- [OAuth](/docs/concepts/oauth): Setting up OAuth credentials and authorization flows.
-- [Webhooks](/docs/guides/webhooks): Configuring and handling webhooks.
-- [Workflows](/docs/guides/workflows): Multi-step agent execution workflows.
+### Getting started
+- [Introduction](https://docs.corsair.dev/introduction): What Corsair is and when to use it.
+- [Quick start](https://docs.corsair.dev/quick-start): A working integration in five steps, powered by Hub.
+- [Set up with your agent](https://docs.corsair.dev/getting-started/set-up-with-your-agent): One prompt from an empty app to a connected integration.
 
-### Platform & Architecture
-- [Model Context Protocol (MCP)](/docs/mcp-adapters/overview): Connecting Corsair to Anthropic, OpenAI, or LangChain agents via MCP.
-- [Studio](/docs/studio/overview): Using the Corsair Studio dashboard.
-- [Production Deployments](/docs/production/oauth-process): Configuring production OAuth callbacks.
+### Frameworks & adapters
+- [Frameworks](https://docs.corsair.dev/frameworks/next): Mount Corsair on Next.js, Express, Hono, Remix, and more.
+- [React hooks & Corsair Connect](https://docs.corsair.dev/adapters/react): Typed React hooks plus `<CorsairProvider>`, which opens a connect dialog and resumes the failed work when a tenant isn't connected.
+- [Vanilla client](https://docs.corsair.dev/adapters/client): Typed fetch wrapper for the management API, any JS runtime.
 
-### Plugins & Integrations
-- [Built-in Plugins](/docs/guides/plugins): List of supported plugins (e.g. GitHub, Slack, Hubspot, Zendesk, Calendly, Bitwarden, Zoom).
-- [Creating Custom Plugins](/docs/guides/create-your-own-plugin): How to scaffold and write a new integration plugin.
+### Core concepts
+- [Auth](https://docs.corsair.dev/concepts/auth): OAuth, API keys, and bot tokens, handled automatically.
+- [Permissions](https://docs.corsair.dev/concepts/permissions): Gate destructive agent actions behind human approval.
+- [Multi-tenancy](https://docs.corsair.dev/concepts/multi-tenancy): Per-tenant credentials and data from one flag.
+- [Database](https://docs.corsair.dev/concepts/database): Six tables, always-fresh integration data, tenant-scoped.
+- [Webhooks](https://docs.corsair.dev/concepts/webhooks): One verified endpoint for every provider event.
+- [Error handling](https://docs.corsair.dev/concepts/error-handling): Retry strategies and the typed AuthMissingError / ReconnectRequiredError.
+
+### Use with AI
+- [MCP adapters](https://docs.corsair.dev/mcp-adapters/mcp-adapters): Anthropic, OpenAI, Vercel AI SDK, Mastra, and coding agents over MCP.
+
+### Hub
+- [Overview](https://docs.corsair.dev/hub/overview): The hosted relay for connect flows and approvals — stores none of your credentials.
+
+### Plugins & integrations
+- [Plugins](https://docs.corsair.dev/guides/plugins): Hundreds of integrations (GitHub, Slack, HubSpot, Zendesk, Calendly, Zoom, and more).
+- [Create your own plugin](https://docs.corsair.dev/guides/create-your-own-plugin): Scaffold and write a new integration plugin.


### PR DESCRIPTION
Follow-up to #1209 (stacked on it — the Corsair Connect docs it adds are the base for this). Retarget to `main` once #1209 merges.

**Framework guides** — a Corsair Connect example in the Next, Remix, and TanStack guides, each wired to that framework's own refresh:
- Next → `router.refresh()`
- Remix → `useRevalidator().revalidate()` (provider in `app/root.tsx`)
- TanStack → `router.invalidate()` (provider in the root route)

Each notes that the `<CorsairBoundary>` read helper is **Next-RSC-specific** — Remix and TanStack read in loaders, so there `call` and `connect` are the surfaces that apply.

**Reachability** — the SDK reference pages (`adapters/handlers`, `adapters/client`, `adapters/react`) were orphaned (not in the sidebar), which hid Corsair Connect. Added them under a collapsible **SDK** group in Reference.

**Boundary note** — `<CorsairBoundary>` reads provider context and throws without a `<CorsairProvider>` ancestor; the docs now say so.

**"Go green" → "Start the server"** across the framework + handler guides. The body still points at the App-sync dot as the success signal.

Docs-only. `docs.json` validated as JSON; every new link resolves.