### PR TITLE
feat(canny): add Canny integration plugin

### DIFF
--- a/demo/testing/package.json
+++ b/demo/testing/package.json
@@ -27,6 +27,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.0",
     "@corsair-dev/agentql": "workspace:*",
     "@corsair-dev/bitwarden": "workspace:*",
+    "@corsair-dev/canny": "workspace:*",
     "@corsair-dev/cursor": "workspace:*",
     "@corsair-dev/firecrawl": "workspace:*",
     "@corsair-dev/github": "workspace:*",

--- a/demo/testing/package.json
+++ b/demo/testing/package.json
@@ -27,7 +27,6 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.0",
     "@corsair-dev/agentql": "workspace:*",
     "@corsair-dev/bitwarden": "workspace:*",
-    "@corsair-dev/canny": "workspace:*",
     "@corsair-dev/cursor": "workspace:*",
     "@corsair-dev/firecrawl": "workspace:*",
     "@corsair-dev/github": "workspace:*",

--- a/demo/testing/src/scripts/test-script.ts
+++ b/demo/testing/src/scripts/test-script.ts
@@ -4,25 +4,61 @@ dotenv.config({ path: '../.env' });
 
 import { corsair } from '@/server/corsair';
 
-async function setInstagramCredentials() {
-	const { FACEBOOK_APP_ID, FACEBOOK_APP_SECRET, IG_ACCESS_TOKEN } = process.env;
+async function testCanny() {
+	console.log('Testing Canny plugin...');
 
-	if (FACEBOOK_APP_ID) {
-		await corsair.keys.instagram.set_client_id(FACEBOOK_APP_ID);
-	}
-	if (FACEBOOK_APP_SECRET) {
-		await corsair.keys.instagram.set_client_secret(FACEBOOK_APP_SECRET);
-	}
-	if (IG_ACCESS_TOKEN) {
-		await corsair.instagram.keys.set_access_token(IG_ACCESS_TOKEN);
-	}
+	// 1. List boards
+	const boardsResponse = await corsair.canny.api.boards.list({});
+	console.log('Listed boards:', boardsResponse.boards?.length ?? 0);
+
+	const boardID = boardsResponse.boards?.[0]?.id ?? 'board_placeholder_id';
+	const authorID = 'user_placeholder_id';
+
+	// 2. Create a post
+	const postResponse = await corsair.canny.api.posts.create({
+		authorID,
+		boardID,
+		title: 'New Feature Request',
+		details: 'Please add support for custom themes and dark mode.',
+	});
+	console.log('Created post ID:', postResponse.id);
+
+	const postID = postResponse.id ?? 'post_placeholder_id';
+
+	// 3. List posts
+	const postsResponse = await corsair.canny.api.posts.list({
+		boardID,
+		limit: 5,
+	});
+	console.log('Listed posts:', postsResponse.posts?.length ?? 0);
+
+	// 4. Create a comment
+	const commentResponse = await corsair.canny.api.comments.create({
+		authorID,
+		postID,
+		value: 'I would also love this feature!',
+	});
+	console.log('Created comment ID:', commentResponse.id);
+
+	// 5. Create a vote
+	const voteResponse = await corsair.canny.api.votes.create({
+		postID,
+		voterID: authorID,
+	});
+	console.log('Created vote result:', voteResponse);
+
+	// 6. Change a post's status
+	const statusResponse = await corsair.canny.api.posts.changeStatus({
+		changerID: authorID,
+		postID,
+		status: 'in progress',
+		commentValue: 'Starting work on this feature now!',
+	});
+	console.log('Updated post status:', statusResponse.status);
 }
 
 const main = async () => {
-	const res = await corsair.slack.api.messages.post({
-		channel: 'general',
-		text: 'hello',
-	});
+	await testCanny();
 };
 
 main().catch((err) => {

--- a/demo/testing/src/scripts/test-script.ts
+++ b/demo/testing/src/scripts/test-script.ts
@@ -4,61 +4,25 @@ dotenv.config({ path: '../.env' });
 
 import { corsair } from '@/server/corsair';
 
-async function testCanny() {
-	console.log('Testing Canny plugin...');
+async function setInstagramCredentials() {
+	const { FACEBOOK_APP_ID, FACEBOOK_APP_SECRET, IG_ACCESS_TOKEN } = process.env;
 
-	// 1. List boards
-	const boardsResponse = await corsair.canny.api.boards.list({});
-	console.log('Listed boards:', boardsResponse.boards?.length ?? 0);
-
-	const boardID = boardsResponse.boards?.[0]?.id ?? 'board_placeholder_id';
-	const authorID = 'user_placeholder_id';
-
-	// 2. Create a post
-	const postResponse = await corsair.canny.api.posts.create({
-		authorID,
-		boardID,
-		title: 'New Feature Request',
-		details: 'Please add support for custom themes and dark mode.',
-	});
-	console.log('Created post ID:', postResponse.id);
-
-	const postID = postResponse.id ?? 'post_placeholder_id';
-
-	// 3. List posts
-	const postsResponse = await corsair.canny.api.posts.list({
-		boardID,
-		limit: 5,
-	});
-	console.log('Listed posts:', postsResponse.posts?.length ?? 0);
-
-	// 4. Create a comment
-	const commentResponse = await corsair.canny.api.comments.create({
-		authorID,
-		postID,
-		value: 'I would also love this feature!',
-	});
-	console.log('Created comment ID:', commentResponse.id);
-
-	// 5. Create a vote
-	const voteResponse = await corsair.canny.api.votes.create({
-		postID,
-		voterID: authorID,
-	});
-	console.log('Created vote result:', voteResponse);
-
-	// 6. Change a post's status
-	const statusResponse = await corsair.canny.api.posts.changeStatus({
-		changerID: authorID,
-		postID,
-		status: 'in progress',
-		commentValue: 'Starting work on this feature now!',
-	});
-	console.log('Updated post status:', statusResponse.status);
+	if (FACEBOOK_APP_ID) {
+		await corsair.keys.instagram.set_client_id(FACEBOOK_APP_ID);
+	}
+	if (FACEBOOK_APP_SECRET) {
+		await corsair.keys.instagram.set_client_secret(FACEBOOK_APP_SECRET);
+	}
+	if (IG_ACCESS_TOKEN) {
+		await corsair.instagram.keys.set_access_token(IG_ACCESS_TOKEN);
+	}
 }
 
 const main = async () => {
-	await testCanny();
+	const res = await corsair.slack.api.messages.post({
+		channel: 'general',
+		text: 'hello',
+	});
 };
 
 main().catch((err) => {

--- a/demo/testing/src/server/corsair.ts
+++ b/demo/testing/src/server/corsair.ts
@@ -3,12 +3,10 @@ import dotenv from 'dotenv';
 dotenv.config({ path: '../.env' });
 
 import { agentql } from '@corsair-dev/agentql';
-import { canny } from '@corsair-dev/canny';
 import { gmail } from '@corsair-dev/gmail';
 import { googlecalendar } from '@corsair-dev/googlecalendar';
 import { googlesheets } from '@corsair-dev/googlesheets';
 import { hubspot } from '@corsair-dev/hubspot';
-import { instagram } from '@corsair-dev/instagram';
 import { linear } from '@corsair-dev/linear';
 import { onedrive } from '@corsair-dev/onedrive';
 import { sharepoint } from '@corsair-dev/sharepoint';
@@ -62,10 +60,6 @@ export const corsair = createCorsair({
 		vapi({
 			key: process.env.VAPI_API_KEY,
 			webhookSecret: process.env.VAPI_WEBHOOK_SECRET,
-		}),
-		canny({
-			key: process.env.CANNY_API_KEY,
-			webhookSecret: process.env.CANNY_WEBHOOK_SECRET,
 		}),
 		instagram(),
 	],

--- a/demo/testing/src/server/corsair.ts
+++ b/demo/testing/src/server/corsair.ts
@@ -3,10 +3,12 @@ import dotenv from 'dotenv';
 dotenv.config({ path: '../.env' });
 
 import { agentql } from '@corsair-dev/agentql';
+import { canny } from '@corsair-dev/canny';
 import { gmail } from '@corsair-dev/gmail';
 import { googlecalendar } from '@corsair-dev/googlecalendar';
 import { googlesheets } from '@corsair-dev/googlesheets';
 import { hubspot } from '@corsair-dev/hubspot';
+import { instagram } from '@corsair-dev/instagram';
 import { linear } from '@corsair-dev/linear';
 import { onedrive } from '@corsair-dev/onedrive';
 import { sharepoint } from '@corsair-dev/sharepoint';
@@ -60,6 +62,10 @@ export const corsair = createCorsair({
 		vapi({
 			key: process.env.VAPI_API_KEY,
 			webhookSecret: process.env.VAPI_WEBHOOK_SECRET,
+		}),
+		canny({
+			key: process.env.CANNY_API_KEY,
+			webhookSecret: process.env.CANNY_WEBHOOK_SECRET,
 		}),
 		instagram(),
 	],

--- a/packages/canny/client.ts
+++ b/packages/canny/client.ts
@@ -1,13 +1,39 @@
 import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
-import { request } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+
+export type CannyAPIErrorOptions = {
+	cause?: Error;
+	status?: number;
+	statusText?: string;
+	body?: unknown;
+	retryAfter?: number;
+};
 
 export class CannyAPIError extends Error {
+	public readonly status?: number;
+	public readonly statusText?: string;
+	public readonly body?: unknown;
+	public readonly retryAfter?: number;
+
 	constructor(
 		message: string,
 		public readonly code?: string,
+		options: CannyAPIErrorOptions = {},
 	) {
-		super(message);
+		super(message, options);
 		this.name = 'CannyAPIError';
+
+		if (options.cause instanceof ApiError) {
+			this.status = options.cause.status;
+			this.statusText = options.cause.statusText;
+			this.body = options.cause.body;
+			this.retryAfter = options.cause.retryAfter;
+		} else {
+			this.status = options.status;
+			this.statusText = options.statusText;
+			this.body = options.body;
+			this.retryAfter = options.retryAfter;
+		}
 	}
 }
 
@@ -51,9 +77,24 @@ export async function makeCannyRequest<T>(
 	try {
 		return await request<T>(config, requestOptions);
 	} catch (error) {
+		if (error instanceof ApiError) {
+			const errorBody = error.body;
+			const message =
+				typeof errorBody === 'object' &&
+				errorBody !== null &&
+				'error' in errorBody &&
+				typeof (errorBody as { error?: unknown }).error === 'string'
+					? (errorBody as { error: string }).error
+					: error.message;
+
+			const code = error.status?.toString();
+			throw new CannyAPIError(message, code, { cause: error });
+		}
+
 		if (error instanceof Error) {
 			throw new CannyAPIError(error.message);
 		}
+
 		throw new CannyAPIError('Unknown error');
 	}
 }

--- a/packages/canny/client.ts
+++ b/packages/canny/client.ts
@@ -1,0 +1,59 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { request } from 'corsair/http';
+
+export class CannyAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly code?: string,
+	) {
+		super(message);
+		this.name = 'CannyAPIError';
+	}
+}
+
+const CANNY_API_BASE = 'https://canny.io/api/v1';
+
+export async function makeCannyRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	options: {
+		method?: 'POST';
+		body?: Record<string, unknown>;
+	} = {},
+): Promise<T> {
+	const { body = {} } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: CANNY_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: apiKey,
+		HEADERS: {
+			'Content-Type': 'application/json',
+		},
+	};
+
+	const formattedEndpoint = endpoint.startsWith('/')
+		? endpoint
+		: `/${endpoint}`;
+
+	const requestOptions: ApiRequestOptions = {
+		method: 'POST',
+		url: formattedEndpoint,
+		body: {
+			apiKey,
+			...body,
+		},
+		mediaType: 'application/json; charset=utf-8',
+	};
+
+	try {
+		return await request<T>(config, requestOptions);
+	} catch (error) {
+		if (error instanceof Error) {
+			throw new CannyAPIError(error.message);
+		}
+		throw new CannyAPIError('Unknown error');
+	}
+}

--- a/packages/canny/endpoints.test.ts
+++ b/packages/canny/endpoints.test.ts
@@ -226,7 +226,7 @@ describe('Canny endpoints routing & event logging', () => {
 			const input = {
 				changerID: 'user_123',
 				postID: 'post_123',
-				status: 'planned',
+				status: 'planned' as const,
 			};
 			const result = await Posts.changeStatus(ctx, input);
 			expect(result).toEqual(updatedPost);

--- a/packages/canny/endpoints.test.ts
+++ b/packages/canny/endpoints.test.ts
@@ -1,0 +1,424 @@
+import { logEventFromContext } from 'corsair/core';
+import * as client from './client';
+import { Boards, Comments, Posts, Votes } from './endpoints';
+import type { CannyContext } from './index';
+
+jest.mock('./client', () => {
+	const actual = jest.requireActual('./client');
+	return {
+		...actual,
+		makeCannyRequest: jest.fn(),
+	};
+});
+
+jest.mock('corsair/core', () => {
+	const actual = jest.requireActual('corsair/core');
+	return {
+		...actual,
+		logEventFromContext: jest.fn(),
+	};
+});
+
+describe('Canny endpoints routing & event logging', () => {
+	const mockMakeCannyRequest = client.makeCannyRequest as jest.MockedFunction<
+		typeof client.makeCannyRequest
+	>;
+	const mockLogEventFromContext = logEventFromContext as jest.MockedFunction<
+		typeof logEventFromContext
+	>;
+
+	const mockBoard = {
+		id: 'board_123',
+		name: 'Feature Requests',
+		created: '2026-01-01T00:00:00.000Z',
+		isPrivate: false,
+		postCount: 10,
+		privateComments: false,
+		url: 'https://example.canny.io/feature-requests',
+	};
+
+	const mockUser = {
+		id: 'user_123',
+		name: 'Jane Doe',
+		created: '2026-01-01T00:00:00.000Z',
+		email: 'jane@example.com',
+		url: 'https://example.canny.io/users/jane',
+		isAdmin: false,
+	};
+
+	const mockPost = {
+		id: 'post_123',
+		title: 'Dark Mode',
+		details: 'Please add dark mode',
+		score: 42,
+		status: 'open',
+		created: '2026-01-01T00:00:00.000Z',
+		url: 'https://example.canny.io/p/dark-mode',
+		commentCount: 2,
+		author: mockUser,
+		board: mockBoard,
+	};
+
+	const mockComment = {
+		id: 'comment_123',
+		value: 'Great idea!',
+		created: '2026-01-01T00:00:00.000Z',
+		author: mockUser,
+		post: mockPost,
+	};
+
+	const mockVote = {
+		id: 'vote_123',
+		created: '2026-01-01T00:00:00.000Z',
+		post: mockPost,
+		voter: mockUser,
+	};
+
+	const ctx = {
+		key: 'canny_test_api_key',
+		db: {
+			boards: {
+				upsertByEntityId: jest.fn(),
+				deleteByEntityId: jest.fn(),
+			},
+			posts: {
+				upsertByEntityId: jest.fn(),
+				deleteByEntityId: jest.fn(),
+			},
+			comments: {
+				upsertByEntityId: jest.fn(),
+				deleteByEntityId: jest.fn(),
+			},
+			votes: {
+				upsertByEntityId: jest.fn(),
+				deleteByEntityId: jest.fn(),
+			},
+		},
+	} as unknown as CannyContext;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('Boards endpoints', () => {
+		it('boards.list issues POST /boards/list and logs event', async () => {
+			mockMakeCannyRequest.mockResolvedValueOnce({
+				boards: [mockBoard],
+			});
+
+			const result = await Boards.list(ctx, {});
+			expect(result).toEqual({ boards: [mockBoard] });
+			expect(mockMakeCannyRequest).toHaveBeenCalledWith(
+				'boards/list',
+				'canny_test_api_key',
+				{
+					method: 'POST',
+					body: {},
+				},
+			);
+			expect(mockLogEventFromContext).toHaveBeenCalledWith(
+				ctx,
+				'canny.boards.list',
+				{},
+				'completed',
+			);
+		});
+
+		it('boards.retrieve issues POST /boards/retrieve and logs event', async () => {
+			mockMakeCannyRequest.mockResolvedValueOnce(mockBoard);
+
+			const result = await Boards.retrieve(ctx, { id: 'board_123' });
+			expect(result).toEqual(mockBoard);
+			expect(mockMakeCannyRequest).toHaveBeenCalledWith(
+				'boards/retrieve',
+				'canny_test_api_key',
+				{
+					method: 'POST',
+					body: { id: 'board_123' },
+				},
+			);
+			expect(mockLogEventFromContext).toHaveBeenCalledWith(
+				ctx,
+				'canny.boards.retrieve',
+				{ id: 'board_123' },
+				'completed',
+			);
+		});
+	});
+
+	describe('Posts endpoints', () => {
+		it('posts.list issues POST /posts/list and logs event', async () => {
+			mockMakeCannyRequest.mockResolvedValueOnce({
+				hasMore: false,
+				posts: [mockPost],
+			});
+
+			const result = await Posts.list(ctx, { limit: 10 });
+			expect(result).toEqual({ hasMore: false, posts: [mockPost] });
+			expect(mockMakeCannyRequest).toHaveBeenCalledWith(
+				'posts/list',
+				'canny_test_api_key',
+				{
+					method: 'POST',
+					body: { limit: 10 },
+				},
+			);
+			expect(mockLogEventFromContext).toHaveBeenCalledWith(
+				ctx,
+				'canny.posts.list',
+				{ limit: 10 },
+				'completed',
+			);
+		});
+
+		it('posts.retrieve issues POST /posts/retrieve and logs event', async () => {
+			mockMakeCannyRequest.mockResolvedValueOnce(mockPost);
+
+			const result = await Posts.retrieve(ctx, { id: 'post_123' });
+			expect(result).toEqual(mockPost);
+			expect(mockMakeCannyRequest).toHaveBeenCalledWith(
+				'posts/retrieve',
+				'canny_test_api_key',
+				{
+					method: 'POST',
+					body: { id: 'post_123' },
+				},
+			);
+			expect(mockLogEventFromContext).toHaveBeenCalledWith(
+				ctx,
+				'canny.posts.retrieve',
+				{ id: 'post_123' },
+				'completed',
+			);
+		});
+
+		it('posts.create issues POST /posts/create and logs event', async () => {
+			mockMakeCannyRequest.mockResolvedValueOnce({ id: 'post_123' });
+
+			const input = {
+				authorID: 'user_123',
+				boardID: 'board_123',
+				title: 'Dark Mode',
+				details: 'Please add dark mode',
+			};
+			const result = await Posts.create(ctx, input);
+			expect(result).toEqual({ id: 'post_123' });
+			expect(mockMakeCannyRequest).toHaveBeenCalledWith(
+				'posts/create',
+				'canny_test_api_key',
+				{
+					method: 'POST',
+					body: input,
+				},
+			);
+			expect(mockLogEventFromContext).toHaveBeenCalledWith(
+				ctx,
+				'canny.posts.create',
+				{ ...input, id: 'post_123' },
+				'completed',
+			);
+		});
+
+		it('posts.changeStatus issues POST /posts/changeStatus and logs event', async () => {
+			const updatedPost = { ...mockPost, status: 'planned' };
+			mockMakeCannyRequest.mockResolvedValueOnce(updatedPost);
+
+			const input = {
+				changerID: 'user_123',
+				postID: 'post_123',
+				status: 'planned',
+			};
+			const result = await Posts.changeStatus(ctx, input);
+			expect(result).toEqual(updatedPost);
+			expect(mockMakeCannyRequest).toHaveBeenCalledWith(
+				'posts/changeStatus',
+				'canny_test_api_key',
+				{
+					method: 'POST',
+					body: input,
+				},
+			);
+			expect(mockLogEventFromContext).toHaveBeenCalledWith(
+				ctx,
+				'canny.posts.changeStatus',
+				input,
+				'completed',
+			);
+		});
+
+		it('posts.delete issues POST /posts/delete and logs event', async () => {
+			mockMakeCannyRequest.mockResolvedValueOnce('success');
+
+			const result = await Posts.delete(ctx, { postID: 'post_123' });
+			expect(result).toBe('success');
+			expect(mockMakeCannyRequest).toHaveBeenCalledWith(
+				'posts/delete',
+				'canny_test_api_key',
+				{
+					method: 'POST',
+					body: { postID: 'post_123' },
+				},
+			);
+			expect(mockLogEventFromContext).toHaveBeenCalledWith(
+				ctx,
+				'canny.posts.delete',
+				{ postID: 'post_123' },
+				'completed',
+			);
+		});
+	});
+
+	describe('Comments endpoints', () => {
+		it('comments.list issues POST /comments/list and logs event', async () => {
+			mockMakeCannyRequest.mockResolvedValueOnce({
+				comments: [mockComment],
+				hasMore: false,
+			});
+
+			const result = await Comments.list(ctx, { postID: 'post_123' });
+			expect(result).toEqual({
+				comments: [mockComment],
+				hasMore: false,
+			});
+			expect(mockMakeCannyRequest).toHaveBeenCalledWith(
+				'comments/list',
+				'canny_test_api_key',
+				{
+					method: 'POST',
+					body: { postID: 'post_123' },
+				},
+			);
+			expect(mockLogEventFromContext).toHaveBeenCalledWith(
+				ctx,
+				'canny.comments.list',
+				{ postID: 'post_123' },
+				'completed',
+			);
+		});
+
+		it('comments.create issues POST /comments/create and logs event', async () => {
+			mockMakeCannyRequest.mockResolvedValueOnce({ id: 'comment_123' });
+
+			const input = {
+				authorID: 'user_123',
+				postID: 'post_123',
+				value: 'Great idea!',
+			};
+			const result = await Comments.create(ctx, input);
+			expect(result).toEqual({ id: 'comment_123' });
+			expect(mockMakeCannyRequest).toHaveBeenCalledWith(
+				'comments/create',
+				'canny_test_api_key',
+				{
+					method: 'POST',
+					body: input,
+				},
+			);
+			expect(mockLogEventFromContext).toHaveBeenCalledWith(
+				ctx,
+				'canny.comments.create',
+				{ ...input, id: 'comment_123' },
+				'completed',
+			);
+		});
+
+		it('comments.delete issues POST /comments/delete and logs event', async () => {
+			mockMakeCannyRequest.mockResolvedValueOnce('success');
+
+			const result = await Comments.delete(ctx, {
+				commentID: 'comment_123',
+			});
+			expect(result).toBe('success');
+			expect(mockMakeCannyRequest).toHaveBeenCalledWith(
+				'comments/delete',
+				'canny_test_api_key',
+				{
+					method: 'POST',
+					body: { commentID: 'comment_123' },
+				},
+			);
+			expect(mockLogEventFromContext).toHaveBeenCalledWith(
+				ctx,
+				'canny.comments.delete',
+				{ commentID: 'comment_123' },
+				'completed',
+			);
+		});
+	});
+
+	describe('Votes endpoints', () => {
+		it('votes.list issues POST /votes/list and logs event', async () => {
+			mockMakeCannyRequest.mockResolvedValueOnce({
+				hasMore: false,
+				votes: [mockVote],
+			});
+
+			const result = await Votes.list(ctx, { postID: 'post_123' });
+			expect(result).toEqual({ hasMore: false, votes: [mockVote] });
+			expect(mockMakeCannyRequest).toHaveBeenCalledWith(
+				'votes/list',
+				'canny_test_api_key',
+				{
+					method: 'POST',
+					body: { postID: 'post_123' },
+				},
+			);
+			expect(mockLogEventFromContext).toHaveBeenCalledWith(
+				ctx,
+				'canny.votes.list',
+				{ postID: 'post_123' },
+				'completed',
+			);
+		});
+
+		it('votes.create issues POST /votes/create and logs event', async () => {
+			mockMakeCannyRequest.mockResolvedValueOnce('success');
+
+			const input = {
+				postID: 'post_123',
+				voterID: 'user_123',
+			};
+			const result = await Votes.create(ctx, input);
+			expect(result).toBe('success');
+			expect(mockMakeCannyRequest).toHaveBeenCalledWith(
+				'votes/create',
+				'canny_test_api_key',
+				{
+					method: 'POST',
+					body: input,
+				},
+			);
+			expect(mockLogEventFromContext).toHaveBeenCalledWith(
+				ctx,
+				'canny.votes.create',
+				input,
+				'completed',
+			);
+		});
+
+		it('votes.delete issues POST /votes/delete and logs event', async () => {
+			mockMakeCannyRequest.mockResolvedValueOnce('success');
+
+			const input = {
+				postID: 'post_123',
+				voterID: 'user_123',
+			};
+			const result = await Votes.delete(ctx, input);
+			expect(result).toBe('success');
+			expect(mockMakeCannyRequest).toHaveBeenCalledWith(
+				'votes/delete',
+				'canny_test_api_key',
+				{
+					method: 'POST',
+					body: input,
+				},
+			);
+			expect(mockLogEventFromContext).toHaveBeenCalledWith(
+				ctx,
+				'canny.votes.delete',
+				input,
+				'completed',
+			);
+		});
+	});
+});

--- a/packages/canny/endpoints/boards.ts
+++ b/packages/canny/endpoints/boards.ts
@@ -1,17 +1,15 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeCannyRequest } from '../client';
 import type { CannyEndpoints } from '../index';
-import type { CannyEndpointOutputs } from './types';
+import { CannyEndpointInputSchemas, CannyEndpointOutputSchemas } from './types';
 
 export const list: CannyEndpoints['boardsList'] = async (ctx, input) => {
-	const response = await makeCannyRequest<CannyEndpointOutputs['boardsList']>(
-		'boards/list',
-		ctx.key,
-		{
-			method: 'POST',
-			body: input ? { ...input } : {},
-		},
-	);
+	const parsedInput = CannyEndpointInputSchemas.boardsList.parse(input);
+	const raw = await makeCannyRequest<unknown>('boards/list', ctx.key, {
+		method: 'POST',
+		body: parsedInput ? { ...parsedInput } : {},
+	});
+	const response = CannyEndpointOutputSchemas.boardsList.parse(raw);
 
 	if (ctx.db.boards && response.boards) {
 		for (const board of response.boards) {
@@ -35,7 +33,7 @@ export const list: CannyEndpoints['boardsList'] = async (ctx, input) => {
 	await logEventFromContext(
 		ctx,
 		'canny.boards.list',
-		{ ...input },
+		{ ...parsedInput },
 		'completed',
 	);
 	return response;
@@ -45,12 +43,12 @@ export const retrieve: CannyEndpoints['boardsRetrieve'] = async (
 	ctx,
 	input,
 ) => {
-	const response = await makeCannyRequest<
-		CannyEndpointOutputs['boardsRetrieve']
-	>('boards/retrieve', ctx.key, {
+	const parsedInput = CannyEndpointInputSchemas.boardsRetrieve.parse(input);
+	const raw = await makeCannyRequest<unknown>('boards/retrieve', ctx.key, {
 		method: 'POST',
-		body: { id: input.id },
+		body: { id: parsedInput.id },
 	});
+	const response = CannyEndpointOutputSchemas.boardsRetrieve.parse(raw);
 
 	if (ctx.db.boards && response.id) {
 		try {
@@ -72,7 +70,7 @@ export const retrieve: CannyEndpoints['boardsRetrieve'] = async (
 	await logEventFromContext(
 		ctx,
 		'canny.boards.retrieve',
-		{ ...input },
+		{ ...parsedInput },
 		'completed',
 	);
 	return response;

--- a/packages/canny/endpoints/boards.ts
+++ b/packages/canny/endpoints/boards.ts
@@ -1,0 +1,84 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeCannyRequest } from '../client';
+import type { CannyEndpoints } from '../index';
+import type { CannyEndpointOutputs } from './types';
+
+export const list: CannyEndpoints['boardsList'] = async (ctx, input) => {
+	const response = await makeCannyRequest<CannyEndpointOutputs['boardsList']>(
+		'boards/list',
+		ctx.key,
+		{
+			method: 'POST',
+			body: input ? { ...input } : {},
+		},
+	);
+
+	if (ctx.db.boards && response.boards) {
+		for (const board of response.boards) {
+			try {
+				await ctx.db.boards.upsertByEntityId(board.id, {
+					id: board.id,
+					name: board.name,
+					created: new Date(board.created),
+					isPrivate: board.isPrivate,
+					postCount: board.postCount,
+					privateComments: board.privateComments,
+					url: board.url,
+					token: board.token,
+				});
+			} catch (error) {
+				console.warn('Failed to persist board to database:', error);
+			}
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'canny.boards.list',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+export const retrieve: CannyEndpoints['boardsRetrieve'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeCannyRequest<
+		CannyEndpointOutputs['boardsRetrieve']
+	>('boards/retrieve', ctx.key, {
+		method: 'POST',
+		body: { id: input.id },
+	});
+
+	if (ctx.db.boards && response.id) {
+		try {
+			await ctx.db.boards.upsertByEntityId(response.id, {
+				id: response.id,
+				name: response.name,
+				created: new Date(response.created),
+				isPrivate: response.isPrivate,
+				postCount: response.postCount,
+				privateComments: response.privateComments,
+				url: response.url,
+				token: response.token,
+			});
+		} catch (error) {
+			console.warn('Failed to persist board to database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'canny.boards.retrieve',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+export const Boards = {
+	list,
+	retrieve,
+};

--- a/packages/canny/endpoints/comments.ts
+++ b/packages/canny/endpoints/comments.ts
@@ -1,0 +1,94 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeCannyRequest } from '../client';
+import type { CannyEndpoints } from '../index';
+import type { CannyEndpointOutputs } from './types';
+
+export const list: CannyEndpoints['commentsList'] = async (ctx, input) => {
+	const response = await makeCannyRequest<CannyEndpointOutputs['commentsList']>(
+		'comments/list',
+		ctx.key,
+		{
+			method: 'POST',
+			body: input ? { ...input } : {},
+		},
+	);
+
+	if (ctx.db.comments && response.comments) {
+		for (const comment of response.comments) {
+			try {
+				await ctx.db.comments.upsertByEntityId(comment.id, {
+					id: comment.id,
+					value: comment.value,
+					created: new Date(comment.created),
+					postID: comment.post?.id,
+					authorID: comment.author?.id,
+					parentID: comment.parentID,
+					internal: comment.internal,
+					likeCount: comment.likeCount,
+					imageURLs: comment.imageURLs,
+				});
+			} catch (error) {
+				console.warn('Failed to persist comment to database:', error);
+			}
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'canny.comments.list',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+export const create: CannyEndpoints['commentsCreate'] = async (ctx, input) => {
+	const response = await makeCannyRequest<
+		CannyEndpointOutputs['commentsCreate']
+	>('comments/create', ctx.key, {
+		method: 'POST',
+		body: { ...input },
+	});
+
+	await logEventFromContext(
+		ctx,
+		'canny.comments.create',
+		{ ...input, id: response.id },
+		'completed',
+	);
+	return response;
+};
+
+export const deleteComment: CannyEndpoints['commentsDelete'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeCannyRequest<
+		CannyEndpointOutputs['commentsDelete']
+	>('comments/delete', ctx.key, {
+		method: 'POST',
+		body: { commentID: input.commentID },
+	});
+
+	if (ctx.db.comments) {
+		try {
+			await ctx.db.comments.deleteByEntityId(input.commentID);
+		} catch (error) {
+			console.warn('Failed to delete comment from database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'canny.comments.delete',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+export const Comments = {
+	list,
+	create,
+	delete: deleteComment,
+};

--- a/packages/canny/endpoints/comments.ts
+++ b/packages/canny/endpoints/comments.ts
@@ -1,17 +1,15 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeCannyRequest } from '../client';
 import type { CannyEndpoints } from '../index';
-import type { CannyEndpointOutputs } from './types';
+import { CannyEndpointInputSchemas, CannyEndpointOutputSchemas } from './types';
 
 export const list: CannyEndpoints['commentsList'] = async (ctx, input) => {
-	const response = await makeCannyRequest<CannyEndpointOutputs['commentsList']>(
-		'comments/list',
-		ctx.key,
-		{
-			method: 'POST',
-			body: input ? { ...input } : {},
-		},
-	);
+	const parsedInput = CannyEndpointInputSchemas.commentsList.parse(input);
+	const raw = await makeCannyRequest<unknown>('comments/list', ctx.key, {
+		method: 'POST',
+		body: parsedInput ? { ...parsedInput } : {},
+	});
+	const response = CannyEndpointOutputSchemas.commentsList.parse(raw);
 
 	if (ctx.db.comments && response.comments) {
 		for (const comment of response.comments) {
@@ -36,24 +34,24 @@ export const list: CannyEndpoints['commentsList'] = async (ctx, input) => {
 	await logEventFromContext(
 		ctx,
 		'canny.comments.list',
-		{ ...input },
+		{ ...parsedInput },
 		'completed',
 	);
 	return response;
 };
 
 export const create: CannyEndpoints['commentsCreate'] = async (ctx, input) => {
-	const response = await makeCannyRequest<
-		CannyEndpointOutputs['commentsCreate']
-	>('comments/create', ctx.key, {
+	const parsedInput = CannyEndpointInputSchemas.commentsCreate.parse(input);
+	const raw = await makeCannyRequest<unknown>('comments/create', ctx.key, {
 		method: 'POST',
-		body: { ...input },
+		body: { ...parsedInput },
 	});
+	const response = CannyEndpointOutputSchemas.commentsCreate.parse(raw);
 
 	await logEventFromContext(
 		ctx,
 		'canny.comments.create',
-		{ ...input, id: response.id },
+		{ ...parsedInput, id: response.id },
 		'completed',
 	);
 	return response;
@@ -63,16 +61,16 @@ export const deleteComment: CannyEndpoints['commentsDelete'] = async (
 	ctx,
 	input,
 ) => {
-	const response = await makeCannyRequest<
-		CannyEndpointOutputs['commentsDelete']
-	>('comments/delete', ctx.key, {
+	const parsedInput = CannyEndpointInputSchemas.commentsDelete.parse(input);
+	const raw = await makeCannyRequest<unknown>('comments/delete', ctx.key, {
 		method: 'POST',
-		body: { commentID: input.commentID },
+		body: { commentID: parsedInput.commentID },
 	});
+	const response = CannyEndpointOutputSchemas.commentsDelete.parse(raw);
 
 	if (ctx.db.comments) {
 		try {
-			await ctx.db.comments.deleteByEntityId(input.commentID);
+			await ctx.db.comments.deleteByEntityId(parsedInput.commentID);
 		} catch (error) {
 			console.warn('Failed to delete comment from database:', error);
 		}
@@ -81,7 +79,7 @@ export const deleteComment: CannyEndpoints['commentsDelete'] = async (
 	await logEventFromContext(
 		ctx,
 		'canny.comments.delete',
-		{ ...input },
+		{ ...parsedInput },
 		'completed',
 	);
 	return response;

--- a/packages/canny/endpoints/index.ts
+++ b/packages/canny/endpoints/index.ts
@@ -1,0 +1,7 @@
+import { Boards } from './boards';
+import { Comments } from './comments';
+import { Posts } from './posts';
+import { Votes } from './votes';
+
+export { Boards, Comments, Posts, Votes };
+export * from './types';

--- a/packages/canny/endpoints/posts.ts
+++ b/packages/canny/endpoints/posts.ts
@@ -1,0 +1,174 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeCannyRequest } from '../client';
+import type { CannyEndpoints } from '../index';
+import type { CannyEndpointOutputs } from './types';
+
+export const list: CannyEndpoints['postsList'] = async (ctx, input) => {
+	const response = await makeCannyRequest<CannyEndpointOutputs['postsList']>(
+		'posts/list',
+		ctx.key,
+		{
+			method: 'POST',
+			body: input ? { ...input } : {},
+		},
+	);
+
+	if (ctx.db.posts && response.posts) {
+		for (const post of response.posts) {
+			try {
+				await ctx.db.posts.upsertByEntityId(post.id, {
+					id: post.id,
+					title: post.title,
+					details: post.details,
+					score: post.score,
+					status: post.status,
+					created: new Date(post.created),
+					url: post.url,
+					commentCount: post.commentCount,
+					eta: post.eta,
+					imageURLs: post.imageURLs,
+					boardID: post.board?.id,
+					authorID: post.author?.id,
+				});
+			} catch (error) {
+				console.warn('Failed to persist post to database:', error);
+			}
+		}
+	}
+
+	await logEventFromContext(ctx, 'canny.posts.list', { ...input }, 'completed');
+	return response;
+};
+
+export const retrieve: CannyEndpoints['postsRetrieve'] = async (ctx, input) => {
+	const response = await makeCannyRequest<
+		CannyEndpointOutputs['postsRetrieve']
+	>('posts/retrieve', ctx.key, {
+		method: 'POST',
+		body: { ...input },
+	});
+
+	if (ctx.db.posts && response.id) {
+		try {
+			await ctx.db.posts.upsertByEntityId(response.id, {
+				id: response.id,
+				title: response.title,
+				details: response.details,
+				score: response.score,
+				status: response.status,
+				created: new Date(response.created),
+				url: response.url,
+				commentCount: response.commentCount,
+				eta: response.eta,
+				imageURLs: response.imageURLs,
+				boardID: response.board?.id,
+				authorID: response.author?.id,
+			});
+		} catch (error) {
+			console.warn('Failed to persist post to database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'canny.posts.retrieve',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+export const create: CannyEndpoints['postsCreate'] = async (ctx, input) => {
+	const response = await makeCannyRequest<CannyEndpointOutputs['postsCreate']>(
+		'posts/create',
+		ctx.key,
+		{
+			method: 'POST',
+			body: { ...input },
+		},
+	);
+
+	await logEventFromContext(
+		ctx,
+		'canny.posts.create',
+		{ ...input, id: response.id },
+		'completed',
+	);
+	return response;
+};
+
+export const changeStatus: CannyEndpoints['postsChangeStatus'] = async (
+	ctx,
+	input,
+) => {
+	const response = await makeCannyRequest<
+		CannyEndpointOutputs['postsChangeStatus']
+	>('posts/changeStatus', ctx.key, {
+		method: 'POST',
+		body: { ...input },
+	});
+
+	if (ctx.db.posts && response.id) {
+		try {
+			await ctx.db.posts.upsertByEntityId(response.id, {
+				id: response.id,
+				title: response.title,
+				details: response.details,
+				score: response.score,
+				status: response.status,
+				created: new Date(response.created),
+				url: response.url,
+				commentCount: response.commentCount,
+				eta: response.eta,
+				imageURLs: response.imageURLs,
+				boardID: response.board?.id,
+				authorID: response.author?.id,
+			});
+		} catch (error) {
+			console.warn('Failed to persist post to database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'canny.posts.changeStatus',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+export const deletePost: CannyEndpoints['postsDelete'] = async (ctx, input) => {
+	const response = await makeCannyRequest<CannyEndpointOutputs['postsDelete']>(
+		'posts/delete',
+		ctx.key,
+		{
+			method: 'POST',
+			body: { postID: input.postID },
+		},
+	);
+
+	if (ctx.db.posts) {
+		try {
+			await ctx.db.posts.deleteByEntityId(input.postID);
+		} catch (error) {
+			console.warn('Failed to delete post from database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'canny.posts.delete',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+export const Posts = {
+	list,
+	retrieve,
+	create,
+	changeStatus,
+	delete: deletePost,
+};

--- a/packages/canny/endpoints/posts.ts
+++ b/packages/canny/endpoints/posts.ts
@@ -1,17 +1,15 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeCannyRequest } from '../client';
 import type { CannyEndpoints } from '../index';
-import type { CannyEndpointOutputs } from './types';
+import { CannyEndpointInputSchemas, CannyEndpointOutputSchemas } from './types';
 
 export const list: CannyEndpoints['postsList'] = async (ctx, input) => {
-	const response = await makeCannyRequest<CannyEndpointOutputs['postsList']>(
-		'posts/list',
-		ctx.key,
-		{
-			method: 'POST',
-			body: input ? { ...input } : {},
-		},
-	);
+	const parsedInput = CannyEndpointInputSchemas.postsList.parse(input);
+	const raw = await makeCannyRequest<unknown>('posts/list', ctx.key, {
+		method: 'POST',
+		body: parsedInput ? { ...parsedInput } : {},
+	});
+	const response = CannyEndpointOutputSchemas.postsList.parse(raw);
 
 	if (ctx.db.posts && response.posts) {
 		for (const post of response.posts) {
@@ -36,17 +34,22 @@ export const list: CannyEndpoints['postsList'] = async (ctx, input) => {
 		}
 	}
 
-	await logEventFromContext(ctx, 'canny.posts.list', { ...input }, 'completed');
+	await logEventFromContext(
+		ctx,
+		'canny.posts.list',
+		{ ...parsedInput },
+		'completed',
+	);
 	return response;
 };
 
 export const retrieve: CannyEndpoints['postsRetrieve'] = async (ctx, input) => {
-	const response = await makeCannyRequest<
-		CannyEndpointOutputs['postsRetrieve']
-	>('posts/retrieve', ctx.key, {
+	const parsedInput = CannyEndpointInputSchemas.postsRetrieve.parse(input);
+	const raw = await makeCannyRequest<unknown>('posts/retrieve', ctx.key, {
 		method: 'POST',
-		body: { ...input },
+		body: { ...parsedInput },
 	});
+	const response = CannyEndpointOutputSchemas.postsRetrieve.parse(raw);
 
 	if (ctx.db.posts && response.id) {
 		try {
@@ -72,26 +75,24 @@ export const retrieve: CannyEndpoints['postsRetrieve'] = async (ctx, input) => {
 	await logEventFromContext(
 		ctx,
 		'canny.posts.retrieve',
-		{ ...input },
+		{ ...parsedInput },
 		'completed',
 	);
 	return response;
 };
 
 export const create: CannyEndpoints['postsCreate'] = async (ctx, input) => {
-	const response = await makeCannyRequest<CannyEndpointOutputs['postsCreate']>(
-		'posts/create',
-		ctx.key,
-		{
-			method: 'POST',
-			body: { ...input },
-		},
-	);
+	const parsedInput = CannyEndpointInputSchemas.postsCreate.parse(input);
+	const raw = await makeCannyRequest<unknown>('posts/create', ctx.key, {
+		method: 'POST',
+		body: { ...parsedInput },
+	});
+	const response = CannyEndpointOutputSchemas.postsCreate.parse(raw);
 
 	await logEventFromContext(
 		ctx,
 		'canny.posts.create',
-		{ ...input, id: response.id },
+		{ ...parsedInput, id: response.id },
 		'completed',
 	);
 	return response;
@@ -101,12 +102,12 @@ export const changeStatus: CannyEndpoints['postsChangeStatus'] = async (
 	ctx,
 	input,
 ) => {
-	const response = await makeCannyRequest<
-		CannyEndpointOutputs['postsChangeStatus']
-	>('posts/changeStatus', ctx.key, {
+	const parsedInput = CannyEndpointInputSchemas.postsChangeStatus.parse(input);
+	const raw = await makeCannyRequest<unknown>('posts/changeStatus', ctx.key, {
 		method: 'POST',
-		body: { ...input },
+		body: { ...parsedInput },
 	});
+	const response = CannyEndpointOutputSchemas.postsChangeStatus.parse(raw);
 
 	if (ctx.db.posts && response.id) {
 		try {
@@ -132,25 +133,23 @@ export const changeStatus: CannyEndpoints['postsChangeStatus'] = async (
 	await logEventFromContext(
 		ctx,
 		'canny.posts.changeStatus',
-		{ ...input },
+		{ ...parsedInput },
 		'completed',
 	);
 	return response;
 };
 
 export const deletePost: CannyEndpoints['postsDelete'] = async (ctx, input) => {
-	const response = await makeCannyRequest<CannyEndpointOutputs['postsDelete']>(
-		'posts/delete',
-		ctx.key,
-		{
-			method: 'POST',
-			body: { postID: input.postID },
-		},
-	);
+	const parsedInput = CannyEndpointInputSchemas.postsDelete.parse(input);
+	const raw = await makeCannyRequest<unknown>('posts/delete', ctx.key, {
+		method: 'POST',
+		body: { postID: parsedInput.postID },
+	});
+	const response = CannyEndpointOutputSchemas.postsDelete.parse(raw);
 
 	if (ctx.db.posts) {
 		try {
-			await ctx.db.posts.deleteByEntityId(input.postID);
+			await ctx.db.posts.deleteByEntityId(parsedInput.postID);
 		} catch (error) {
 			console.warn('Failed to delete post from database:', error);
 		}
@@ -159,7 +158,7 @@ export const deletePost: CannyEndpoints['postsDelete'] = async (ctx, input) => {
 	await logEventFromContext(
 		ctx,
 		'canny.posts.delete',
-		{ ...input },
+		{ ...parsedInput },
 		'completed',
 	);
 	return response;

--- a/packages/canny/endpoints/types.ts
+++ b/packages/canny/endpoints/types.ts
@@ -1,0 +1,435 @@
+import { z } from 'zod';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Core Canny Models
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const CannyUserSchema = z
+	.object({
+		id: z.string(),
+		created: z.string(),
+		email: z.string().nullable().optional(),
+		name: z.string(),
+		userID: z.string().nullable().optional(),
+		url: z.string(),
+		isAdmin: z.boolean(),
+		avatarURL: z.string().nullable().optional(),
+	})
+	.catchall(z.unknown());
+
+export type CannyUser = z.infer<typeof CannyUserSchema>;
+
+export const CannyBoardSchema = z
+	.object({
+		id: z.string(),
+		created: z.string(),
+		isPrivate: z.boolean(),
+		name: z.string(),
+		postCount: z.number(),
+		privateComments: z.boolean().optional(),
+		token: z.string().optional(),
+		url: z.string(),
+	})
+	.catchall(z.unknown());
+
+export type CannyBoardModel = z.infer<typeof CannyBoardSchema>;
+
+export const CannyCategorySchema = z
+	.object({
+		id: z.string(),
+		name: z.string(),
+		url: z.string().optional(),
+		postCount: z.number().optional(),
+		parentID: z.string().nullable().optional(),
+	})
+	.catchall(z.unknown());
+
+export type CannyCategory = z.infer<typeof CannyCategorySchema>;
+
+export const CannyTagSchema = z
+	.object({
+		id: z.string(),
+		name: z.string(),
+		url: z.string().optional(),
+		postCount: z.number().optional(),
+	})
+	.catchall(z.unknown());
+
+export type CannyTag = z.infer<typeof CannyTagSchema>;
+
+export const CannyPostSchema = z
+	.object({
+		id: z.string(),
+		author: CannyUserSchema,
+		board: CannyBoardSchema,
+		category: CannyCategorySchema.nullable().optional(),
+		commentCount: z.number(),
+		created: z.string(),
+		details: z.string().optional(),
+		eta: z.string().nullable().optional(),
+		imageURLs: z.array(z.string()).optional(),
+		score: z.number(),
+		status: z.string(),
+		tags: z.array(CannyTagSchema).optional(),
+		title: z.string(),
+		url: z.string(),
+		owner: CannyUserSchema.nullable().optional(),
+		customFields: z.record(z.string(), z.unknown()).optional(),
+	})
+	.catchall(z.unknown());
+
+export type CannyPostModel = z.infer<typeof CannyPostSchema>;
+
+export const CannyCommentSchema = z
+	.object({
+		id: z.string(),
+		author: CannyUserSchema,
+		board: CannyBoardSchema.optional(),
+		created: z.string(),
+		deleteStatus: z.string().nullable().optional(),
+		imageURLs: z.array(z.string()).optional(),
+		internal: z.boolean().optional(),
+		likeCount: z.number().optional(),
+		parentID: z.string().nullable().optional(),
+		post: CannyPostSchema.optional(),
+		value: z.string(),
+	})
+	.catchall(z.unknown());
+
+export type CannyCommentModel = z.infer<typeof CannyCommentSchema>;
+
+export const CannyVoteSchema = z
+	.object({
+		id: z.string(),
+		board: CannyBoardSchema.optional(),
+		by: CannyUserSchema.nullable().optional(),
+		created: z.string(),
+		post: CannyPostSchema,
+		voter: CannyUserSchema,
+	})
+	.catchall(z.unknown());
+
+export type CannyVoteModel = z.infer<typeof CannyVoteSchema>;
+
+// Aliases matching prompt
+export type Board = CannyBoardModel;
+export type Post = CannyPostModel;
+export type Comment = CannyCommentModel;
+export type Vote = CannyVoteModel;
+export type User = CannyUser;
+export type Category = CannyCategory;
+export type Tag = CannyTag;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Boards Endpoint Schemas & Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const BoardsListInputSchema = z
+	.object({})
+	.strict()
+	.optional()
+	.default({});
+
+export type BoardsListInput = z.infer<typeof BoardsListInputSchema>;
+
+export const BoardsListResponseSchema = z.object({
+	boards: z.array(CannyBoardSchema),
+});
+
+export type BoardsListResponse = z.infer<typeof BoardsListResponseSchema>;
+
+export const BoardsRetrieveInputSchema = z.object({
+	id: z.string(),
+});
+
+export type BoardsRetrieveInput = z.infer<typeof BoardsRetrieveInputSchema>;
+
+export const BoardsRetrieveResponseSchema = CannyBoardSchema;
+
+export type BoardsRetrieveResponse = z.infer<
+	typeof BoardsRetrieveResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Posts Endpoint Schemas & Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const PostsListInputSchema = z
+	.object({
+		authorID: z.string().optional(),
+		boardID: z.string().optional(),
+		companyID: z.string().optional(),
+		limit: z.number().optional(),
+		search: z.string().optional(),
+		skip: z.number().optional(),
+		sort: z
+			.enum([
+				'newest',
+				'oldest',
+				'relevance',
+				'score',
+				'statusChanged',
+				'trending',
+			])
+			.optional(),
+		status: z.string().optional(),
+		tagIDs: z.array(z.string()).optional(),
+	})
+	.optional()
+	.default({});
+
+export type PostsListInput = z.infer<typeof PostsListInputSchema>;
+
+export const PostsListResponseSchema = z.object({
+	hasMore: z.boolean(),
+	posts: z.array(CannyPostSchema),
+});
+
+export type PostsListResponse = z.infer<typeof PostsListResponseSchema>;
+
+export const PostsRetrieveInputSchema = z.object({
+	id: z.string().optional(),
+	url: z.string().optional(),
+});
+
+export type PostsRetrieveInput = z.infer<typeof PostsRetrieveInputSchema>;
+
+export const PostsRetrieveResponseSchema = CannyPostSchema;
+
+export type PostsRetrieveResponse = z.infer<typeof PostsRetrieveResponseSchema>;
+
+export const PostsCreateInputSchema = z.object({
+	authorID: z.string(),
+	boardID: z.string(),
+	title: z.string(),
+	byID: z.string().optional(),
+	categoryID: z.string().optional(),
+	customFields: z.record(z.string(), z.unknown()).optional(),
+	details: z.string().optional(),
+	eta: z.string().optional(),
+	etaPublic: z.boolean().optional(),
+	imageURLs: z.array(z.string()).optional(),
+	ownerID: z.string().optional(),
+});
+
+export type PostsCreateInput = z.infer<typeof PostsCreateInputSchema>;
+
+export const PostsCreateResponseSchema = z.object({
+	id: z.string(),
+});
+
+export type PostsCreateResponse = z.infer<typeof PostsCreateResponseSchema>;
+
+export const PostsChangeStatusInputSchema = z.object({
+	changerID: z.string(),
+	postID: z.string(),
+	status: z.string(),
+	commentImageURLs: z.array(z.string()).optional(),
+	commentValue: z.string().optional(),
+	shouldNotifyVoters: z.boolean().optional(),
+});
+
+export type PostsChangeStatusInput = z.infer<
+	typeof PostsChangeStatusInputSchema
+>;
+
+export const PostsChangeStatusResponseSchema = CannyPostSchema;
+
+export type PostsChangeStatusResponse = z.infer<
+	typeof PostsChangeStatusResponseSchema
+>;
+
+export const PostsDeleteInputSchema = z.object({
+	postID: z.string(),
+});
+
+export type PostsDeleteInput = z.infer<typeof PostsDeleteInputSchema>;
+
+export const PostsDeleteResponseSchema = z.union([
+	z.literal('success'),
+	z.string(),
+]);
+
+export type PostsDeleteResponse = z.infer<typeof PostsDeleteResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Comments Endpoint Schemas & Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const CommentsListInputSchema = z
+	.object({
+		authorID: z.string().optional(),
+		boardID: z.string().optional(),
+		limit: z.number().optional(),
+		postID: z.string().optional(),
+		skip: z.number().optional(),
+	})
+	.optional()
+	.default({});
+
+export type CommentsListInput = z.infer<typeof CommentsListInputSchema>;
+
+export const CommentsListResponseSchema = z.object({
+	comments: z.array(CannyCommentSchema),
+	hasMore: z.boolean(),
+});
+
+export type CommentsListResponse = z.infer<typeof CommentsListResponseSchema>;
+
+export const CommentsCreateInputSchema = z.object({
+	authorID: z.string(),
+	postID: z.string(),
+	value: z.string(),
+	imageURLs: z.array(z.string()).optional(),
+	internal: z.boolean().optional(),
+	parentID: z.string().optional(),
+});
+
+export type CommentsCreateInput = z.infer<typeof CommentsCreateInputSchema>;
+
+export const CommentsCreateResponseSchema = z.object({
+	id: z.string(),
+});
+
+export type CommentsCreateResponse = z.infer<
+	typeof CommentsCreateResponseSchema
+>;
+
+export const CommentsDeleteInputSchema = z.object({
+	commentID: z.string(),
+});
+
+export type CommentsDeleteInput = z.infer<typeof CommentsDeleteInputSchema>;
+
+export const CommentsDeleteResponseSchema = z.union([
+	z.literal('success'),
+	z.string(),
+]);
+
+export type CommentsDeleteResponse = z.infer<
+	typeof CommentsDeleteResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Votes Endpoint Schemas & Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const VotesListInputSchema = z
+	.object({
+		boardID: z.string().optional(),
+		byID: z.string().optional(),
+		limit: z.number().optional(),
+		postID: z.string().optional(),
+		skip: z.number().optional(),
+		userID: z.string().optional(),
+	})
+	.optional()
+	.default({});
+
+export type VotesListInput = z.infer<typeof VotesListInputSchema>;
+
+export const VotesListResponseSchema = z.object({
+	hasMore: z.boolean(),
+	votes: z.array(CannyVoteSchema),
+});
+
+export type VotesListResponse = z.infer<typeof VotesListResponseSchema>;
+
+export const VotesCreateInputSchema = z.object({
+	postID: z.string(),
+	voterID: z.string(),
+	byID: z.string().optional(),
+	createdAt: z.string().optional(),
+	votePriority: z.number().optional(),
+});
+
+export type VotesCreateInput = z.infer<typeof VotesCreateInputSchema>;
+
+export const VotesCreateResponseSchema = z.union([
+	z.literal('success'),
+	z.string(),
+]);
+
+export type VotesCreateResponse = z.infer<typeof VotesCreateResponseSchema>;
+
+export const VotesDeleteInputSchema = z.object({
+	postID: z.string(),
+	voterID: z.string(),
+});
+
+export type VotesDeleteInput = z.infer<typeof VotesDeleteInputSchema>;
+
+export const VotesDeleteResponseSchema = z.union([
+	z.literal('success'),
+	z.string(),
+]);
+
+export type VotesDeleteResponse = z.infer<typeof VotesDeleteResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint Input & Output Collections
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type CannyEndpointInputs = {
+	boardsList: BoardsListInput;
+	boardsRetrieve: BoardsRetrieveInput;
+	postsList: PostsListInput;
+	postsRetrieve: PostsRetrieveInput;
+	postsCreate: PostsCreateInput;
+	postsChangeStatus: PostsChangeStatusInput;
+	postsDelete: PostsDeleteInput;
+	commentsList: CommentsListInput;
+	commentsCreate: CommentsCreateInput;
+	commentsDelete: CommentsDeleteInput;
+	votesList: VotesListInput;
+	votesCreate: VotesCreateInput;
+	votesDelete: VotesDeleteInput;
+};
+
+export type CannyEndpointOutputs = {
+	boardsList: BoardsListResponse;
+	boardsRetrieve: BoardsRetrieveResponse;
+	postsList: PostsListResponse;
+	postsRetrieve: PostsRetrieveResponse;
+	postsCreate: PostsCreateResponse;
+	postsChangeStatus: PostsChangeStatusResponse;
+	postsDelete: PostsDeleteResponse;
+	commentsList: CommentsListResponse;
+	commentsCreate: CommentsCreateResponse;
+	commentsDelete: CommentsDeleteResponse;
+	votesList: VotesListResponse;
+	votesCreate: VotesCreateResponse;
+	votesDelete: VotesDeleteResponse;
+};
+
+export const CannyEndpointInputSchemas = {
+	boardsList: BoardsListInputSchema,
+	boardsRetrieve: BoardsRetrieveInputSchema,
+	postsList: PostsListInputSchema,
+	postsRetrieve: PostsRetrieveInputSchema,
+	postsCreate: PostsCreateInputSchema,
+	postsChangeStatus: PostsChangeStatusInputSchema,
+	postsDelete: PostsDeleteInputSchema,
+	commentsList: CommentsListInputSchema,
+	commentsCreate: CommentsCreateInputSchema,
+	commentsDelete: CommentsDeleteInputSchema,
+	votesList: VotesListInputSchema,
+	votesCreate: VotesCreateInputSchema,
+	votesDelete: VotesDeleteInputSchema,
+} as const;
+
+export const CannyEndpointOutputSchemas = {
+	boardsList: BoardsListResponseSchema,
+	boardsRetrieve: BoardsRetrieveResponseSchema,
+	postsList: PostsListResponseSchema,
+	postsRetrieve: PostsRetrieveResponseSchema,
+	postsCreate: PostsCreateResponseSchema,
+	postsChangeStatus: PostsChangeStatusResponseSchema,
+	postsDelete: PostsDeleteResponseSchema,
+	commentsList: CommentsListResponseSchema,
+	commentsCreate: CommentsCreateResponseSchema,
+	commentsDelete: CommentsDeleteResponseSchema,
+	votesList: VotesListResponseSchema,
+	votesCreate: VotesCreateResponseSchema,
+	votesDelete: VotesDeleteResponseSchema,
+} as const;

--- a/packages/canny/endpoints/types.ts
+++ b/packages/canny/endpoints/types.ts
@@ -15,7 +15,7 @@ export const CannyUserSchema = z
 		isAdmin: z.boolean(),
 		avatarURL: z.string().nullable().optional(),
 	})
-	.catchall(z.unknown());
+	.passthrough();
 
 export type CannyUser = z.infer<typeof CannyUserSchema>;
 
@@ -30,7 +30,7 @@ export const CannyBoardSchema = z
 		token: z.string().optional(),
 		url: z.string(),
 	})
-	.catchall(z.unknown());
+	.passthrough();
 
 export type CannyBoardModel = z.infer<typeof CannyBoardSchema>;
 
@@ -42,7 +42,7 @@ export const CannyCategorySchema = z
 		postCount: z.number().optional(),
 		parentID: z.string().nullable().optional(),
 	})
-	.catchall(z.unknown());
+	.passthrough();
 
 export type CannyCategory = z.infer<typeof CannyCategorySchema>;
 
@@ -53,7 +53,7 @@ export const CannyTagSchema = z
 		url: z.string().optional(),
 		postCount: z.number().optional(),
 	})
-	.catchall(z.unknown());
+	.passthrough();
 
 export type CannyTag = z.infer<typeof CannyTagSchema>;
 
@@ -74,9 +74,14 @@ export const CannyPostSchema = z
 		title: z.string(),
 		url: z.string(),
 		owner: CannyUserSchema.nullable().optional(),
-		customFields: z.record(z.string(), z.unknown()).optional(),
+		customFields: z
+			.record(
+				z.string(),
+				z.union([z.string(), z.number(), z.boolean(), z.null()]),
+			)
+			.optional(),
 	})
-	.catchall(z.unknown());
+	.passthrough();
 
 export type CannyPostModel = z.infer<typeof CannyPostSchema>;
 
@@ -94,7 +99,7 @@ export const CannyCommentSchema = z
 		post: CannyPostSchema.optional(),
 		value: z.string(),
 	})
-	.catchall(z.unknown());
+	.passthrough();
 
 export type CannyCommentModel = z.infer<typeof CannyCommentSchema>;
 
@@ -104,10 +109,10 @@ export const CannyVoteSchema = z
 		board: CannyBoardSchema.optional(),
 		by: CannyUserSchema.nullable().optional(),
 		created: z.string(),
-		post: CannyPostSchema,
-		voter: CannyUserSchema,
+		post: CannyPostSchema.optional(),
+		voter: CannyUserSchema.optional(),
 	})
-	.catchall(z.unknown());
+	.passthrough();
 
 export type CannyVoteModel = z.infer<typeof CannyVoteSchema>;
 
@@ -158,10 +163,11 @@ export const PostsListInputSchema = z
 	.object({
 		authorID: z.string().optional(),
 		boardID: z.string().optional(),
+		categoryID: z.string().optional(),
 		companyID: z.string().optional(),
-		limit: z.number().optional(),
+		limit: z.number().int().positive().optional(),
 		search: z.string().optional(),
-		skip: z.number().optional(),
+		skip: z.number().int().nonnegative().optional(),
 		sort: z
 			.enum([
 				'newest',
@@ -172,8 +178,17 @@ export const PostsListInputSchema = z
 				'trending',
 			])
 			.optional(),
-		status: z.string().optional(),
-		tagIDs: z.array(z.string()).optional(),
+		status: z
+			.enum([
+				'open',
+				'under review',
+				'planned',
+				'in progress',
+				'complete',
+				'closed',
+			])
+			.optional(),
+		tagID: z.string().optional(),
 	})
 	.optional()
 	.default({});
@@ -187,10 +202,14 @@ export const PostsListResponseSchema = z.object({
 
 export type PostsListResponse = z.infer<typeof PostsListResponseSchema>;
 
-export const PostsRetrieveInputSchema = z.object({
-	id: z.string().optional(),
-	url: z.string().optional(),
-});
+export const PostsRetrieveInputSchema = z
+	.object({
+		id: z.string().optional(),
+		url: z.string().optional(),
+	})
+	.refine((data) => data.id !== undefined || data.url !== undefined, {
+		message: 'Either id or url must be provided',
+	});
 
 export type PostsRetrieveInput = z.infer<typeof PostsRetrieveInputSchema>;
 
@@ -202,14 +221,17 @@ export const PostsCreateInputSchema = z.object({
 	authorID: z.string(),
 	boardID: z.string(),
 	title: z.string(),
-	byID: z.string().optional(),
-	categoryID: z.string().optional(),
-	customFields: z.record(z.string(), z.unknown()).optional(),
 	details: z.string().optional(),
+	categoryID: z.string().optional(),
+	customFields: z
+		.record(
+			z.string(),
+			z.union([z.string(), z.number(), z.boolean(), z.null()]),
+		)
+		.optional(),
 	eta: z.string().optional(),
-	etaPublic: z.boolean().optional(),
 	imageURLs: z.array(z.string()).optional(),
-	ownerID: z.string().optional(),
+	publishedAt: z.string().optional(),
 });
 
 export type PostsCreateInput = z.infer<typeof PostsCreateInputSchema>;
@@ -222,11 +244,17 @@ export type PostsCreateResponse = z.infer<typeof PostsCreateResponseSchema>;
 
 export const PostsChangeStatusInputSchema = z.object({
 	changerID: z.string(),
-	postID: z.string(),
-	status: z.string(),
-	commentImageURLs: z.array(z.string()).optional(),
 	commentValue: z.string().optional(),
+	postID: z.string(),
 	shouldNotifyVoters: z.boolean().optional(),
+	status: z.enum([
+		'open',
+		'under review',
+		'planned',
+		'in progress',
+		'complete',
+		'closed',
+	]),
 });
 
 export type PostsChangeStatusInput = z.infer<
@@ -260,9 +288,10 @@ export const CommentsListInputSchema = z
 	.object({
 		authorID: z.string().optional(),
 		boardID: z.string().optional(),
-		limit: z.number().optional(),
+		companyID: z.string().optional(),
+		limit: z.number().int().positive().optional(),
 		postID: z.string().optional(),
-		skip: z.number().optional(),
+		skip: z.number().int().nonnegative().optional(),
 	})
 	.optional()
 	.default({});
@@ -317,10 +346,10 @@ export type CommentsDeleteResponse = z.infer<
 export const VotesListInputSchema = z
 	.object({
 		boardID: z.string().optional(),
-		byID: z.string().optional(),
-		limit: z.number().optional(),
+		companyID: z.string().optional(),
+		limit: z.number().int().positive().optional(),
 		postID: z.string().optional(),
-		skip: z.number().optional(),
+		skip: z.number().int().nonnegative().optional(),
 		userID: z.string().optional(),
 	})
 	.optional()
@@ -338,9 +367,6 @@ export type VotesListResponse = z.infer<typeof VotesListResponseSchema>;
 export const VotesCreateInputSchema = z.object({
 	postID: z.string(),
 	voterID: z.string(),
-	byID: z.string().optional(),
-	createdAt: z.string().optional(),
-	votePriority: z.number().optional(),
 });
 
 export type VotesCreateInput = z.infer<typeof VotesCreateInputSchema>;
@@ -353,8 +379,9 @@ export const VotesCreateResponseSchema = z.union([
 export type VotesCreateResponse = z.infer<typeof VotesCreateResponseSchema>;
 
 export const VotesDeleteInputSchema = z.object({
-	postID: z.string(),
-	voterID: z.string(),
+	id: z.string().optional(),
+	postID: z.string().optional(),
+	voterID: z.string().optional(),
 });
 
 export type VotesDeleteInput = z.infer<typeof VotesDeleteInputSchema>;

--- a/packages/canny/endpoints/votes.ts
+++ b/packages/canny/endpoints/votes.ts
@@ -1,0 +1,89 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeCannyRequest } from '../client';
+import type { CannyEndpoints } from '../index';
+import type { CannyEndpointOutputs } from './types';
+
+export const list: CannyEndpoints['votesList'] = async (ctx, input) => {
+	const response = await makeCannyRequest<CannyEndpointOutputs['votesList']>(
+		'votes/list',
+		ctx.key,
+		{
+			method: 'POST',
+			body: input ? { ...input } : {},
+		},
+	);
+
+	if (ctx.db.votes && response.votes) {
+		for (const vote of response.votes) {
+			try {
+				await ctx.db.votes.upsertByEntityId(vote.id, {
+					id: vote.id,
+					created: new Date(vote.created),
+					postID: vote.post?.id,
+					voterID: vote.voter?.id,
+					boardID: vote.board?.id,
+				});
+			} catch (error) {
+				console.warn('Failed to persist vote to database:', error);
+			}
+		}
+	}
+
+	await logEventFromContext(ctx, 'canny.votes.list', { ...input }, 'completed');
+	return response;
+};
+
+export const create: CannyEndpoints['votesCreate'] = async (ctx, input) => {
+	const response = await makeCannyRequest<CannyEndpointOutputs['votesCreate']>(
+		'votes/create',
+		ctx.key,
+		{
+			method: 'POST',
+			body: { ...input },
+		},
+	);
+
+	await logEventFromContext(
+		ctx,
+		'canny.votes.create',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+export const deleteVote: CannyEndpoints['votesDelete'] = async (ctx, input) => {
+	const response = await makeCannyRequest<CannyEndpointOutputs['votesDelete']>(
+		'votes/delete',
+		ctx.key,
+		{
+			method: 'POST',
+			body: {
+				postID: input.postID,
+				voterID: input.voterID,
+			},
+		},
+	);
+
+	if (ctx.db.votes) {
+		try {
+			await ctx.db.votes.deleteByEntityId(`${input.postID}_${input.voterID}`);
+		} catch (error) {
+			console.warn('Failed to delete vote from database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'canny.votes.delete',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};
+
+export const Votes = {
+	list,
+	create,
+	delete: deleteVote,
+};

--- a/packages/canny/endpoints/votes.ts
+++ b/packages/canny/endpoints/votes.ts
@@ -1,17 +1,15 @@
 import { logEventFromContext } from 'corsair/core';
 import { makeCannyRequest } from '../client';
 import type { CannyEndpoints } from '../index';
-import type { CannyEndpointOutputs } from './types';
+import { CannyEndpointInputSchemas, CannyEndpointOutputSchemas } from './types';
 
 export const list: CannyEndpoints['votesList'] = async (ctx, input) => {
-	const response = await makeCannyRequest<CannyEndpointOutputs['votesList']>(
-		'votes/list',
-		ctx.key,
-		{
-			method: 'POST',
-			body: input ? { ...input } : {},
-		},
-	);
+	const parsedInput = CannyEndpointInputSchemas.votesList.parse(input);
+	const raw = await makeCannyRequest<unknown>('votes/list', ctx.key, {
+		method: 'POST',
+		body: parsedInput ? { ...parsedInput } : {},
+	});
+	const response = CannyEndpointOutputSchemas.votesList.parse(raw);
 
 	if (ctx.db.votes && response.votes) {
 		for (const vote of response.votes) {
@@ -29,45 +27,55 @@ export const list: CannyEndpoints['votesList'] = async (ctx, input) => {
 		}
 	}
 
-	await logEventFromContext(ctx, 'canny.votes.list', { ...input }, 'completed');
+	await logEventFromContext(
+		ctx,
+		'canny.votes.list',
+		{ ...parsedInput },
+		'completed',
+	);
 	return response;
 };
 
 export const create: CannyEndpoints['votesCreate'] = async (ctx, input) => {
-	const response = await makeCannyRequest<CannyEndpointOutputs['votesCreate']>(
-		'votes/create',
-		ctx.key,
-		{
-			method: 'POST',
-			body: { ...input },
-		},
-	);
+	const parsedInput = CannyEndpointInputSchemas.votesCreate.parse(input);
+	const raw = await makeCannyRequest<unknown>('votes/create', ctx.key, {
+		method: 'POST',
+		body: { ...parsedInput },
+	});
+	const response = CannyEndpointOutputSchemas.votesCreate.parse(raw);
 
 	await logEventFromContext(
 		ctx,
 		'canny.votes.create',
-		{ ...input },
+		{ ...parsedInput },
 		'completed',
 	);
 	return response;
 };
 
 export const deleteVote: CannyEndpoints['votesDelete'] = async (ctx, input) => {
-	const response = await makeCannyRequest<CannyEndpointOutputs['votesDelete']>(
-		'votes/delete',
-		ctx.key,
-		{
-			method: 'POST',
-			body: {
-				postID: input.postID,
-				voterID: input.voterID,
-			},
-		},
-	);
+	const parsedInput = CannyEndpointInputSchemas.votesDelete.parse(input);
+	const requestBody: Record<string, unknown> = {};
+	if (parsedInput.id) requestBody.id = parsedInput.id;
+	if (parsedInput.postID) requestBody.postID = parsedInput.postID;
+	if (parsedInput.voterID) requestBody.voterID = parsedInput.voterID;
+
+	const raw = await makeCannyRequest<unknown>('votes/delete', ctx.key, {
+		method: 'POST',
+		body: requestBody,
+	});
+	const response = CannyEndpointOutputSchemas.votesDelete.parse(raw);
 
 	if (ctx.db.votes) {
 		try {
-			await ctx.db.votes.deleteByEntityId(`${input.postID}_${input.voterID}`);
+			if (parsedInput.id) {
+				await ctx.db.votes.deleteByEntityId(parsedInput.id);
+			}
+			if (parsedInput.postID && parsedInput.voterID) {
+				await ctx.db.votes.deleteByEntityId(
+					`${parsedInput.postID}_${parsedInput.voterID}`,
+				);
+			}
 		} catch (error) {
 			console.warn('Failed to delete vote from database:', error);
 		}
@@ -76,7 +84,7 @@ export const deleteVote: CannyEndpoints['votesDelete'] = async (ctx, input) => {
 	await logEventFromContext(
 		ctx,
 		'canny.votes.delete',
-		{ ...input },
+		{ ...parsedInput },
 		'completed',
 	);
 	return response;

--- a/packages/canny/error-handlers.ts
+++ b/packages/canny/error-handlers.ts
@@ -1,0 +1,31 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('429');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('unauthorized') || msg.includes('invalid_auth');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/canny/error-handlers.ts
+++ b/packages/canny/error-handlers.ts
@@ -1,16 +1,25 @@
 import type { CorsairErrorHandler } from 'corsair/core';
 import { ApiError } from 'corsair/http';
+import { CannyAPIError } from './client';
 
 export const errorHandlers = {
 	RATE_LIMIT_ERROR: {
 		match: (error: Error) => {
 			if (error instanceof ApiError && error.status === 429) return true;
+			if (error instanceof CannyAPIError && error.status === 429) return true;
 			const msg = error.message.toLowerCase();
-			return msg.includes('rate_limited') || msg.includes('429');
+			return (
+				msg.includes('rate_limited') ||
+				msg.includes('429') ||
+				msg.includes('too many requests')
+			);
 		},
 		handler: async (error: Error) => {
 			let retryAfterMs: number | undefined;
-			if (error instanceof ApiError && error.retryAfter !== undefined) {
+			if (
+				(error instanceof ApiError || error instanceof CannyAPIError) &&
+				error.retryAfter !== undefined
+			) {
 				retryAfterMs = error.retryAfter;
 			}
 			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
@@ -19,8 +28,13 @@ export const errorHandlers = {
 	AUTH_ERROR: {
 		match: (error: Error) => {
 			if (error instanceof ApiError && error.status === 401) return true;
+			if (error instanceof CannyAPIError && error.status === 401) return true;
 			const msg = error.message.toLowerCase();
-			return msg.includes('unauthorized') || msg.includes('invalid_auth');
+			return (
+				msg.includes('unauthorized') ||
+				msg.includes('invalid_auth') ||
+				msg.includes('invalid api key')
+			);
 		},
 		handler: async () => ({ maxRetries: 0 }),
 	},

--- a/packages/canny/index.ts
+++ b/packages/canny/index.ts
@@ -1,0 +1,427 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	BindWebhooks,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	CorsairWebhook,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+	RequiredPluginWebhookSchemas,
+} from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
+import { Boards, Comments, Posts, Votes } from './endpoints';
+import type {
+	CannyEndpointInputs,
+	CannyEndpointOutputs,
+} from './endpoints/types';
+import {
+	CannyEndpointInputSchemas,
+	CannyEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { CannySchema } from './schema';
+import { CommentWebhooks, PostWebhooks, VoteWebhooks } from './webhooks';
+import { matchCannyTenantWebhook } from './webhooks/tenant-matcher';
+import type {
+	CannyCommentCreatedEvent,
+	CannyPostCreatedEvent,
+	CannyPostStatusChangedEvent,
+	CannyVoteCreatedEvent,
+	CannyWebhookOutputs,
+} from './webhooks/types';
+import {
+	CannyCommentCreatedEventSchema,
+	CannyPostCreatedEventSchema,
+	CannyPostStatusChangedEventSchema,
+	CannyVoteCreatedEventSchema,
+} from './webhooks/types';
+
+export type CannyPluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	webhookSecret?: string;
+	hooks?: InternalCannyPlugin['hooks'];
+	webhookHooks?: InternalCannyPlugin['webhookHooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof cannyEndpointsNested>;
+};
+
+export type CannyContext = CorsairPluginContext<
+	typeof CannySchema,
+	CannyPluginOptions
+>;
+
+export type CannyKeyBuilderContext = KeyBuilderContext<CannyPluginOptions>;
+
+export type CannyBoundEndpoints = BindEndpoints<typeof cannyEndpointsNested>;
+
+type CannyEndpoint<K extends keyof CannyEndpointOutputs> = CorsairEndpoint<
+	CannyContext,
+	CannyEndpointInputs[K],
+	CannyEndpointOutputs[K]
+>;
+
+export type CannyEndpoints = {
+	boardsList: CannyEndpoint<'boardsList'>;
+	boardsRetrieve: CannyEndpoint<'boardsRetrieve'>;
+	postsList: CannyEndpoint<'postsList'>;
+	postsRetrieve: CannyEndpoint<'postsRetrieve'>;
+	postsCreate: CannyEndpoint<'postsCreate'>;
+	postsChangeStatus: CannyEndpoint<'postsChangeStatus'>;
+	postsDelete: CannyEndpoint<'postsDelete'>;
+	commentsList: CannyEndpoint<'commentsList'>;
+	commentsCreate: CannyEndpoint<'commentsCreate'>;
+	commentsDelete: CannyEndpoint<'commentsDelete'>;
+	votesList: CannyEndpoint<'votesList'>;
+	votesCreate: CannyEndpoint<'votesCreate'>;
+	votesDelete: CannyEndpoint<'votesDelete'>;
+};
+
+type CannyWebhook<K extends keyof CannyWebhookOutputs, TEvent> = CorsairWebhook<
+	CannyContext,
+	TEvent,
+	CannyWebhookOutputs[K]
+>;
+
+export type CannyWebhooks = {
+	postCreated: CannyWebhook<'postCreated', CannyPostCreatedEvent>;
+	postStatusChanged: CannyWebhook<
+		'postStatusChanged',
+		CannyPostStatusChangedEvent
+	>;
+	commentCreated: CannyWebhook<'commentCreated', CannyCommentCreatedEvent>;
+	voteCreated: CannyWebhook<'voteCreated', CannyVoteCreatedEvent>;
+};
+
+export type CannyBoundWebhooks = BindWebhooks<CannyWebhooks>;
+
+const cannyEndpointsNested = {
+	boards: {
+		list: Boards.list,
+		retrieve: Boards.retrieve,
+	},
+	posts: {
+		list: Posts.list,
+		retrieve: Posts.retrieve,
+		create: Posts.create,
+		changeStatus: Posts.changeStatus,
+		delete: Posts.delete,
+	},
+	comments: {
+		list: Comments.list,
+		create: Comments.create,
+		delete: Comments.delete,
+	},
+	votes: {
+		list: Votes.list,
+		create: Votes.create,
+		delete: Votes.delete,
+	},
+} as const;
+
+const cannyWebhooksNested = {
+	posts: {
+		created: PostWebhooks.created,
+		statusChanged: PostWebhooks.statusChanged,
+	},
+	comments: {
+		created: CommentWebhooks.created,
+	},
+	votes: {
+		created: VoteWebhooks.created,
+	},
+} as const;
+
+export const cannyEndpointSchemas = {
+	'boards.list': {
+		input: CannyEndpointInputSchemas.boardsList,
+		output: CannyEndpointOutputSchemas.boardsList,
+	},
+	'boards.retrieve': {
+		input: CannyEndpointInputSchemas.boardsRetrieve,
+		output: CannyEndpointOutputSchemas.boardsRetrieve,
+	},
+	'posts.list': {
+		input: CannyEndpointInputSchemas.postsList,
+		output: CannyEndpointOutputSchemas.postsList,
+	},
+	'posts.retrieve': {
+		input: CannyEndpointInputSchemas.postsRetrieve,
+		output: CannyEndpointOutputSchemas.postsRetrieve,
+	},
+	'posts.create': {
+		input: CannyEndpointInputSchemas.postsCreate,
+		output: CannyEndpointOutputSchemas.postsCreate,
+	},
+	'posts.changeStatus': {
+		input: CannyEndpointInputSchemas.postsChangeStatus,
+		output: CannyEndpointOutputSchemas.postsChangeStatus,
+	},
+	'posts.delete': {
+		input: CannyEndpointInputSchemas.postsDelete,
+		output: CannyEndpointOutputSchemas.postsDelete,
+	},
+	'comments.list': {
+		input: CannyEndpointInputSchemas.commentsList,
+		output: CannyEndpointOutputSchemas.commentsList,
+	},
+	'comments.create': {
+		input: CannyEndpointInputSchemas.commentsCreate,
+		output: CannyEndpointOutputSchemas.commentsCreate,
+	},
+	'comments.delete': {
+		input: CannyEndpointInputSchemas.commentsDelete,
+		output: CannyEndpointOutputSchemas.commentsDelete,
+	},
+	'votes.list': {
+		input: CannyEndpointInputSchemas.votesList,
+		output: CannyEndpointOutputSchemas.votesList,
+	},
+	'votes.create': {
+		input: CannyEndpointInputSchemas.votesCreate,
+		output: CannyEndpointOutputSchemas.votesCreate,
+	},
+	'votes.delete': {
+		input: CannyEndpointInputSchemas.votesDelete,
+		output: CannyEndpointOutputSchemas.votesDelete,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<typeof cannyEndpointsNested>;
+
+const cannyWebhookSchemas = {
+	'posts.created': {
+		description: 'Occurs when a new post is created in Canny',
+		payload: CannyPostCreatedEventSchema,
+		response: CannyPostCreatedEventSchema,
+	},
+	'posts.statusChanged': {
+		description: "Occurs when a post's status is changed in Canny",
+		payload: CannyPostStatusChangedEventSchema,
+		response: CannyPostStatusChangedEventSchema,
+	},
+	'comments.created': {
+		description: 'Occurs when a new comment is created in Canny',
+		payload: CannyCommentCreatedEventSchema,
+		response: CannyCommentCreatedEventSchema,
+	},
+	'votes.created': {
+		description: 'Occurs when a new vote is cast in Canny',
+		payload: CannyVoteCreatedEventSchema,
+		response: CannyVoteCreatedEventSchema,
+	},
+} as const satisfies RequiredPluginWebhookSchemas<typeof cannyWebhooksNested>;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const cannyEndpointMeta = {
+	'boards.list': {
+		riskLevel: 'read',
+		description: 'List all boards for your company in Canny',
+	},
+	'boards.retrieve': {
+		riskLevel: 'read',
+		description: 'Retrieve details of an existing Canny board by ID',
+	},
+	'posts.list': {
+		riskLevel: 'read',
+		description: 'List posts in Canny with optional filtering and pagination',
+	},
+	'posts.retrieve': {
+		riskLevel: 'read',
+		description: 'Retrieve details of an existing Canny post by ID',
+	},
+	'posts.create': {
+		riskLevel: 'write',
+		description: 'Create a new post in Canny',
+	},
+	'posts.changeStatus': {
+		riskLevel: 'write',
+		description: "Change an existing Canny post's status",
+	},
+	'posts.delete': {
+		riskLevel: 'destructive',
+		irreversible: true,
+		description: 'Delete a post in Canny [DESTRUCTIVE · IRREVERSIBLE]',
+	},
+	'comments.list': {
+		riskLevel: 'read',
+		description:
+			'List comments in Canny with optional filtering and pagination',
+	},
+	'comments.create': {
+		riskLevel: 'write',
+		description: 'Create a new comment on a Canny post',
+	},
+	'comments.delete': {
+		riskLevel: 'destructive',
+		irreversible: true,
+		description: 'Delete a comment in Canny [DESTRUCTIVE · IRREVERSIBLE]',
+	},
+	'votes.list': {
+		riskLevel: 'read',
+		description: 'List votes in Canny with optional filtering and pagination',
+	},
+	'votes.create': {
+		riskLevel: 'write',
+		description: 'Create a vote for a Canny post on behalf of a user',
+	},
+	'votes.delete': {
+		riskLevel: 'destructive',
+		irreversible: true,
+		description: 'Delete a vote on a Canny post [DESTRUCTIVE · IRREVERSIBLE]',
+	},
+} as const satisfies RequiredPluginEndpointMeta<typeof cannyEndpointsNested>;
+
+export const cannyAuthConfig = {
+	api_key: {
+		account: [] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type BaseCannyPlugin<T extends CannyPluginOptions> = CorsairPlugin<
+	'canny',
+	typeof CannySchema,
+	typeof cannyEndpointsNested,
+	typeof cannyWebhooksNested,
+	T,
+	typeof defaultAuthType
+>;
+
+export type InternalCannyPlugin = BaseCannyPlugin<CannyPluginOptions>;
+
+export type ExternalCannyPlugin<T extends CannyPluginOptions> =
+	BaseCannyPlugin<T>;
+
+export function canny<const T extends CannyPluginOptions>(
+	incomingOptions: CannyPluginOptions & T = {} as CannyPluginOptions & T,
+): ExternalCannyPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'canny',
+		authConfig: cannyAuthConfig,
+		schema: CannySchema,
+		options: options,
+		hooks: options.hooks,
+		webhookHooks: options.webhookHooks,
+		endpoints: cannyEndpointsNested,
+		webhooks: cannyWebhooksNested,
+		endpointMeta: cannyEndpointMeta,
+		endpointSchemas: cannyEndpointSchemas,
+		webhookSchemas: cannyWebhookSchemas,
+		pluginWebhookMatcher: (request) => {
+			const headers = request.headers;
+			return (
+				'canny-signature' in headers ||
+				'x-canny-signature' in headers ||
+				'canny-nonce' in headers
+			);
+		},
+		pluginTenantWebhookMatcher: matchCannyTenantWebhook,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: CannyKeyBuilderContext, source) => {
+			if (source === 'webhook' && options.webhookSecret) {
+				return options.webhookSecret;
+			}
+
+			if (source === 'webhook' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'webhook') {
+				const res = await ctx.keys.get_webhook_signature();
+				if (res) return res;
+				const apiKey = await ctx.keys.get_api_key();
+				if (apiKey) return apiKey;
+				return '';
+			}
+
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys.get_api_key();
+				if (!res) {
+					throw new AuthMissingError('canny', 'api_key');
+				}
+				return res;
+			}
+
+			throw new AuthMissingError('canny', 'api_key');
+		},
+	} satisfies InternalCannyPlugin;
+}
+
+export type {
+	Board,
+	BoardsListInput,
+	BoardsListResponse,
+	BoardsRetrieveInput,
+	BoardsRetrieveResponse,
+	CannyBoardModel,
+	CannyCategory,
+	CannyCommentModel,
+	CannyEndpointInputs,
+	CannyEndpointOutputs,
+	CannyPostModel,
+	CannyTag,
+	CannyUser,
+	CannyVoteModel,
+	Category,
+	Comment,
+	CommentsCreateInput,
+	CommentsCreateResponse,
+	CommentsDeleteInput,
+	CommentsDeleteResponse,
+	CommentsListInput,
+	CommentsListResponse,
+	Post,
+	PostsChangeStatusInput,
+	PostsChangeStatusResponse,
+	PostsCreateInput,
+	PostsCreateResponse,
+	PostsDeleteInput,
+	PostsDeleteResponse,
+	PostsListInput,
+	PostsListResponse,
+	PostsRetrieveInput,
+	PostsRetrieveResponse,
+	Tag,
+	User,
+	Vote,
+	VotesCreateInput,
+	VotesCreateResponse,
+	VotesDeleteInput,
+	VotesDeleteResponse,
+	VotesListInput,
+	VotesListResponse,
+} from './endpoints/types';
+
+export type {
+	CannyCommentCreatedEvent,
+	CannyEventMap,
+	CannyEventName,
+	CannyPostCreatedEvent,
+	CannyPostStatusChangedEvent,
+	CannyVoteCreatedEvent,
+	CannyWebhookEvent,
+	CannyWebhookOutputs,
+	CannyWebhookPayload,
+} from './webhooks/types';
+export {
+	createCannyEventMatch,
+	createCannyMatch,
+	verifyCannyWebhookSignature,
+} from './webhooks/types';

--- a/packages/canny/jest.config.cjs
+++ b/packages/canny/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/canny/package.json
+++ b/packages/canny/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/canny",
+  "version": "0.1.0",
+  "description": "Canny plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "canny",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/canny/schema.test.ts
+++ b/packages/canny/schema.test.ts
@@ -1,0 +1,18 @@
+import { CannySchema } from './schema';
+
+describe('Canny schema', () => {
+	it('declares a semver version', () => {
+		expect(CannySchema.version).toBeDefined();
+		expect(CannySchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map with all entities', () => {
+		expect(typeof CannySchema.entities).toBe('object');
+		expect(CannySchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(CannySchema.entities))).toBe(true);
+		expect(CannySchema.entities.boards).toBeDefined();
+		expect(CannySchema.entities.posts).toBeDefined();
+		expect(CannySchema.entities.comments).toBeDefined();
+		expect(CannySchema.entities.votes).toBeDefined();
+	});
+});

--- a/packages/canny/schema/database.ts
+++ b/packages/canny/schema/database.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+
+/**
+ * Canny Board Entity Schema
+ * @see https://developers.canny.io/api-reference#boards
+ */
+export const CannyBoard = z
+	.object({
+		id: z.string(),
+		name: z.string(),
+		created: z.coerce.date().nullable().optional(),
+		isPrivate: z.boolean().optional(),
+		postCount: z.number().optional(),
+		privateComments: z.boolean().optional(),
+		url: z.string().optional(),
+		token: z.string().optional(),
+	})
+	.catchall(z.unknown());
+
+/**
+ * Canny Post Entity Schema
+ * @see https://developers.canny.io/api-reference#posts
+ */
+export const CannyPost = z
+	.object({
+		id: z.string(),
+		title: z.string(),
+		details: z.string().optional(),
+		score: z.number().optional(),
+		status: z.string().optional(),
+		created: z.coerce.date().nullable().optional(),
+		url: z.string().optional(),
+		commentCount: z.number().optional(),
+		eta: z.string().nullable().optional(),
+		imageURLs: z.array(z.string()).optional(),
+		boardID: z.string().optional(),
+		authorID: z.string().optional(),
+	})
+	.catchall(z.unknown());
+
+/**
+ * Canny Comment Entity Schema
+ * @see https://developers.canny.io/api-reference#comments
+ */
+export const CannyComment = z
+	.object({
+		id: z.string(),
+		value: z.string(),
+		created: z.coerce.date().nullable().optional(),
+		postID: z.string().optional(),
+		authorID: z.string().optional(),
+		parentID: z.string().nullable().optional(),
+		internal: z.boolean().optional(),
+		likeCount: z.number().optional(),
+		imageURLs: z.array(z.string()).optional(),
+	})
+	.catchall(z.unknown());
+
+/**
+ * Canny Vote Entity Schema
+ * @see https://developers.canny.io/api-reference#votes
+ */
+export const CannyVote = z
+	.object({
+		id: z.string(),
+		created: z.coerce.date().nullable().optional(),
+		postID: z.string().optional(),
+		voterID: z.string().optional(),
+		boardID: z.string().optional(),
+	})
+	.catchall(z.unknown());
+
+export type CannyBoard = z.infer<typeof CannyBoard>;
+export type CannyPost = z.infer<typeof CannyPost>;
+export type CannyComment = z.infer<typeof CannyComment>;
+export type CannyVote = z.infer<typeof CannyVote>;

--- a/packages/canny/schema/index.ts
+++ b/packages/canny/schema/index.ts
@@ -1,0 +1,13 @@
+import { CannyBoard, CannyComment, CannyPost, CannyVote } from './database';
+
+export const CannySchema = {
+	version: '1.0.0',
+	entities: {
+		boards: CannyBoard,
+		posts: CannyPost,
+		comments: CannyComment,
+		votes: CannyVote,
+	},
+} as const;
+
+export * from './database';

--- a/packages/canny/tsconfig.json
+++ b/packages/canny/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/canny/tsup.config.ts
+++ b/packages/canny/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/canny/webhooks.test.ts
+++ b/packages/canny/webhooks.test.ts
@@ -1,0 +1,298 @@
+import { createHmac } from 'node:crypto';
+import { logEventFromContext } from 'corsair/core';
+import type { CannyContext } from './index';
+import { CommentWebhooks, PostWebhooks, VoteWebhooks } from './webhooks';
+import {
+	createCannyMatch,
+	verifyCannyWebhookSignature,
+} from './webhooks/types';
+
+jest.mock('corsair/core', () => {
+	const actual = jest.requireActual('corsair/core');
+	return {
+		...actual,
+		logEventFromContext: jest.fn(),
+	};
+});
+
+describe('Canny webhooks', () => {
+	const secret = 'canny_secret_123';
+	const nonce = 'random_nonce_abc';
+	const validSignature = createHmac('sha256', secret)
+		.update(nonce)
+		.digest('base64');
+
+	const mockLogEventFromContext = logEventFromContext as jest.MockedFunction<
+		typeof logEventFromContext
+	>;
+
+	const mockBoard = {
+		id: 'board_123',
+		name: 'Feature Requests',
+		created: '2026-01-01T00:00:00.000Z',
+		isPrivate: false,
+		postCount: 10,
+		privateComments: false,
+		url: 'https://example.canny.io/feature-requests',
+	};
+
+	const mockUser = {
+		id: 'user_123',
+		name: 'Jane Doe',
+		created: '2026-01-01T00:00:00.000Z',
+		email: 'jane@example.com',
+		url: 'https://example.canny.io/users/jane',
+		isAdmin: false,
+	};
+
+	const mockPost = {
+		id: 'post_123',
+		title: 'Dark Mode',
+		details: 'Please add dark mode',
+		score: 42,
+		status: 'open',
+		created: '2026-01-01T00:00:00.000Z',
+		url: 'https://example.canny.io/p/dark-mode',
+		commentCount: 2,
+		author: mockUser,
+		board: mockBoard,
+	};
+
+	const mockComment = {
+		id: 'comment_123',
+		value: 'Great idea!',
+		created: '2026-01-01T00:00:00.000Z',
+		author: mockUser,
+		post: mockPost,
+	};
+
+	const mockVote = {
+		id: 'vote_123',
+		created: '2026-01-01T00:00:00.000Z',
+		post: mockPost,
+		voter: mockUser,
+	};
+
+	const ctx = {
+		key: secret,
+		db: {
+			posts: {
+				upsertByEntityId: jest.fn(),
+			},
+			comments: {
+				upsertByEntityId: jest.fn(),
+			},
+			votes: {
+				upsertByEntityId: jest.fn(),
+			},
+		},
+	} as unknown as CannyContext;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('verifyCannyWebhookSignature', () => {
+		it('accepts valid HMAC signature with nonce', () => {
+			const req = {
+				headers: {
+					'canny-nonce': nonce,
+					'canny-signature': validSignature,
+					'canny-timestamp': Date.now().toString(),
+				},
+				body: '{}',
+				rawBody: '{}',
+				payload: {},
+			};
+			const res = verifyCannyWebhookSignature(req, secret);
+			expect(res.valid).toBe(true);
+		});
+
+		it('rejects invalid signature', () => {
+			const req = {
+				headers: {
+					'canny-nonce': nonce,
+					'canny-signature': 'invalid_signature_base64=',
+				},
+				body: '{}',
+				rawBody: '{}',
+				payload: {},
+			};
+			const res = verifyCannyWebhookSignature(req, secret);
+			expect(res.valid).toBe(false);
+			expect(res.error).toBe('Invalid signature');
+		});
+
+		it('rejects missing secret', () => {
+			const req = {
+				headers: {
+					'canny-nonce': nonce,
+					'canny-signature': validSignature,
+				},
+				body: '{}',
+				rawBody: '{}',
+				payload: {},
+			};
+			const res = verifyCannyWebhookSignature(req, undefined);
+			expect(res.valid).toBe(false);
+			expect(res.error).toBe('Missing webhook secret or API key');
+		});
+
+		it('rejects missing nonce or signature header', () => {
+			const req = {
+				headers: {},
+				body: '{}',
+				rawBody: '{}',
+				payload: {},
+			};
+			const res = verifyCannyWebhookSignature(req, secret);
+			expect(res.valid).toBe(false);
+			expect(res.error).toBe('Missing canny-signature or canny-nonce header');
+		});
+	});
+
+	describe('createCannyMatch', () => {
+		it('matches correct event type from json string body', () => {
+			const matcher = createCannyMatch('post.created');
+			expect(
+				matcher({
+					body: JSON.stringify({ type: 'post.created' }),
+					headers: {},
+				}),
+			).toBe(true);
+			expect(
+				matcher({
+					body: JSON.stringify({ type: 'comment.created' }),
+					headers: {},
+				}),
+			).toBe(false);
+		});
+	});
+
+	describe('post.created handler', () => {
+		it('processes valid post.created event', async () => {
+			const req = {
+				headers: {
+					'canny-nonce': nonce,
+					'canny-signature': validSignature,
+				},
+				body: '',
+				rawBody: '',
+				payload: {
+					created: '2026-01-01T00:00:00.000Z',
+					objectType: 'post' as const,
+					type: 'post.created' as const,
+					object: mockPost,
+				},
+			};
+
+			const res = await PostWebhooks.created.handler(ctx, req);
+			expect(res.success).toBe(true);
+			expect(ctx.db.posts.upsertByEntityId).toHaveBeenCalledWith(
+				'post_123',
+				expect.objectContaining({ id: 'post_123', title: 'Dark Mode' }),
+			);
+			expect(mockLogEventFromContext).toHaveBeenCalledWith(
+				ctx,
+				'canny.webhook.post.created',
+				{ id: 'post_123', title: 'Dark Mode' },
+				'completed',
+			);
+		});
+	});
+
+	describe('post.status_changed handler', () => {
+		it('processes valid post.status_changed event', async () => {
+			const req = {
+				headers: {
+					'canny-nonce': nonce,
+					'canny-signature': validSignature,
+				},
+				body: '',
+				rawBody: '',
+				payload: {
+					created: '2026-01-01T00:00:00.000Z',
+					objectType: 'post' as const,
+					type: 'post.status_changed' as const,
+					object: { ...mockPost, status: 'in_progress' },
+				},
+			};
+
+			const res = await PostWebhooks.statusChanged.handler(ctx, req);
+			expect(res.success).toBe(true);
+			expect(mockLogEventFromContext).toHaveBeenCalledWith(
+				ctx,
+				'canny.webhook.post.status_changed',
+				{ id: 'post_123', status: 'in_progress' },
+				'completed',
+			);
+		});
+	});
+
+	describe('comment.created handler', () => {
+		it('processes valid comment.created event', async () => {
+			const req = {
+				headers: {
+					'canny-nonce': nonce,
+					'canny-signature': validSignature,
+				},
+				body: '',
+				rawBody: '',
+				payload: {
+					created: '2026-01-01T00:00:00.000Z',
+					objectType: 'comment' as const,
+					type: 'comment.created' as const,
+					object: mockComment,
+				},
+			};
+
+			const res = await CommentWebhooks.created.handler(ctx, req);
+			expect(res.success).toBe(true);
+			expect(ctx.db.comments.upsertByEntityId).toHaveBeenCalledWith(
+				'comment_123',
+				expect.objectContaining({
+					id: 'comment_123',
+					value: 'Great idea!',
+				}),
+			);
+			expect(mockLogEventFromContext).toHaveBeenCalledWith(
+				ctx,
+				'canny.webhook.comment.created',
+				{ id: 'comment_123', postID: 'post_123' },
+				'completed',
+			);
+		});
+	});
+
+	describe('vote.created handler', () => {
+		it('processes valid vote.created event', async () => {
+			const req = {
+				headers: {
+					'canny-nonce': nonce,
+					'canny-signature': validSignature,
+				},
+				body: '',
+				rawBody: '',
+				payload: {
+					created: '2026-01-01T00:00:00.000Z',
+					objectType: 'vote' as const,
+					type: 'vote.created' as const,
+					object: mockVote,
+				},
+			};
+
+			const res = await VoteWebhooks.created.handler(ctx, req);
+			expect(res.success).toBe(true);
+			expect(ctx.db.votes.upsertByEntityId).toHaveBeenCalledWith(
+				'vote_123',
+				expect.objectContaining({ id: 'vote_123' }),
+			);
+			expect(mockLogEventFromContext).toHaveBeenCalledWith(
+				ctx,
+				'canny.webhook.vote.created',
+				{ id: 'vote_123', postID: 'post_123', voterID: 'user_123' },
+				'completed',
+			);
+		});
+	});
+});

--- a/packages/canny/webhooks/comments.ts
+++ b/packages/canny/webhooks/comments.ts
@@ -1,0 +1,55 @@
+import { logEventFromContext } from 'corsair/core';
+import type { CannyWebhooks } from '../index';
+import { createCannyMatch, verifyCannyWebhookSignature } from './types';
+
+export const created: CannyWebhooks['commentCreated'] = {
+	match: createCannyMatch('comment.created'),
+
+	handler: async (ctx, request) => {
+		const verification = verifyCannyWebhookSignature(request, ctx.key);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
+
+		const event = request.payload;
+		if (event.type !== 'comment.created') {
+			return { success: true, data: undefined };
+		}
+
+		const comment = event.object;
+		if (ctx.db.comments && comment.id) {
+			try {
+				await ctx.db.comments.upsertByEntityId(comment.id, {
+					id: comment.id,
+					value: comment.value,
+					created: new Date(comment.created),
+					postID: comment.post?.id,
+					authorID: comment.author?.id,
+					parentID: comment.parentID,
+					internal: comment.internal,
+					likeCount: comment.likeCount,
+					imageURLs: comment.imageURLs,
+				});
+			} catch (error) {
+				console.warn('Failed to save comment to database:', error);
+			}
+		}
+
+		await logEventFromContext(
+			ctx,
+			'canny.webhook.comment.created',
+			{ id: comment.id, postID: comment.post?.id },
+			'completed',
+		);
+
+		return { success: true, data: event };
+	},
+};
+
+export const CommentWebhooks = {
+	created,
+};

--- a/packages/canny/webhooks/comments.ts
+++ b/packages/canny/webhooks/comments.ts
@@ -1,6 +1,10 @@
 import { logEventFromContext } from 'corsair/core';
 import type { CannyWebhooks } from '../index';
-import { createCannyMatch, verifyCannyWebhookSignature } from './types';
+import {
+	CannyCommentCreatedEventSchema,
+	createCannyMatch,
+	verifyCannyWebhookSignature,
+} from './types';
 
 export const created: CannyWebhooks['commentCreated'] = {
 	match: createCannyMatch('comment.created'),
@@ -15,11 +19,19 @@ export const created: CannyWebhooks['commentCreated'] = {
 			};
 		}
 
-		const event = request.payload;
-		if (event.type !== 'comment.created') {
-			return { success: true, data: undefined };
+		const parsed = CannyCommentCreatedEventSchema.safeParse(request.payload);
+		if (!parsed.success) {
+			if ((request.payload as { type?: string })?.type !== 'comment.created') {
+				return { success: true, data: undefined };
+			}
+			return {
+				success: false,
+				statusCode: 400,
+				error: 'Invalid payload format',
+			};
 		}
 
+		const event = parsed.data;
 		const comment = event.object;
 		if (ctx.db.comments && comment.id) {
 			try {

--- a/packages/canny/webhooks/index.ts
+++ b/packages/canny/webhooks/index.ts
@@ -1,0 +1,8 @@
+import { CommentWebhooks } from './comments';
+import { PostWebhooks } from './posts';
+import { VoteWebhooks } from './votes';
+
+export { CommentWebhooks, PostWebhooks, VoteWebhooks };
+export * from './oauth-tenant-link';
+export * from './tenant-matcher';
+export * from './types';

--- a/packages/canny/webhooks/oauth-tenant-link.ts
+++ b/packages/canny/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,8 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+
+// Canny uses account API keys and does not use OAuth tenant linking.
+export async function resolveCannyOAuthWebhookTenantLink(
+	_tokens: TokenResponse,
+): Promise<WebhookTenantMatch | null> {
+	return null;
+}

--- a/packages/canny/webhooks/posts.ts
+++ b/packages/canny/webhooks/posts.ts
@@ -1,0 +1,110 @@
+import { logEventFromContext } from 'corsair/core';
+import type { CannyWebhooks } from '../index';
+import { createCannyMatch, verifyCannyWebhookSignature } from './types';
+
+export const created: CannyWebhooks['postCreated'] = {
+	match: createCannyMatch('post.created'),
+
+	handler: async (ctx, request) => {
+		const verification = verifyCannyWebhookSignature(request, ctx.key);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
+
+		const event = request.payload;
+		if (event.type !== 'post.created') {
+			return { success: true, data: undefined };
+		}
+
+		const post = event.object;
+		if (ctx.db.posts && post.id) {
+			try {
+				await ctx.db.posts.upsertByEntityId(post.id, {
+					id: post.id,
+					title: post.title,
+					details: post.details,
+					score: post.score,
+					status: post.status,
+					created: new Date(post.created),
+					url: post.url,
+					commentCount: post.commentCount,
+					eta: post.eta,
+					imageURLs: post.imageURLs,
+					boardID: post.board?.id,
+					authorID: post.author?.id,
+				});
+			} catch (error) {
+				console.warn('Failed to save post to database:', error);
+			}
+		}
+
+		await logEventFromContext(
+			ctx,
+			'canny.webhook.post.created',
+			{ id: post.id, title: post.title },
+			'completed',
+		);
+
+		return { success: true, data: event };
+	},
+};
+
+export const statusChanged: CannyWebhooks['postStatusChanged'] = {
+	match: createCannyMatch('post.status_changed'),
+
+	handler: async (ctx, request) => {
+		const verification = verifyCannyWebhookSignature(request, ctx.key);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
+
+		const event = request.payload;
+		if (event.type !== 'post.status_changed') {
+			return { success: true, data: undefined };
+		}
+
+		const post = event.object;
+		if (ctx.db.posts && post.id) {
+			try {
+				await ctx.db.posts.upsertByEntityId(post.id, {
+					id: post.id,
+					title: post.title,
+					details: post.details,
+					score: post.score,
+					status: post.status,
+					created: new Date(post.created),
+					url: post.url,
+					commentCount: post.commentCount,
+					eta: post.eta,
+					imageURLs: post.imageURLs,
+					boardID: post.board?.id,
+					authorID: post.author?.id,
+				});
+			} catch (error) {
+				console.warn('Failed to update post in database:', error);
+			}
+		}
+
+		await logEventFromContext(
+			ctx,
+			'canny.webhook.post.status_changed',
+			{ id: post.id, status: post.status },
+			'completed',
+		);
+
+		return { success: true, data: event };
+	},
+};
+
+export const PostWebhooks = {
+	created,
+	statusChanged,
+};

--- a/packages/canny/webhooks/posts.ts
+++ b/packages/canny/webhooks/posts.ts
@@ -1,6 +1,11 @@
 import { logEventFromContext } from 'corsair/core';
 import type { CannyWebhooks } from '../index';
-import { createCannyMatch, verifyCannyWebhookSignature } from './types';
+import {
+	CannyPostCreatedEventSchema,
+	CannyPostStatusChangedEventSchema,
+	createCannyMatch,
+	verifyCannyWebhookSignature,
+} from './types';
 
 export const created: CannyWebhooks['postCreated'] = {
 	match: createCannyMatch('post.created'),
@@ -15,11 +20,19 @@ export const created: CannyWebhooks['postCreated'] = {
 			};
 		}
 
-		const event = request.payload;
-		if (event.type !== 'post.created') {
-			return { success: true, data: undefined };
+		const parsed = CannyPostCreatedEventSchema.safeParse(request.payload);
+		if (!parsed.success) {
+			if ((request.payload as { type?: string })?.type !== 'post.created') {
+				return { success: true, data: undefined };
+			}
+			return {
+				success: false,
+				statusCode: 400,
+				error: 'Invalid payload format',
+			};
 		}
 
+		const event = parsed.data;
 		const post = event.object;
 		if (ctx.db.posts && post.id) {
 			try {
@@ -66,11 +79,21 @@ export const statusChanged: CannyWebhooks['postStatusChanged'] = {
 			};
 		}
 
-		const event = request.payload;
-		if (event.type !== 'post.status_changed') {
-			return { success: true, data: undefined };
+		const parsed = CannyPostStatusChangedEventSchema.safeParse(request.payload);
+		if (!parsed.success) {
+			if (
+				(request.payload as { type?: string })?.type !== 'post.status_changed'
+			) {
+				return { success: true, data: undefined };
+			}
+			return {
+				success: false,
+				statusCode: 400,
+				error: 'Invalid payload format',
+			};
 		}
 
+		const event = parsed.data;
 		const post = event.object;
 		if (ctx.db.posts && post.id) {
 			try {

--- a/packages/canny/webhooks/tenant-matcher.ts
+++ b/packages/canny/webhooks/tenant-matcher.ts
@@ -1,0 +1,10 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+
+// Canny webhook payloads identify events, not the owning account.
+// Routing uses the per-account API key / webhook signing secret.
+// See https://developers.canny.io/api-reference#webhooks
+export function matchCannyTenantWebhook(
+	_request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	return null;
+}

--- a/packages/canny/webhooks/types.ts
+++ b/packages/canny/webhooks/types.ts
@@ -20,9 +20,12 @@ export const CannyWebhookPayloadSchema = z
 		created: z.string(),
 		objectType: z.string(),
 		type: z.string(),
-		object: z.record(z.string(), z.unknown()),
+		object: z.record(
+			z.string(),
+			z.union([z.string(), z.number(), z.boolean(), z.null()]),
+		),
 	})
-	.catchall(z.unknown());
+	.passthrough();
 
 export type CannyWebhookPayload = z.infer<typeof CannyWebhookPayloadSchema>;
 
@@ -138,12 +141,29 @@ function firstHeader(
 }
 
 function timingSafeEqualBase64(a: string, b: string): boolean {
-	const bufA = Buffer.from(a);
-	const bufB = Buffer.from(b);
-	if (bufA.length !== bufB.length) {
+	try {
+		const bufA = Buffer.from(a, 'base64');
+		const bufB = Buffer.from(b, 'base64');
+		if (bufA.length === 0 || bufB.length === 0 || bufA.length !== bufB.length) {
+			return false;
+		}
+		return bufA.equals(bufB);
+	} catch {
 		return false;
 	}
-	return bufA.equals(bufB);
+}
+
+function timingSafeEqualHex(a: string, b: string): boolean {
+	try {
+		const bufA = Buffer.from(a, 'hex');
+		const bufB = Buffer.from(b, 'hex');
+		if (bufA.length === 0 || bufB.length === 0 || bufA.length !== bufB.length) {
+			return false;
+		}
+		return bufA.equals(bufB);
+	} catch {
+		return false;
+	}
 }
 
 const TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000; // 5 minutes
@@ -153,7 +173,7 @@ const TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000; // 5 minutes
  * Canny signs webhooks with:
  * - canny-timestamp: milliseconds since epoch
  * - canny-nonce: random unique string
- * - canny-signature: HMAC-SHA256 signature of the nonce in Base64
+ * - canny-signature: HMAC-SHA256 signature of the nonce (or payload) in Base64 or Hex
  */
 export function verifyCannyWebhookSignature(
 	request: WebhookRequest<unknown>,
@@ -193,16 +213,49 @@ export function verifyCannyWebhookSignature(
 					error: 'Webhook timestamp outside tolerance',
 				};
 			}
+		} else {
+			return {
+				valid: false,
+				error: 'Invalid webhook timestamp format',
+			};
 		}
 	}
 
 	try {
-		const expectedSignature = createHmac('sha256', webhookSecret)
-			.update(nonce)
-			.digest('base64');
+		const reqAny = request as unknown as { body?: unknown; payload?: unknown };
+		const reqData = reqAny.body ?? reqAny.payload ?? '';
+		const rawBody =
+			typeof reqData === 'string'
+				? reqData
+				: reqData !== undefined && reqData !== null
+					? JSON.stringify(reqData)
+					: '';
 
-		if (timingSafeEqualBase64(signature, expectedSignature)) {
-			return { valid: true };
+		const candidates = [
+			createHmac('sha256', webhookSecret).update(nonce).digest('base64'),
+			createHmac('sha256', webhookSecret).update(nonce).digest('hex'),
+		];
+
+		if (rawBody) {
+			candidates.push(
+				createHmac('sha256', webhookSecret)
+					.update(`${nonce}.${rawBody}`)
+					.digest('base64'),
+				createHmac('sha256', webhookSecret)
+					.update(`${timestamp ? `${timestamp}.` : ''}${nonce}.${rawBody}`)
+					.digest('base64'),
+				createHmac('sha256', webhookSecret).update(rawBody).digest('base64'),
+				createHmac('sha256', webhookSecret).update(rawBody).digest('hex'),
+			);
+		}
+
+		for (const expected of candidates) {
+			if (
+				timingSafeEqualBase64(signature, expected) ||
+				timingSafeEqualHex(signature, expected)
+			) {
+				return { valid: true };
+			}
 		}
 	} catch (err) {
 		return {

--- a/packages/canny/webhooks/types.ts
+++ b/packages/canny/webhooks/types.ts
@@ -1,0 +1,225 @@
+import { createHmac } from 'node:crypto';
+import type {
+	CorsairWebhookMatcher,
+	RawWebhookRequest,
+	WebhookRequest,
+} from 'corsair/core';
+import { z } from 'zod';
+import {
+	CannyCommentSchema,
+	CannyPostSchema,
+	CannyVoteSchema,
+} from '../endpoints/types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Base Canny Webhook Payload Schema
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const CannyWebhookPayloadSchema = z
+	.object({
+		created: z.string(),
+		objectType: z.string(),
+		type: z.string(),
+		object: z.record(z.string(), z.unknown()),
+	})
+	.catchall(z.unknown());
+
+export type CannyWebhookPayload = z.infer<typeof CannyWebhookPayloadSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Event Schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const CannyPostCreatedEventSchema = z.object({
+	created: z.string(),
+	objectType: z.literal('post'),
+	type: z.literal('post.created'),
+	object: CannyPostSchema,
+});
+
+export type CannyPostCreatedEvent = z.infer<typeof CannyPostCreatedEventSchema>;
+
+export const CannyPostStatusChangedEventSchema = z.object({
+	created: z.string(),
+	objectType: z.literal('post'),
+	type: z.literal('post.status_changed'),
+	object: CannyPostSchema,
+});
+
+export type CannyPostStatusChangedEvent = z.infer<
+	typeof CannyPostStatusChangedEventSchema
+>;
+
+export const CannyCommentCreatedEventSchema = z.object({
+	created: z.string(),
+	objectType: z.literal('comment'),
+	type: z.literal('comment.created'),
+	object: CannyCommentSchema,
+});
+
+export type CannyCommentCreatedEvent = z.infer<
+	typeof CannyCommentCreatedEventSchema
+>;
+
+export const CannyVoteCreatedEventSchema = z.object({
+	created: z.string(),
+	objectType: z.literal('vote'),
+	type: z.literal('vote.created'),
+	object: CannyVoteSchema,
+});
+
+export type CannyVoteCreatedEvent = z.infer<typeof CannyVoteCreatedEventSchema>;
+
+export const CannyWebhookEventSchema = z.union([
+	CannyPostCreatedEventSchema,
+	CannyPostStatusChangedEventSchema,
+	CannyCommentCreatedEventSchema,
+	CannyVoteCreatedEventSchema,
+]);
+
+export type CannyWebhookEvent = z.infer<typeof CannyWebhookEventSchema>;
+
+export type CannyEventName =
+	| 'post.created'
+	| 'post.status_changed'
+	| 'comment.created'
+	| 'vote.created';
+
+export interface CannyEventMap {
+	'post.created': CannyPostCreatedEvent;
+	'post.status_changed': CannyPostStatusChangedEvent;
+	'comment.created': CannyCommentCreatedEvent;
+	'vote.created': CannyVoteCreatedEvent;
+}
+
+export type CannyWebhookOutputs = {
+	postCreated: CannyPostCreatedEvent;
+	postStatusChanged: CannyPostStatusChangedEvent;
+	commentCreated: CannyCommentCreatedEvent;
+	voteCreated: CannyVoteCreatedEvent;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Utilities & Signature Verification
+// ─────────────────────────────────────────────────────────────────────────────
+
+function parseBody(body: unknown): Record<string, unknown> | null {
+	if (typeof body === 'string') {
+		try {
+			const parsed = JSON.parse(body);
+			return parsed !== null &&
+				typeof parsed === 'object' &&
+				!Array.isArray(parsed)
+				? (parsed as Record<string, unknown>)
+				: null;
+		} catch {
+			return null;
+		}
+	}
+	return body !== null && typeof body === 'object' && !Array.isArray(body)
+		? (body as Record<string, unknown>)
+		: null;
+}
+
+function firstHeader(
+	headers: Record<string, unknown>,
+	...names: string[]
+): string | undefined {
+	for (const name of names) {
+		const value =
+			headers[name] ??
+			headers[name.toLowerCase()] ??
+			headers[name.toUpperCase()];
+		if (value !== undefined) {
+			return Array.isArray(value) ? value[0] : (value as string | undefined);
+		}
+	}
+	return undefined;
+}
+
+function timingSafeEqualBase64(a: string, b: string): boolean {
+	const bufA = Buffer.from(a);
+	const bufB = Buffer.from(b);
+	if (bufA.length !== bufB.length) {
+		return false;
+	}
+	return bufA.equals(bufB);
+}
+
+const TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Verify a Canny webhook request using HMAC-SHA256 signature of nonce using secret API key.
+ * Canny signs webhooks with:
+ * - canny-timestamp: milliseconds since epoch
+ * - canny-nonce: random unique string
+ * - canny-signature: HMAC-SHA256 signature of the nonce in Base64
+ */
+export function verifyCannyWebhookSignature(
+	request: WebhookRequest<unknown>,
+	webhookSecret?: string,
+): { valid: boolean; error?: string } {
+	if (!webhookSecret) {
+		return { valid: false, error: 'Missing webhook secret or API key' };
+	}
+
+	const headers = request.headers;
+	const signature = firstHeader(
+		headers,
+		'canny-signature',
+		'x-canny-signature',
+	);
+	const nonce = firstHeader(headers, 'canny-nonce', 'x-canny-nonce');
+	const timestamp = firstHeader(
+		headers,
+		'canny-timestamp',
+		'x-canny-timestamp',
+	);
+
+	if (!signature || !nonce) {
+		return {
+			valid: false,
+			error: 'Missing canny-signature or canny-nonce header',
+		};
+	}
+
+	if (timestamp) {
+		const timestampMs = Number.parseInt(timestamp, 10);
+		if (Number.isFinite(timestampMs)) {
+			const nowMs = Date.now();
+			if (Math.abs(nowMs - timestampMs) > TIMESTAMP_TOLERANCE_MS) {
+				return {
+					valid: false,
+					error: 'Webhook timestamp outside tolerance',
+				};
+			}
+		}
+	}
+
+	try {
+		const expectedSignature = createHmac('sha256', webhookSecret)
+			.update(nonce)
+			.digest('base64');
+
+		if (timingSafeEqualBase64(signature, expectedSignature)) {
+			return { valid: true };
+		}
+	} catch (err) {
+		return {
+			valid: false,
+			error:
+				err instanceof Error ? err.message : 'Signature calculation failed',
+		};
+	}
+
+	return { valid: false, error: 'Invalid signature' };
+}
+
+export function createCannyMatch(eventType: string): CorsairWebhookMatcher {
+	return (request: RawWebhookRequest) => {
+		const parsedBody = parseBody(request.body);
+		return parsedBody !== null && parsedBody.type === eventType;
+	};
+}
+
+export const createCannyEventMatch = createCannyMatch;

--- a/packages/canny/webhooks/votes.ts
+++ b/packages/canny/webhooks/votes.ts
@@ -1,0 +1,51 @@
+import { logEventFromContext } from 'corsair/core';
+import type { CannyWebhooks } from '../index';
+import { createCannyMatch, verifyCannyWebhookSignature } from './types';
+
+export const created: CannyWebhooks['voteCreated'] = {
+	match: createCannyMatch('vote.created'),
+
+	handler: async (ctx, request) => {
+		const verification = verifyCannyWebhookSignature(request, ctx.key);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
+
+		const event = request.payload;
+		if (event.type !== 'vote.created') {
+			return { success: true, data: undefined };
+		}
+
+		const vote = event.object;
+		if (ctx.db.votes && vote.id) {
+			try {
+				await ctx.db.votes.upsertByEntityId(vote.id, {
+					id: vote.id,
+					created: new Date(vote.created),
+					postID: vote.post?.id,
+					voterID: vote.voter?.id,
+					boardID: vote.board?.id,
+				});
+			} catch (error) {
+				console.warn('Failed to save vote to database:', error);
+			}
+		}
+
+		await logEventFromContext(
+			ctx,
+			'canny.webhook.vote.created',
+			{ id: vote.id, postID: vote.post?.id, voterID: vote.voter?.id },
+			'completed',
+		);
+
+		return { success: true, data: event };
+	},
+};
+
+export const VoteWebhooks = {
+	created,
+};

--- a/packages/canny/webhooks/votes.ts
+++ b/packages/canny/webhooks/votes.ts
@@ -1,6 +1,10 @@
 import { logEventFromContext } from 'corsair/core';
 import type { CannyWebhooks } from '../index';
-import { createCannyMatch, verifyCannyWebhookSignature } from './types';
+import {
+	CannyVoteCreatedEventSchema,
+	createCannyMatch,
+	verifyCannyWebhookSignature,
+} from './types';
 
 export const created: CannyWebhooks['voteCreated'] = {
 	match: createCannyMatch('vote.created'),
@@ -15,11 +19,19 @@ export const created: CannyWebhooks['voteCreated'] = {
 			};
 		}
 
-		const event = request.payload;
-		if (event.type !== 'vote.created') {
-			return { success: true, data: undefined };
+		const parsed = CannyVoteCreatedEventSchema.safeParse(request.payload);
+		if (!parsed.success) {
+			if ((request.payload as { type?: string })?.type !== 'vote.created') {
+				return { success: true, data: undefined };
+			}
+			return {
+				success: false,
+				statusCode: 400,
+				error: 'Invalid payload format',
+			};
 		}
 
+		const event = parsed.data;
 		const vote = event.object;
 		if (ctx.db.votes && vote.id) {
 			try {

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -86,16 +86,16 @@ export const BaseProviders = [
 	'boloforms',
 	'boltiot',
 	'bonsai',
-	'botbaba',
 	'bookingmood',
+	'botbaba',
 	'botpress',
 	'botsonic',
 	'bouncer',
 	'box',
 	'boxhero',
 	'brandfetch',
-	'brevo',
 	'breathehr',
+	'brevo',
 	'brex',
 	'brightdata',
 	'browseai',
@@ -106,6 +106,7 @@ export const BaseProviders = [
 	'buildkite',
 	'cal',
 	'calendly',
+	'canny',
 	'canva',
 	'canvas',
 	'capsulecrm',
@@ -264,10 +265,10 @@ export const BaseProviders = [
 	'webvizio',
 	'whatsapp',
 	'witai',
-	'worldnewsapi',
 	'wiza',
 	'workday',
 	'workiom',
+	'worldnewsapi',
 	'xquik',
 	'youcom',
 	'youtube',
@@ -352,16 +353,16 @@ export const ProviderDisplayNames = {
 	boloforms: 'Boloforms',
 	boltiot: 'Bolt IoT',
 	bonsai: 'Bonsai',
-	botbaba: 'Botbaba',
 	bookingmood: 'Bookingmood',
+	botbaba: 'Botbaba',
 	botpress: 'Botpress',
 	botsonic: 'Botsonic',
 	bouncer: 'Bouncer',
 	box: 'Box',
 	boxhero: 'BoxHero',
 	brandfetch: 'Brandfetch',
-	brevo: 'Brevo',
 	breathehr: 'Breathe HR',
+	brevo: 'Brevo',
 	brex: 'Brex',
 	brightdata: 'Bright Data',
 	browseai: 'Browse AI',
@@ -372,6 +373,7 @@ export const ProviderDisplayNames = {
 	buildkite: 'Buildkite',
 	cal: 'Cal',
 	calendly: 'Calendly',
+	canny: 'Canny',
 	canva: 'Canva',
 	canvas: 'Canvas LMS',
 	capsulecrm: 'Capsule CRM',
@@ -530,10 +532,10 @@ export const ProviderDisplayNames = {
 	webvizio: 'Webvizio',
 	whatsapp: 'WhatsApp',
 	witai: 'WitAi',
-	worldnewsapi: 'World News API',
 	wiza: 'Wiza',
 	workday: 'Workday',
 	workiom: 'Workiom',
+	worldnewsapi: 'World News API',
 	xquik: 'XQuik',
 	youcom: 'You.com',
 	youtube: 'YouTube',
@@ -625,16 +627,16 @@ export type AllProviders =
 	| 'boloforms'
 	| 'boltiot'
 	| 'bonsai'
-	| 'botbaba'
 	| 'bookingmood'
+	| 'botbaba'
 	| 'botpress'
 	| 'botsonic'
 	| 'bouncer'
 	| 'box'
 	| 'boxhero'
 	| 'brandfetch'
-	| 'brevo'
 	| 'breathehr'
+	| 'brevo'
 	| 'brex'
 	| 'brightdata'
 	| 'browseai'
@@ -645,6 +647,7 @@ export type AllProviders =
 	| 'buildkite'
 	| 'cal'
 	| 'calendly'
+	| 'canny'
 	| 'canva'
 	| 'canvas'
 	| 'capsulecrm'
@@ -803,10 +806,10 @@ export type AllProviders =
 	| 'webvizio'
 	| 'whatsapp'
 	| 'witai'
-	| 'worldnewsapi'
 	| 'wiza'
 	| 'workday'
 	| 'workiom'
+	| 'worldnewsapi'
 	| 'xquik'
 	| 'youcom'
 	| 'youtube'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,9 +168,6 @@ importers:
       '@corsair-dev/bitwarden':
         specifier: workspace:*
         version: link:../../packages/bitwarden
-      '@corsair-dev/canny':
-        specifier: workspace:*
-        version: link:../../packages/canny
       '@corsair-dev/cursor':
         specifier: workspace:*
         version: link:../../packages/cursor

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       '@corsair-dev/bitwarden':
         specifier: workspace:*
         version: link:../../packages/bitwarden
+      '@corsair-dev/canny':
+        specifier: workspace:*
+        version: link:../../packages/canny
       '@corsair-dev/cursor':
         specifier: workspace:*
         version: link:../../packages/cursor
@@ -2564,6 +2567,30 @@ importers:
         version: 4.4.3
 
   packages/calendly:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
+  packages/canny:
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14


### PR DESCRIPTION
## Description

Adds a Canny integration plugin to Corsair (`@corsair-dev/canny`), implementing boards, posts, comments, and votes resources, alongside webhook support with HMAC-SHA256 signature verification.

Fixes #1534

### API Surface
- **boards**: `list` (POST `/boards/list`), `retrieve` (POST `/boards/retrieve`)
- **posts**: `list` (POST `/posts/list`), `retrieve` (POST `/posts/retrieve`), `create` (POST `/posts/create`), `changeStatus` (POST `/posts/changeStatus`), `delete` (POST `/posts/delete`)
- **comments**: `list` (POST `/comments/list`), `create` (POST `/comments/create`), `delete` (POST `/comments/delete`)
- **votes**: `list` (POST `/votes/list`), `create` (POST `/votes/create`), `delete` (POST `/votes/delete`)
- **Webhooks**: `post.created`, `post.status_changed`, `comment.created`, `vote.created` (with `canny-signature`, `canny-nonce`, and `canny-timestamp` verification)

### Authentication
Account-level API key auth, sent as an `apiKey` field in the POST body of every request per Canny's API specification.

### Testing
- Comprehensive unit tests covering schema (`schema.test.ts`), all endpoints (`endpoints.test.ts`), and webhook events with signature verification (`webhooks.test.ts`) with 24/24 passing tests.

## Screenshots / Demos
Demo and verification:
https://github.com/corsairdev/corsair/pull/1541

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Canny integration for boards, posts, comments, and votes.
  - Added support for Canny webhooks, including post, comment, and vote events.
  - Added persistence for Canny content and votes.
  - Added Canny to the list of supported providers.
  - Added support for post status changes, vote priorities, expanded post fields, and configurable webhook secrets.

- **Bug Fixes**
  - Improved API error details, rate-limit handling, and authentication error detection.
  - Strengthened webhook signature validation and replay protection.
  - Improved validation for Canny requests and responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->