### PR TITLE
fix(corsair): validate KEK on first key access, not at construction

### DIFF
--- a/packages/corsair/core/auth/errors/index.ts
+++ b/packages/corsair/core/auth/errors/index.ts
@@ -1,3 +1,3 @@
 export { AuthMissingError } from './auth-missing';
-export { CorsairKekMissingError, resolveKekAtInit } from './kek-missing';
+export { CorsairKekMissingError } from './kek-missing';
 export { createMissingConfigProxy } from './missing-config';

--- a/packages/corsair/core/auth/errors/kek-missing.ts
+++ b/packages/corsair/core/auth/errors/kek-missing.ts
@@ -9,26 +9,3 @@ export class CorsairKekMissingError extends Error {
 		this.name = 'CorsairKekMissingError';
 	}
 }
-
-/**
- * Validates the KEK when a database is configured. Fails at init with a clear
- * error instead of deferring to a proxy on first `corsair.keys` access.
- *
- * The KEK is returned byte-for-byte — never trimmed. scrypt uses the raw
- * string as password input when wrapping DEKs; normalizing whitespace would
- * break decryption of credentials encrypted with the original key material.
- */
-export function resolveKekAtInit(
-	kek: string | undefined,
-	hasDatabase: boolean,
-): string {
-	if (!hasDatabase) {
-		return kek ?? '';
-	}
-
-	if (kek === undefined || kek === '') {
-		throw new CorsairKekMissingError();
-	}
-
-	return kek;
-}

--- a/packages/corsair/core/auth/errors/missing-config.ts
+++ b/packages/corsair/core/auth/errors/missing-config.ts
@@ -1,4 +1,5 @@
 import { KEY_LENGTH } from '../encryption';
+import { CorsairKekMissingError } from './kek-missing';
 
 /**
  * Creates a proxy that throws helpful errors when accessing keys without proper configuration.
@@ -20,6 +21,9 @@ export function createMissingConfigProxy<T>(
 
 	return new Proxy(proxyTarget, {
 		get(_target, prop) {
+			if (hasDatabase && !hasKek) {
+				throw new CorsairKekMissingError();
+			}
 			const isPlural = missingConfig.length > 1;
 			throw new Error(
 				`corsair.keys.${String(prop)}: Cannot access keys because ${missingConfig.join(' and ')} ${isPlural ? 'are' : 'is'} not configured. ` +

--- a/packages/corsair/core/auth/index.ts
+++ b/packages/corsair/core/auth/index.ts
@@ -14,7 +14,6 @@ export {
 	AuthMissingError,
 	CorsairKekMissingError,
 	createMissingConfigProxy,
-	resolveKekAtInit,
 } from './errors';
 export type { TokenResponse } from './exchange';
 // Token exchange utility

--- a/packages/corsair/core/index.ts
+++ b/packages/corsair/core/index.ts
@@ -6,7 +6,7 @@ import {
 	CORSAIR_TUNNEL_PATH,
 	CORSAIR_TUNNEL_ZONE,
 } from '../hub/tunnel/constants';
-import { createMissingConfigProxy, resolveKekAtInit } from './auth/errors';
+import { createMissingConfigProxy } from './auth/errors';
 import type { CorsairSingleTenantClient, CorsairTenantWrapper } from './client';
 import { buildCorsairClient, buildIntegrationKeys } from './client';
 import { resolveRootPermissionsConfig } from './config/resolve-root-permissions';
@@ -73,10 +73,10 @@ export function createCorsair<const Plugins extends readonly CorsairPlugin[]>(
 		? createCorsairDatabase(config.database)
 		: undefined;
 
-	const kek = resolveKekAtInit(config.kek, !!resolvedDatabase);
+	const kek = config.kek;
 
-	// Build integration-level keys when database + KEK are configured.
-	// Missing database still uses a lazy proxy; missing KEK with database throws above.
+	// Build integration-level keys when database + KEK are configured;
+	// otherwise a proxy throws a clear error on first key access.
 	type IntegrationKeysType = ReturnType<typeof buildIntegrationKeys<Plugins>>;
 
 	const integrationKeys: IntegrationKeysType =

--- a/packages/corsair/package.json
+++ b/packages/corsair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corsair",
-  "version": "0.1.123",
+  "version": "0.1.124",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/corsair/tests/kek-config.test.ts
+++ b/packages/corsair/tests/kek-config.test.ts
@@ -1,19 +1,60 @@
+import { slack } from '@corsair-dev/slack';
 import { createCorsair } from '../core';
 import { decryptDEK, encryptDEK, generateDEK } from '../core/auth/encryption';
-import {
-	CorsairKekMissingError,
-	resolveKekAtInit,
-} from '../core/auth/errors/kek-missing';
+import { CorsairKekMissingError } from '../core/auth/errors/kek-missing';
+import { createMissingConfigProxy } from '../core/auth/errors/missing-config';
 import { getCorsairInternal } from '../core/utils/corsair-instance';
 import { createTestDatabase } from './setup-db';
 
-describe('resolveKekAtInit', () => {
-	it('preserves byte-exact KEK including surrounding whitespace', () => {
-		const kek = '  test-kek  ';
-		expect(resolveKekAtInit(kek, true)).toBe(kek);
+describe('createCorsair — KEK validation', () => {
+	let env: ReturnType<typeof createTestDatabase>;
+	afterEach(() => env.cleanup());
+
+	it('does not throw at construction when the KEK is empty', () => {
+		env = createTestDatabase();
+		expect(() =>
+			createCorsair({
+				plugins: [slack({ authType: 'api_key', key: 'fake-key' })],
+				database: env.db,
+				kek: '',
+				multiTenancy: false,
+			}),
+		).not.toThrow();
 	});
 
-	it('does not trim KEK — a trimmed key cannot decrypt DEKs wrapped with the original', async () => {
+	it('stores the byte-exact KEK on the internal config', () => {
+		env = createTestDatabase();
+		const kek = '  byte-exact-kek  ';
+		const corsair = createCorsair({
+			plugins: [slack({ authType: 'api_key', key: 'fake-key' })],
+			database: env.db,
+			kek,
+			multiTenancy: false,
+		});
+
+		expect(getCorsairInternal(corsair).kek).toBe(kek);
+	});
+});
+
+describe('createMissingConfigProxy', () => {
+	it('throws CorsairKekMissingError on access when a database is configured without a KEK', () => {
+		const keys = createMissingConfigProxy<Record<string, unknown>>(true, false);
+		expect(() => keys.get_integration_credentials).toThrow(
+			CorsairKekMissingError,
+		);
+	});
+
+	it('reports both missing pieces when database and KEK are absent', () => {
+		const keys = createMissingConfigProxy<Record<string, unknown>>(
+			false,
+			false,
+		);
+		expect(() => keys.get_integration_credentials).toThrow(/database and kek/);
+	});
+});
+
+describe('KEK byte-exactness', () => {
+	it('a trimmed KEK cannot decrypt DEKs wrapped with the original', async () => {
 		const kek = '  padded-kek  ';
 		const encryptedDek = await encryptDEK(generateDEK(), kek);
 
@@ -21,43 +62,5 @@ describe('resolveKekAtInit', () => {
 			expect.any(String),
 		);
 		await expect(decryptDEK(encryptedDek, kek.trim())).rejects.toThrow();
-	});
-
-	it('throws CorsairKekMissingError when database is configured without KEK', () => {
-		expect(() => resolveKekAtInit(undefined, true)).toThrow(
-			CorsairKekMissingError,
-		);
-		expect(() => resolveKekAtInit('', true)).toThrow(CorsairKekMissingError);
-	});
-
-	it('allows missing KEK when no database is configured', () => {
-		expect(resolveKekAtInit(undefined, false)).toBe('');
-	});
-});
-
-describe('createCorsair — KEK validation', () => {
-	let env: ReturnType<typeof createTestDatabase>;
-	afterEach(() => env?.cleanup?.());
-
-	it('throws CorsairKekMissingError at init when database is configured without KEK', () => {
-		env = createTestDatabase();
-		expect(() =>
-			createCorsair({
-				plugins: [],
-				database: env.db,
-			} as any),
-		).toThrow(CorsairKekMissingError);
-	});
-
-	it('stores the byte-exact KEK on the internal config when database is configured', () => {
-		env = createTestDatabase();
-		const kek = '  byte-exact-kek  ';
-		const corsair = createCorsair({
-			plugins: [],
-			database: env.db,
-			kek,
-		} as any);
-
-		expect(getCorsairInternal(corsair).kek).toBe(kek);
 	});
 });

--- a/packages/corsair/tests/kek-config.test.ts
+++ b/packages/corsair/tests/kek-config.test.ts
@@ -56,11 +56,10 @@ describe('createMissingConfigProxy', () => {
 describe('KEK byte-exactness', () => {
 	it('a trimmed KEK cannot decrypt DEKs wrapped with the original', async () => {
 		const kek = '  padded-kek  ';
-		const encryptedDek = await encryptDEK(generateDEK(), kek);
+		const dek = generateDEK();
+		const encryptedDek = await encryptDEK(dek, kek);
 
-		await expect(decryptDEK(encryptedDek, kek)).resolves.toEqual(
-			expect.any(String),
-		);
+		await expect(decryptDEK(encryptedDek, kek)).resolves.toBe(dek);
 		await expect(decryptDEK(encryptedDek, kek.trim())).rejects.toThrow();
 	});
 });


### PR DESCRIPTION
## Problem
#1442 made `createCorsair` throw `CorsairKekMissingError` at construction when a database is configured without a KEK. `next build` evaluates route modules, so this broke the `@corsair/www` Vercel build and every plugin PR's corsair suite.

## Fix
Drop the eager check and rely on the existing lazy key proxy, which now throws `CorsairKekMissingError` on first `corsair.keys` access. Construction no longer requires a KEK — the clear error fires when keys are actually used. No app changes needed.

## Verify
- corsair suite: 496 passed
- `hooks`/`retry` pass unmodified (still `kek: ''`) — the SDK fix is the fix
- typecheck: no new errors; biome clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration error handling by reporting missing encryption keys when they are first needed.
  * Applications can now initialize with an empty encryption key and receive a clearer error upon key access.
  * Encryption keys are preserved exactly as provided, without automatic modification.

* **Chores**
  * Updated the package version to 0.1.124.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->