### PR TITLE
feat: add Reply.io integration

### DIFF
--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -86,16 +86,16 @@ export const BaseProviders = [
 	'boloforms',
 	'boltiot',
 	'bonsai',
-	'botbaba',
 	'bookingmood',
+	'botbaba',
 	'botpress',
 	'botsonic',
 	'bouncer',
 	'box',
 	'boxhero',
 	'brandfetch',
-	'brevo',
 	'breathehr',
+	'brevo',
 	'brex',
 	'brightdata',
 	'browseai',
@@ -214,6 +214,7 @@ export const BaseProviders = [
 	'razorpay',
 	'reddit',
 	'removebg',
+	'reply',
 	'resend',
 	'retailed',
 	'salesforce',
@@ -264,10 +265,10 @@ export const BaseProviders = [
 	'webvizio',
 	'whatsapp',
 	'witai',
-	'worldnewsapi',
 	'wiza',
 	'workday',
 	'workiom',
+	'worldnewsapi',
 	'xquik',
 	'youcom',
 	'youtube',
@@ -352,16 +353,16 @@ export const ProviderDisplayNames = {
 	boloforms: 'Boloforms',
 	boltiot: 'Bolt IoT',
 	bonsai: 'Bonsai',
-	botbaba: 'Botbaba',
 	bookingmood: 'Bookingmood',
+	botbaba: 'Botbaba',
 	botpress: 'Botpress',
 	botsonic: 'Botsonic',
 	bouncer: 'Bouncer',
 	box: 'Box',
 	boxhero: 'BoxHero',
 	brandfetch: 'Brandfetch',
-	brevo: 'Brevo',
 	breathehr: 'Breathe HR',
+	brevo: 'Brevo',
 	brex: 'Brex',
 	brightdata: 'Bright Data',
 	browseai: 'Browse AI',
@@ -480,6 +481,7 @@ export const ProviderDisplayNames = {
 	razorpay: 'Razorpay',
 	reddit: 'Reddit',
 	removebg: 'remove.bg',
+	reply: 'Reply',
 	resend: 'Resend',
 	retailed: 'Retailed',
 	salesforce: 'Salesforce',
@@ -530,10 +532,10 @@ export const ProviderDisplayNames = {
 	webvizio: 'Webvizio',
 	whatsapp: 'WhatsApp',
 	witai: 'WitAi',
-	worldnewsapi: 'World News API',
 	wiza: 'Wiza',
 	workday: 'Workday',
 	workiom: 'Workiom',
+	worldnewsapi: 'World News API',
 	xquik: 'XQuik',
 	youcom: 'You.com',
 	youtube: 'YouTube',
@@ -625,16 +627,16 @@ export type AllProviders =
 	| 'boloforms'
 	| 'boltiot'
 	| 'bonsai'
-	| 'botbaba'
 	| 'bookingmood'
+	| 'botbaba'
 	| 'botpress'
 	| 'botsonic'
 	| 'bouncer'
 	| 'box'
 	| 'boxhero'
 	| 'brandfetch'
-	| 'brevo'
 	| 'breathehr'
+	| 'brevo'
 	| 'brex'
 	| 'brightdata'
 	| 'browseai'
@@ -753,6 +755,7 @@ export type AllProviders =
 	| 'razorpay'
 	| 'reddit'
 	| 'removebg'
+	| 'reply'
 	| 'resend'
 	| 'retailed'
 	| 'salesforce'
@@ -803,10 +806,10 @@ export type AllProviders =
 	| 'webvizio'
 	| 'whatsapp'
 	| 'witai'
-	| 'worldnewsapi'
 	| 'wiza'
 	| 'workday'
 	| 'workiom'
+	| 'worldnewsapi'
 	| 'xquik'
 	| 'youcom'
 	| 'youtube'

--- a/packages/reply/client.ts
+++ b/packages/reply/client.ts
@@ -1,0 +1,77 @@
+ import type { ApiRequestOptions } from 'corsair/http';
+import type { OpenAPIConfig } from 'corsair/http';
+
+import { request } from 'corsair/http';
+
+export class ReplyAPIError extends Error {
+    constructor(
+        message: string,
+        public readonly code?: string,
+    ) {
+        super(message);
+        this.name = 'ReplyAPIError';
+    }
+}
+
+/**
+ * Reply.io API v3 base URL.
+ *
+ * Reply's current API documentation uses:
+ * https://api.reply.io/v3
+ */
+const REPLY_API_BASE = 'https://api.reply.io/v3';
+
+export async function makeReplyRequest<T>(
+    endpoint: string,
+    apiKey: string,
+    options: {
+        method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+        body?: Record<string, unknown>;
+        query?: Record<string, string | number | boolean | undefined>;
+    } = {},
+): Promise<T> {
+    const { method = 'GET', body, query } = options;
+
+    const config: OpenAPIConfig = {
+        BASE: REPLY_API_BASE,
+        VERSION: '3',
+        WITH_CREDENTIALS: false,
+        CREDENTIALS: 'omit',
+
+        // Corsair's HTTP layer uses TOKEN for authenticated requests.
+        // The Reply API expects the API key as a Bearer token.
+        TOKEN: apiKey,
+
+        HEADERS: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+        },
+    };
+
+    const requestOptions: ApiRequestOptions = {
+        method,
+        url: endpoint,
+        body:
+            method === 'POST' ||
+            method === 'PUT' ||
+            method === 'PATCH'
+                ? body
+                : undefined,
+        mediaType: 'application/json; charset=utf-8',
+        query,
+    };
+
+    try {
+        return await request<T>(config, requestOptions);
+    } catch (error) {
+        if (error instanceof ReplyAPIError) {
+            throw error;
+        }
+
+        if (error instanceof Error) {
+            throw new ReplyAPIError(error.message);
+        }
+
+        throw new ReplyAPIError('Unknown Reply.io API error');
+    }
+}

--- a/packages/reply/endpoints/example.ts
+++ b/packages/reply/endpoints/example.ts
@@ -1,0 +1,20 @@
+import type { ReplyEndpoints } from '..';
+import type { ReplyEndpointOutputs } from './types';
+import { makeReplyRequest } from '../client';
+
+export const createPersonalList: ReplyEndpoints['createPersonalList'] = async (
+    ctx,
+    input,
+) => {
+    const response = await makeReplyRequest<
+        ReplyEndpointOutputs['createPersonalList']
+    >('v3/contact-lists', ctx.key, {
+        method: 'POST',
+        body: {
+            name: input.name,
+            isShared: input.isShared ?? false,
+        },
+    });
+
+    return response;
+};

--- a/packages/reply/endpoints/index.ts
+++ b/packages/reply/endpoints/index.ts
@@ -1,0 +1,7 @@
+import { createPersonalList } from './example';
+
+export const Example = {
+    createPersonalList,
+};
+
+export * from './types';

--- a/packages/reply/endpoints/types.ts
+++ b/packages/reply/endpoints/types.ts
@@ -1,0 +1,36 @@
+ import { z } from 'zod';
+
+const CreatePersonalListInputSchema = z.object({
+    name: z.string().min(1),
+    isShared: z.boolean().optional(),
+});
+
+const CreatePersonalListResponseSchema = z.object({
+    id: z.number(),
+    name: z.string(),
+    isShared: z.boolean().optional(),
+});
+
+export type CreatePersonalListInput = z.infer<
+    typeof CreatePersonalListInputSchema
+>;
+
+export type CreatePersonalListResponse = z.infer<
+    typeof CreatePersonalListResponseSchema
+>;
+
+export type ReplyEndpointInputs = {
+    createPersonalList: CreatePersonalListInput;
+};
+
+export type ReplyEndpointOutputs = {
+    createPersonalList: CreatePersonalListResponse;
+};
+
+export const ReplyEndpointInputSchemas = {
+    createPersonalList: CreatePersonalListInputSchema,
+} as const;
+
+export const ReplyEndpointOutputSchemas = {
+    createPersonalList: CreatePersonalListResponseSchema,
+} as const;

--- a/packages/reply/error-handlers.ts
+++ b/packages/reply/error-handlers.ts
@@ -1,0 +1,31 @@
+import { ApiError } from 'corsair/http';
+import type { CorsairErrorHandler } from 'corsair/core';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('429');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('unauthorized') || msg.includes('invalid_auth');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/reply/index.ts
+++ b/packages/reply/index.ts
@@ -1,0 +1,200 @@
+import type {
+	BindEndpoints,
+	BindWebhooks,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	CorsairWebhook,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+	RequiredPluginWebhookSchemas,
+} from 'corsair/core';
+import type { AuthTypes } from 'corsair/core';
+import type { ReplyEndpointInputs, ReplyEndpointOutputs } from './endpoints/types';
+import { ReplyEndpointInputSchemas, ReplyEndpointOutputSchemas } from './endpoints/types';
+import type {
+	ReplyWebhookOutputs,
+	ExampleEvent,
+} from './webhooks/types';
+import { ExampleEventSchema } from './webhooks/types';
+import { Example } from './endpoints';
+import { ReplySchema } from './schema';
+import { ExampleWebhooks } from './webhooks';
+import { errorHandlers } from './error-handlers';
+import { matchReplyTenantWebhook } from './webhooks/tenant-matcher';
+import { resolveReplyOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
+
+export type ReplyPluginOptions = {
+	authType?: PickAuth<'api_key' | 'oauth_2'>;
+	key?: string;
+	webhookSecret?: string;
+	hooks?: InternalReplyPlugin['hooks'];
+	webhookHooks?: InternalReplyPlugin['webhookHooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof replyEndpointsNested>;
+};
+
+export type ReplyContext = CorsairPluginContext<
+	typeof ReplySchema,
+	ReplyPluginOptions
+>;
+
+export type ReplyKeyBuilderContext = KeyBuilderContext<ReplyPluginOptions>;
+
+export type ReplyBoundEndpoints = BindEndpoints<typeof replyEndpointsNested>;
+
+type ReplyEndpoint<
+	K extends keyof ReplyEndpointOutputs,
+> = CorsairEndpoint<
+	ReplyContext,
+	ReplyEndpointInputs[K],
+	ReplyEndpointOutputs[K]
+>;
+
+export type ReplyEndpoints = {
+    createPersonalList: ReplyEndpoint<'createPersonalList'>;
+};
+
+type ReplyWebhook<
+	K extends keyof ReplyWebhookOutputs,
+	TEvent,
+> = CorsairWebhook<ReplyContext, TEvent, ReplyWebhookOutputs[K]>;
+
+export type ReplyWebhooks = {
+	example: ReplyWebhook<'example', ExampleEvent>;
+};
+
+export type ReplyBoundWebhooks = BindWebhooks<ReplyWebhooks>;
+
+const replyEndpointsNested = {
+    createPersonalList: Example.createPersonalList,
+} as const;
+
+const replyWebhooksNested = {
+	example: {
+		example: ExampleWebhooks.example,
+	},
+} as const;
+
+export const replyEndpointSchemas = {
+    'createPersonalList': {
+        input: ReplyEndpointInputSchemas.createPersonalList,
+        output: ReplyEndpointOutputSchemas.createPersonalList,
+    },
+} as const satisfies RequiredPluginEndpointSchemas<typeof replyEndpointsNested>;
+
+const replyWebhookSchemas = {
+	'example.example': {
+		description: 'An example webhook event',
+		payload: ExampleEventSchema,
+		response: ExampleEventSchema,
+	},
+} as const satisfies RequiredPluginWebhookSchemas<typeof replyWebhooksNested>;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const replyEndpointMeta = {
+    'createPersonalList': {
+        riskLevel: 'write',
+        description: 'Create a personal contact list in Reply.io',
+    },
+} as const satisfies RequiredPluginEndpointMeta<typeof replyEndpointsNested>;
+
+export const replyAuthConfig = {
+	api_key: {
+		account: ['tenant_external_id'] as const,
+	},
+	oauth_2: {
+		account: ['tenant_external_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type BaseReplyPlugin<T extends ReplyPluginOptions> = CorsairPlugin<
+	'reply',
+	typeof ReplySchema,
+	typeof replyEndpointsNested,
+	typeof replyWebhooksNested,
+	T,
+	typeof defaultAuthType
+>;
+
+export type InternalReplyPlugin = BaseReplyPlugin<ReplyPluginOptions>;
+
+export type ExternalReplyPlugin<T extends ReplyPluginOptions> =
+	BaseReplyPlugin<T>;
+
+export function reply<const T extends ReplyPluginOptions>(
+	incomingOptions: ReplyPluginOptions & T = {} as ReplyPluginOptions & T,
+): ExternalReplyPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'reply',
+		authConfig: replyAuthConfig,
+		schema: ReplySchema,
+		options: options,
+		hooks: options.hooks,
+		webhookHooks: options.webhookHooks,
+		endpoints: replyEndpointsNested,
+		webhooks: replyWebhooksNested,
+		endpointMeta: replyEndpointMeta,
+		endpointSchemas: replyEndpointSchemas,
+		webhookSchemas: replyWebhookSchemas,
+		pluginWebhookMatcher: (request) => {
+			const headers = request.headers;
+			// TODO: Update to match your webhook signature headers
+			return 'x-reply-signature' in headers;
+		},
+		pluginTenantWebhookMatcher: matchReplyTenantWebhook,
+		oauthWebhookTenantLinkResolver: resolveReplyOAuthWebhookTenantLink,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: ReplyKeyBuilderContext, source) => {
+			if (source === 'webhook' && options.webhookSecret) {
+				return options.webhookSecret;
+			}
+
+			if (source === 'webhook') {
+				const res = await ctx.keys.get_webhook_signature();
+				return res ?? '';
+			}
+
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys.get_api_key();
+				return res ?? '';
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'oauth_2') {
+				const res = await ctx.keys.get_access_token();
+				return res ?? '';
+			}
+
+			return '';
+		},
+	} satisfies InternalReplyPlugin;
+}
+
+export type {
+	ExampleEvent,
+	ReplyWebhookOutputs,
+} from './webhooks/types';
+
+export type {
+	ReplyEndpointInputs,
+	ReplyEndpointOutputs,
+	ExampleGetInput,
+	ExampleGetResponse,
+} from './endpoints/types';

--- a/packages/reply/jest.config.cjs
+++ b/packages/reply/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/reply/package.json
+++ b/packages/reply/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/reply",
+  "version": "0.1.0",
+  "description": "Reply plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "reply",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/reply/schema.test.ts
+++ b/packages/reply/schema.test.ts
@@ -1,0 +1,20 @@
+import { ReplySchema } from './schema';
+
+describe('Reply schema', () => {
+	it('declares a semver version', () => {
+		expect(ReplySchema.version).toBeDefined();
+		expect(ReplySchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof ReplySchema.entities).toBe('object');
+		expect(ReplySchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(ReplySchema.entities))).toBe(true);
+		for (const entity of Object.values(ReplySchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/reply/schema/database.ts
+++ b/packages/reply/schema/database.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+// TODO: Define your database entities here
+// export const ReplyExample = z.object({
+// 	id: z.string(),
+// 	name: z.string(),
+// 	created_at: z.coerce.date().nullable().optional(),
+// });
+// export type ReplyExample = z.infer<typeof ReplyExample>;

--- a/packages/reply/schema/index.ts
+++ b/packages/reply/schema/index.ts
@@ -1,0 +1,4 @@
+export const ReplySchema = {
+	version: '1.0.0',
+	entities: {},
+} as const;

--- a/packages/reply/tsconfig.json
+++ b/packages/reply/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": [
+      "esnext"
+    ],
+    "types": [
+      "node",
+      "jest"
+    ],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "./**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ],
+  "references": []
+}

--- a/packages/reply/tsup.config.ts
+++ b/packages/reply/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/reply/webhooks/example.ts
+++ b/packages/reply/webhooks/example.ts
@@ -1,0 +1,27 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ReplyWebhooks } from '..';
+import { createReplyMatch, verifyReplyWebhookSignature } from './types';
+
+export const example: ReplyWebhooks['example'] = {
+	match: createReplyMatch('example'),
+
+	handler: async (ctx, request) => {
+		const verification = verifyReplyWebhookSignature(request, ctx.key);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
+
+		const event = request.payload;
+		if (event.type !== 'example') {
+			return { success: true, data: undefined };
+		}
+
+		await logEventFromContext(ctx, 'reply.webhook.example', { ...event }, 'completed');
+
+		return { success: true, data: event };
+	},
+};

--- a/packages/reply/webhooks/index.ts
+++ b/packages/reply/webhooks/index.ts
@@ -1,0 +1,9 @@
+import { example } from './example';
+
+export const ExampleWebhooks = {
+	example: example,
+};
+
+export * from './types';
+export * from './tenant-matcher';
+export * from './oauth-tenant-link';

--- a/packages/reply/webhooks/oauth-tenant-link.ts
+++ b/packages/reply/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,31 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, toExternalId } from 'corsair/core';
+
+// TODO: Rename linkType 'tenant_external_id' to match pluginTenantWebhookMatcher.
+// Called after OAuth to store the routing id on corsair_accounts.config.
+export async function resolveReplyOAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): Promise<WebhookTenantMatch | null> {
+	// TODO: Read from token response when the provider includes a stable id.
+	// const externalId = toExternalId(asRecord(tokens.team)?.id);
+	const externalId = toExternalId(tokens.tenant_external_id);
+	if (externalId) {
+		return { linkType: 'tenant_external_id', externalId };
+	}
+
+	const accessToken = tokens.access_token;
+	if (!accessToken) return null;
+
+	// TODO: Fetch from provider API when the token response omits the id.
+	// const response = await fetch('https://api.example.com/me', {
+	// 	headers: { Authorization: `Bearer ${accessToken}` },
+	// });
+	// if (!response.ok) return null;
+	// const payload = (await response.json()) as { id?: string };
+	// const fetchedId = toExternalId(payload.id);
+	// return fetchedId
+	// 	? { linkType: 'tenant_external_id', externalId: fetchedId }
+	// 	: null;
+
+	return null;
+}

--- a/packages/reply/webhooks/tenant-matcher.ts
+++ b/packages/reply/webhooks/tenant-matcher.ts
@@ -1,0 +1,25 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// TODO: Rename linkType 'tenant_external_id' to match the provider field
+// (e.g. team_id, installation_id, organization_id). Must match authConfig.account
+// and oauthWebhookTenantLinkResolver.
+// Return null for URL verification / handshake payloads that have no tenant id.
+export function matchReplyTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	// TODO: Extract the stable external id from the webhook payload.
+	// Example:
+	// const externalId = firstString([body.tenant_external_id, asRecord(body.data)?.id]);
+	const externalId = firstString([
+		body.tenant_external_id,
+		asRecord(body.data)?.tenant_external_id,
+	]);
+
+	if (!externalId) return null;
+
+	return { linkType: 'tenant_external_id', externalId };
+}

--- a/packages/reply/webhooks/types.ts
+++ b/packages/reply/webhooks/types.ts
@@ -1,0 +1,58 @@
+import type { CorsairWebhookMatcher, RawWebhookRequest, WebhookRequest } from 'corsair/core';
+import { z } from 'zod';
+
+export const ReplyWebhookPayloadSchema = z.object({
+	type: z.string(),
+	created_at: z.string(),
+	data: z.record(z.string(), z.unknown()),
+});
+
+export type ReplyWebhookPayload = z.infer<
+	typeof ReplyWebhookPayloadSchema
+>;
+
+export const ExampleEventSchema = ReplyWebhookPayloadSchema.extend({
+	type: z.literal('example'),
+	data: z
+		.object({
+			id: z.string(),
+		})
+		.loose(),
+});
+
+export type ExampleEvent = z.infer<typeof ExampleEventSchema>;
+
+export type ReplyWebhookOutputs = {
+	example: ExampleEvent;
+};
+
+function parseBody(body: unknown): Record<string, unknown> | null {
+	if (typeof body === 'string') {
+		try {
+			const parsed = JSON.parse(body);
+			return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+				? (parsed as Record<string, unknown>)
+				: null;
+		} catch {
+			return null;
+		}
+	}
+	return body !== null && typeof body === 'object' && !Array.isArray(body)
+		? (body as Record<string, unknown>)
+		: null;
+}
+
+export function createReplyMatch(eventType: string): CorsairWebhookMatcher {
+	return (request: RawWebhookRequest) => {
+		const parsedBody = parseBody(request.body);
+		return parsedBody !== null && parsedBody.type === eventType;
+	};
+}
+
+export function verifyReplyWebhookSignature(
+	request: WebhookRequest<ReplyWebhookPayload>,
+	secret: string,
+): { valid: boolean; error?: string } {
+	// TODO: Implement webhook signature verification
+	return { valid: true };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5481,6 +5481,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/reply:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/resend:
     devDependencies:
       '@types/jest':


### PR DESCRIPTION
## Description

This PR adds the initial Reply.io integration for Corsair.

### Changes
- Added Reply.io plugin scaffold and API key authentication.
- Added the `Create Personal List` endpoint.
- Added input/output schemas for the endpoint.
- Added Reply.io API client configuration and error handling.
- Linked the integration request issue.

### Related Issue

Closes #1583

## Checklist

- [ ] I have run `pnpm lint` and all checks pass
- [ ] I have run `pnpm typecheck` and there are no TypeScript errors
- [ ] I have run `pnpm build` and all packages build successfully
- [ ] I have run `pnpm test` and all tests pass
- [ ] I have added or updated tests where applicable
- [ ] I have added or updated necessary documentation

## Screenshots / Demos

Not applicable — this is an API integration.

## Additional Notes

Reply.io does not require webhook/trigger support for this initial integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Reply.io integration.
  * Added Reply.io provider availability and display labels.
  * Added an endpoint for creating personal contact lists.
  * Added typed Reply.io webhook handling, including event matching and tenant identification.
  * Added configurable handling for authentication failures and rate limits.
* **Tests**
  * Added validation tests for the Reply.io integration schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->