### PR TITLE
feat: add Campaign Cleaner plugin

### DIFF
--- a/packages/campaigncleaner/client.ts
+++ b/packages/campaigncleaner/client.ts
@@ -1,0 +1,60 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+
+export class CampaignCleanerAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly status?: number,
+	) {
+		super(message);
+		this.name = 'CampaignCleanerAPIError';
+	}
+}
+
+const CAMPAIGNCLEANER_API_BASE = 'https://api.campaigncleaner.com';
+
+export async function makeCampaignCleanerRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	options: {
+		method?: 'GET' | 'POST' | 'DELETE';
+		body?: Record<string, unknown>;
+		query?: Record<string, string | number | boolean | undefined>;
+	} = {},
+): Promise<T> {
+	const { method = 'GET', body, query } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: CAMPAIGNCLEANER_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: undefined,
+		HEADERS: {
+			'Content-Type': 'application/json',
+			'X-CC-API-Key': apiKey,
+		},
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint,
+		body: method === 'POST' ? body : undefined,
+		mediaType: 'application/json',
+		query,
+	};
+
+	try {
+		return await request<T>(config, requestOptions);
+	} catch (error) {
+		if (error instanceof ApiError) {
+			throw new CampaignCleanerAPIError(error.message, error.status);
+		}
+
+		if (error instanceof Error) {
+			throw new CampaignCleanerAPIError(error.message);
+		}
+
+		throw new CampaignCleanerAPIError('Unknown error');
+	}
+}

--- a/packages/campaigncleaner/endpoints/index.ts
+++ b/packages/campaigncleaner/endpoints/index.ts
@@ -1,0 +1,124 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeCampaignCleanerRequest } from '../client';
+import type {
+	CampaignCleanerEndpointInputs,
+	CampaignCleanerEndpointOutputs,
+} from './types';
+
+export const DeleteCampaign = {
+	remove: async (
+		ctx: any,
+		input: CampaignCleanerEndpointInputs['deleteCampaign'],
+	): Promise<CampaignCleanerEndpointOutputs['deleteCampaign']> => {
+		const response = await makeCampaignCleanerRequest<
+			CampaignCleanerEndpointOutputs['deleteCampaign']
+		>('v1/delete_campaign', ctx.key, {
+			method: 'POST',
+			body: {
+				campaign: {
+					id: input.campaignId,
+				},
+			},
+		});
+
+		await logEventFromContext(ctx, 'campaign_cleaner.delete_campaign', {
+			campaignId: input.campaignId,
+		});
+
+		return response;
+	},
+};
+
+export const GetCampaignList = {
+	list: async (
+		ctx: any,
+		_input: CampaignCleanerEndpointInputs['getCampaignList'],
+	): Promise<CampaignCleanerEndpointOutputs['getCampaignList']> => {
+		const response = await makeCampaignCleanerRequest<
+			CampaignCleanerEndpointOutputs['getCampaignList']
+		>('v1/get_campaign_list', ctx.key, {
+			method: 'GET',
+		});
+
+		await logEventFromContext(ctx, 'campaign_cleaner.get_campaign_list', {});
+
+		return response;
+	},
+};
+
+export const GetCampaignStatus = {
+	status: async (
+		ctx: any,
+		input: CampaignCleanerEndpointInputs['getCampaignStatus'],
+	): Promise<CampaignCleanerEndpointOutputs['getCampaignStatus']> => {
+		const response = await makeCampaignCleanerRequest<
+			CampaignCleanerEndpointOutputs['getCampaignStatus']
+		>('v1/get_campaign_status', ctx.key, {
+			method: 'POST',
+			body: {
+				campaign: {
+					id: input.campaignId,
+				},
+			},
+		});
+
+		await logEventFromContext(ctx, 'campaign_cleaner.get_campaign_status', {
+			campaignId: input.campaignId,
+		});
+
+		return response;
+	},
+};
+
+export const GetCampaignPdfAnalysis = {
+	pdfAnalysis: async (
+		ctx: any,
+		input: CampaignCleanerEndpointInputs['getCampaignPdfAnalysis'],
+	): Promise<CampaignCleanerEndpointOutputs['getCampaignPdfAnalysis']> => {
+		const response = await makeCampaignCleanerRequest<
+			CampaignCleanerEndpointOutputs['getCampaignPdfAnalysis']
+		>('v1/get_campaign_pdf_analysis', ctx.key, {
+			method: 'POST',
+			body: {
+				campaign: {
+					id: input.campaignId,
+				},
+			},
+		});
+
+		await logEventFromContext(
+			ctx,
+			'campaign_cleaner.get_campaign_pdf_analysis',
+			{
+				campaignId: input.campaignId,
+			},
+		);
+
+		return response;
+	},
+};
+
+export const GetCredits = {
+	credits: async (
+		ctx: any,
+		_input: CampaignCleanerEndpointInputs['getCredits'],
+	): Promise<CampaignCleanerEndpointOutputs['getCredits']> => {
+		const response = await makeCampaignCleanerRequest<
+			CampaignCleanerEndpointOutputs['getCredits']
+		>('v1/get_credits', ctx.key, {
+			method: 'GET',
+		});
+
+		await logEventFromContext(ctx, 'campaign_cleaner.get_credits', {});
+
+		return response;
+	},
+};
+
+export const CampaignCleanerEndpoints = {
+	deleteCampaign: DeleteCampaign,
+	getCampaignList: GetCampaignList,
+	getCampaignStatus: GetCampaignStatus,
+	getCampaignPdfAnalysis: GetCampaignPdfAnalysis,
+	getCredits: GetCredits,
+} as const;

--- a/packages/campaigncleaner/endpoints/types.ts
+++ b/packages/campaigncleaner/endpoints/types.ts
@@ -1,0 +1,125 @@
+import { z } from 'zod';
+
+// ─────────────────────────────────────────────
+// Delete Campaign
+// ─────────────────────────────────────────────
+const DeleteCampaignInputSchema = z.object({
+	campaignId: z.string(),
+});
+
+export type DeleteCampaignInput = z.infer<typeof DeleteCampaignInputSchema>;
+
+const DeleteCampaignResponseSchema = z.object({
+	status: z.enum(['success', 'failure']),
+	error: z.string().optional(),
+});
+
+export type DeleteCampaignResponse = z.infer<
+	typeof DeleteCampaignResponseSchema
+>;
+
+// ─────────────────────────────────────────────
+// Get Campaign PDF Analysis
+// ─────────────────────────────────────────────
+const GetCampaignPdfAnalysisInputSchema = z.object({
+	campaignId: z.string(),
+});
+
+export type GetCampaignPdfAnalysisInput = z.infer<
+	typeof GetCampaignPdfAnalysisInputSchema
+>;
+
+const GetCampaignPdfAnalysisResponseSchema = z.unknown();
+
+export type GetCampaignPdfAnalysisResponse = z.infer<
+	typeof GetCampaignPdfAnalysisResponseSchema
+>;
+
+// ─────────────────────────────────────────────
+// Get Campaign List
+// ─────────────────────────────────────────────
+const GetCampaignListInputSchema = z.object({});
+
+export type GetCampaignListInput = z.infer<typeof GetCampaignListInputSchema>;
+
+const CampaignSchema = z.object({
+	id: z.string(),
+	campaign_name: z.string(),
+	status: z.enum(['processing', 'completed', 'paused']),
+	date_added: z.string(),
+});
+
+const GetCampaignListResponseSchema = z.object({
+	campaign_list: z.array(CampaignSchema),
+});
+
+export type GetCampaignListResponse = z.infer<
+	typeof GetCampaignListResponseSchema
+>;
+
+// ─────────────────────────────────────────────
+// Get Campaign Status
+// ─────────────────────────────────────────────
+const GetCampaignStatusInputSchema = z.object({
+	campaignId: z.string(),
+});
+
+export type GetCampaignStatusInput = z.infer<
+	typeof GetCampaignStatusInputSchema
+>;
+
+const GetCampaignStatusResponseSchema = z.object({
+	campaign_status: CampaignSchema.optional(),
+});
+
+export type GetCampaignStatusResponse = z.infer<
+	typeof GetCampaignStatusResponseSchema
+>;
+
+// ─────────────────────────────────────────────
+// Get Credits
+// ─────────────────────────────────────────────
+const GetCreditsInputSchema = z.object({});
+
+export type GetCreditsInput = z.infer<typeof GetCreditsInputSchema>;
+
+const GetCreditsResponseSchema = z.object({
+	credits: z.number(),
+});
+
+export type GetCreditsResponse = z.infer<typeof GetCreditsResponseSchema>;
+
+// ─────────────────────────────────────────────
+// Endpoint input/output maps
+// ─────────────────────────────────────────────
+export type CampaignCleanerEndpointInputs = {
+	deleteCampaign: DeleteCampaignInput;
+	getCampaignPdfAnalysis: GetCampaignPdfAnalysisInput;
+	getCampaignList: GetCampaignListInput;
+	getCampaignStatus: GetCampaignStatusInput;
+	getCredits: GetCreditsInput;
+};
+
+export type CampaignCleanerEndpointOutputs = {
+	deleteCampaign: DeleteCampaignResponse;
+	getCampaignPdfAnalysis: GetCampaignPdfAnalysisResponse;
+	getCampaignList: GetCampaignListResponse;
+	getCampaignStatus: GetCampaignStatusResponse;
+	getCredits: GetCreditsResponse;
+};
+
+export const CampaignCleanerEndpointInputSchemas = {
+	deleteCampaign: DeleteCampaignInputSchema,
+	getCampaignPdfAnalysis: GetCampaignPdfAnalysisInputSchema,
+	getCampaignList: GetCampaignListInputSchema,
+	getCampaignStatus: GetCampaignStatusInputSchema,
+	getCredits: GetCreditsInputSchema,
+} as const;
+
+export const CampaignCleanerEndpointOutputSchemas = {
+	deleteCampaign: DeleteCampaignResponseSchema,
+	getCampaignPdfAnalysis: GetCampaignPdfAnalysisResponseSchema,
+	getCampaignList: GetCampaignListResponseSchema,
+	getCampaignStatus: GetCampaignStatusResponseSchema,
+	getCredits: GetCreditsResponseSchema,
+} as const;

--- a/packages/campaigncleaner/error-handlers.ts
+++ b/packages/campaigncleaner/error-handlers.ts
@@ -1,0 +1,31 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('429');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('unauthorized') || msg.includes('invalid_auth');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/campaigncleaner/index.ts
+++ b/packages/campaigncleaner/index.ts
@@ -1,0 +1,212 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+} from 'corsair/core';
+import {
+	DeleteCampaign,
+	GetCampaignList,
+	GetCampaignPdfAnalysis,
+	GetCampaignStatus,
+	GetCredits,
+} from './endpoints';
+import type {
+	CampaignCleanerEndpointInputs,
+	CampaignCleanerEndpointOutputs,
+} from './endpoints/types';
+import {
+	CampaignCleanerEndpointInputSchemas,
+	CampaignCleanerEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { CampaignCleanerSchema } from './schema';
+
+export type CampaignCleanerPluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	hooks?: InternalCampaignCleanerPlugin['hooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof campaignCleanerEndpointsNested>;
+};
+
+export type CampaignCleanerContext = CorsairPluginContext<
+	typeof CampaignCleanerSchema,
+	CampaignCleanerPluginOptions
+>;
+
+export type CampaignCleanerKeyBuilderContext =
+	KeyBuilderContext<CampaignCleanerPluginOptions>;
+
+export type CampaignCleanerBoundEndpoints = BindEndpoints<
+	typeof campaignCleanerEndpointsNested
+>;
+
+type CampaignCleanerEndpoint<K extends keyof CampaignCleanerEndpointOutputs> =
+	CorsairEndpoint<
+		CampaignCleanerContext,
+		CampaignCleanerEndpointInputs[K],
+		CampaignCleanerEndpointOutputs[K]
+	>;
+
+export type CampaignCleanerEndpoints = {
+	deleteCampaign: CampaignCleanerEndpoint<'deleteCampaign'>;
+	getCampaignList: CampaignCleanerEndpoint<'getCampaignList'>;
+	getCampaignStatus: CampaignCleanerEndpoint<'getCampaignStatus'>;
+	getCampaignPdfAnalysis: CampaignCleanerEndpoint<'getCampaignPdfAnalysis'>;
+	getCredits: CampaignCleanerEndpoint<'getCredits'>;
+};
+
+const campaignCleanerEndpointsNested = {
+	deleteCampaign: {
+		remove: DeleteCampaign.remove,
+	},
+	getCampaignList: {
+		list: GetCampaignList.list,
+	},
+	getCampaignStatus: {
+		status: GetCampaignStatus.status,
+	},
+	getCampaignPdfAnalysis: {
+		pdfAnalysis: GetCampaignPdfAnalysis.pdfAnalysis,
+	},
+	getCredits: {
+		credits: GetCredits.credits,
+	},
+} as const;
+
+export const campaignCleanerEndpointSchemas = {
+	'deleteCampaign.remove': {
+		input: CampaignCleanerEndpointInputSchemas.deleteCampaign,
+		output: CampaignCleanerEndpointOutputSchemas.deleteCampaign,
+	},
+	'getCampaignList.list': {
+		input: CampaignCleanerEndpointInputSchemas.getCampaignList,
+		output: CampaignCleanerEndpointOutputSchemas.getCampaignList,
+	},
+	'getCampaignStatus.status': {
+		input: CampaignCleanerEndpointInputSchemas.getCampaignStatus,
+		output: CampaignCleanerEndpointOutputSchemas.getCampaignStatus,
+	},
+	'getCampaignPdfAnalysis.pdfAnalysis': {
+		input: CampaignCleanerEndpointInputSchemas.getCampaignPdfAnalysis,
+		output: CampaignCleanerEndpointOutputSchemas.getCampaignPdfAnalysis,
+	},
+	'getCredits.credits': {
+		input: CampaignCleanerEndpointInputSchemas.getCredits,
+		output: CampaignCleanerEndpointOutputSchemas.getCredits,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<
+	typeof campaignCleanerEndpointsNested
+>;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const campaignCleanerEndpointMeta = {
+	'deleteCampaign.remove': {
+		riskLevel: 'write',
+		description: 'Delete a saved Campaign Cleaner campaign',
+	},
+	'getCampaignList.list': {
+		riskLevel: 'read',
+		description: 'Get the list of saved Campaign Cleaner campaigns',
+	},
+	'getCampaignStatus.status': {
+		riskLevel: 'read',
+		description: 'Get the status of a Campaign Cleaner campaign',
+	},
+	'getCampaignPdfAnalysis.pdfAnalysis': {
+		riskLevel: 'read',
+		description: 'Download PDF analysis for a Campaign Cleaner campaign',
+	},
+	'getCredits.credits': {
+		riskLevel: 'read',
+		description: 'Get the remaining Campaign Cleaner credits',
+	},
+} as const satisfies RequiredPluginEndpointMeta<
+	typeof campaignCleanerEndpointsNested
+>;
+
+export const campaignCleanerAuthConfig = {
+	api_key: {
+		account: ['tenant_external_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type BaseCampaignCleanerPlugin<T extends CampaignCleanerPluginOptions> =
+	CorsairPlugin<
+		'campaigncleaner',
+		typeof CampaignCleanerSchema,
+		typeof campaignCleanerEndpointsNested,
+		{},
+		T,
+		typeof defaultAuthType
+	>;
+
+export type InternalCampaignCleanerPlugin =
+	BaseCampaignCleanerPlugin<CampaignCleanerPluginOptions>;
+
+export type ExternalCampaignCleanerPlugin<
+	T extends CampaignCleanerPluginOptions,
+> = BaseCampaignCleanerPlugin<T>;
+
+export function campaigncleaner<const T extends CampaignCleanerPluginOptions>(
+	incomingOptions: CampaignCleanerPluginOptions &
+		T = {} as CampaignCleanerPluginOptions & T,
+): ExternalCampaignCleanerPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: 'api_key' as const,
+	};
+
+	return {
+		id: 'campaigncleaner',
+		authConfig: campaignCleanerAuthConfig,
+		schema: CampaignCleanerSchema,
+		options,
+		hooks: options.hooks,
+		endpoints: campaignCleanerEndpointsNested,
+		webhooks: {},
+		endpointMeta: campaignCleanerEndpointMeta,
+		endpointSchemas: campaignCleanerEndpointSchemas,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: CampaignCleanerKeyBuilderContext, source) => {
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys.get_api_key();
+				return res ?? '';
+			}
+
+			return '';
+		},
+	} satisfies InternalCampaignCleanerPlugin;
+}
+
+export type {
+	CampaignCleanerEndpointInputs,
+	CampaignCleanerEndpointOutputs,
+	DeleteCampaignInput,
+	DeleteCampaignResponse,
+	GetCampaignListInput,
+	GetCampaignListResponse,
+	GetCampaignPdfAnalysisInput,
+	GetCampaignPdfAnalysisResponse,
+	GetCampaignStatusInput,
+	GetCampaignStatusResponse,
+	GetCreditsInput,
+	GetCreditsResponse,
+} from './endpoints/types';

--- a/packages/campaigncleaner/jest.config.cjs
+++ b/packages/campaigncleaner/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/campaigncleaner/package.json
+++ b/packages/campaigncleaner/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/campaigncleaner",
+  "version": "0.1.0",
+  "description": "CampaignCleaner plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "campaigncleaner",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/campaigncleaner/schema.test.ts
+++ b/packages/campaigncleaner/schema.test.ts
@@ -1,0 +1,22 @@
+import { CampaignCleanerSchema } from './schema';
+
+describe('CampaignCleaner schema', () => {
+	it('declares a semver version', () => {
+		expect(CampaignCleanerSchema.version).toBeDefined();
+		expect(CampaignCleanerSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof CampaignCleanerSchema.entities).toBe('object');
+		expect(CampaignCleanerSchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(CampaignCleanerSchema.entities))).toBe(
+			true,
+		);
+		for (const entity of Object.values(CampaignCleanerSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/campaigncleaner/schema/index.ts
+++ b/packages/campaigncleaner/schema/index.ts
@@ -1,0 +1,4 @@
+export const CampaignCleanerSchema = {
+	version: '1.0.0',
+	entities: {},
+} as const;

--- a/packages/campaigncleaner/tsconfig.json
+++ b/packages/campaigncleaner/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/campaigncleaner/tsup.config.ts
+++ b/packages/campaigncleaner/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -86,16 +86,16 @@ export const BaseProviders = [
 	'boloforms',
 	'boltiot',
 	'bonsai',
-	'botbaba',
 	'bookingmood',
+	'botbaba',
 	'botpress',
 	'botsonic',
 	'bouncer',
 	'box',
 	'boxhero',
 	'brandfetch',
-	'brevo',
 	'breathehr',
+	'brevo',
 	'brex',
 	'brightdata',
 	'browseai',
@@ -106,6 +106,7 @@ export const BaseProviders = [
 	'buildkite',
 	'cal',
 	'calendly',
+	'campaigncleaner',
 	'canva',
 	'canvas',
 	'capsulecrm',
@@ -264,10 +265,10 @@ export const BaseProviders = [
 	'webvizio',
 	'whatsapp',
 	'witai',
-	'worldnewsapi',
 	'wiza',
 	'workday',
 	'workiom',
+	'worldnewsapi',
 	'xquik',
 	'youcom',
 	'youtube',
@@ -352,16 +353,16 @@ export const ProviderDisplayNames = {
 	boloforms: 'Boloforms',
 	boltiot: 'Bolt IoT',
 	bonsai: 'Bonsai',
-	botbaba: 'Botbaba',
 	bookingmood: 'Bookingmood',
+	botbaba: 'Botbaba',
 	botpress: 'Botpress',
 	botsonic: 'Botsonic',
 	bouncer: 'Bouncer',
 	box: 'Box',
 	boxhero: 'BoxHero',
 	brandfetch: 'Brandfetch',
-	brevo: 'Brevo',
 	breathehr: 'Breathe HR',
+	brevo: 'Brevo',
 	brex: 'Brex',
 	brightdata: 'Bright Data',
 	browseai: 'Browse AI',
@@ -372,6 +373,7 @@ export const ProviderDisplayNames = {
 	buildkite: 'Buildkite',
 	cal: 'Cal',
 	calendly: 'Calendly',
+	campaigncleaner: 'CampaignCleaner',
 	canva: 'Canva',
 	canvas: 'Canvas LMS',
 	capsulecrm: 'Capsule CRM',
@@ -530,10 +532,10 @@ export const ProviderDisplayNames = {
 	webvizio: 'Webvizio',
 	whatsapp: 'WhatsApp',
 	witai: 'WitAi',
-	worldnewsapi: 'World News API',
 	wiza: 'Wiza',
 	workday: 'Workday',
 	workiom: 'Workiom',
+	worldnewsapi: 'World News API',
 	xquik: 'XQuik',
 	youcom: 'You.com',
 	youtube: 'YouTube',
@@ -625,16 +627,16 @@ export type AllProviders =
 	| 'boloforms'
 	| 'boltiot'
 	| 'bonsai'
-	| 'botbaba'
 	| 'bookingmood'
+	| 'botbaba'
 	| 'botpress'
 	| 'botsonic'
 	| 'bouncer'
 	| 'box'
 	| 'boxhero'
 	| 'brandfetch'
-	| 'brevo'
 	| 'breathehr'
+	| 'brevo'
 	| 'brex'
 	| 'brightdata'
 	| 'browseai'
@@ -645,6 +647,7 @@ export type AllProviders =
 	| 'buildkite'
 	| 'cal'
 	| 'calendly'
+	| 'campaigncleaner'
 	| 'canva'
 	| 'canvas'
 	| 'capsulecrm'
@@ -803,10 +806,10 @@ export type AllProviders =
 	| 'webvizio'
 	| 'whatsapp'
 	| 'witai'
-	| 'worldnewsapi'
 	| 'wiza'
 	| 'workday'
 	| 'workiom'
+	| 'worldnewsapi'
 	| 'xquik'
 	| 'youcom'
 	| 'youtube'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2587,6 +2587,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/campaigncleaner:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/canva:
     devDependencies:
       '@types/jest':


### PR DESCRIPTION
## Summary

- Add Campaign Cleaner API integration
- Add API key authentication using X-CC-API-Key
- Add 5 Campaign Cleaner operations:
  - Delete Campaign
  - Get Campaign List
  - Get Campaign Status
  - Download Campaign PDF Analysis
  - Get Credits
- Add typed Zod schemas and error handling
- Add plugin schema tests

## Issue

Closes #1335

## Validation

- TypeScript typecheck passed
- Plugin structural validation passed
- Campaign Cleaner build passed
- Jest tests passed (2/2)
- Root typecheck passed during push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Campaign Cleaner integration support.
  - Added access to campaign lists, statuses, PDF analysis, credits, and campaign deletion.
  - Added API-key authentication and structured request/response validation.
  - Added automatic retry handling for rate-limit errors and clear handling for authentication failures.
  - Added Campaign Cleaner to the available provider list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->