### PR TITLE
fix(www): stop OSS search from jumping and wiping tag clicks

### DIFF
--- a/www/src/app/oss/integration-search.tsx
+++ b/www/src/app/oss/integration-search.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { cn } from '@/lib/utils';
 import { useOssNavigation } from './oss-navigation';
+import { shouldApplySearch, shouldSyncSearchValue } from './oss-search-sync';
 import { buildOssHref, parseTagSlugs } from './oss-url';
 
 const DEBOUNCE_MS = 500;
@@ -15,9 +16,25 @@ export function IntegrationSearch({ defaultValue }: { defaultValue: string }) {
 	const searchParams = useSearchParams();
 	const [value, setValue] = useState(defaultValue);
 	const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const paramsRef = useRef(searchParams);
+	paramsRef.current = searchParams;
+	const lastAppliedRef = useRef(defaultValue);
 
 	useEffect(() => {
-		setValue(defaultValue);
+		const isFocused =
+			typeof document !== 'undefined' &&
+			document.activeElement === inputRef.current;
+		if (
+			shouldSyncSearchValue({
+				defaultValue,
+				lastApplied: lastAppliedRef.current,
+				isFocused,
+			})
+		) {
+			lastAppliedRef.current = defaultValue;
+			setValue(defaultValue);
+		}
 	}, [defaultValue]);
 
 	useEffect(() => {
@@ -28,22 +45,31 @@ export function IntegrationSearch({ defaultValue }: { defaultValue: string }) {
 
 	const applySearch = (query: string) => {
 		const trimmed = query.trim();
-		const current = searchParams.get('q')?.trim() ?? '';
 
-		if (trimmed === current) return;
+		if (!shouldApplySearch(trimmed, lastAppliedRef.current)) return;
 
-		const tags = parseTagSlugs(searchParams.get('tags') ?? undefined);
+		lastAppliedRef.current = trimmed;
+		const tags = parseTagSlugs(paramsRef.current.get('tags') ?? undefined);
 		navigate(buildOssHref({ q: trimmed, tags }));
 	};
 
-	const handleChange = (next: string) => {
+	const scheduleSearch = (next: string, immediate = false) => {
 		setValue(next);
 
 		if (debounceRef.current) clearTimeout(debounceRef.current);
 
+		if (immediate) {
+			applySearch(next);
+			return;
+		}
+
 		debounceRef.current = setTimeout(() => {
 			applySearch(next);
 		}, DEBOUNCE_MS);
+	};
+
+	const handleChange = (next: string) => {
+		scheduleSearch(next);
 	};
 
 	return (
@@ -54,10 +80,17 @@ export function IntegrationSearch({ defaultValue }: { defaultValue: string }) {
 				aria-hidden
 			/>
 			<input
+				ref={inputRef}
 				type="search"
 				aria-label="Search integrations"
 				value={value}
 				onChange={(event) => handleChange(event.target.value)}
+				onKeyDown={(event) => {
+					if (event.key === 'Enter') {
+						event.preventDefault();
+						scheduleSearch(value, true);
+					}
+				}}
 				placeholder="Search integrations..."
 				className={cn(
 					'w-full border border-[#1c1c1c1a] bg-white py-2.5 pr-4 pl-10 text-sm transition-colors',

--- a/www/src/app/oss/oss-integrations-shell.tsx
+++ b/www/src/app/oss/oss-integrations-shell.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { ReactNode } from 'react';
+import { Suspense } from 'react';
 
 import { IntegrationSearch } from './integration-search';
 import { OssIntegrationsResults } from './oss-integrations-results';
@@ -27,12 +28,16 @@ function OssIntegrationsShellInner({
 	return (
 		<>
 			<div className="mb-6">
-				<ViewTabs activeView={view} />
+				<Suspense fallback={null}>
+					<ViewTabs activeView={view} />
+				</Suspense>
 			</div>
 
 			{view === 'integrations' ? (
 				<div className="mb-4 space-y-3">
-					<IntegrationSearch defaultValue={q} />
+					<Suspense fallback={null}>
+						<IntegrationSearch defaultValue={q} />
+					</Suspense>
 					{tagFilter}
 				</div>
 			) : null}

--- a/www/src/app/oss/oss-navigation.tsx
+++ b/www/src/app/oss/oss-navigation.tsx
@@ -6,7 +6,7 @@ import { createContext, useContext, useTransition } from 'react';
 
 type OssNavigationContextValue = {
 	isPending: boolean;
-	navigate: (href: string) => void;
+	navigate: (href: string, options?: { scroll?: boolean }) => void;
 };
 
 const OssNavigationContext = createContext<OssNavigationContextValue | null>(
@@ -17,9 +17,9 @@ export function OssNavigationProvider({ children }: { children: ReactNode }) {
 	const router = useRouter();
 	const [isPending, startTransition] = useTransition();
 
-	const navigate = (href: string) => {
+	const navigate = (href: string, options?: { scroll?: boolean }) => {
 		startTransition(() => {
-			router.replace(href);
+			router.replace(href, { scroll: options?.scroll ?? false });
 		});
 	};
 

--- a/www/src/app/oss/oss-search-sync.test.ts
+++ b/www/src/app/oss/oss-search-sync.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { shouldApplySearch, shouldSyncSearchValue } from './oss-search-sync';
+
+describe('shouldSyncSearchValue', () => {
+	it('syncs external changes even while focused', () => {
+		assert.equal(
+			shouldSyncSearchValue({
+				defaultValue: '',
+				lastApplied: 'slack',
+				isFocused: true,
+			}),
+			true,
+		);
+	});
+
+	it('skips own-navigation catch-up while focused (user typed ahead)', () => {
+		assert.equal(
+			shouldSyncSearchValue({
+				defaultValue: 's',
+				lastApplied: 's',
+				isFocused: true,
+			}),
+			false,
+		);
+	});
+
+	it('syncs when blurred', () => {
+		assert.equal(
+			shouldSyncSearchValue({
+				defaultValue: 's',
+				lastApplied: 's',
+				isFocused: false,
+			}),
+			true,
+		);
+	});
+});
+
+describe('shouldApplySearch', () => {
+	it('navigates on clear even when the URL has not caught up', () => {
+		assert.equal(shouldApplySearch('', 'hello'), true);
+	});
+
+	it('skips repeat searches for the applied query', () => {
+		assert.equal(shouldApplySearch('hello', 'hello'), false);
+	});
+});

--- a/www/src/app/oss/oss-search-sync.ts
+++ b/www/src/app/oss/oss-search-sync.ts
@@ -1,0 +1,19 @@
+export function shouldSyncSearchValue({
+	defaultValue,
+	lastApplied,
+	isFocused,
+}: {
+	defaultValue: string;
+	lastApplied: string;
+	isFocused: boolean;
+}): boolean {
+	if (defaultValue !== lastApplied) return true;
+	return !isFocused;
+}
+
+export function shouldApplySearch(
+	trimmed: string,
+	lastApplied: string,
+): boolean {
+	return trimmed !== lastApplied;
+}


### PR DESCRIPTION
Search on /oss jumped to the top on every keystroke. Typing, then clicking a tag before the debounce landed, lost the tag. Clearing the box while a search was in flight did nothing.

Client navigations now keep scroll position. Search applies against last intent, not the lagging URL, and reads current tags when the timer fires.

## Test plan
- [ ] Type in OSS search: page stays put, results follow after debounce
- [ ] Type, click a tag before 500ms: tag still in the URL
- [ ] Search, then clear before the previous request lands: box and results go empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration search synchronization when users type, clear, or revisit searches.
  * Prevented duplicate searches and preserved user-entered text while the search field is focused.
  * Pressing Enter now applies the search immediately.
  * Navigation no longer unexpectedly scrolls the page during updates.
  * Added smoother loading behavior for integration tabs and search content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->