### PR TITLE
feat(dictionaryapi): add Merriam-Webster dictionary integration

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1085,6 +1085,14 @@
                 ]
               },
               {
+                "group": "Dictionary API",
+                "pages": [
+                  "plugins/dictionaryapi/overview",
+                  "plugins/dictionaryapi/api",
+                  "plugins/dictionaryapi/database"
+                ]
+              },
+              {
                 "group": "Diffbot",
                 "pages": [
                   "plugins/diffbot/overview",

--- a/docs/plugins/dictionaryapi/api.mdx
+++ b/docs/plugins/dictionaryapi/api.mdx
@@ -1,0 +1,74 @@
+---
+title: API
+description: "API reference for Dictionary API: every `dictionaryapi.api.*` operation with input and output types."
+---
+
+Every `dictionaryapi.api.*` operation is listed below with parameter shapes and return types from the plugin Zod schemas.
+
+<Info>
+**New to Corsair?** See [API access](/concepts/api), [authentication](/concepts/auth), and [error handling](/concepts/error-handling).
+</Info>
+
+## Entries
+
+### get
+
+`entries.get`
+
+Look up a word in Merriam-Webster Collegiate Dictionary, returning definitions, headword, part of speech, and pronunciations — or spelling suggestions if not found
+
+**Risk:** `read`
+
+```ts
+await corsair.dictionaryapi.api.entries.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `word` | `string` | Yes | — |
+
+
+
+**Output:** `object[]`
+
+<AccordionGroup>
+<Accordion title="Output full type">
+
+```ts
+(
+  {
+    meta?: {
+      id: string,
+      uuid?: string,
+      sort?: string,
+      src?: string,
+      section?: string,
+      stems?: string[],
+      offensive?: boolean
+    },
+    hwi?: {
+      hw?: string,
+      prs?: {
+        mw?: string,
+        sound?: {
+          audio?: string,
+          ref?: string
+        }
+      }[]
+    },
+    fl?: string,
+    shortdef?: string[],
+    date?: string,
+    def?: any[],
+    et?: any[]
+  } | string
+)[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+---
+

--- a/docs/plugins/dictionaryapi/database.mdx
+++ b/docs/plugins/dictionaryapi/database.mdx
@@ -1,0 +1,12 @@
+---
+title: Database
+description: "Dictionary API local sync: searchable entities, `.search()` filters, and operators."
+---
+
+The Dictionary API plugin syncs data locally. Use `corsair.dictionaryapi.db.<entity>.search({ data, limit?, offset? })` with the filters listed per entity.
+
+<Info>
+**New to Corsair?** See [database operations](/concepts/database), [data synchronization](/concepts/integrations), and [multi-tenancy](/concepts/multi-tenancy).
+</Info>
+
+

--- a/docs/plugins/dictionaryapi/overview.mdx
+++ b/docs/plugins/dictionaryapi/overview.mdx
@@ -1,0 +1,118 @@
+---
+title: Overview
+description: "Merriam-Webster Collegiate Dictionary API integration for word definitions and spelling suggestions."
+---
+
+Use **Dictionary API** through Corsair: one client, typed API calls.
+
+**What you get:**
+
+- 1 typed API operations
+
+## Setup
+
+<Steps>
+
+<Step title="Install">
+<CodeGroup>
+```bash npm
+npm install corsair @corsair-dev/dictionaryapi
+```
+```bash yarn
+yarn add corsair @corsair-dev/dictionaryapi
+```
+```bash pnpm
+pnpm install corsair @corsair-dev/dictionaryapi
+```
+```bash bun
+bun add corsair @corsair-dev/dictionaryapi
+```
+</CodeGroup>
+
+</Step>
+
+<Step title="Add the plugin">
+```ts corsair.ts
+import Database from 'better-sqlite3';
+import { createCorsair } from 'corsair';
+import { dictionaryapi } from '@corsair-dev/dictionaryapi';
+
+export const corsair = createCorsair({
+	plugins: [
+		dictionaryapi(),
+	],
+	database: new Database('corsair.db'),
+	kek: process.env.CORSAIR_KEK!,
+	hub: {
+		projectApiKey: process.env.CORSAIR_API_KEY!,
+		signingSecret: process.env.CORSAIR_SIGNING_SECRET!,
+	},
+});
+```
+
+Multi-tenancy is the default — scope calls with `corsair.withTenant(id)`. See [Quick start](/quick-start) for KEK + Hub keys, and [Multi-tenancy](/concepts/multi-tenancy) for account isolation.
+
+</Step>
+
+<Step title="Choose authentication">
+<Tabs>
+<Tab title="API Key (Recommended)">
+
+No setup required yet. When you make your first request as a tenant, Corsair prompts for the API key.
+
+```ts
+dictionaryapi()
+```
+
+More: [API Key](/concepts/api-key)
+
+</Tab>
+</Tabs>
+
+</Step>
+
+<Step title="Connect a tenant">
+Mint a connect link and send the tenant to it. Hub hosts the page and delivers the result to your app — see [Connect / OAuth](/management/connect).
+
+```ts
+const { connectUrl } = await corsair.manage.connect.createLink({
+	plugin: 'dictionaryapi',
+	tenantId: 'acme',
+});
+// redirect the user's browser to connectUrl
+```
+
+</Step>
+
+</Steps>
+
+## Example API calls
+
+**Look up word definition**
+
+```ts
+const tenant = corsair.withTenant('acme');
+await tenant.dictionaryapi.api.entries.get({ word: 'computer' });
+```
+
+
+**Write**
+
+_No write-style endpoint inferred; pick any operation from the [API](/plugins/dictionaryapi/api) reference._
+
+
+See the full list on the [API](/plugins/dictionaryapi/api) page.
+
+## What's next
+
+<CardGroup cols={2}>
+  <Card title="API reference" href="/plugins/dictionaryapi/api">
+    Every `dictionaryapi.api.*` operation with input and output types.
+  </Card>
+  <Card title="Connect / OAuth" href="/management/connect">
+    createLink, Hub delivery, and tenant connect flows.
+  </Card>
+  <Card title="Use with agents" href="/mcp-adapters/mcp-adapters">
+    Expose this plugin's operations as MCP tools.
+  </Card>
+</CardGroup>

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -86,16 +86,16 @@ export const BaseProviders = [
 	'boloforms',
 	'boltiot',
 	'bonsai',
-	'botbaba',
 	'bookingmood',
+	'botbaba',
 	'botpress',
 	'botsonic',
 	'bouncer',
 	'box',
 	'boxhero',
 	'brandfetch',
-	'brevo',
 	'breathehr',
+	'brevo',
 	'brex',
 	'brightdata',
 	'browseai',
@@ -132,6 +132,7 @@ export const BaseProviders = [
 	'datarobot',
 	'deepseek',
 	'devinmcp',
+	'dictionaryapi',
 	'diffbot',
 	'digitalocean',
 	'discord',
@@ -264,10 +265,10 @@ export const BaseProviders = [
 	'webvizio',
 	'whatsapp',
 	'witai',
-	'worldnewsapi',
 	'wiza',
 	'workday',
 	'workiom',
+	'worldnewsapi',
 	'xquik',
 	'youcom',
 	'youtube',
@@ -352,16 +353,16 @@ export const ProviderDisplayNames = {
 	boloforms: 'Boloforms',
 	boltiot: 'Bolt IoT',
 	bonsai: 'Bonsai',
-	botbaba: 'Botbaba',
 	bookingmood: 'Bookingmood',
+	botbaba: 'Botbaba',
 	botpress: 'Botpress',
 	botsonic: 'Botsonic',
 	bouncer: 'Bouncer',
 	box: 'Box',
 	boxhero: 'BoxHero',
 	brandfetch: 'Brandfetch',
-	brevo: 'Brevo',
 	breathehr: 'Breathe HR',
+	brevo: 'Brevo',
 	brex: 'Brex',
 	brightdata: 'Bright Data',
 	browseai: 'Browse AI',
@@ -398,6 +399,7 @@ export const ProviderDisplayNames = {
 	datarobot: 'DataRobot',
 	deepseek: 'DeepSeek',
 	devinmcp: 'Devin MCP',
+	dictionaryapi: 'DictionaryApi',
 	diffbot: 'Diffbot',
 	digitalocean: 'DigitalOcean',
 	discord: 'Discord',
@@ -530,10 +532,10 @@ export const ProviderDisplayNames = {
 	webvizio: 'Webvizio',
 	whatsapp: 'WhatsApp',
 	witai: 'WitAi',
-	worldnewsapi: 'World News API',
 	wiza: 'Wiza',
 	workday: 'Workday',
 	workiom: 'Workiom',
+	worldnewsapi: 'World News API',
 	xquik: 'XQuik',
 	youcom: 'You.com',
 	youtube: 'YouTube',
@@ -625,16 +627,16 @@ export type AllProviders =
 	| 'boloforms'
 	| 'boltiot'
 	| 'bonsai'
-	| 'botbaba'
 	| 'bookingmood'
+	| 'botbaba'
 	| 'botpress'
 	| 'botsonic'
 	| 'bouncer'
 	| 'box'
 	| 'boxhero'
 	| 'brandfetch'
-	| 'brevo'
 	| 'breathehr'
+	| 'brevo'
 	| 'brex'
 	| 'brightdata'
 	| 'browseai'
@@ -671,6 +673,7 @@ export type AllProviders =
 	| 'datarobot'
 	| 'deepseek'
 	| 'devinmcp'
+	| 'dictionaryapi'
 	| 'diffbot'
 	| 'digitalocean'
 	| 'discord'
@@ -803,10 +806,10 @@ export type AllProviders =
 	| 'webvizio'
 	| 'whatsapp'
 	| 'witai'
-	| 'worldnewsapi'
 	| 'wiza'
 	| 'workday'
 	| 'workiom'
+	| 'worldnewsapi'
 	| 'xquik'
 	| 'youcom'
 	| 'youtube'

--- a/packages/dictionaryapi/api.test.ts
+++ b/packages/dictionaryapi/api.test.ts
@@ -1,0 +1,210 @@
+import { ApiError } from 'corsair/http';
+import { DictionaryApiAPIError, getEntry } from './client';
+import { Entries } from './endpoints';
+import { GetEntryInputSchema, GetEntryOutputSchema } from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+
+jest.mock('corsair/http', () => {
+	const actual = jest.requireActual('corsair/http');
+	return {
+		...actual,
+		request: jest.fn(),
+	};
+});
+
+jest.mock('corsair/core', () => {
+	const actual = jest.requireActual('corsair/core');
+	return {
+		...actual,
+		logEventFromContext: jest.fn().mockResolvedValue(undefined),
+	};
+});
+
+import { request } from 'corsair/http';
+
+const mockedRequest = request as jest.MockedFunction<typeof request>;
+
+describe('DictionaryApi Input Schema', () => {
+	it('accepts valid words', () => {
+		const parsed = GetEntryInputSchema.parse({ word: 'computer' });
+		expect(parsed.word).toBe('computer');
+	});
+
+	it('trims leading and trailing whitespace', () => {
+		const parsed = GetEntryInputSchema.parse({ word: '  hello  ' });
+		expect(parsed.word).toBe('hello');
+	});
+
+	it('rejects empty words', () => {
+		expect(() => GetEntryInputSchema.parse({ word: '' })).toThrow();
+		expect(() => GetEntryInputSchema.parse({ word: '   ' })).toThrow();
+	});
+
+	it('rejects missing word property', () => {
+		expect(() => GetEntryInputSchema.parse({})).toThrow();
+	});
+});
+
+describe('DictionaryApi Output Schema', () => {
+	it('parses valid Merriam-Webster dictionary entry objects', () => {
+		const fixture = [
+			{
+				meta: {
+					id: 'computer',
+					uuid: '1234-abcd',
+					src: 'collegiate',
+					stems: ['computer', 'computers'],
+					offensive: false,
+				},
+				hwi: {
+					hw: 'com*put*er',
+					prs: [
+						{
+							mw: 'kəm-ˈpyü-tər',
+							sound: { audio: 'comput01' },
+						},
+					],
+				},
+				fl: 'noun',
+				shortdef: [
+					'one that computes',
+					'a programmable electronic device designed to process data',
+				],
+			},
+		];
+
+		const result = GetEntryOutputSchema.parse(fixture);
+		expect(result).toHaveLength(1);
+		const first = result[0];
+		expect(typeof first).toBe('object');
+		if (typeof first === 'object' && first !== null && 'meta' in first) {
+			expect(first.meta?.id).toBe('computer');
+			expect(first.fl).toBe('noun');
+			expect(first.shortdef).toContain('one that computes');
+			expect(first.hwi?.hw).toBe('com*put*er');
+		}
+	});
+
+	it('parses spelling suggestions when a word is not found', () => {
+		const suggestionsFixture = [
+			'computr',
+			'computer',
+			'computers',
+			'compute',
+			'commuter',
+		];
+
+		const result = GetEntryOutputSchema.parse(suggestionsFixture);
+		expect(result).toHaveLength(5);
+		expect(typeof result[0]).toBe('string');
+		expect(result[0]).toBe('computr');
+		expect(result).toContain('computer');
+	});
+});
+
+describe('DictionaryApi Client', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('throws error when API key is missing', async () => {
+		await expect(getEntry('hello', '')).rejects.toThrow(DictionaryApiAPIError);
+		await expect(getEntry('hello', '')).rejects.toThrow(
+			'Merriam-Webster API key is required',
+		);
+	});
+
+	it('calls request with correct endpoint and key query parameter', async () => {
+		const mockResponse = [{ meta: { id: 'hello' } }];
+		mockedRequest.mockResolvedValueOnce(mockResponse);
+
+		const data = await getEntry('hello', 'test-api-key');
+
+		expect(mockedRequest).toHaveBeenCalledTimes(1);
+		const callConfig = mockedRequest.mock.calls[0]![0];
+		const callOptions = mockedRequest.mock.calls[0]![1];
+
+		expect(callConfig.BASE).toBe(
+			'https://www.dictionaryapi.com/api/v3/references/collegiate/json',
+		);
+		expect(callOptions.method).toBe('GET');
+		expect(callOptions.url).toBe('/hello');
+		expect(callOptions.query).toEqual({ key: 'test-api-key' });
+		expect(data).toEqual(mockResponse);
+	});
+
+	it('throws DictionaryApiAPIError when Merriam-Webster returns plain text error string', async () => {
+		mockedRequest.mockResolvedValueOnce(
+			'Invalid API key or not subscribed to this database.',
+		);
+
+		await expect(getEntry('hello', 'invalid-key')).rejects.toThrow(
+			'Invalid API key or not subscribed to this database.',
+		);
+	});
+
+	it('wraps generic errors into DictionaryApiAPIError', async () => {
+		mockedRequest.mockRejectedValueOnce(new Error('Network offline'));
+
+		await expect(getEntry('hello', 'test-key')).rejects.toThrow(
+			'Network offline',
+		);
+	});
+});
+
+describe('DictionaryApi Error Handlers', () => {
+	it('identifies 429 rate limit errors and returns retry config', async () => {
+		const rateLimitError = new ApiError(
+			{ method: 'GET', url: '/test' },
+			{
+				body: { message: 'Too Many Requests' },
+				ok: false,
+				status: 429,
+				statusText: 'Too Many Requests',
+				url: '/test',
+			},
+			'rate_limited',
+		);
+
+		expect(errorHandlers.RATE_LIMIT_ERROR.match(rateLimitError)).toBe(true);
+		const handlerResult =
+			await errorHandlers.RATE_LIMIT_ERROR.handler(rateLimitError);
+		expect(handlerResult.maxRetries).toBe(5);
+	});
+
+	it('identifies 401 and invalid API key errors as auth errors', async () => {
+		const authError = new Error('Invalid API key or not subscribed');
+		expect(errorHandlers.AUTH_ERROR.match(authError)).toBe(true);
+		const handlerResult = await errorHandlers.AUTH_ERROR.handler(authError);
+		expect(handlerResult.maxRetries).toBe(0);
+	});
+
+	it('identifies 404 not found errors', async () => {
+		const notFoundError = new Error('Resource not found: 404');
+		expect(errorHandlers.NOT_FOUND_ERROR.match(notFoundError)).toBe(true);
+	});
+});
+
+describe('DictionaryApi entries.get Endpoint', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('executes entries.get successfully and returns validated output', async () => {
+		const mockEntries = [
+			{
+				meta: { id: 'test' },
+				shortdef: ['a procedure for critical evaluation'],
+			},
+		];
+		mockedRequest.mockResolvedValueOnce(mockEntries);
+
+		const fakeContext = {
+			key: 'valid-api-key',
+		};
+
+		const result = await Entries.get(fakeContext as never, { word: 'test' });
+		expect(result).toHaveLength(1);
+		expect((result[0] as { meta: { id: string } }).meta.id).toBe('test');
+	});
+});

--- a/packages/dictionaryapi/client.ts
+++ b/packages/dictionaryapi/client.ts
@@ -1,0 +1,61 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+
+export class DictionaryApiAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly code?: string,
+	) {
+		super(message);
+		this.name = 'DictionaryApiAPIError';
+	}
+}
+
+export const DICTIONARYAPI_API_BASE =
+	'https://www.dictionaryapi.com/api/v3/references/collegiate/json';
+
+function buildConfig(): OpenAPIConfig {
+	return {
+		BASE: DICTIONARYAPI_API_BASE,
+		VERSION: '3',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: undefined,
+		HEADERS: {},
+	};
+}
+
+export async function getEntry(word: string, apiKey: string): Promise<unknown> {
+	if (!apiKey) {
+		throw new DictionaryApiAPIError('Merriam-Webster API key is required');
+	}
+
+	const requestOptions: ApiRequestOptions = {
+		method: 'GET',
+		url: `/${encodeURIComponent(word)}`,
+		mediaType: 'application/json; charset=utf-8',
+		query: {
+			key: apiKey,
+		},
+	};
+
+	let body: unknown;
+	try {
+		body = await request<unknown>(buildConfig(), requestOptions);
+	} catch (error) {
+		if (error instanceof ApiError) {
+			throw error;
+		}
+		if (error instanceof Error) {
+			throw new DictionaryApiAPIError(error.message);
+		}
+		throw new DictionaryApiAPIError('Unknown error');
+	}
+
+	// Merriam-Webster returns a plain text string on invalid key (e.g. "Invalid API key or not subscribed to this database.")
+	if (typeof body === 'string') {
+		throw new DictionaryApiAPIError(body);
+	}
+
+	return body;
+}

--- a/packages/dictionaryapi/endpoints/entries.ts
+++ b/packages/dictionaryapi/endpoints/entries.ts
@@ -1,0 +1,18 @@
+import { logEventFromContext } from 'corsair/core';
+import type { DictionaryApiEndpoints } from '..';
+import { getEntry } from '../client';
+import { GetEntryOutputSchema } from './types';
+
+export const get: DictionaryApiEndpoints['entriesGet'] = async (ctx, input) => {
+	const rawData = await getEntry(input.word, ctx.key);
+	const response = GetEntryOutputSchema.parse(rawData);
+
+	await logEventFromContext(
+		ctx,
+		'dictionaryapi.entries.get',
+		{ word: input.word },
+		'completed',
+	);
+
+	return response;
+};

--- a/packages/dictionaryapi/endpoints/index.ts
+++ b/packages/dictionaryapi/endpoints/index.ts
@@ -1,0 +1,7 @@
+import { get as entriesGet } from './entries';
+
+export const Entries = {
+	get: entriesGet,
+};
+
+export * from './types';

--- a/packages/dictionaryapi/endpoints/types.ts
+++ b/packages/dictionaryapi/endpoints/types.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+
+export const GetEntryInputSchema = z.object({
+	word: z.string().trim().min(1, 'Word must not be empty'),
+});
+
+export type GetEntryInput = z.infer<typeof GetEntryInputSchema>;
+
+export const DictionaryEntryMetaSchema = z
+	.object({
+		id: z.string(),
+		uuid: z.string().optional(),
+		sort: z.string().optional(),
+		src: z.string().optional(),
+		section: z.string().optional(),
+		stems: z.array(z.string()).optional(),
+		offensive: z.boolean().optional(),
+	})
+	.passthrough();
+
+export type DictionaryEntryMeta = z.infer<typeof DictionaryEntryMetaSchema>;
+
+export const DictionaryEntryPronunciationSchema = z
+	.object({
+		mw: z.string().optional(),
+		sound: z
+			.object({
+				audio: z.string().optional(),
+				ref: z.string().optional(),
+			})
+			.passthrough()
+			.optional(),
+	})
+	.passthrough();
+
+export type DictionaryEntryPronunciation = z.infer<
+	typeof DictionaryEntryPronunciationSchema
+>;
+
+export const DictionaryEntryHeadwordSchema = z
+	.object({
+		hw: z.string().optional(),
+		prs: z.array(DictionaryEntryPronunciationSchema).optional(),
+	})
+	.passthrough();
+
+export type DictionaryEntryHeadword = z.infer<
+	typeof DictionaryEntryHeadwordSchema
+>;
+
+export const DictionaryEntrySchema = z
+	.object({
+		meta: DictionaryEntryMetaSchema.optional(),
+		hwi: DictionaryEntryHeadwordSchema.optional(),
+		fl: z.string().optional(),
+		shortdef: z.array(z.string()).optional(),
+		date: z.string().optional(),
+		def: z.array(z.unknown()).optional(),
+		et: z.array(z.unknown()).optional(),
+	})
+	.passthrough();
+
+export type DictionaryEntry = z.infer<typeof DictionaryEntrySchema>;
+
+export const GetEntryOutputSchema = z.array(
+	z.union([DictionaryEntrySchema, z.string()]),
+);
+
+export type GetEntryOutput = z.infer<typeof GetEntryOutputSchema>;
+
+export type DictionaryApiEndpointInputs = {
+	entriesGet: GetEntryInput;
+};
+
+export type DictionaryApiEndpointOutputs = {
+	entriesGet: GetEntryOutput;
+};
+
+export const DictionaryApiEndpointInputSchemas = {
+	entriesGet: GetEntryInputSchema,
+} as const;
+
+export const DictionaryApiEndpointOutputSchemas = {
+	entriesGet: GetEntryOutputSchema,
+} as const;

--- a/packages/dictionaryapi/error-handlers.ts
+++ b/packages/dictionaryapi/error-handlers.ts
@@ -1,0 +1,44 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('429');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('unauthorized') ||
+				msg.includes('invalid_auth') ||
+				msg.includes('invalid api key') ||
+				msg.includes('not subscribed')
+			);
+		},
+		handler: async (_error: Error) => ({ maxRetries: 0 }),
+	},
+	NOT_FOUND_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 404) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('not found') || msg.includes('404');
+		},
+		handler: async (_error: Error) => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async (_error: Error) => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/dictionaryapi/index.ts
+++ b/packages/dictionaryapi/index.ts
@@ -1,0 +1,174 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+} from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
+import { Entries } from './endpoints';
+import type {
+	DictionaryApiEndpointInputs,
+	DictionaryApiEndpointOutputs,
+} from './endpoints/types';
+import {
+	DictionaryApiEndpointInputSchemas,
+	DictionaryApiEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { DictionaryApiSchema } from './schema';
+import { matchDictionaryApiTenantWebhook } from './webhooks/tenant-matcher';
+
+export type DictionaryApiPluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	hooks?: InternalDictionaryApiPlugin['hooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof dictionaryApiEndpointsNested>;
+};
+
+export type DictionaryApiContext = CorsairPluginContext<
+	typeof DictionaryApiSchema,
+	DictionaryApiPluginOptions
+>;
+
+export type DictionaryApiKeyBuilderContext =
+	KeyBuilderContext<DictionaryApiPluginOptions>;
+
+export type DictionaryApiBoundEndpoints = BindEndpoints<
+	typeof dictionaryApiEndpointsNested
+>;
+
+type DictionaryApiEndpoint<K extends keyof DictionaryApiEndpointOutputs> =
+	CorsairEndpoint<
+		DictionaryApiContext,
+		DictionaryApiEndpointInputs[K],
+		DictionaryApiEndpointOutputs[K]
+	>;
+
+export type DictionaryApiEndpoints = {
+	entriesGet: DictionaryApiEndpoint<'entriesGet'>;
+};
+
+const dictionaryApiEndpointsNested = {
+	entries: {
+		get: Entries.get,
+	},
+} as const;
+
+// Merriam-Webster has no webhooks — it is a public read-only API.
+const dictionaryApiWebhooksNested = {} as const;
+
+export const dictionaryApiEndpointSchemas = {
+	'entries.get': {
+		input: DictionaryApiEndpointInputSchemas.entriesGet,
+		output: DictionaryApiEndpointOutputSchemas.entriesGet,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<
+	typeof dictionaryApiEndpointsNested
+>;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const dictionaryApiEndpointMeta = {
+	'entries.get': {
+		riskLevel: 'read',
+		description:
+			'Look up a word in Merriam-Webster Collegiate Dictionary, returning definitions, headword, part of speech, and pronunciations — or spelling suggestions if not found',
+	},
+} as const satisfies RequiredPluginEndpointMeta<
+	typeof dictionaryApiEndpointsNested
+>;
+
+export const dictionaryApiAuthConfig = {
+	api_key: {},
+} as const satisfies PluginAuthConfig;
+
+export type BaseDictionaryApiPlugin<T extends DictionaryApiPluginOptions> =
+	CorsairPlugin<
+		'dictionaryapi',
+		typeof DictionaryApiSchema,
+		typeof dictionaryApiEndpointsNested,
+		typeof dictionaryApiWebhooksNested,
+		T,
+		typeof defaultAuthType
+	>;
+
+export type InternalDictionaryApiPlugin =
+	BaseDictionaryApiPlugin<DictionaryApiPluginOptions>;
+
+export type ExternalDictionaryApiPlugin<T extends DictionaryApiPluginOptions> =
+	BaseDictionaryApiPlugin<T>;
+
+export function dictionaryapi<const T extends DictionaryApiPluginOptions>(
+	incomingOptions: DictionaryApiPluginOptions &
+		T = {} as DictionaryApiPluginOptions & T,
+): ExternalDictionaryApiPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'dictionaryapi',
+		authConfig: dictionaryApiAuthConfig,
+		schema: DictionaryApiSchema,
+		options: options,
+		hooks: options.hooks,
+		webhookHooks: undefined,
+		endpoints: dictionaryApiEndpointsNested,
+		webhooks: dictionaryApiWebhooksNested,
+		endpointMeta: dictionaryApiEndpointMeta,
+		endpointSchemas: dictionaryApiEndpointSchemas,
+		pluginWebhookMatcher: (_request) => false,
+		pluginTenantWebhookMatcher: matchDictionaryApiTenantWebhook,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: DictionaryApiKeyBuilderContext, source) => {
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys.get_api_key();
+				if (!res) {
+					throw new AuthMissingError('dictionaryapi', 'api_key');
+				}
+				return res;
+			}
+
+			throw new AuthMissingError('dictionaryapi', 'api_key');
+		},
+	} satisfies InternalDictionaryApiPlugin;
+}
+
+export type {
+	DictionaryApiEndpointInputs,
+	DictionaryApiEndpointOutputs,
+	DictionaryEntry,
+	DictionaryEntryHeadword,
+	DictionaryEntryMeta,
+	DictionaryEntryPronunciation,
+	GetEntryInput,
+	GetEntryOutput,
+} from './endpoints/types';
+export {
+	DictionaryApiEndpointInputSchemas,
+	DictionaryApiEndpointOutputSchemas,
+	DictionaryEntryHeadwordSchema,
+	DictionaryEntryMetaSchema,
+	DictionaryEntryPronunciationSchema,
+	DictionaryEntrySchema,
+	GetEntryInputSchema,
+	GetEntryOutputSchema,
+} from './endpoints/types';
+export { DictionaryApiSchema } from './schema';
+export type { DictionaryApiWebhookOutputs } from './webhooks/types';

--- a/packages/dictionaryapi/jest.config.cjs
+++ b/packages/dictionaryapi/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/dictionaryapi/package.json
+++ b/packages/dictionaryapi/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/dictionaryapi",
+  "version": "0.1.0",
+  "description": "DictionaryApi plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "dictionaryapi",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/dictionaryapi/plugin-docs.yaml
+++ b/packages/dictionaryapi/plugin-docs.yaml
@@ -1,0 +1,8 @@
+displayName: Dictionary API
+description: Merriam-Webster Collegiate Dictionary API integration for word definitions and spelling suggestions.
+examples:
+  read:
+    path: entries.get
+    title: Look up word definition
+    args:
+      word: computer

--- a/packages/dictionaryapi/schema.test.ts
+++ b/packages/dictionaryapi/schema.test.ts
@@ -1,0 +1,20 @@
+import { DictionaryApiSchema } from './schema';
+
+describe('DictionaryApi schema', () => {
+	it('declares a semver version', () => {
+		expect(DictionaryApiSchema.version).toBeDefined();
+		expect(DictionaryApiSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof DictionaryApiSchema.entities).toBe('object');
+		expect(DictionaryApiSchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(DictionaryApiSchema.entities))).toBe(true);
+		for (const entity of Object.values(DictionaryApiSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/dictionaryapi/schema/database.ts
+++ b/packages/dictionaryapi/schema/database.ts
@@ -1,0 +1,7 @@
+// TODO: Define your database entities here
+// export const DictionaryApiExample = z.object({
+// 	id: z.string(),
+// 	name: z.string(),
+// 	created_at: z.coerce.date().nullable().optional(),
+// });
+// export type DictionaryApiExample = z.infer<typeof DictionaryApiExample>;

--- a/packages/dictionaryapi/schema/index.ts
+++ b/packages/dictionaryapi/schema/index.ts
@@ -1,0 +1,4 @@
+export const DictionaryApiSchema = {
+	version: '1.0.0',
+	entities: {},
+} as const;

--- a/packages/dictionaryapi/tsconfig.json
+++ b/packages/dictionaryapi/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/dictionaryapi/tsup.config.ts
+++ b/packages/dictionaryapi/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/dictionaryapi/webhooks/index.ts
+++ b/packages/dictionaryapi/webhooks/index.ts
@@ -1,0 +1,2 @@
+// Merriam-Webster does not support webhooks.
+export type { DictionaryApiWebhookOutputs } from './types';

--- a/packages/dictionaryapi/webhooks/tenant-matcher.ts
+++ b/packages/dictionaryapi/webhooks/tenant-matcher.ts
@@ -1,0 +1,8 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+
+// Merriam-Webster has no webhook delivery mechanism.
+export function matchDictionaryApiTenantWebhook(
+	_request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	return null;
+}

--- a/packages/dictionaryapi/webhooks/types.ts
+++ b/packages/dictionaryapi/webhooks/types.ts
@@ -1,0 +1,2 @@
+// The Merriam-Webster Dictionary API is a public read-only API with no webhook delivery mechanism.
+export type DictionaryApiWebhookOutputs = Record<string, never>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3397,6 +3397,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/dictionaryapi:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/diffbot:
     devDependencies:
       '@types/jest':


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

This PR adds the `@corsair-dev/dictionaryapi` integration package to Corsair, enabling Corsair users and AI agents to query the Merriam-Webster Collegiate Dictionary API through the unified Corsair interface.

### Summary of Implementation

- **Package**: Added `@corsair-dev/dictionaryapi` under `packages/dictionaryapi/`.
- **Authentication**: Configured `authType: 'api_key'`, passing the credential securely as query parameter `?key=apiKey` to the Merriam-Webster Collegiate endpoint (`https://www.dictionaryapi.com/api/v3/references/collegiate/json/{word}`).
- **Operation (`entries.get`)**:
  - Callable as `await corsair.dictionaryapi.api.entries.get({ word: "hello" })`.
  - **Input Schema**: Validated with Zod (`GetEntryInputSchema`), enforcing non-empty, trimmed strings.
  - **Output Schema**: Validated with Zod (`GetEntryOutputSchema`) supporting both rich dictionary entry objects (`meta`, `hwi`, `fl`, `def`, `shortdef`, `date`, `et`) and spelling suggestion strings (`string[]`) when a query word is misspelled or not found.
- **Error Handling**: Implemented custom `errorHandlers` covering:
  - `RATE_LIMIT_ERROR`: Matches HTTP 429 and extracts `retryAfterMs`.
  - `AUTH_ERROR`: Handles 401 and Merriam-Webster plain-text error messages (e.g. invalid / unsubscribed API keys).
  - `NOT_FOUND_ERROR`: Handles HTTP 404 responses.
  - `DEFAULT`: Fallback handler with no retries.
- **Zero Webhook Residue (R5)**: Merriam-Webster is a query-based API without webhook push delivery; webhooks are configured as `{}` and template boilerplate was cleanly removed.
- **Documentation**: Added `plugin-docs.yaml` and generated Mintlify documentation under `docs/plugins/dictionaryapi/` (`overview.mdx`, `api.mdx`, `database.mdx`) and registered the plugin navigation in `docs/docs.json`.
- **Testing**: Added unit and schema test suites in `api.test.ts` and `schema.test.ts` with 16 automated tests covering entries lookup, spelling suggestions, empty input rejection, invalid API keys, rate limiting, and endpoint execution.

Fixes # <!-- Add issue number here if applicable, e.g. Fixes #123 -->

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

![plugin demo placeholder](https://placehold.co/800x450/1a1a2e/eaeaea?text=Demo+video+pending+human+recording)

Human will replace with real recording before merge.


### Test Verification
```text
PASS packages/dictionaryapi/schema.test.ts
  DictionaryApi schema
    √ declares a semver version
    √ declares an entities map

PASS packages/dictionaryapi/api.test.ts
  DictionaryApi Input Schema
    √ accepts valid words
    √ trims leading and trailing whitespace
    √ rejects empty words
    √ rejects missing word property
  DictionaryApi Output Schema
    √ parses valid Merriam-Webster dictionary entry objects
    √ parses spelling suggestions when a word is not found
  DictionaryApi Client
    √ throws error when API key is missing
    √ calls request with correct endpoint and key query parameter
    √ throws DictionaryApiAPIError when Merriam-Webster returns plain text error string
    √ wraps generic errors into DictionaryApiAPIError
  DictionaryApi Error Handlers
    √ identifies 429 rate limit errors and returns retry config
    √ identifies 401 and invalid API key errors as auth errors
    √ identifies 404 not found errors
  DictionaryApi entries.get Endpoint
    √ executes entries.get successfully and returns validated output

Test Suites: 2 passed, 2 total
Tests:       16 passed, 16 total


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Dictionary API integration for looking up word definitions through the Merriam-Webster Collegiate Dictionary API.
  - Added API-key authentication, rate-limit handling, and common authentication and not-found error handling.
  - Added numerous provider integrations, including Dictionary API, Borneo, Wix, and others.

- **Documentation**
  - Added setup guidance, authentication instructions, usage examples, and API reference documentation.
  - Expanded documentation navigation with cloud, client, AI SDK adapter, and plugin resources.
  - Clarified that Dictionary API data is not synchronized locally or searchable as database entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->