### PR TITLE
ci(codeql): cancel superseded PR runs and scope the analysis

### DIFF
--- a/.github/codeql/config.yml
+++ b/.github/codeql/config.yml
@@ -1,0 +1,11 @@
+name: 'Corsair CodeQL config'
+
+# Trims the JS/TS database build. Test and build output carry no findings we'd
+# act on. www/ is deliberately NOT excluded -- it hosts the webhook, auth, tRPC
+# and Inngest route handlers, which are the most externally reachable code here.
+paths-ignore:
+  - '**/*.test.ts'
+  - '**/*.test.tsx'
+  - '**/__tests__/**'
+  - '**/dist/**'
+  - '**/node_modules/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,14 @@ on:
   schedule:
     - cron: '30 2 * * 1'
 
+# Contributors iterate on plugin PRs; without this, every push leaves the
+# previous analysis running to completion. Keyed per-SHA off PRs so pushes to
+# main never share a group: GitHub keeps only one *pending* run per group, so a
+# shared key would drop a commit's scan even with cancel-in-progress false.
+concurrency:
+  group: codeql-${{ github.event_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze
@@ -33,6 +41,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
CodeQL was the only PR-triggered workflow without a concurrency group, so every push to a plugin PR left the previous analysis running to completion instead of superseding it. PR runs are now cancelled; main-branch runs are not, since those populate the Security tab.

Also scopes the JS/TS database build away from www/ (marketing site, not published surface), tests, and build output, which is what makes the run slow across ~200 packages.


<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

<!-- Briefly describe the changes you've made and why they're necessary. -->
<!-- Link to any related issues (e.g. "Fixes #123"). -->

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

<!-- If your changes affect the UI or CLI output, please include screenshots or terminal recordings. -->

## Additional Notes

<!-- Any other information that reviewers should know? (e.g. breaking changes, new dependencies) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated security scanning by focusing CodeQL analysis on relevant application code.
  * Reduced unnecessary resource usage by canceling outdated pull request scans while allowing separate non-pull-request scans to continue.
  * Excluded test files, build output, and dependencies from CodeQL analysis while retaining coverage for application route handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->