### PR TITLE
feat(chaser): add Chaser accounts receivable integration

### DIFF
--- a/packages/chaser/client.ts
+++ b/packages/chaser/client.ts
@@ -1,0 +1,57 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+
+export class ChaserAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly status?: number,
+		public readonly code?: string,
+	) {
+		super(message);
+		this.name = 'ChaserAPIError';
+	}
+}
+
+const CHASER_API_BASE = 'https://openapi.chaserhq.com';
+
+export async function makeChaserRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	apiSecret: string,
+	options: {
+		method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+		body?: Record<string, unknown>;
+		query?: Record<string, string | number | boolean | undefined>;
+	} = {},
+): Promise<T> {
+	const { method = 'GET', body, query } = options;
+	const credentials = Buffer.from(`${apiKey}:${apiSecret}`).toString('base64');
+	const config: OpenAPIConfig = {
+		BASE: CHASER_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		HEADERS: {
+			'Content-Type': 'application/json',
+			Authorization: `Basic ${credentials}`,
+		},
+	};
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint,
+		body: method !== 'GET' ? body : undefined,
+		mediaType: 'application/json; charset=utf-8',
+		query: method === 'GET' ? query : undefined,
+	};
+	try {
+		return await request<T>(config, requestOptions);
+	} catch (error) {
+		if (error instanceof ApiError) {
+			throw error;
+		}
+		if (error instanceof Error) {
+			throw new ChaserAPIError(error.message);
+		}
+		throw new ChaserAPIError('Unknown Chaser API error');
+	}
+}

--- a/packages/chaser/endpoints/chaser.ts
+++ b/packages/chaser/endpoints/chaser.ts
@@ -1,0 +1,76 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeChaserRequest } from '../client';
+import type { ChaserEndpointInputs, ChaserEndpointOutputs } from './types';
+
+export const listCustomers = async (
+	ctx: any,
+	_input?: any,
+): Promise<ChaserEndpointOutputs['listCustomers']> => {
+	const input = ctx.input as ChaserEndpointInputs['listCustomers'];
+	const response = await makeChaserRequest<
+		ChaserEndpointOutputs['listCustomers']
+	>('/v1/customers', ctx.key, ctx.secret ?? '', {
+		method: 'GET',
+		query: input,
+	});
+	await logEventFromContext(ctx, 'chaser.customers.list', {}, 'completed');
+	return response;
+};
+
+export const listInvoices = async (
+	ctx: any,
+	_input?: any,
+): Promise<ChaserEndpointOutputs['listInvoices']> => {
+	const input = ctx.input as ChaserEndpointInputs['listInvoices'];
+	const response = await makeChaserRequest<
+		ChaserEndpointOutputs['listInvoices']
+	>('/v1/invoices', ctx.key, ctx.secret ?? '', { method: 'GET', query: input });
+	await logEventFromContext(ctx, 'chaser.invoices.list', {}, 'completed');
+	return response;
+};
+
+export const getInvoice = async (
+	ctx: any,
+	_input?: any,
+): Promise<ChaserEndpointOutputs['getInvoice']> => {
+	const input = ctx.input as ChaserEndpointInputs['getInvoice'];
+	const response = await makeChaserRequest<ChaserEndpointOutputs['getInvoice']>(
+		`/v1/invoices/${input.id}`,
+		ctx.key,
+		ctx.secret ?? '',
+		{ method: 'GET' },
+	);
+	await logEventFromContext(
+		ctx,
+		'chaser.invoices.get',
+		{ id: input.id },
+		'completed',
+	);
+	return response;
+};
+
+export const listCreditNotes = async (
+	ctx: any,
+	_input?: any,
+): Promise<ChaserEndpointOutputs['listCreditNotes']> => {
+	const input = ctx.input as ChaserEndpointInputs['listCreditNotes'];
+	const response = await makeChaserRequest<
+		ChaserEndpointOutputs['listCreditNotes']
+	>('/v1/credit-notes', ctx.key, ctx.secret ?? '', {
+		method: 'GET',
+		query: input,
+	});
+	await logEventFromContext(ctx, 'chaser.credit-notes.list', {}, 'completed');
+	return response;
+};
+
+export const getOrganization = async (
+	ctx: any,
+	_input?: any,
+): Promise<ChaserEndpointOutputs['getOrganization']> => {
+	const response = await makeChaserRequest<
+		ChaserEndpointOutputs['getOrganization']
+	>('/v1/organization', ctx.key, ctx.secret ?? '', { method: 'GET' });
+	await logEventFromContext(ctx, 'chaser.organization.get', {}, 'completed');
+	return response;
+};

--- a/packages/chaser/endpoints/chaser.ts
+++ b/packages/chaser/endpoints/chaser.ts
@@ -9,7 +9,7 @@ export const listCustomers = async (
 	const input = ctx.input as ChaserEndpointInputs['listCustomers'];
 	const response = await makeChaserRequest<
 		ChaserEndpointOutputs['listCustomers']
-	>('/v1/customers', ctx.key, ctx.secret ?? '', {
+	>('/v1/customers', ctx.key, ctx.options?.secret ?? '', {
 		method: 'GET',
 		query: input,
 	});
@@ -24,7 +24,10 @@ export const listInvoices = async (
 	const input = ctx.input as ChaserEndpointInputs['listInvoices'];
 	const response = await makeChaserRequest<
 		ChaserEndpointOutputs['listInvoices']
-	>('/v1/invoices', ctx.key, ctx.secret ?? '', { method: 'GET', query: input });
+	>('/v1/invoices', ctx.key, ctx.options?.secret ?? '', {
+		method: 'GET',
+		query: input,
+	});
 	await logEventFromContext(ctx, 'chaser.invoices.list', {}, 'completed');
 	return response;
 };
@@ -37,7 +40,7 @@ export const getInvoice = async (
 	const response = await makeChaserRequest<ChaserEndpointOutputs['getInvoice']>(
 		`/v1/invoices/${input.id}`,
 		ctx.key,
-		ctx.secret ?? '',
+		ctx.options?.secret ?? '',
 		{ method: 'GET' },
 	);
 	await logEventFromContext(
@@ -56,7 +59,7 @@ export const listCreditNotes = async (
 	const input = ctx.input as ChaserEndpointInputs['listCreditNotes'];
 	const response = await makeChaserRequest<
 		ChaserEndpointOutputs['listCreditNotes']
-	>('/v1/credit-notes', ctx.key, ctx.secret ?? '', {
+	>('/v1/credit-notes', ctx.key, ctx.options?.secret ?? '', {
 		method: 'GET',
 		query: input,
 	});
@@ -70,7 +73,7 @@ export const getOrganization = async (
 ): Promise<ChaserEndpointOutputs['getOrganization']> => {
 	const response = await makeChaserRequest<
 		ChaserEndpointOutputs['getOrganization']
-	>('/v1/organization', ctx.key, ctx.secret ?? '', { method: 'GET' });
+	>('/v1/organization', ctx.key, ctx.options?.secret ?? '', { method: 'GET' });
 	await logEventFromContext(ctx, 'chaser.organization.get', {}, 'completed');
 	return response;
 };

--- a/packages/chaser/endpoints/endpoints.test.ts
+++ b/packages/chaser/endpoints/endpoints.test.ts
@@ -20,6 +20,7 @@ const createContext = (input: unknown = {}) =>
 		key: 'chaser-test-api-key',
 		$getAccountId: jest.fn().mockReturnValue('test-account'),
 		secret: 'chaser-test-api-secret',
+		options: { secret: 'chaser-test-api-secret' },
 		db: {},
 		input,
 	}) as any;

--- a/packages/chaser/endpoints/endpoints.test.ts
+++ b/packages/chaser/endpoints/endpoints.test.ts
@@ -1,0 +1,135 @@
+import * as client from '../client';
+import {
+	getInvoice,
+	getOrganization,
+	listCreditNotes,
+	listCustomers,
+	listInvoices,
+} from './chaser';
+
+jest.mock('../client', () => ({
+	makeChaserRequest: jest.fn(),
+}));
+
+const mockedRequest = client.makeChaserRequest as jest.MockedFunction<
+	typeof client.makeChaserRequest
+>;
+
+const createContext = (input: unknown = {}) =>
+	({
+		key: 'chaser-test-api-key',
+		$getAccountId: jest.fn().mockReturnValue('test-account'),
+		secret: 'chaser-test-api-secret',
+		db: {},
+		input,
+	}) as any;
+
+describe('Chaser endpoints', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('customers', () => {
+		it('lists all customers', async () => {
+			const response = {
+				data: [{ id: 'cust_1', name: 'Acme Corp' }],
+				total: 1,
+			};
+			mockedRequest.mockResolvedValueOnce(response);
+			const result = await listCustomers(createContext({}));
+			expect(mockedRequest).toHaveBeenCalledWith(
+				'/v1/customers',
+				'chaser-test-api-key',
+				'chaser-test-api-secret',
+				expect.objectContaining({ method: 'GET' }),
+			);
+			expect(result).toEqual(response);
+		});
+	});
+
+	describe('invoices', () => {
+		it('lists all invoices', async () => {
+			const response = {
+				data: [
+					{
+						id: 'inv_1',
+						customer_id: 'cust_1',
+						amount: 100,
+						currency: 'GBP',
+						status: 'open',
+					},
+				],
+				total: 1,
+			};
+			mockedRequest.mockResolvedValueOnce(response);
+			const result = await listInvoices(createContext({}));
+			expect(mockedRequest).toHaveBeenCalledWith(
+				'/v1/invoices',
+				'chaser-test-api-key',
+				'chaser-test-api-secret',
+				expect.objectContaining({ method: 'GET' }),
+			);
+			expect(result).toEqual(response);
+		});
+
+		it('gets an invoice by ID', async () => {
+			const response = {
+				id: 'inv_1',
+				customer_id: 'cust_1',
+				amount: 100,
+				currency: 'GBP',
+				status: 'open',
+			};
+			mockedRequest.mockResolvedValueOnce(response);
+			const result = await getInvoice(createContext({ id: 'inv_1' }));
+			expect(mockedRequest).toHaveBeenCalledWith(
+				'/v1/invoices/inv_1',
+				'chaser-test-api-key',
+				'chaser-test-api-secret',
+				expect.objectContaining({ method: 'GET' }),
+			);
+			expect(result).toEqual(response);
+		});
+	});
+
+	describe('credit notes', () => {
+		it('lists all credit notes', async () => {
+			const response = {
+				data: [
+					{
+						id: 'cn_1',
+						customer_id: 'cust_1',
+						amount: 50,
+						currency: 'GBP',
+						status: 'issued',
+					},
+				],
+				total: 1,
+			};
+			mockedRequest.mockResolvedValueOnce(response);
+			const result = await listCreditNotes(createContext({}));
+			expect(mockedRequest).toHaveBeenCalledWith(
+				'/v1/credit-notes',
+				'chaser-test-api-key',
+				'chaser-test-api-secret',
+				expect.objectContaining({ method: 'GET' }),
+			);
+			expect(result).toEqual(response);
+		});
+	});
+
+	describe('organization', () => {
+		it('gets organization details', async () => {
+			const response = { id: 'org_1', name: 'Test Org' };
+			mockedRequest.mockResolvedValueOnce(response);
+			const result = await getOrganization(createContext({}));
+			expect(mockedRequest).toHaveBeenCalledWith(
+				'/v1/organization',
+				'chaser-test-api-key',
+				'chaser-test-api-secret',
+				expect.objectContaining({ method: 'GET' }),
+			);
+			expect(result).toEqual(response);
+		});
+	});
+});

--- a/packages/chaser/endpoints/index.ts
+++ b/packages/chaser/endpoints/index.ts
@@ -1,0 +1,7 @@
+export {
+	getInvoice,
+	getOrganization,
+	listCreditNotes,
+	listCustomers,
+	listInvoices,
+} from './chaser';

--- a/packages/chaser/endpoints/types.ts
+++ b/packages/chaser/endpoints/types.ts
@@ -1,0 +1,109 @@
+import { z } from 'zod';
+
+// Customers
+const CustomerSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	email: z.string().optional(),
+	status: z.string().optional(),
+});
+
+const ListCustomersInputSchema = z.object({
+	page: z.number().int().positive().optional(),
+	limit: z.number().int().positive().optional(),
+});
+
+const ListCustomersOutputSchema = z.object({
+	data: z.array(CustomerSchema),
+	total: z.number().int().optional(),
+});
+
+// Invoices
+const InvoiceSchema = z.object({
+	id: z.string(),
+	customer_id: z.string(),
+	amount: z.number(),
+	currency: z.string(),
+	status: z.string(),
+	due_date: z.string().optional(),
+});
+
+const ListInvoicesInputSchema = z.object({
+	page: z.number().int().positive().optional(),
+	limit: z.number().int().positive().optional(),
+	customer_id: z.string().optional(),
+});
+
+const ListInvoicesOutputSchema = z.object({
+	data: z.array(InvoiceSchema),
+	total: z.number().int().optional(),
+});
+
+const GetInvoiceInputSchema = z.object({
+	id: z.string(),
+});
+
+// Credit Notes
+const CreditNoteSchema = z.object({
+	id: z.string(),
+	customer_id: z.string(),
+	amount: z.number(),
+	currency: z.string(),
+	status: z.string(),
+});
+
+const ListCreditNotesInputSchema = z.object({
+	page: z.number().int().positive().optional(),
+	limit: z.number().int().positive().optional(),
+});
+
+const ListCreditNotesOutputSchema = z.object({
+	data: z.array(CreditNoteSchema),
+	total: z.number().int().optional(),
+});
+
+// Organizations
+const OrganizationSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	email: z.string().optional(),
+});
+
+const GetOrganizationOutputSchema = OrganizationSchema;
+
+export type ListCustomersInput = z.infer<typeof ListCustomersInputSchema>;
+export type ListInvoicesInput = z.infer<typeof ListInvoicesInputSchema>;
+export type GetInvoiceInput = z.infer<typeof GetInvoiceInputSchema>;
+export type ListCreditNotesInput = z.infer<typeof ListCreditNotesInputSchema>;
+
+export type ChaserEndpointInputs = {
+	listCustomers: ListCustomersInput;
+	listInvoices: ListInvoicesInput;
+	getInvoice: GetInvoiceInput;
+	listCreditNotes: ListCreditNotesInput;
+	getOrganization: Record<string, never>;
+};
+
+export type ChaserEndpointOutputs = {
+	listCustomers: z.infer<typeof ListCustomersOutputSchema>;
+	listInvoices: z.infer<typeof ListInvoicesOutputSchema>;
+	getInvoice: z.infer<typeof InvoiceSchema>;
+	listCreditNotes: z.infer<typeof ListCreditNotesOutputSchema>;
+	getOrganization: z.infer<typeof GetOrganizationOutputSchema>;
+};
+
+export const ChaserEndpointInputSchemas = {
+	listCustomers: ListCustomersInputSchema,
+	listInvoices: ListInvoicesInputSchema,
+	getInvoice: GetInvoiceInputSchema,
+	listCreditNotes: ListCreditNotesInputSchema,
+	getOrganization: z.object({}),
+} as const;
+
+export const ChaserEndpointOutputSchemas = {
+	listCustomers: ListCustomersOutputSchema,
+	listInvoices: ListInvoicesOutputSchema,
+	getInvoice: InvoiceSchema,
+	listCreditNotes: ListCreditNotesOutputSchema,
+	getOrganization: GetOrganizationOutputSchema,
+} as const;

--- a/packages/chaser/error-handlers.ts
+++ b/packages/chaser/error-handlers.ts
@@ -1,0 +1,31 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('429');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('unauthorized') || msg.includes('invalid_auth');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/chaser/index.ts
+++ b/packages/chaser/index.ts
@@ -1,0 +1,192 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+} from 'corsair/core';
+import {
+	getInvoice,
+	getOrganization,
+	listCreditNotes,
+	listCustomers,
+	listInvoices,
+} from './endpoints/chaser';
+import type {
+	ChaserEndpointInputs,
+	ChaserEndpointOutputs,
+} from './endpoints/types';
+import {
+	ChaserEndpointInputSchemas,
+	ChaserEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { ChaserSchema } from './schema';
+
+export type ChaserPluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	secret?: string;
+	hooks?: InternalChaserPlugin['hooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof chaserEndpointsNested>;
+};
+
+export type ChaserContext = CorsairPluginContext<
+	typeof ChaserSchema,
+	ChaserPluginOptions
+>;
+
+export type ChaserKeyBuilderContext = KeyBuilderContext<ChaserPluginOptions>;
+
+export type ChaserBoundEndpoints = BindEndpoints<typeof chaserEndpointsNested>;
+
+type ChaserEndpoint<K extends keyof ChaserEndpointOutputs> = CorsairEndpoint<
+	ChaserContext,
+	ChaserEndpointInputs[K],
+	ChaserEndpointOutputs[K]
+>;
+
+export type ChaserEndpoints = {
+	listCustomers: ChaserEndpoint<'listCustomers'>;
+	listInvoices: ChaserEndpoint<'listInvoices'>;
+	getInvoice: ChaserEndpoint<'getInvoice'>;
+	listCreditNotes: ChaserEndpoint<'listCreditNotes'>;
+	getOrganization: ChaserEndpoint<'getOrganization'>;
+};
+
+const chaserEndpointsNested = {
+	customers: {
+		list: listCustomers,
+	},
+	invoices: {
+		list: listInvoices,
+		get: getInvoice,
+	},
+	creditNotes: {
+		list: listCreditNotes,
+	},
+	organization: {
+		get: getOrganization,
+	},
+} as const;
+
+export const chaserEndpointSchemas = {
+	'customers.list': {
+		input: ChaserEndpointInputSchemas.listCustomers,
+		output: ChaserEndpointOutputSchemas.listCustomers,
+	},
+	'invoices.list': {
+		input: ChaserEndpointInputSchemas.listInvoices,
+		output: ChaserEndpointOutputSchemas.listInvoices,
+	},
+	'invoices.get': {
+		input: ChaserEndpointInputSchemas.getInvoice,
+		output: ChaserEndpointOutputSchemas.getInvoice,
+	},
+	'creditNotes.list': {
+		input: ChaserEndpointInputSchemas.listCreditNotes,
+		output: ChaserEndpointOutputSchemas.listCreditNotes,
+	},
+	'organization.get': {
+		input: ChaserEndpointInputSchemas.getOrganization,
+		output: ChaserEndpointOutputSchemas.getOrganization,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<
+	typeof chaserEndpointsNested
+>;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const chaserEndpointMeta = {
+	'customers.list': {
+		riskLevel: 'read',
+		description: 'List all customers',
+	},
+	'invoices.list': {
+		riskLevel: 'read',
+		description: 'List all invoices',
+	},
+	'invoices.get': {
+		riskLevel: 'read',
+		description: 'Get an invoice by ID',
+	},
+	'creditNotes.list': {
+		riskLevel: 'read',
+		description: 'List all credit notes',
+	},
+	'organization.get': {
+		riskLevel: 'read',
+		description: 'Get organization details',
+	},
+} as const satisfies RequiredPluginEndpointMeta<typeof chaserEndpointsNested>;
+
+export const chaserAuthConfig = {
+	api_key: {
+		account: ['tenant_external_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type BaseChaserPlugin<T extends ChaserPluginOptions> = CorsairPlugin<
+	'chaser',
+	typeof ChaserSchema,
+	typeof chaserEndpointsNested,
+	{},
+	T,
+	typeof defaultAuthType
+>;
+
+export type InternalChaserPlugin = BaseChaserPlugin<ChaserPluginOptions>;
+
+export type ExternalChaserPlugin<T extends ChaserPluginOptions> =
+	BaseChaserPlugin<T>;
+
+export function chaser<const T extends ChaserPluginOptions>(
+	incomingOptions: ChaserPluginOptions & T = {} as ChaserPluginOptions & T,
+): ExternalChaserPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+
+	return {
+		id: 'chaser',
+		authConfig: chaserAuthConfig,
+		schema: ChaserSchema,
+		options,
+		hooks: options.hooks,
+		endpoints: chaserEndpointsNested,
+		webhooks: {},
+		endpointMeta: chaserEndpointMeta,
+		endpointSchemas: chaserEndpointSchemas,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: ChaserKeyBuilderContext, source) => {
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const key = await ctx.keys.get_api_key();
+				if (!key) {
+					throw new Error('Chaser API key is required.');
+				}
+				return key;
+			}
+			throw new Error('Chaser API key is required.');
+		},
+	} satisfies InternalChaserPlugin;
+}
+
+export type {
+	ChaserEndpointInputs,
+	ChaserEndpointOutputs,
+} from './endpoints/types';

--- a/packages/chaser/jest.config.cjs
+++ b/packages/chaser/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/chaser/package.json
+++ b/packages/chaser/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/chaser",
+  "version": "0.1.0",
+  "description": "Chaser plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "chaser",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/chaser/schema.test.ts
+++ b/packages/chaser/schema.test.ts
@@ -1,0 +1,20 @@
+import { ChaserSchema } from './schema';
+
+describe('Chaser schema', () => {
+	it('declares a semver version', () => {
+		expect(ChaserSchema.version).toBeDefined();
+		expect(ChaserSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof ChaserSchema.entities).toBe('object');
+		expect(ChaserSchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(ChaserSchema.entities))).toBe(true);
+		for (const entity of Object.values(ChaserSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/chaser/schema/database.ts
+++ b/packages/chaser/schema/database.ts
@@ -1,0 +1,1 @@
+// No database entities required for the Chaser plugin.

--- a/packages/chaser/schema/index.ts
+++ b/packages/chaser/schema/index.ts
@@ -1,0 +1,4 @@
+export const ChaserSchema = {
+	version: '1.0.0',
+	entities: {},
+} as const;

--- a/packages/chaser/tsconfig.json
+++ b/packages/chaser/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/chaser/tsup.config.ts
+++ b/packages/chaser/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -94,6 +94,7 @@ export const BaseProviders = [
 	'box',
 	'boxhero',
 	'brandfetch',
+	'chaser',
 	'brevo',
 	'breathehr',
 	'brex',
@@ -360,6 +361,7 @@ export const ProviderDisplayNames = {
 	box: 'Box',
 	boxhero: 'BoxHero',
 	brandfetch: 'Brandfetch',
+	chaser: 'Chaser',
 	brevo: 'Brevo',
 	breathehr: 'Breathe HR',
 	brex: 'Brex',
@@ -633,6 +635,7 @@ export type AllProviders =
 	| 'box'
 	| 'boxhero'
 	| 'brandfetch'
+	| 'chaser'
 	| 'brevo'
 	| 'breathehr'
 	| 'brex'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2707,6 +2707,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/chaser:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/chatbotkit:
     devDependencies:
       '@types/jest':


### PR DESCRIPTION
## Description

Adds a Chaser accounts receivable integration plugin to Corsair with support for listing customers, listing and getting invoices, listing credit notes, and getting organization details using the Chaser API. Implements Basic Auth (API key + secret), zod schema validation, error handling with rate-limit support, and full endpoint test coverage.

Fixes #1549

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos 
<img width="421" height="490" alt="image" src="https://github.com/user-attachments/assets/cd6e9557-9473-4977-8bf4-d517c7616f96" />


7/7 Chaser endpoint tests passing:
- ✅ lists all customers
- ✅ lists all invoices
- ✅ gets an invoice by ID
- ✅ lists all credit notes
- ✅ gets organization details

## Additional Notes

Chaser uses Basic Authentication with API key as username and API secret as password. Base URL: https://openapi.chaserhq.com. No breaking changes. New dependency: `@corsair-dev/chaser`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Chaser integration with authenticated API access.
  * Added customer, invoice, credit note, invoice lookup, and organization operations.
  * Added request input and response validation.
  * Added structured error handling, including rate-limit retry behavior.
  * Added Chaser as a supported provider with package and schema support.

* **Tests**
  * Added automated coverage for Chaser endpoints and schema behavior.
  * Added validation of request methods, paths, authentication, filters, and returned data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->