### PR TITLE
fix: import instagram in testing demo

### DIFF
--- a/demo/testing/src/server/corsair.ts
+++ b/demo/testing/src/server/corsair.ts
@@ -7,6 +7,7 @@ import { gmail } from '@corsair-dev/gmail';
 import { googlecalendar } from '@corsair-dev/googlecalendar';
 import { googlesheets } from '@corsair-dev/googlesheets';
 import { hubspot } from '@corsair-dev/hubspot';
+import { instagram } from '@corsair-dev/instagram';
 import { linear } from '@corsair-dev/linear';
 import { onedrive } from '@corsair-dev/onedrive';
 import { sharepoint } from '@corsair-dev/sharepoint';
@@ -14,7 +15,6 @@ import { slack } from '@corsair-dev/slack';
 import { twilio } from '@corsair-dev/twilio';
 import { vapi } from '@corsair-dev/vapi';
 import { createCorsair } from 'corsair';
-
 import { sqlite } from '../db';
 
 const hubProjectApiKey =


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

Imports the missing `instagram` plugin in `demo/testing/src/server/corsair.ts`.

The testing demo registers `instagram()` in the plugins array, but the function was not imported, causing the demo to fail at startup with:

`ReferenceError: instagram is not defined`

After adding the import, the demo proceeds past Corsair initialization successfully.

## Checklist

- [ ] I have run `pnpm lint` and all checks pass
- [ ] I have run `pnpm typecheck` and there are no TypeScript errors
- [ ] I have run `pnpm build` and all packages build successfully
- [ ] I have run `pnpm test` and all tests pass
- [ ] I have added or updated tests where applicable
- [ ] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

Not applicable.

## Additional Notes

No new dependencies or breaking changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Instagram integration to the Corsair configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->