### PR TITLE
feat: add Wix MCP integration

### DIFF
--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -86,16 +86,16 @@ export const BaseProviders = [
 	'boloforms',
 	'boltiot',
 	'bonsai',
-	'botbaba',
 	'bookingmood',
+	'botbaba',
 	'botpress',
 	'botsonic',
 	'bouncer',
 	'box',
 	'boxhero',
 	'brandfetch',
-	'brevo',
 	'breathehr',
+	'brevo',
 	'brex',
 	'brightdata',
 	'browseai',
@@ -264,10 +264,11 @@ export const BaseProviders = [
 	'webvizio',
 	'whatsapp',
 	'witai',
-	'worldnewsapi',
+	'wixmcp',
 	'wiza',
 	'workday',
 	'workiom',
+	'worldnewsapi',
 	'xquik',
 	'youcom',
 	'youtube',
@@ -352,16 +353,16 @@ export const ProviderDisplayNames = {
 	boloforms: 'Boloforms',
 	boltiot: 'Bolt IoT',
 	bonsai: 'Bonsai',
-	botbaba: 'Botbaba',
 	bookingmood: 'Bookingmood',
+	botbaba: 'Botbaba',
 	botpress: 'Botpress',
 	botsonic: 'Botsonic',
 	bouncer: 'Bouncer',
 	box: 'Box',
 	boxhero: 'BoxHero',
 	brandfetch: 'Brandfetch',
-	brevo: 'Brevo',
 	breathehr: 'Breathe HR',
+	brevo: 'Brevo',
 	brex: 'Brex',
 	brightdata: 'Bright Data',
 	browseai: 'Browse AI',
@@ -530,10 +531,11 @@ export const ProviderDisplayNames = {
 	webvizio: 'Webvizio',
 	whatsapp: 'WhatsApp',
 	witai: 'WitAi',
-	worldnewsapi: 'World News API',
+	wixmcp: 'WixMcp',
 	wiza: 'Wiza',
 	workday: 'Workday',
 	workiom: 'Workiom',
+	worldnewsapi: 'World News API',
 	xquik: 'XQuik',
 	youcom: 'You.com',
 	youtube: 'YouTube',
@@ -625,16 +627,16 @@ export type AllProviders =
 	| 'boloforms'
 	| 'boltiot'
 	| 'bonsai'
-	| 'botbaba'
 	| 'bookingmood'
+	| 'botbaba'
 	| 'botpress'
 	| 'botsonic'
 	| 'bouncer'
 	| 'box'
 	| 'boxhero'
 	| 'brandfetch'
-	| 'brevo'
 	| 'breathehr'
+	| 'brevo'
 	| 'brex'
 	| 'brightdata'
 	| 'browseai'
@@ -803,10 +805,11 @@ export type AllProviders =
 	| 'webvizio'
 	| 'whatsapp'
 	| 'witai'
-	| 'worldnewsapi'
+	| 'wixmcp'
 	| 'wiza'
 	| 'workday'
 	| 'workiom'
+	| 'worldnewsapi'
 	| 'xquik'
 	| 'youcom'
 	| 'youtube'

--- a/packages/wixmcp/client.ts
+++ b/packages/wixmcp/client.ts
@@ -1,0 +1,43 @@
+import { request } from 'corsair/http';
+
+const WIXMCP_API_BASE = 'https://mcp.wix.com/mcp';
+
+export type WixMcpToolCall = {
+  name: string;
+  arguments?: Record<string, unknown>;
+};
+
+export async function callWixMcpTool<T>(
+  tool: WixMcpToolCall,
+  accessToken: string,
+): Promise<T> {
+  const response = await request<T>(
+    {
+      BASE: WIXMCP_API_BASE,
+      VERSION: '1.0',
+      WITH_CREDENTIALS: false,
+      CREDENTIALS: 'omit',
+      TOKEN: accessToken,
+      HEADERS: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+    {
+      method: 'POST',
+      url: '',
+      body: {
+        jsonrpc: '2.0',
+        id: Date.now(),
+        method: 'tools/call',
+        params: {
+          name: tool.name,
+          arguments: tool.arguments ?? {},
+        },
+      },
+      mediaType: 'application/json',
+    },
+  );
+
+  return response;
+}

--- a/packages/wixmcp/endpoints/example.ts
+++ b/packages/wixmcp/endpoints/example.ts
@@ -1,0 +1,23 @@
+import { logEventFromContext } from 'corsair/core';
+import type { WixMcpEndpoints } from '..';
+import type { CallToolResponse } from './types';
+import { callWixMcpTool } from '../client';
+
+export const callTool: WixMcpEndpoints['callTool'] = async (ctx, input) => {
+	const response = await callWixMcpTool<CallToolResponse>(
+		{
+			name: input.name,
+			arguments: input.arguments,
+		},
+		ctx.key,
+	);
+
+	await logEventFromContext(
+		ctx,
+		'wixmcp.tool.call',
+		{ name: input.name },
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/wixmcp/endpoints/index.ts
+++ b/packages/wixmcp/endpoints/index.ts
@@ -1,0 +1,7 @@
+import { callTool } from './example';
+
+export const WixMcp = {
+  callTool,
+};
+
+export * from './types';

--- a/packages/wixmcp/endpoints/types.ts
+++ b/packages/wixmcp/endpoints/types.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+const CallToolInputSchema = z.object({
+  name: z.string(),
+  arguments: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type CallToolInput = z.infer<typeof CallToolInputSchema>;
+
+const CallToolResponseSchema = z.unknown();
+
+export type CallToolResponse = z.infer<typeof CallToolResponseSchema>;
+
+export type WixMcpEndpointInputs = {
+  callTool: CallToolInput;
+};
+
+export type WixMcpEndpointOutputs = {
+  callTool: CallToolResponse;
+};
+
+export const WixMcpEndpointInputSchemas = {
+  callTool: CallToolInputSchema,
+} as const;
+
+export const WixMcpEndpointOutputSchemas = {
+  callTool: CallToolResponseSchema,
+} as const;

--- a/packages/wixmcp/error-handlers.ts
+++ b/packages/wixmcp/error-handlers.ts
@@ -1,0 +1,31 @@
+import { ApiError } from 'corsair/http';
+import type { CorsairErrorHandler } from 'corsair/core';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('429');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('unauthorized') || msg.includes('invalid_auth');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/wixmcp/index.ts
+++ b/packages/wixmcp/index.ts
@@ -1,0 +1,243 @@
+import type {
+	BindEndpoints,
+	BindWebhooks,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	CorsairWebhook,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+	RequiredPluginWebhookSchemas,
+} from 'corsair/core';
+import type { AuthTypes } from 'corsair/core';
+
+import type {
+	WixMcpEndpointInputs,
+	WixMcpEndpointOutputs,
+} from './endpoints/types';
+import {
+	WixMcpEndpointInputSchemas,
+	WixMcpEndpointOutputSchemas,
+} from './endpoints/types';
+
+import type {
+	WixMcpWebhookOutputs,
+	ExampleEvent,
+} from './webhooks/types';
+import { ExampleEventSchema } from './webhooks/types';
+
+import { WixMcp } from './endpoints';
+import { WixMcpSchema } from './schema';
+import { ExampleWebhooks } from './webhooks';
+import { errorHandlers } from './error-handlers';
+import { matchWixMcpTenantWebhook } from './webhooks/tenant-matcher';
+import { resolveWixMcpOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
+
+export type WixMcpPluginOptions = {
+	authType?: PickAuth<'api_key' | 'oauth_2'>;
+	key?: string;
+	webhookSecret?: string;
+	hooks?: InternalWixMcpPlugin['hooks'];
+	webhookHooks?: InternalWixMcpPlugin['webhookHooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof wixMcpEndpointsNested>;
+};
+
+export type WixMcpContext = CorsairPluginContext<
+	typeof WixMcpSchema,
+	WixMcpPluginOptions
+>;
+
+export type WixMcpKeyBuilderContext =
+	KeyBuilderContext<WixMcpPluginOptions>;
+
+export type WixMcpBoundEndpoints =
+	BindEndpoints<typeof wixMcpEndpointsNested>;
+
+type WixMcpEndpoint<
+	K extends keyof WixMcpEndpointOutputs,
+> = CorsairEndpoint<
+	WixMcpContext,
+	WixMcpEndpointInputs[K],
+	WixMcpEndpointOutputs[K]
+>;
+
+export type WixMcpEndpoints = {
+	callTool: WixMcpEndpoint<'callTool'>;
+};
+
+type WixMcpWebhook<
+	K extends keyof WixMcpWebhookOutputs,
+	TEvent,
+> = CorsairWebhook<WixMcpContext, TEvent, WixMcpWebhookOutputs[K]>;
+
+export type WixMcpWebhooks = {
+	example: WixMcpWebhook<'example', ExampleEvent>;
+};
+
+export type WixMcpBoundWebhooks =
+	BindWebhooks<WixMcpWebhooks>;
+
+const wixMcpEndpointsNested = {
+	mcp: {
+		callTool: WixMcp.callTool,
+	},
+} as const;
+
+const wixMcpWebhooksNested = {
+	example: {
+		example: ExampleWebhooks.example,
+	},
+} as const;
+
+export const wixMcpEndpointSchemas = {
+	'mcp.callTool': {
+		input: WixMcpEndpointInputSchemas.callTool,
+		output: WixMcpEndpointOutputSchemas.callTool,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<
+	typeof wixMcpEndpointsNested
+>;
+
+const wixMcpWebhookSchemas = {
+	'example.example': {
+		description: 'An example webhook event',
+		payload: ExampleEventSchema,
+		response: ExampleEventSchema,
+	},
+} as const satisfies RequiredPluginWebhookSchemas<
+	typeof wixMcpWebhooksNested
+>;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const wixMcpEndpointMeta = {
+	'mcp.callTool': {
+		riskLevel: 'write',
+		description: 'Call a tool on the Wix MCP server',
+	},
+} as const satisfies RequiredPluginEndpointMeta<
+	typeof wixMcpEndpointsNested
+>;
+
+export const wixMcpAuthConfig = {
+	api_key: {
+		account: ['tenant_external_id'] as const,
+	},
+	oauth_2: {
+		account: ['tenant_external_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type BaseWixMcpPlugin<
+	T extends WixMcpPluginOptions,
+> = CorsairPlugin<
+	'wixmcp',
+	typeof WixMcpSchema,
+	typeof wixMcpEndpointsNested,
+	typeof wixMcpWebhooksNested,
+	T,
+	typeof defaultAuthType
+>;
+
+export type InternalWixMcpPlugin =
+	BaseWixMcpPlugin<WixMcpPluginOptions>;
+
+export type ExternalWixMcpPlugin<
+	T extends WixMcpPluginOptions,
+> = BaseWixMcpPlugin<T>;
+
+export function wixmcp<
+	const T extends WixMcpPluginOptions,
+>(
+	incomingOptions: WixMcpPluginOptions & T =
+		{} as WixMcpPluginOptions & T,
+): ExternalWixMcpPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+
+	return {
+		id: 'wixmcp',
+		authConfig: wixMcpAuthConfig,
+		schema: WixMcpSchema,
+		options,
+		hooks: options.hooks,
+		webhookHooks: options.webhookHooks,
+		endpoints: wixMcpEndpointsNested,
+		webhooks: wixMcpWebhooksNested,
+		endpointMeta: wixMcpEndpointMeta,
+		endpointSchemas: wixMcpEndpointSchemas,
+		webhookSchemas: wixMcpWebhookSchemas,
+
+		pluginWebhookMatcher: (request) => {
+			const headers = request.headers;
+			return 'x-wixmcp-signature' in headers;
+		},
+
+		pluginTenantWebhookMatcher:
+			matchWixMcpTenantWebhook,
+
+		oauthWebhookTenantLinkResolver:
+			resolveWixMcpOAuthWebhookTenantLink,
+
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+
+		keyBuilder: async (
+			ctx: WixMcpKeyBuilderContext,
+			source,
+		) => {
+			if (source === 'webhook' && options.webhookSecret) {
+				return options.webhookSecret;
+			}
+
+			if (source === 'webhook') {
+				const res = await ctx.keys.get_webhook_signature();
+				return res ?? '';
+			}
+
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (
+				source === 'endpoint' &&
+				ctx.authType === 'api_key'
+			) {
+				const res = await ctx.keys.get_api_key();
+				return res ?? '';
+			}
+
+			if (
+				source === 'endpoint' &&
+				ctx.authType === 'oauth_2'
+			) {
+				const res = await ctx.keys.get_access_token();
+				return res ?? '';
+			}
+
+			return '';
+		},
+	} satisfies InternalWixMcpPlugin;
+}
+
+export type {
+	ExampleEvent,
+	WixMcpWebhookOutputs,
+} from './webhooks/types';
+
+export type {
+	WixMcpEndpointInputs,
+	WixMcpEndpointOutputs,
+	CallToolInput,
+	CallToolResponse,
+} from './endpoints/types';

--- a/packages/wixmcp/jest.config.cjs
+++ b/packages/wixmcp/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/wixmcp/package.json
+++ b/packages/wixmcp/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/wixmcp",
+  "version": "0.1.0",
+  "description": "WixMcp plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "wixmcp",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/wixmcp/schema.test.ts
+++ b/packages/wixmcp/schema.test.ts
@@ -1,0 +1,20 @@
+import { WixMcpSchema } from './schema';
+
+describe('WixMcp schema', () => {
+	it('declares a semver version', () => {
+		expect(WixMcpSchema.version).toBeDefined();
+		expect(WixMcpSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof WixMcpSchema.entities).toBe('object');
+		expect(WixMcpSchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(WixMcpSchema.entities))).toBe(true);
+		for (const entity of Object.values(WixMcpSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/wixmcp/schema/database.ts
+++ b/packages/wixmcp/schema/database.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+// TODO: Define your database entities here
+// export const WixMcpExample = z.object({
+// 	id: z.string(),
+// 	name: z.string(),
+// 	created_at: z.coerce.date().nullable().optional(),
+// });
+// export type WixMcpExample = z.infer<typeof WixMcpExample>;

--- a/packages/wixmcp/schema/index.ts
+++ b/packages/wixmcp/schema/index.ts
@@ -1,0 +1,4 @@
+export const WixMcpSchema = {
+	version: '1.0.0',
+	entities: {},
+} as const;

--- a/packages/wixmcp/tsconfig.json
+++ b/packages/wixmcp/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": [
+      "esnext"
+    ],
+    "types": [
+      "node",
+      "jest"
+    ],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "./**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ],
+  "references": []
+}

--- a/packages/wixmcp/tsup.config.ts
+++ b/packages/wixmcp/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/wixmcp/webhooks/example.ts
+++ b/packages/wixmcp/webhooks/example.ts
@@ -1,0 +1,27 @@
+import { logEventFromContext } from 'corsair/core';
+import type { WixMcpWebhooks } from '..';
+import { createWixMcpMatch, verifyWixMcpWebhookSignature } from './types';
+
+export const example: WixMcpWebhooks['example'] = {
+	match: createWixMcpMatch('example'),
+
+	handler: async (ctx, request) => {
+		const verification = verifyWixMcpWebhookSignature(request, ctx.key);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
+
+		const event = request.payload;
+		if (event.type !== 'example') {
+			return { success: true, data: undefined };
+		}
+
+		await logEventFromContext(ctx, 'wixmcp.webhook.example', { ...event }, 'completed');
+
+		return { success: true, data: event };
+	},
+};

--- a/packages/wixmcp/webhooks/index.ts
+++ b/packages/wixmcp/webhooks/index.ts
@@ -1,0 +1,9 @@
+import { example } from './example';
+
+export const ExampleWebhooks = {
+	example: example,
+};
+
+export * from './types';
+export * from './tenant-matcher';
+export * from './oauth-tenant-link';

--- a/packages/wixmcp/webhooks/oauth-tenant-link.ts
+++ b/packages/wixmcp/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,31 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, toExternalId } from 'corsair/core';
+
+// TODO: Rename linkType 'tenant_external_id' to match pluginTenantWebhookMatcher.
+// Called after OAuth to store the routing id on corsair_accounts.config.
+export async function resolveWixMcpOAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): Promise<WebhookTenantMatch | null> {
+	// TODO: Read from token response when the provider includes a stable id.
+	// const externalId = toExternalId(asRecord(tokens.team)?.id);
+	const externalId = toExternalId(tokens.tenant_external_id);
+	if (externalId) {
+		return { linkType: 'tenant_external_id', externalId };
+	}
+
+	const accessToken = tokens.access_token;
+	if (!accessToken) return null;
+
+	// TODO: Fetch from provider API when the token response omits the id.
+	// const response = await fetch('https://api.example.com/me', {
+	// 	headers: { Authorization: `Bearer ${accessToken}` },
+	// });
+	// if (!response.ok) return null;
+	// const payload = (await response.json()) as { id?: string };
+	// const fetchedId = toExternalId(payload.id);
+	// return fetchedId
+	// 	? { linkType: 'tenant_external_id', externalId: fetchedId }
+	// 	: null;
+
+	return null;
+}

--- a/packages/wixmcp/webhooks/tenant-matcher.ts
+++ b/packages/wixmcp/webhooks/tenant-matcher.ts
@@ -1,0 +1,25 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// TODO: Rename linkType 'tenant_external_id' to match the provider field
+// (e.g. team_id, installation_id, organization_id). Must match authConfig.account
+// and oauthWebhookTenantLinkResolver.
+// Return null for URL verification / handshake payloads that have no tenant id.
+export function matchWixMcpTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	// TODO: Extract the stable external id from the webhook payload.
+	// Example:
+	// const externalId = firstString([body.tenant_external_id, asRecord(body.data)?.id]);
+	const externalId = firstString([
+		body.tenant_external_id,
+		asRecord(body.data)?.tenant_external_id,
+	]);
+
+	if (!externalId) return null;
+
+	return { linkType: 'tenant_external_id', externalId };
+}

--- a/packages/wixmcp/webhooks/types.ts
+++ b/packages/wixmcp/webhooks/types.ts
@@ -1,0 +1,58 @@
+import type { CorsairWebhookMatcher, RawWebhookRequest, WebhookRequest } from 'corsair/core';
+import { z } from 'zod';
+
+export const WixMcpWebhookPayloadSchema = z.object({
+	type: z.string(),
+	created_at: z.string(),
+	data: z.record(z.string(), z.unknown()),
+});
+
+export type WixMcpWebhookPayload = z.infer<
+	typeof WixMcpWebhookPayloadSchema
+>;
+
+export const ExampleEventSchema = WixMcpWebhookPayloadSchema.extend({
+	type: z.literal('example'),
+	data: z
+		.object({
+			id: z.string(),
+		})
+		.loose(),
+});
+
+export type ExampleEvent = z.infer<typeof ExampleEventSchema>;
+
+export type WixMcpWebhookOutputs = {
+	example: ExampleEvent;
+};
+
+function parseBody(body: unknown): Record<string, unknown> | null {
+	if (typeof body === 'string') {
+		try {
+			const parsed = JSON.parse(body);
+			return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+				? (parsed as Record<string, unknown>)
+				: null;
+		} catch {
+			return null;
+		}
+	}
+	return body !== null && typeof body === 'object' && !Array.isArray(body)
+		? (body as Record<string, unknown>)
+		: null;
+}
+
+export function createWixMcpMatch(eventType: string): CorsairWebhookMatcher {
+	return (request: RawWebhookRequest) => {
+		const parsedBody = parseBody(request.body);
+		return parsedBody !== null && parsedBody.type === eventType;
+	};
+}
+
+export function verifyWixMcpWebhookSignature(
+	request: WebhookRequest<WixMcpWebhookPayload>,
+	secret: string,
+): { valid: boolean; error?: string } {
+	// TODO: Implement webhook signature verification
+	return { valid: true };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6788,6 +6788,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/wixmcp:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/wiza:
     devDependencies:
       '@types/jest':


### PR DESCRIPTION
## Description

This PR adds a Wix MCP integration to Corsair OSS.

The integration adds support for calling tools through the Wix MCP server, along with Wix MCP authentication, endpoint schemas, plugin configuration, and error handling.

## Checklist

- [ ] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [ ] I have run `pnpm build` and all packages build successfully
- [ ] I have run `pnpm test` and all tests pass
- [ ] I have added or updated tests where applicable
- [ ] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

Not applicable.

## Additional Notes

- Added Wix MCP plugin package.
- Added Wix MCP tool calling endpoint.
- Added API key and OAuth 2 authentication support.
- Added endpoint schemas and plugin configuration.
- `pnpm typecheck` passes.
- `pnpm run validate:plugins` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Wix MCP integration with support for tool calls and endpoint schemas.
  - Added example webhook handling, event matching, and tenant routing.
  - Added OAuth tenant linking and webhook authentication handling.
  - Added retry behavior for rate limits and handling for authentication errors.
  - Registered Wix MCP as an available provider.
- **Tests**
  - Added schema validation tests for the Wix MCP integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->