### PR TITLE
docs(quick-start): add one-line install for the Corsair agent skill

### DIFF
--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -9,15 +9,13 @@ import MountHandlerNextjs from '/snippets/mount-handler-nextjs.mdx';
 
 Hub hosts the OAuth connect, approval, and webhook surfaces, so there are no connect pages, callback routes, or per-environment redirect URIs to build. Credentials are encrypted and stored in your own database. Hub stores none.
 
-<Note>
-**Rather have your coding agent do it?** Install the Corsair skill, then ask your agent to set Corsair up — it runs this whole walkthrough for you and doesn't stop until a real call returns data.
+<div style={{ maxWidth: '30rem', marginLeft: 'auto' }}>
 
-```bash
+```bash Set up with your agent
 npx skills add https://github.com/corsairdev/corsair --skill corsair
 ```
 
-Works in Claude Code and any agent that supports skills. Prefer to wire it yourself? Follow the steps below.
-</Note>
+</div>
 
 <Steps>
 

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -9,6 +9,16 @@ import MountHandlerNextjs from '/snippets/mount-handler-nextjs.mdx';
 
 Hub hosts the OAuth connect, approval, and webhook surfaces, so there are no connect pages, callback routes, or per-environment redirect URIs to build. Credentials are encrypted and stored in your own database. Hub stores none.
 
+<Note>
+**Rather have your coding agent do it?** Install the Corsair skill, then ask your agent to set Corsair up — it runs this whole walkthrough for you and doesn't stop until a real call returns data.
+
+```bash
+npx skills add https://github.com/corsairdev/corsair --skill corsair
+```
+
+Works in Claude Code and any agent that supports skills. Prefer to wire it yourself? Follow the steps below.
+</Note>
+
 <Steps>
 
 <Step>

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -9,7 +9,7 @@ import MountHandlerNextjs from '/snippets/mount-handler-nextjs.mdx';
 
 Hub hosts the OAuth connect, approval, and webhook surfaces, so there are no connect pages, callback routes, or per-environment redirect URIs to build. Credentials are encrypted and stored in your own database. Hub stores none.
 
-<div style={{ maxWidth: '30rem', marginLeft: 'auto' }}>
+<div style={{ width: 'fit-content', maxWidth: '100%', marginLeft: 'auto' }}>
 
 ```bash Set up with your agent
 npx skills add https://github.com/corsairdev/corsair --skill corsair

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -9,13 +9,9 @@ import MountHandlerNextjs from '/snippets/mount-handler-nextjs.mdx';
 
 Hub hosts the OAuth connect, approval, and webhook surfaces, so there are no connect pages, callback routes, or per-environment redirect URIs to build. Credentials are encrypted and stored in your own database. Hub stores none.
 
-<div style={{ width: 'fit-content', maxWidth: '100%', marginLeft: 'auto' }}>
-
 ```bash Set up with your agent
 npx skills add https://github.com/corsairdev/corsair --skill corsair
 ```
-
-</div>
 
 <Steps>
 


### PR DESCRIPTION
## What

Adds a one-line install for the Corsair agent skill at the top of the Quick start, as an alternative to the manual five-step walkthrough:

```
npx skills add https://github.com/corsairdev/corsair --skill corsair
```

A user (or their coding agent) can grab the skill and let the agent run the whole setup, instead of wiring it by hand.

## Where

A `<Note>` callout above the `<Steps>` in `quick-start.mdx` — copyable command, with a line back to the manual path for those who prefer it. `<Note>` is a built-in Mintlify component (already used across the docs), so no import.

## Verify

Render it on the Mintlify preview for this PR — the callout sits under the intro paragraph with a copy button on the command.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the quick-start guide with a Bash code block showing the skill installation command:
    `npx skills add https://github.com/corsairdev/corsair --skill corsair`
  * The command can be copied and run directly during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->