### PR TITLE
fix(corsair): pass a test kek after resolveKekAtInit

### DIFF
--- a/packages/corsair/tests/hooks.test.ts
+++ b/packages/corsair/tests/hooks.test.ts
@@ -61,7 +61,7 @@ describe('Endpoint Hooks', () => {
 			const modifiedText = 'Modified by before hook';
 
 			const corsair = createCorsair({
-				kek: '',
+				kek: 'test-kek',
 				plugins: [
 					slack({
 						authType: 'api_key',
@@ -109,7 +109,7 @@ describe('Endpoint Hooks', () => {
 			const modifiedText = 'Modified text';
 
 			const corsair = createCorsair({
-				kek: '',
+				kek: 'test-kek',
 				plugins: [
 					slack({
 						authType: 'api_key',
@@ -157,7 +157,7 @@ describe('Endpoint Hooks', () => {
 
 		it('should allow before hook to add new properties to args', async () => {
 			const corsair = createCorsair({
-				kek: '',
+				kek: 'test-kek',
 				plugins: [
 					slack({
 						authType: 'api_key',
@@ -224,7 +224,7 @@ describe('Endpoint Hooks', () => {
 				null;
 
 			const corsair = createCorsair({
-				kek: '',
+				kek: 'test-kek',
 				plugins: [
 					slack({
 						authType: 'api_key',
@@ -295,7 +295,7 @@ describe('Endpoint Hooks', () => {
 			);
 
 			const corsair = createCorsair({
-				kek: '',
+				kek: 'test-kek',
 				plugins: [
 					slack({
 						authType: 'api_key',
@@ -369,7 +369,7 @@ describe('Endpoint Hooks', () => {
 			const executionOrder: string[] = [];
 
 			const corsair = createCorsair({
-				kek: '',
+				kek: 'test-kek',
 				plugins: [
 					slack({
 						authType: 'api_key',
@@ -446,7 +446,7 @@ describe('Endpoint Hooks', () => {
 
 		it('should allow both hooks to modify their respective data', async () => {
 			const corsair = createCorsair({
-				kek: '',
+				kek: 'test-kek',
 				plugins: [
 					slack({
 						authType: 'api_key',
@@ -507,7 +507,7 @@ describe('Endpoint Hooks', () => {
 	describe('Nested Endpoint Hooks', () => {
 		it('should work with nested endpoint paths', async () => {
 			const corsair = createCorsair({
-				kek: '',
+				kek: 'test-kek',
 				plugins: [
 					slack({
 						authType: 'api_key',

--- a/packages/corsair/tests/retry-recover.test.ts
+++ b/packages/corsair/tests/retry-recover.test.ts
@@ -61,7 +61,7 @@ describe('Endpoint retry', () => {
 		});
 
 		const corsair = createCorsair({
-			kek: '',
+			kek: 'test-kek',
 			database: testDb.db,
 			multiTenancy: false,
 			plugins: [
@@ -92,7 +92,7 @@ describe('Endpoint retry', () => {
 		mockedMakeSlackRequest.mockRejectedValue(rateLimitApiError());
 
 		const corsair = createCorsair({
-			kek: '',
+			kek: 'test-kek',
 			database: testDb.db,
 			multiTenancy: false,
 			plugins: [


### PR DESCRIPTION
## Summary
-  throws when `kek` is empty and a database is set. `hooks` and `retry-recover` still passed `kek: ''`, so every plugin PR that touches `constants.ts` fails `corsair#test`.
- Use `kek: 'test-kek'` like the other core tests.

## Test plan
- [ ] `corsair#test` (`hooks.test.ts`, `retry-recover.test.ts`)
- [ ] Re-run CI on an open plugin PR after this lands


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configurations to use a representative encryption key value.
  * Existing test behavior and assertions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->