### PR TITLE
feat(chatwork): add Chatwork integration plugin

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1002,6 +1002,15 @@
                 ]
               },
               {
+                "group": "Chatwork",
+                "pages": [
+                  "plugins/chatwork/overview",
+                  "plugins/chatwork/api",
+                  "plugins/chatwork/database",
+                  "plugins/chatwork/webhooks"
+                ]
+              },
+              {
                 "group": "ChMeetings",
                 "pages": [
                   "plugins/chmeetings/overview",

--- a/docs/plugins/chatwork/api.mdx
+++ b/docs/plugins/chatwork/api.mdx
@@ -1,0 +1,316 @@
+---
+title: API
+description: "API reference for Chatwork: every `chatwork.api.*` operation with input and output types."
+---
+
+Every `chatwork.api.*` operation is listed below with parameter shapes and return types from the plugin Zod schemas.
+
+<Info>
+**New to Corsair?** See [API access](/concepts/api), [authentication](/concepts/auth), and [error handling](/concepts/error-handling).
+</Info>
+
+## Account
+
+### get
+
+`account.get`
+
+Get profile information of the authenticated user
+
+**Risk:** `read`
+
+```ts
+await corsair.chatwork.api.account.get({});
+```
+
+**Input:** _empty object_
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `account_id` | `number` | Yes | The Chatwork account ID |
+| `room_id` | `number` | Yes | The user personal room ID |
+| `name` | `string` | Yes | The user name |
+| `chatwork_id` | `string` | No | The Chatwork ID handle |
+| `organization_id` | `number` | No | The organization ID |
+| `organization_name` | `string` | No | The organization name |
+| `department` | `string` | No | The department name |
+| `title` | `string` | No | The user title/position |
+| `url` | `string` | No | The user website URL |
+| `introduction` | `string` | No | The user profile introduction |
+| `mail` | `string` | No | The user email address |
+| `tel_organization` | `string` | No | Organization phone number |
+| `tel_extension` | `string` | No | Extension phone number |
+| `tel_mobile` | `string` | No | Mobile phone number |
+| `skype` | `string` | No | Skype handle |
+| `facebook` | `string` | No | Facebook profile |
+| `twitter` | `string` | No | Twitter/X handle |
+| `avatar_image_url` | `string` | No | Avatar image URL |
+
+
+
+---
+
+## Members
+
+### list
+
+`members.list`
+
+List members belonging to a chat room
+
+**Risk:** `read`
+
+```ts
+await corsair.chatwork.api.members.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `room_id` | `number` | Yes | The ID of the room |
+
+
+
+**Output:** `object[]`
+
+<AccordionGroup>
+<Accordion title="Output full type">
+
+```ts
+{
+  account_id: number,
+  role: admin | member | readonly | string,
+  name: string,
+  chatwork_id?: string,
+  organization_id?: number,
+  organization_name?: string,
+  department?: string,
+  avatar_image_url?: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+---
+
+## Messages
+
+### get
+
+`messages.get`
+
+Get a specific message from a chat room
+
+**Risk:** `read`
+
+```ts
+await corsair.chatwork.api.messages.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `room_id` | `number` | Yes | The ID of the room |
+| `message_id` | `string` | Yes | The ID of the message to retrieve |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `message_id` | `string` | Yes | The unique message ID |
+| `account` | `object` | Yes | The sender profile summary |
+| `body` | `string` | Yes | The message content |
+| `send_time` | `number` | Yes | Sent timestamp in Unix seconds |
+| `update_time` | `number` | Yes | Updated timestamp in Unix seconds (0 if not updated) |
+
+<AccordionGroup>
+<Accordion title="account full type">
+
+```ts
+{
+  account_id: number,
+  name: string,
+  avatar_image_url?: string
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### list
+
+`messages.list`
+
+List messages in a chat room
+
+**Risk:** `read`
+
+```ts
+await corsair.chatwork.api.messages.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `room_id` | `number` | Yes | The ID of the room |
+| `force` | `0 \| 1` | No | 0: get only unread messages (default), 1: get up to 100 latest messages |
+
+
+
+**Output:** `object[]`
+
+<AccordionGroup>
+<Accordion title="Output full type">
+
+```ts
+{
+  message_id: string,
+  account: {
+    account_id: number,
+    name: string,
+    avatar_image_url?: string
+  },
+  body: string,
+  send_time: number,
+  update_time: number
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+---
+
+### send
+
+`messages.send`
+
+Send a new message to a chat room
+
+**Risk:** `write`
+
+```ts
+await corsair.chatwork.api.messages.send({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `room_id` | `number` | Yes | The ID of the room to post to |
+| `body` | `string` | Yes | The message body text |
+| `self_unread` | `0 \| 1 \| boolean` | No | Whether the posted message should be marked as unread for the sender (0: read, 1: unread) |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `message_id` | `string` | Yes | The ID of the created message |
+
+
+
+---
+
+## Rooms
+
+### get
+
+`rooms.get`
+
+Get details of a specific chat room
+
+**Risk:** `read`
+
+```ts
+await corsair.chatwork.api.rooms.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `room_id` | `number` | Yes | The ID of the room to retrieve |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `room_id` | `number` | Yes | The room ID |
+| `name` | `string` | Yes | The room name |
+| `type` | `string` | Yes | The room type (e.g. my, direct, group) |
+| `role` | `string` | Yes | The current user role in the room (e.g. admin, member, readonly) |
+| `sticky` | `boolean` | Yes | Whether the room is pinned |
+| `unread_num` | `number` | Yes | Number of unread messages |
+| `mention_num` | `number` | Yes | Number of unread mentions |
+| `mytask_num` | `number` | Yes | Number of open tasks assigned to me |
+| `message_num` | `number` | Yes | Total number of messages in the room |
+| `file_num` | `number` | Yes | Total number of files in the room |
+| `task_num` | `number` | Yes | Total number of tasks in the room |
+| `icon_path` | `string` | Yes | Icon image URL or icon path |
+| `last_update_time` | `number` | Yes | Last updated timestamp in Unix seconds |
+| `description` | `string` | No | Detailed room description |
+
+
+
+---
+
+### list
+
+`rooms.list`
+
+List chat rooms the authenticated user belongs to
+
+**Risk:** `read`
+
+```ts
+await corsair.chatwork.api.rooms.list({});
+```
+
+**Input:** _empty object_
+
+
+**Output:** `object[]`
+
+<AccordionGroup>
+<Accordion title="Output full type">
+
+```ts
+{
+  room_id: number,
+  name: string,
+  type: string,
+  role: string,
+  sticky: boolean,
+  unread_num: number,
+  mention_num: number,
+  mytask_num: number,
+  message_num: number,
+  file_num: number,
+  task_num: number,
+  icon_path: string,
+  last_update_time: number,
+  description?: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+---
+

--- a/docs/plugins/chatwork/database.mdx
+++ b/docs/plugins/chatwork/database.mdx
@@ -1,0 +1,149 @@
+---
+title: Database
+description: "Chatwork local sync: searchable entities, `.search()` filters, and operators."
+---
+
+The Chatwork plugin syncs data locally. Use `corsair.chatwork.db.<entity>.search({ data, limit?, offset? })` with the filters listed per entity.
+
+<Info>
+**New to Corsair?** See [database operations](/concepts/database), [data synchronization](/concepts/integrations), and [multi-tenancy](/concepts/multi-tenancy).
+</Info>
+
+## Accounts
+
+Path: `chatwork.db.accounts.search`
+
+```ts
+const rows = await corsair.chatwork.db.accounts.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `account_id` | `number` | equals, gt, gte, lt, lte, in |
+| `room_id` | `number` | equals, gt, gte, lt, lte, in |
+| `name` | `string` | equals, contains, startsWith, endsWith, in |
+| `chatwork_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `organization_id` | `number` | equals, gt, gte, lt, lte, in |
+| `organization_name` | `string` | equals, contains, startsWith, endsWith, in |
+| `department` | `string` | equals, contains, startsWith, endsWith, in |
+| `title` | `string` | equals, contains, startsWith, endsWith, in |
+| `url` | `string` | equals, contains, startsWith, endsWith, in |
+| `introduction` | `string` | equals, contains, startsWith, endsWith, in |
+| `mail` | `string` | equals, contains, startsWith, endsWith, in |
+| `tel_organization` | `string` | equals, contains, startsWith, endsWith, in |
+| `tel_extension` | `string` | equals, contains, startsWith, endsWith, in |
+| `tel_mobile` | `string` | equals, contains, startsWith, endsWith, in |
+| `skype` | `string` | equals, contains, startsWith, endsWith, in |
+| `facebook` | `string` | equals, contains, startsWith, endsWith, in |
+| `twitter` | `string` | equals, contains, startsWith, endsWith, in |
+| `avatar_image_url` | `string` | equals, contains, startsWith, endsWith, in |
+| `createdAt` | `date` | equals, before, after, between |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+
+## Members
+
+Path: `chatwork.db.members.search`
+
+```ts
+const rows = await corsair.chatwork.db.members.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `account_id` | `number` | equals, gt, gte, lt, lte, in |
+| `room_id` | `number` | equals, gt, gte, lt, lte, in |
+| `role` | `string` | equals, contains, startsWith, endsWith, in |
+| `name` | `string` | equals, contains, startsWith, endsWith, in |
+| `chatwork_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `organization_id` | `number` | equals, gt, gte, lt, lte, in |
+| `organization_name` | `string` | equals, contains, startsWith, endsWith, in |
+| `department` | `string` | equals, contains, startsWith, endsWith, in |
+| `avatar_image_url` | `string` | equals, contains, startsWith, endsWith, in |
+| `createdAt` | `date` | equals, before, after, between |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+
+## Messages
+
+Path: `chatwork.db.messages.search`
+
+```ts
+const rows = await corsair.chatwork.db.messages.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `message_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `room_id` | `number` | equals, gt, gte, lt, lte, in |
+| `body` | `string` | equals, contains, startsWith, endsWith, in |
+| `send_time` | `number` | equals, gt, gte, lt, lte, in |
+| `update_time` | `number` | equals, gt, gte, lt, lte, in |
+| `createdAt` | `date` | equals, before, after, between |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+
+## Rooms
+
+Path: `chatwork.db.rooms.search`
+
+```ts
+const rows = await corsair.chatwork.db.rooms.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `room_id` | `number` | equals, gt, gte, lt, lte, in |
+| `name` | `string` | equals, contains, startsWith, endsWith, in |
+| `type` | `string` | equals, contains, startsWith, endsWith, in |
+| `role` | `string` | equals, contains, startsWith, endsWith, in |
+| `sticky` | `boolean` | equals |
+| `unread_num` | `number` | equals, gt, gte, lt, lte, in |
+| `mention_num` | `number` | equals, gt, gte, lt, lte, in |
+| `mytask_num` | `number` | equals, gt, gte, lt, lte, in |
+| `message_num` | `number` | equals, gt, gte, lt, lte, in |
+| `file_num` | `number` | equals, gt, gte, lt, lte, in |
+| `task_num` | `number` | equals, gt, gte, lt, lte, in |
+| `icon_path` | `string` | equals, contains, startsWith, endsWith, in |
+| `last_update_time` | `number` | equals, gt, gte, lt, lte, in |
+| `description` | `string` | equals, contains, startsWith, endsWith, in |
+| `createdAt` | `date` | equals, before, after, between |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+

--- a/docs/plugins/chatwork/overview.mdx
+++ b/docs/plugins/chatwork/overview.mdx
@@ -1,0 +1,177 @@
+---
+title: Overview
+description: "Business chat and communication tool for team messaging, room management, and collaboration."
+---
+
+Use **Chatwork** through Corsair: one client, typed API calls, local DB sync, and incoming webhooks.
+
+**What you get:**
+
+- 7 typed API operations
+- 4 synced entities (`accounts`, `members`, `messages`, `rooms`) for fast `.search()` / `.list()`
+- 3 incoming webhook event types
+
+## Setup
+
+<Steps>
+
+<Step title="Install">
+<CodeGroup>
+```bash npm
+npm install corsair @corsair-dev/chatwork
+```
+```bash yarn
+yarn add corsair @corsair-dev/chatwork
+```
+```bash pnpm
+pnpm install corsair @corsair-dev/chatwork
+```
+```bash bun
+bun add corsair @corsair-dev/chatwork
+```
+</CodeGroup>
+
+</Step>
+
+<Step title="Add the plugin">
+```ts corsair.ts
+import Database from 'better-sqlite3';
+import { createCorsair } from 'corsair';
+import { chatwork } from '@corsair-dev/chatwork';
+
+export const corsair = createCorsair({
+	plugins: [
+		chatwork(),
+	],
+	database: new Database('corsair.db'),
+	kek: process.env.CORSAIR_KEK!,
+	hub: {
+		projectApiKey: process.env.CORSAIR_API_KEY!,
+		signingSecret: process.env.CORSAIR_SIGNING_SECRET!,
+	},
+});
+```
+
+Multi-tenancy is the default — scope calls with `corsair.withTenant(id)`. See [Quick start](/quick-start) for KEK + Hub keys, and [Multi-tenancy](/concepts/multi-tenancy) for account isolation.
+
+</Step>
+
+<Step title="Choose authentication">
+<Tabs>
+<Tab title="OAuth 2.0 (Recommended)">
+
+Open [hub.corsair.dev](https://hub.corsair.dev/dashboard), navigate to your project, and enter the **client ID** and **client secret** from your Chatwork OAuth app.
+
+```ts
+chatwork()
+```
+
+More: [OAuth 2.0](/concepts/oauth)
+
+</Tab>
+<Tab title="API Key">
+
+No setup required yet. When you make your first request as a tenant, Corsair prompts for the API key.
+
+```ts
+chatwork({
+	authType: 'api_key',
+})
+```
+
+More: [API Key](/concepts/api-key)
+
+</Tab>
+</Tabs>
+
+</Step>
+
+<Step title="Connect a tenant">
+Mint a connect link and send the tenant to it. Hub hosts the page and delivers the result to your app — see [Connect / OAuth](/management/connect).
+
+```ts
+const { connectUrl } = await corsair.manage.connect.createLink({
+	plugin: 'chatwork',
+	tenantId: 'acme',
+});
+// redirect the user's browser to connectUrl
+```
+
+</Step>
+
+</Steps>
+
+## Example API calls
+
+**List rooms**
+
+```ts
+const tenant = corsair.withTenant('acme');
+await tenant.chatwork.api.rooms.list({});
+```
+
+
+**Send a message to a room**
+
+```ts
+const tenant = corsair.withTenant('acme');
+await tenant.chatwork.api.messages.send({ room_id: 123456, body: 'Hello from Corsair!' });
+```
+
+
+See the full list on the [API](/plugins/chatwork/api) page.
+
+## Query synced data
+
+Search synced rooms without hitting the Chatwork API.
+
+```ts
+const tenant = corsair.withTenant('acme');
+const rows = await tenant.chatwork.db.rooms.search({
+	data: { type: 'group' },
+	limit: 20,
+});
+```
+
+Synced entities: `accounts`, `members`, `messages`, `rooms`. See [Database](/plugins/chatwork/database) for filters and operators.
+
+## Webhooks
+
+React when someone posts a new message in a room.
+
+```ts
+chatwork({
+    webhookHooks: {
+        messages: {
+            created: {
+                after: async (ctx, result) => {
+                    const body = result.data?.webhook_event?.body;
+                    console.log('New message received:', body);
+                }
+            },
+        },
+    },
+})
+```
+
+Mount your framework handler once (see [Frameworks](/frameworks/next)), then point the provider at that URL. Full event list: [Webhooks](/plugins/chatwork/webhooks). Concepts: [Webhooks](/concepts/webhooks), [Hooks](/concepts/hooks).
+
+## What's next
+
+<CardGroup cols={2}>
+  <Card title="API reference" href="/plugins/chatwork/api">
+    Every `chatwork.api.*` operation with input and output types.
+  </Card>
+  <Card title="Database" href="/plugins/chatwork/database">
+    Synced entities, search filters, and operators.
+  </Card>
+  <Card title="Webhooks" href="/plugins/chatwork/webhooks">
+    Event paths, payloads, and `webhookHooks` examples.
+  </Card>
+  <Card title="Connect / OAuth" href="/management/connect">
+    createLink, Hub delivery, and tenant connect flows.
+  </Card>
+  <Card title="Use with agents" href="/mcp-adapters/mcp-adapters">
+    Expose this plugin's operations as MCP tools.
+  </Card>
+</CardGroup>

--- a/docs/plugins/chatwork/webhooks.mdx
+++ b/docs/plugins/chatwork/webhooks.mdx
@@ -1,0 +1,265 @@
+---
+title: Webhooks
+description: "Chatwork incoming webhooks: event paths, payloads, and response data."
+---
+
+The Chatwork plugin handles incoming webhooks. Point your provider’s subscription URL at your Corsair HTTP handler (see [Overview](/plugins/chatwork/overview) for setup context and the exact URL shape).
+
+<Info>
+**New to Corsair?** See [webhooks](/concepts/webhooks) and [hooks](/concepts/hooks).
+</Info>
+
+## Webhook map
+
+- `mentions`
+  - `toMe` (`mentions.toMe`)
+- `messages`
+  - `created` (`messages.created`)
+  - `updated` (`messages.updated`)
+
+## HTTP handler setup
+
+```ts app/api/webhook/route.ts
+import { processWebhook } from "corsair";
+import { corsair } from "@/server/corsair";
+
+export async function POST(request: Request) {
+    const headers = Object.fromEntries(request.headers);
+    const body = await request.json();
+    const result = await processWebhook(corsair, headers, body);
+    return result.response;
+}
+```
+
+## Events
+
+## Mentions
+
+### To Me
+
+`mentions.toMe`
+
+Current user was mentioned in a room message
+
+**Payload**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `webhook_setting_id` | `string \| number` | Yes | — |
+| `webhook_event_type` | `mention_to_me` | Yes | — |
+| `webhook_event_time` | `number` | Yes | — |
+| `webhook_event` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="webhook_event full type">
+
+```ts
+{
+  mention_id: string | number,
+  message_id: string,
+  room_id: number,
+  account_id?: number,
+  from_account_id: number,
+  to_account_id: number,
+  body: string,
+  send_time: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+<AccordionGroup>
+<Accordion title="Response data full type">
+
+```ts
+{
+  webhook_setting_id: string | number,
+  webhook_event_type: mention_to_me,
+  webhook_event_time: number,
+  webhook_event: {
+    mention_id: string | number,
+    message_id: string,
+    room_id: number,
+    account_id?: number,
+    from_account_id: number,
+    to_account_id: number,
+    body: string,
+    send_time: number
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+**`webhookHooks` example**
+
+```ts
+chatwork({
+    webhookHooks: {
+        mentions: {
+            toMe: {
+                before(ctx, args) {
+                    return { ctx, args };
+                },
+                after(ctx, response) {
+                },
+            },
+        },
+    },
+})
+```
+
+---
+
+## Messages
+
+### Created
+
+`messages.created`
+
+A message was created in a room
+
+**Payload**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `webhook_setting_id` | `string \| number` | Yes | — |
+| `webhook_event_type` | `message_created` | Yes | — |
+| `webhook_event_time` | `number` | Yes | — |
+| `webhook_event` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="webhook_event full type">
+
+```ts
+{
+  message_id: string,
+  room_id: number,
+  account_id: number,
+  body: string,
+  send_time: number,
+  update_time?: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+<AccordionGroup>
+<Accordion title="Response data full type">
+
+```ts
+{
+  webhook_setting_id: string | number,
+  webhook_event_type: message_created,
+  webhook_event_time: number,
+  webhook_event: {
+    message_id: string,
+    room_id: number,
+    account_id: number,
+    body: string,
+    send_time: number,
+    update_time?: number
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+**`webhookHooks` example**
+
+```ts
+chatwork({
+    webhookHooks: {
+        messages: {
+            created: {
+                before(ctx, args) {
+                    return { ctx, args };
+                },
+                after(ctx, response) {
+                },
+            },
+        },
+    },
+})
+```
+
+---
+
+### Updated
+
+`messages.updated`
+
+A message was updated in a room
+
+**Payload**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `webhook_setting_id` | `string \| number` | Yes | — |
+| `webhook_event_type` | `message_updated` | Yes | — |
+| `webhook_event_time` | `number` | Yes | — |
+| `webhook_event` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="webhook_event full type">
+
+```ts
+{
+  message_id: string,
+  room_id: number,
+  account_id: number,
+  body: string,
+  send_time: number,
+  update_time: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+<AccordionGroup>
+<Accordion title="Response data full type">
+
+```ts
+{
+  webhook_setting_id: string | number,
+  webhook_event_type: message_updated,
+  webhook_event_time: number,
+  webhook_event: {
+    message_id: string,
+    room_id: number,
+    account_id: number,
+    body: string,
+    send_time: number,
+    update_time: number
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+**`webhookHooks` example**
+
+```ts
+chatwork({
+    webhookHooks: {
+        messages: {
+            updated: {
+                before(ctx, args) {
+                    return { ctx, args };
+                },
+                after(ctx, response) {
+                },
+            },
+        },
+    },
+})
+```
+
+---
+

--- a/packages/chatwork/api.test.ts
+++ b/packages/chatwork/api.test.ts
@@ -1,0 +1,382 @@
+import { ApiError, request } from 'corsair/http';
+import { ChatworkAPIError, makeChatworkRequest } from './client';
+import { Account, Members, Messages, Rooms } from './endpoints';
+import {
+	ChatworkEndpointInputSchemas,
+	ChatworkEndpointOutputSchemas,
+} from './endpoints/types';
+import type { ChatworkContext } from './index';
+import { chatwork, chatworkEndpointSchemas } from './index';
+
+jest.mock('corsair/http', () => {
+	const original = jest.requireActual('corsair/http');
+	return {
+		...original,
+		request: jest.fn(),
+	};
+});
+
+const mockRequest = request as jest.Mock;
+
+function testContext(overrides: Record<string, unknown> = {}): ChatworkContext {
+	return {
+		key: 'test-token',
+		$getAccountId: () => 'test-account-id',
+		options: { authType: 'oauth_2' },
+		logEvent: jest.fn(),
+		db: {},
+		...overrides,
+	} as unknown as ChatworkContext;
+}
+
+describe('Chatwork Plugin Structure', () => {
+	it('exposes the plugin definition with all required properties', () => {
+		const plugin = chatwork();
+		expect(plugin.id).toBe('chatwork');
+		expect(plugin.schema).toBeDefined();
+		expect(plugin.endpoints).toBeDefined();
+		expect(plugin.webhooks).toBeDefined();
+		expect(plugin.oauthConfig).toBeDefined();
+		expect(plugin.oauthConfig?.providerName).toBe('Chatwork');
+		expect(plugin.oauthConfig?.authUrl).toContain('oauth2/login.php');
+		expect(plugin.oauthConfig?.tokenUrl).toContain('token');
+	});
+
+	it('registers all 7 endpoints with matching schemas and metadata', () => {
+		const plugin = chatwork();
+		const expectedEndpoints = [
+			'account.get',
+			'rooms.list',
+			'rooms.get',
+			'messages.list',
+			'messages.get',
+			'messages.send',
+			'members.list',
+		].sort();
+
+		const schemaKeys = Object.keys(chatworkEndpointSchemas).sort();
+		const metaKeys = Object.keys(plugin.endpointMeta ?? {}).sort();
+
+		expect(schemaKeys).toEqual(expectedEndpoints);
+		expect(metaKeys).toEqual(expectedEndpoints);
+	});
+});
+
+describe('Chatwork Endpoints', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('account.get', () => {
+		it('retrieves and validates the current user profile', async () => {
+			const mockAccount = {
+				account_id: 12345,
+				room_id: 99999,
+				name: 'Taro Chatwork',
+				chatwork_id: 'tarocw',
+				organization_id: 101,
+				organization_name: 'Chatwork Corp',
+				department: 'Engineering',
+				title: 'Senior Developer',
+				url: 'https://example.com',
+				introduction: 'Hello from Chatwork',
+				mail: 'taro@example.com',
+				avatar_image_url: 'https://example.com/avatar.png',
+			};
+
+			mockRequest.mockResolvedValueOnce(mockAccount);
+
+			const ctx = testContext();
+			const result = await Account.get(ctx, {});
+
+			expect(mockRequest).toHaveBeenCalledTimes(1);
+			const [config, reqOptions] = mockRequest.mock.calls[0];
+			expect(config.HEADERS.Authorization).toBe('Bearer test-token');
+			expect(reqOptions.url).toBe('me');
+			expect(reqOptions.method).toBe('GET');
+
+			expect(result).toEqual(mockAccount);
+			const parsed = ChatworkEndpointOutputSchemas.accountGet.parse(result);
+			expect(parsed.account_id).toBe(12345);
+		});
+
+		it('supports api_key authentication via X-ChatWorkToken', async () => {
+			mockRequest.mockResolvedValueOnce({
+				account_id: 54321,
+				room_id: 88888,
+				name: 'API Key User',
+			});
+
+			const ctx = testContext({ options: { authType: 'api_key' } });
+			const result = await Account.get(ctx, {});
+
+			const [config] = mockRequest.mock.calls[0];
+			expect(config.HEADERS['X-ChatWorkToken']).toBe('test-token');
+			expect(config.HEADERS.Authorization).toBeUndefined();
+			expect(result.account_id).toBe(54321);
+		});
+	});
+
+	describe('rooms.list', () => {
+		it('lists and validates all rooms', async () => {
+			const mockRooms = [
+				{
+					room_id: 1001,
+					name: 'General Chat',
+					type: 'group',
+					role: 'admin',
+					sticky: true,
+					unread_num: 3,
+					mention_num: 1,
+					mytask_num: 0,
+					message_num: 250,
+					file_num: 12,
+					task_num: 4,
+					icon_path: 'https://example.com/icon.png',
+					last_update_time: 1600000000,
+					description: 'General room for everyone',
+				},
+			];
+
+			mockRequest.mockResolvedValueOnce(mockRooms);
+
+			const ctx = testContext();
+			const result = await Rooms.list(ctx, {});
+
+			expect(result).toHaveLength(1);
+			expect(result[0]!.name).toBe('General Chat');
+			const parsed = ChatworkEndpointOutputSchemas.roomsList.parse(result);
+			expect(parsed[0]!.room_id).toBe(1001);
+		});
+	});
+
+	describe('rooms.get', () => {
+		it('retrieves and validates a single room by room_id', async () => {
+			const mockRoom = {
+				room_id: 1001,
+				name: 'Development Room',
+				type: 'group',
+				role: 'member',
+				sticky: false,
+				unread_num: 0,
+				mention_num: 0,
+				mytask_num: 0,
+				message_num: 50,
+				file_num: 2,
+				task_num: 1,
+				icon_path: 'https://example.com/icon2.png',
+				last_update_time: 1600000100,
+				description: 'Project dev room',
+			};
+
+			mockRequest.mockResolvedValueOnce(mockRoom);
+
+			const ctx = testContext();
+			const input = { room_id: 1001 };
+			ChatworkEndpointInputSchemas.roomsGet.parse(input);
+
+			const result = await Rooms.get(ctx, input);
+
+			const [, reqOptions] = mockRequest.mock.calls[0];
+			expect(reqOptions.url).toBe('rooms/1001');
+			expect(result.name).toBe('Development Room');
+			ChatworkEndpointOutputSchemas.roomsGet.parse(result);
+		});
+	});
+
+	describe('messages.list', () => {
+		it('lists messages for a room with force=1', async () => {
+			const mockMessages = [
+				{
+					message_id: 'msg-1',
+					account: {
+						account_id: 123,
+						name: 'Alice',
+						avatar_image_url: 'https://example.com/alice.png',
+					},
+					body: 'Hello team!',
+					send_time: 1600000001,
+					update_time: 0,
+				},
+			];
+
+			mockRequest.mockResolvedValueOnce(mockMessages);
+
+			const ctx = testContext();
+			const input = { room_id: 1001, force: 1 as const };
+			ChatworkEndpointInputSchemas.messagesList.parse(input);
+
+			const result = await Messages.list(ctx, input);
+
+			const [, reqOptions] = mockRequest.mock.calls[0];
+			expect(reqOptions.url).toBe('rooms/1001/messages');
+			expect(reqOptions.query).toEqual({ force: 1 });
+			expect(result).toHaveLength(1);
+			ChatworkEndpointOutputSchemas.messagesList.parse(result);
+		});
+
+		it('handles HTTP 204 No Content gracefully by returning an empty array', async () => {
+			// When Chatwork returns 204, corsair/http request returns undefined
+			mockRequest.mockResolvedValueOnce(undefined);
+
+			const ctx = testContext();
+			const result = await Messages.list(ctx, { room_id: 1001 });
+
+			expect(result).toEqual([]);
+			const parsed = ChatworkEndpointOutputSchemas.messagesList.parse(result);
+			expect(parsed).toEqual([]);
+		});
+	});
+
+	describe('messages.get', () => {
+		it('retrieves a single message by ID', async () => {
+			const mockMessage = {
+				message_id: 'msg-42',
+				account: {
+					account_id: 456,
+					name: 'Bob',
+				},
+				body: 'Single message content',
+				send_time: 1600000500,
+				update_time: 1600000600,
+			};
+
+			mockRequest.mockResolvedValueOnce(mockMessage);
+
+			const ctx = testContext();
+			const input = { room_id: 1001, message_id: 'msg-42' };
+			ChatworkEndpointInputSchemas.messagesGet.parse(input);
+
+			const result = await Messages.get(ctx, input);
+
+			const [, reqOptions] = mockRequest.mock.calls[0];
+			expect(reqOptions.url).toBe('rooms/1001/messages/msg-42');
+			expect(result.message_id).toBe('msg-42');
+			ChatworkEndpointOutputSchemas.messagesGet.parse(result);
+		});
+	});
+
+	describe('messages.send', () => {
+		it('sends a message using application/x-www-form-urlencoded', async () => {
+			mockRequest.mockResolvedValueOnce({ message_id: 'new-msg-99' });
+
+			const ctx = testContext();
+			const input = {
+				room_id: 1001,
+				body: 'New urgent message',
+				self_unread: 1 as const,
+			};
+			ChatworkEndpointInputSchemas.messagesSend.parse(input);
+
+			const result = await Messages.send(ctx, input);
+
+			const [, reqOptions] = mockRequest.mock.calls[0];
+			expect(reqOptions.url).toBe('rooms/1001/messages');
+			expect(reqOptions.method).toBe('POST');
+			expect(reqOptions.mediaType).toBe('application/x-www-form-urlencoded');
+			expect(reqOptions.body).toBe('body=New+urgent+message&self_unread=1');
+
+			expect(result.message_id).toBe('new-msg-99');
+			ChatworkEndpointOutputSchemas.messagesSend.parse(result);
+		});
+
+		it('formats boolean self_unread as 1 or 0', async () => {
+			mockRequest.mockResolvedValueOnce({ message_id: 'new-msg-100' });
+
+			const ctx = testContext();
+			await Messages.send(ctx, {
+				room_id: 1001,
+				body: 'Test boolean unread',
+				self_unread: true,
+			});
+
+			const [, reqOptions] = mockRequest.mock.calls[0];
+			expect(reqOptions.body).toBe('body=Test+boolean+unread&self_unread=1');
+		});
+	});
+
+	describe('members.list', () => {
+		it('retrieves and validates members list for a room', async () => {
+			const mockMembers = [
+				{
+					account_id: 1,
+					role: 'admin',
+					name: 'Admin User',
+					chatwork_id: 'admin_cw',
+					organization_id: 10,
+					organization_name: 'Corp',
+					department: 'Management',
+					avatar_image_url: 'https://example.com/admin.png',
+				},
+				{
+					account_id: 2,
+					role: 'member',
+					name: 'Normal Member',
+				},
+			];
+
+			mockRequest.mockResolvedValueOnce(mockMembers);
+
+			const ctx = testContext();
+			const input = { room_id: 1001 };
+			ChatworkEndpointInputSchemas.membersList.parse(input);
+
+			const result = await Members.list(ctx, input);
+
+			const [, reqOptions] = mockRequest.mock.calls[0];
+			expect(reqOptions.url).toBe('rooms/1001/members');
+			expect(result).toHaveLength(2);
+			ChatworkEndpointOutputSchemas.membersList.parse(result);
+		});
+	});
+
+	describe('Error and Rate Limit Handling', () => {
+		it('extracts error messages from Chatwork error response format', async () => {
+			const apiError = new ApiError(
+				{ method: 'GET', url: 'me' },
+				{
+					status: 401,
+					statusText: 'Unauthorized',
+					ok: false,
+					body: { errors: ['Invalid API token', 'Token expired'] },
+					url: 'https://api.chatwork.com/v2/me',
+				},
+				'HTTP Error',
+			);
+
+			mockRequest.mockRejectedValueOnce(apiError);
+
+			await expect(makeChatworkRequest('me', 'bad-token')).rejects.toThrow(
+				'Invalid API token, Token expired',
+			);
+		});
+
+		it('preserves status and retryAfter on rate limit 429', async () => {
+			const rateLimitError = new ApiError(
+				{ method: 'GET', url: 'rooms' },
+				{
+					status: 429,
+					statusText: 'Too Many Requests',
+					ok: false,
+					body: { errors: ['Rate limit exceeded'] },
+					url: 'https://api.chatwork.com/v2/rooms',
+				},
+				'Too Many Requests',
+				{ retryAfter: 60 },
+			);
+
+			mockRequest.mockRejectedValueOnce(rateLimitError);
+
+			try {
+				await makeChatworkRequest('rooms', 'valid-token');
+				fail('Expected error to be thrown');
+			} catch (err) {
+				expect(err).toBeInstanceOf(ChatworkAPIError);
+				const cwError = err as ChatworkAPIError;
+				expect(cwError.status).toBe(429);
+				expect(cwError.retryAfter).toBe(60);
+				expect(cwError.errors).toEqual(['Rate limit exceeded']);
+			}
+		});
+	});
+});

--- a/packages/chatwork/client.ts
+++ b/packages/chatwork/client.ts
@@ -1,0 +1,136 @@
+import type {
+	ApiRequestOptions,
+	OpenAPIConfig,
+	RateLimitConfig,
+} from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+
+export class ChatworkAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly status?: number,
+		public readonly retryAfter?: number,
+		public readonly errors?: string[],
+	) {
+		super(message);
+		this.name = 'ChatworkAPIError';
+	}
+}
+
+export const CHATWORK_API_BASE = 'https://api.chatwork.com/v2';
+
+export const CHATWORK_RATE_LIMIT_CONFIG: RateLimitConfig = {
+	enabled: true,
+	maxRetries: 3,
+	initialRetryDelay: 1000,
+	backoffMultiplier: 2,
+	headerNames: {
+		retryAfter: 'Retry-After',
+		resetTime: 'X-RateLimit-Reset',
+		remaining: 'X-RateLimit-Remaining',
+		limit: 'X-RateLimit-Limit',
+	},
+};
+
+export interface ChatworkRequestOptions {
+	method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+	body?: Record<string, unknown> | string;
+	query?: Record<string, string | number | boolean | undefined>;
+	authType?: 'api_key' | 'oauth_2';
+	mediaType?: string;
+}
+
+export async function makeChatworkRequest<T>(
+	endpoint: string,
+	token: string,
+	options: ChatworkRequestOptions = {},
+): Promise<T> {
+	const {
+		method = 'GET',
+		body,
+		query,
+		authType = 'oauth_2',
+		mediaType,
+	} = options;
+
+	const headers: Record<string, string> = {};
+
+	if (authType === 'api_key') {
+		headers['X-ChatWorkToken'] = token;
+	} else {
+		headers.Authorization = `Bearer ${token}`;
+	}
+
+	let requestBody: any;
+	let effectiveMediaType = mediaType ?? 'application/json; charset=utf-8';
+
+	if (method === 'POST' || method === 'PUT') {
+		if (mediaType === 'application/x-www-form-urlencoded') {
+			effectiveMediaType = 'application/x-www-form-urlencoded';
+			if (typeof body === 'object' && body !== null) {
+				const params = new URLSearchParams();
+				for (const [key, value] of Object.entries(body)) {
+					if (value !== undefined && value !== null) {
+						params.append(key, String(value));
+					}
+				}
+				requestBody = params.toString();
+			} else {
+				requestBody = body;
+			}
+		} else {
+			requestBody = body;
+		}
+	}
+
+	const config: OpenAPIConfig = {
+		BASE: CHATWORK_API_BASE,
+		VERSION: 'v2',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: authType === 'oauth_2' ? token : undefined,
+		HEADERS: headers,
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint,
+		body: requestBody,
+		mediaType: effectiveMediaType,
+		query: method === 'GET' ? query : undefined,
+	};
+
+	try {
+		const response = await request<T>(config, requestOptions, {
+			rateLimitConfig: CHATWORK_RATE_LIMIT_CONFIG,
+		});
+
+		// Chatwork returns 204 No Content for endpoints like GET /rooms/{room_id}/messages when empty
+		if (response === undefined || response === null) {
+			return [] as unknown as T;
+		}
+
+		return response;
+	} catch (error) {
+		if (error instanceof ApiError) {
+			const bodyData = error.body as { errors?: string[] } | undefined;
+			const errorList = Array.isArray(bodyData?.errors)
+				? bodyData.errors
+				: undefined;
+			const message =
+				errorList && errorList.length > 0
+					? errorList.join(', ')
+					: error.message;
+			throw new ChatworkAPIError(
+				message,
+				error.status,
+				error.retryAfter,
+				errorList,
+			);
+		}
+		if (error instanceof Error) {
+			throw new ChatworkAPIError(error.message);
+		}
+		throw new ChatworkAPIError('Unknown Chatwork API error');
+	}
+}

--- a/packages/chatwork/endpoints/account.ts
+++ b/packages/chatwork/endpoints/account.ts
@@ -1,0 +1,22 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeChatworkRequest } from '../client';
+import type { ChatworkEndpoints } from '../index';
+import type { ChatworkEndpointOutputs } from './types';
+
+export const get: ChatworkEndpoints['accountGet'] = async (ctx, input) => {
+	const result = await makeChatworkRequest<
+		ChatworkEndpointOutputs['accountGet']
+	>('me', ctx.key, {
+		method: 'GET',
+		authType: ctx.options?.authType,
+	});
+
+	await logEventFromContext(
+		ctx,
+		'chatwork.account.get',
+		{ ...input },
+		'completed',
+	);
+
+	return result;
+};

--- a/packages/chatwork/endpoints/index.ts
+++ b/packages/chatwork/endpoints/index.ts
@@ -1,0 +1,25 @@
+import * as AccountEndpoints from './account';
+import * as MembersEndpoints from './members';
+import * as MessagesEndpoints from './messages';
+import * as RoomsEndpoints from './rooms';
+
+export const Account = {
+	get: AccountEndpoints.get,
+};
+
+export const Rooms = {
+	list: RoomsEndpoints.list,
+	get: RoomsEndpoints.get,
+};
+
+export const Messages = {
+	list: MessagesEndpoints.list,
+	get: MessagesEndpoints.get,
+	send: MessagesEndpoints.send,
+};
+
+export const Members = {
+	list: MembersEndpoints.list,
+};
+
+export * from './types';

--- a/packages/chatwork/endpoints/members.ts
+++ b/packages/chatwork/endpoints/members.ts
@@ -1,0 +1,22 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeChatworkRequest } from '../client';
+import type { ChatworkEndpoints } from '../index';
+import type { ChatworkEndpointOutputs } from './types';
+
+export const list: ChatworkEndpoints['membersList'] = async (ctx, input) => {
+	const result = await makeChatworkRequest<
+		ChatworkEndpointOutputs['membersList']
+	>(`rooms/${input.room_id}/members`, ctx.key, {
+		method: 'GET',
+		authType: ctx.options?.authType,
+	});
+
+	await logEventFromContext(
+		ctx,
+		'chatwork.members.list',
+		{ ...input },
+		'completed',
+	);
+
+	return result;
+};

--- a/packages/chatwork/endpoints/messages.ts
+++ b/packages/chatwork/endpoints/messages.ts
@@ -1,0 +1,79 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeChatworkRequest } from '../client';
+import type { ChatworkEndpoints } from '../index';
+import type { ChatworkEndpointOutputs } from './types';
+
+export const list: ChatworkEndpoints['messagesList'] = async (ctx, input) => {
+	const query: Record<string, string | number | boolean | undefined> = {};
+	if (input.force !== undefined) {
+		query.force = input.force;
+	}
+
+	const result = await makeChatworkRequest<
+		ChatworkEndpointOutputs['messagesList']
+	>(`rooms/${input.room_id}/messages`, ctx.key, {
+		method: 'GET',
+		query,
+		authType: ctx.options?.authType,
+	});
+
+	await logEventFromContext(
+		ctx,
+		'chatwork.messages.list',
+		{ ...input },
+		'completed',
+	);
+
+	return result ?? [];
+};
+
+export const get: ChatworkEndpoints['messagesGet'] = async (ctx, input) => {
+	const result = await makeChatworkRequest<
+		ChatworkEndpointOutputs['messagesGet']
+	>(`rooms/${input.room_id}/messages/${input.message_id}`, ctx.key, {
+		method: 'GET',
+		authType: ctx.options?.authType,
+	});
+
+	await logEventFromContext(
+		ctx,
+		'chatwork.messages.get',
+		{ ...input },
+		'completed',
+	);
+
+	return result;
+};
+
+export const send: ChatworkEndpoints['messagesSend'] = async (ctx, input) => {
+	const payload: Record<string, unknown> = {
+		body: input.body,
+	};
+
+	if (input.self_unread !== undefined) {
+		payload.self_unread =
+			typeof input.self_unread === 'boolean'
+				? input.self_unread
+					? 1
+					: 0
+				: input.self_unread;
+	}
+
+	const result = await makeChatworkRequest<
+		ChatworkEndpointOutputs['messagesSend']
+	>(`rooms/${input.room_id}/messages`, ctx.key, {
+		method: 'POST',
+		body: payload,
+		mediaType: 'application/x-www-form-urlencoded',
+		authType: ctx.options?.authType,
+	});
+
+	await logEventFromContext(
+		ctx,
+		'chatwork.messages.send',
+		{ ...input },
+		'completed',
+	);
+
+	return result;
+};

--- a/packages/chatwork/endpoints/rooms.ts
+++ b/packages/chatwork/endpoints/rooms.ts
@@ -1,0 +1,42 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeChatworkRequest } from '../client';
+import type { ChatworkEndpoints } from '../index';
+import type { ChatworkEndpointOutputs } from './types';
+
+export const list: ChatworkEndpoints['roomsList'] = async (ctx, input) => {
+	const result = await makeChatworkRequest<
+		ChatworkEndpointOutputs['roomsList']
+	>('rooms', ctx.key, {
+		method: 'GET',
+		authType: ctx.options?.authType,
+	});
+
+	await logEventFromContext(
+		ctx,
+		'chatwork.rooms.list',
+		{ ...input },
+		'completed',
+	);
+
+	return result;
+};
+
+export const get: ChatworkEndpoints['roomsGet'] = async (ctx, input) => {
+	const result = await makeChatworkRequest<ChatworkEndpointOutputs['roomsGet']>(
+		`rooms/${input.room_id}`,
+		ctx.key,
+		{
+			method: 'GET',
+			authType: ctx.options?.authType,
+		},
+	);
+
+	await logEventFromContext(
+		ctx,
+		'chatwork.rooms.get',
+		{ ...input },
+		'completed',
+	);
+
+	return result;
+};

--- a/packages/chatwork/endpoints/types.ts
+++ b/packages/chatwork/endpoints/types.ts
@@ -1,0 +1,238 @@
+import { z } from 'zod';
+
+// ==========================================
+// Account Schemas
+// ==========================================
+
+export const AccountGetInputSchema = z.object({});
+
+export const AccountGetResponseSchema = z.object({
+	account_id: z.number().describe('The Chatwork account ID'),
+	room_id: z.number().describe('The user personal room ID'),
+	name: z.string().describe('The user name'),
+	chatwork_id: z.string().optional().describe('The Chatwork ID handle'),
+	organization_id: z.number().optional().describe('The organization ID'),
+	organization_name: z.string().optional().describe('The organization name'),
+	department: z.string().optional().describe('The department name'),
+	title: z.string().optional().describe('The user title/position'),
+	url: z.string().optional().describe('The user website URL'),
+	introduction: z.string().optional().describe('The user profile introduction'),
+	mail: z.string().optional().describe('The user email address'),
+	tel_organization: z.string().optional().describe('Organization phone number'),
+	tel_extension: z.string().optional().describe('Extension phone number'),
+	tel_mobile: z.string().optional().describe('Mobile phone number'),
+	skype: z.string().optional().describe('Skype handle'),
+	facebook: z.string().optional().describe('Facebook profile'),
+	twitter: z.string().optional().describe('Twitter/X handle'),
+	avatar_image_url: z.string().optional().describe('Avatar image URL'),
+});
+
+// ==========================================
+// Rooms Schemas
+// ==========================================
+
+export const RoomsListInputSchema = z.object({});
+
+export const ChatworkRoomSummarySchema = z.object({
+	room_id: z.number().describe('The room ID'),
+	name: z.string().describe('The room name'),
+	type: z.string().describe('The room type (e.g. my, direct, group)'),
+	role: z
+		.string()
+		.describe(
+			'The current user role in the room (e.g. admin, member, readonly)',
+		),
+	sticky: z.boolean().describe('Whether the room is pinned'),
+	unread_num: z.number().describe('Number of unread messages'),
+	mention_num: z.number().describe('Number of unread mentions'),
+	mytask_num: z.number().describe('Number of open tasks assigned to me'),
+	message_num: z.number().describe('Total number of messages in the room'),
+	file_num: z.number().describe('Total number of files in the room'),
+	task_num: z.number().describe('Total number of tasks in the room'),
+	icon_path: z.string().describe('Icon image URL or icon path'),
+	last_update_time: z
+		.number()
+		.describe('Last updated timestamp in Unix seconds'),
+	description: z.string().optional().describe('Room description'),
+});
+
+export const RoomsListResponseSchema = z.array(ChatworkRoomSummarySchema);
+
+export const RoomsGetInputSchema = z.object({
+	room_id: z
+		.number()
+		.int()
+		.positive()
+		.describe('The ID of the room to retrieve'),
+});
+
+export const RoomsGetResponseSchema = z.object({
+	room_id: z.number().describe('The room ID'),
+	name: z.string().describe('The room name'),
+	type: z.string().describe('The room type (e.g. my, direct, group)'),
+	role: z
+		.string()
+		.describe(
+			'The current user role in the room (e.g. admin, member, readonly)',
+		),
+	sticky: z.boolean().describe('Whether the room is pinned'),
+	unread_num: z.number().describe('Number of unread messages'),
+	mention_num: z.number().describe('Number of unread mentions'),
+	mytask_num: z.number().describe('Number of open tasks assigned to me'),
+	message_num: z.number().describe('Total number of messages in the room'),
+	file_num: z.number().describe('Total number of files in the room'),
+	task_num: z.number().describe('Total number of tasks in the room'),
+	icon_path: z.string().describe('Icon image URL or icon path'),
+	last_update_time: z
+		.number()
+		.describe('Last updated timestamp in Unix seconds'),
+	description: z.string().optional().describe('Detailed room description'),
+});
+
+// ==========================================
+// Messages Schemas
+// ==========================================
+
+export const MessagesListInputSchema = z.object({
+	room_id: z.number().int().positive().describe('The ID of the room'),
+	force: z
+		.union([z.literal(0), z.literal(1)])
+		.optional()
+		.describe(
+			'0: get only unread messages (default), 1: get up to 100 latest messages',
+		),
+});
+
+export const ChatworkMessageAccountSchema = z.object({
+	account_id: z.number().describe('The sender account ID'),
+	name: z.string().describe('The sender name'),
+	avatar_image_url: z
+		.string()
+		.optional()
+		.describe('The sender avatar image URL'),
+});
+
+export const ChatworkMessageItemSchema = z.object({
+	message_id: z.string().describe('The unique message ID'),
+	account: ChatworkMessageAccountSchema.describe('The sender profile summary'),
+	body: z.string().describe('The message content'),
+	send_time: z.number().describe('Sent timestamp in Unix seconds'),
+	update_time: z
+		.number()
+		.describe('Updated timestamp in Unix seconds (0 if not updated)'),
+});
+
+export const MessagesListResponseSchema = z.array(ChatworkMessageItemSchema);
+
+export const MessagesGetInputSchema = z.object({
+	room_id: z.number().int().positive().describe('The ID of the room'),
+	message_id: z.string().min(1).describe('The ID of the message to retrieve'),
+});
+
+export const MessagesGetResponseSchema = ChatworkMessageItemSchema;
+
+export const MessagesSendInputSchema = z.object({
+	room_id: z
+		.number()
+		.int()
+		.positive()
+		.describe('The ID of the room to post to'),
+	body: z.string().min(1).describe('The message body text'),
+	self_unread: z
+		.union([z.literal(0), z.literal(1), z.boolean()])
+		.optional()
+		.describe(
+			'Whether the posted message should be marked as unread for the sender (0: read, 1: unread)',
+		),
+});
+
+export const MessagesSendResponseSchema = z.object({
+	message_id: z.string().describe('The ID of the created message'),
+});
+
+// ==========================================
+// Members Schemas
+// ==========================================
+
+export const MembersListInputSchema = z.object({
+	room_id: z.number().int().positive().describe('The ID of the room'),
+});
+
+export const ChatworkMemberItemSchema = z.object({
+	account_id: z.number().describe('The member account ID'),
+	role: z
+		.enum(['admin', 'member', 'readonly'])
+		.or(z.string())
+		.describe('The role in the room'),
+	name: z.string().describe('The member name'),
+	chatwork_id: z.string().optional().describe('The Chatwork ID handle'),
+	organization_id: z.number().optional().describe('Organization ID'),
+	organization_name: z.string().optional().describe('Organization name'),
+	department: z.string().optional().describe('Department name'),
+	avatar_image_url: z.string().optional().describe('Avatar image URL'),
+});
+
+export const MembersListResponseSchema = z.array(ChatworkMemberItemSchema);
+
+// ==========================================
+// Inferred TypeScript Types
+// ==========================================
+
+export type AccountGetInput = z.infer<typeof AccountGetInputSchema>;
+export type AccountGetResponse = z.infer<typeof AccountGetResponseSchema>;
+
+export type RoomsListInput = z.infer<typeof RoomsListInputSchema>;
+export type RoomsListResponse = z.infer<typeof RoomsListResponseSchema>;
+export type RoomsGetInput = z.infer<typeof RoomsGetInputSchema>;
+export type RoomsGetResponse = z.infer<typeof RoomsGetResponseSchema>;
+
+export type MessagesListInput = z.infer<typeof MessagesListInputSchema>;
+export type MessagesListResponse = z.infer<typeof MessagesListResponseSchema>;
+export type MessagesGetInput = z.infer<typeof MessagesGetInputSchema>;
+export type MessagesGetResponse = z.infer<typeof MessagesGetResponseSchema>;
+export type MessagesSendInput = z.infer<typeof MessagesSendInputSchema>;
+export type MessagesSendResponse = z.infer<typeof MessagesSendResponseSchema>;
+
+export type MembersListInput = z.infer<typeof MembersListInputSchema>;
+export type MembersListResponse = z.infer<typeof MembersListResponseSchema>;
+
+// Maps for plugin contracts
+export type ChatworkEndpointInputs = {
+	accountGet: AccountGetInput;
+	roomsList: RoomsListInput;
+	roomsGet: RoomsGetInput;
+	messagesList: MessagesListInput;
+	messagesGet: MessagesGetInput;
+	messagesSend: MessagesSendInput;
+	membersList: MembersListInput;
+};
+
+export type ChatworkEndpointOutputs = {
+	accountGet: AccountGetResponse;
+	roomsList: RoomsListResponse;
+	roomsGet: RoomsGetResponse;
+	messagesList: MessagesListResponse;
+	messagesGet: MessagesGetResponse;
+	messagesSend: MessagesSendResponse;
+	membersList: MembersListResponse;
+};
+
+export const ChatworkEndpointInputSchemas = {
+	accountGet: AccountGetInputSchema,
+	roomsList: RoomsListInputSchema,
+	roomsGet: RoomsGetInputSchema,
+	messagesList: MessagesListInputSchema,
+	messagesGet: MessagesGetInputSchema,
+	messagesSend: MessagesSendInputSchema,
+	membersList: MembersListInputSchema,
+};
+
+export const ChatworkEndpointOutputSchemas = {
+	accountGet: AccountGetResponseSchema,
+	roomsList: RoomsListResponseSchema,
+	roomsGet: RoomsGetResponseSchema,
+	messagesList: MessagesListResponseSchema,
+	messagesGet: MessagesGetResponseSchema,
+	messagesSend: MessagesSendResponseSchema,
+	membersList: MembersListResponseSchema,
+};

--- a/packages/chatwork/error-handlers.ts
+++ b/packages/chatwork/error-handlers.ts
@@ -1,0 +1,74 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+import { ChatworkAPIError } from './client';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error) => {
+			if (error instanceof ChatworkAPIError && error.status === 429) {
+				return true;
+			}
+			if (error instanceof ApiError && error.status === 429) {
+				return true;
+			}
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limit') || msg.includes('429');
+		},
+		handler: async (error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ChatworkAPIError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			} else if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error) => {
+			if (error instanceof ChatworkAPIError && error.status === 401) {
+				return true;
+			}
+			if (error instanceof ApiError && error.status === 401) {
+				return true;
+			}
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('unauthorized') ||
+				msg.includes('invalid_token') ||
+				msg.includes('401')
+			);
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	PERMISSION_ERROR: {
+		match: (error) => {
+			if (error instanceof ChatworkAPIError && error.status === 403) {
+				return true;
+			}
+			if (error instanceof ApiError && error.status === 403) {
+				return true;
+			}
+			const msg = error.message.toLowerCase();
+			return msg.includes('forbidden') || msg.includes('403');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	NOT_FOUND_ERROR: {
+		match: (error) => {
+			if (error instanceof ChatworkAPIError && error.status === 404) {
+				return true;
+			}
+			if (error instanceof ApiError && error.status === 404) {
+				return true;
+			}
+			const msg = error.message.toLowerCase();
+			return msg.includes('not_found') || msg.includes('404');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/chatwork/index.ts
+++ b/packages/chatwork/index.ts
@@ -1,0 +1,344 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	BindWebhooks,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	CorsairWebhook,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+	RequiredPluginWebhookSchemas,
+} from 'corsair/core';
+import { Account, Members, Messages, Rooms } from './endpoints';
+import type {
+	ChatworkEndpointInputs,
+	ChatworkEndpointOutputs,
+} from './endpoints/types';
+import {
+	ChatworkEndpointInputSchemas,
+	ChatworkEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { ChatworkSchema } from './schema';
+import { MentionsWebhooks, MessagesWebhooks } from './webhooks';
+import { resolveChatworkOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
+import { matchChatworkTenantWebhook } from './webhooks/tenant-matcher';
+import type {
+	ChatworkWebhookOutputs,
+	MentionToMeWebhookPayload,
+	MessageCreatedWebhookPayload,
+	MessageUpdatedWebhookPayload,
+} from './webhooks/types';
+import {
+	MentionToMeWebhookPayloadSchema,
+	MessageCreatedWebhookPayloadSchema,
+	MessageUpdatedWebhookPayloadSchema,
+} from './webhooks/types';
+
+export type ChatworkPluginOptions = {
+	authType?: PickAuth<'api_key' | 'oauth_2'>;
+	key?: string;
+	webhookSecret?: string;
+	hooks?: InternalChatworkPlugin['hooks'];
+	webhookHooks?: InternalChatworkPlugin['webhookHooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof chatworkEndpointsNested>;
+};
+
+export type ChatworkContext = CorsairPluginContext<
+	typeof ChatworkSchema,
+	ChatworkPluginOptions
+>;
+
+export type ChatworkKeyBuilderContext =
+	KeyBuilderContext<ChatworkPluginOptions>;
+
+export type ChatworkBoundEndpoints = BindEndpoints<
+	typeof chatworkEndpointsNested
+>;
+
+type ChatworkEndpoint<K extends keyof ChatworkEndpointOutputs> =
+	CorsairEndpoint<
+		ChatworkContext,
+		ChatworkEndpointInputs[K],
+		ChatworkEndpointOutputs[K]
+	>;
+
+export type ChatworkEndpoints = {
+	accountGet: ChatworkEndpoint<'accountGet'>;
+	roomsList: ChatworkEndpoint<'roomsList'>;
+	roomsGet: ChatworkEndpoint<'roomsGet'>;
+	messagesList: ChatworkEndpoint<'messagesList'>;
+	messagesGet: ChatworkEndpoint<'messagesGet'>;
+	messagesSend: ChatworkEndpoint<'messagesSend'>;
+	membersList: ChatworkEndpoint<'membersList'>;
+};
+
+type ChatworkWebhook<
+	K extends keyof ChatworkWebhookOutputs,
+	TEvent,
+> = CorsairWebhook<ChatworkContext, TEvent, ChatworkWebhookOutputs[K]>;
+
+export type ChatworkWebhooks = {
+	messageCreated: ChatworkWebhook<
+		'messageCreated',
+		MessageCreatedWebhookPayload
+	>;
+	messageUpdated: ChatworkWebhook<
+		'messageUpdated',
+		MessageUpdatedWebhookPayload
+	>;
+	mentionToMe: ChatworkWebhook<'mentionToMe', MentionToMeWebhookPayload>;
+};
+
+export type ChatworkBoundWebhooks = BindWebhooks<ChatworkWebhooks>;
+
+const chatworkEndpointsNested = {
+	account: {
+		get: Account.get,
+	},
+	rooms: {
+		list: Rooms.list,
+		get: Rooms.get,
+	},
+	messages: {
+		list: Messages.list,
+		get: Messages.get,
+		send: Messages.send,
+	},
+	members: {
+		list: Members.list,
+	},
+} as const;
+
+const chatworkWebhooksNested = {
+	messages: {
+		created: MessagesWebhooks.created,
+		updated: MessagesWebhooks.updated,
+	},
+	mentions: {
+		toMe: MentionsWebhooks.toMe,
+	},
+} as const;
+
+export const chatworkEndpointSchemas = {
+	'account.get': {
+		input: ChatworkEndpointInputSchemas.accountGet,
+		output: ChatworkEndpointOutputSchemas.accountGet,
+	},
+	'rooms.list': {
+		input: ChatworkEndpointInputSchemas.roomsList,
+		output: ChatworkEndpointOutputSchemas.roomsList,
+	},
+	'rooms.get': {
+		input: ChatworkEndpointInputSchemas.roomsGet,
+		output: ChatworkEndpointOutputSchemas.roomsGet,
+	},
+	'messages.list': {
+		input: ChatworkEndpointInputSchemas.messagesList,
+		output: ChatworkEndpointOutputSchemas.messagesList,
+	},
+	'messages.get': {
+		input: ChatworkEndpointInputSchemas.messagesGet,
+		output: ChatworkEndpointOutputSchemas.messagesGet,
+	},
+	'messages.send': {
+		input: ChatworkEndpointInputSchemas.messagesSend,
+		output: ChatworkEndpointOutputSchemas.messagesSend,
+	},
+	'members.list': {
+		input: ChatworkEndpointInputSchemas.membersList,
+		output: ChatworkEndpointOutputSchemas.membersList,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<
+	typeof chatworkEndpointsNested
+>;
+
+const chatworkWebhookSchemas = {
+	'messages.created': {
+		description: 'A message was created in a room',
+		payload: MessageCreatedWebhookPayloadSchema,
+		response: MessageCreatedWebhookPayloadSchema,
+	},
+	'messages.updated': {
+		description: 'A message was updated in a room',
+		payload: MessageUpdatedWebhookPayloadSchema,
+		response: MessageUpdatedWebhookPayloadSchema,
+	},
+	'mentions.toMe': {
+		description: 'Current user was mentioned in a room message',
+		payload: MentionToMeWebhookPayloadSchema,
+		response: MentionToMeWebhookPayloadSchema,
+	},
+} as const satisfies RequiredPluginWebhookSchemas<
+	typeof chatworkWebhooksNested
+>;
+
+const defaultAuthType: AuthTypes = 'oauth_2' as const;
+
+const chatworkEndpointMeta = {
+	'account.get': {
+		riskLevel: 'read',
+		description: 'Get profile information of the authenticated user',
+	},
+	'rooms.list': {
+		riskLevel: 'read',
+		description: 'List chat rooms the authenticated user belongs to',
+	},
+	'rooms.get': {
+		riskLevel: 'read',
+		description: 'Get details of a specific chat room',
+	},
+	'messages.list': {
+		riskLevel: 'read',
+		description: 'List messages in a chat room',
+	},
+	'messages.get': {
+		riskLevel: 'read',
+		description: 'Get a specific message from a chat room',
+	},
+	'messages.send': {
+		riskLevel: 'write',
+		description: 'Send a new message to a chat room',
+	},
+	'members.list': {
+		riskLevel: 'read',
+		description: 'List members belonging to a chat room',
+	},
+} as const satisfies RequiredPluginEndpointMeta<typeof chatworkEndpointsNested>;
+
+export const chatworkAuthConfig = {
+	api_key: {
+		account: ['account_id'] as const,
+	},
+	oauth_2: {
+		account: ['account_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type BaseChatworkPlugin<T extends ChatworkPluginOptions> = CorsairPlugin<
+	'chatwork',
+	typeof ChatworkSchema,
+	typeof chatworkEndpointsNested,
+	typeof chatworkWebhooksNested,
+	T,
+	typeof defaultAuthType
+>;
+
+export type InternalChatworkPlugin = BaseChatworkPlugin<ChatworkPluginOptions>;
+
+export type ExternalChatworkPlugin<T extends ChatworkPluginOptions> =
+	BaseChatworkPlugin<T>;
+
+export function chatwork<const T extends ChatworkPluginOptions>(
+	incomingOptions: ChatworkPluginOptions & T = {} as ChatworkPluginOptions & T,
+): ExternalChatworkPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'chatwork',
+		authConfig: chatworkAuthConfig,
+		oauthConfig: {
+			providerName: 'Chatwork',
+			authUrl: 'https://www.chatwork.com/packages/oauth2/login.php',
+			tokenUrl: 'https://oauth.chatwork.com/token',
+			scopes: [
+				'users.profile.me:read',
+				'rooms.info:read',
+				'rooms.messages:read',
+				'rooms.members:read',
+				'rooms.messages:write',
+				'offline_access',
+			],
+		},
+		schema: ChatworkSchema,
+		options: options,
+		hooks: options.hooks,
+		webhookHooks: options.webhookHooks,
+		endpoints: chatworkEndpointsNested,
+		webhooks: chatworkWebhooksNested,
+		endpointMeta: chatworkEndpointMeta,
+		endpointSchemas: chatworkEndpointSchemas,
+		webhookSchemas: chatworkWebhookSchemas,
+		pluginWebhookMatcher: (request) => {
+			const headers = request.headers;
+			return (
+				'x-chatworkwebhooksignature' in headers ||
+				'X-ChatWorkWebhookSignature' in headers ||
+				'x-chatwork-signature' in headers
+			);
+		},
+		pluginTenantWebhookMatcher: matchChatworkTenantWebhook,
+		oauthWebhookTenantLinkResolver: resolveChatworkOAuthWebhookTenantLink,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: ChatworkKeyBuilderContext, source) => {
+			if (source === 'webhook' && options.webhookSecret) {
+				return options.webhookSecret;
+			}
+
+			if (source === 'webhook') {
+				const res = await ctx.keys.get_webhook_signature();
+				return res ?? '';
+			}
+
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys.get_api_key();
+				return res ?? '';
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'oauth_2') {
+				const res = await ctx.keys.get_access_token();
+				return res ?? '';
+			}
+
+			return '';
+		},
+	} satisfies InternalChatworkPlugin;
+}
+
+export * from './client';
+export type {
+	AccountGetInput,
+	AccountGetResponse,
+	ChatworkEndpointInputs,
+	ChatworkEndpointOutputs,
+	MembersListInput,
+	MembersListResponse,
+	MessagesGetInput,
+	MessagesGetResponse,
+	MessagesListInput,
+	MessagesListResponse,
+	MessagesSendInput,
+	MessagesSendResponse,
+	RoomsGetInput,
+	RoomsGetResponse,
+	RoomsListInput,
+	RoomsListResponse,
+} from './endpoints/types';
+export * from './error-handlers';
+export * from './schema';
+export type {
+	ChatworkWebhookOutputs,
+	MentionToMeWebhookPayload,
+	MessageCreatedWebhookPayload,
+	MessageUpdatedWebhookPayload,
+} from './webhooks/types';
+export {
+	createChatworkMatch,
+	verifyChatworkWebhookSignature,
+} from './webhooks/types';

--- a/packages/chatwork/jest.config.cjs
+++ b/packages/chatwork/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/chatwork/oauth-config.test.ts
+++ b/packages/chatwork/oauth-config.test.ts
@@ -1,0 +1,87 @@
+import { chatwork, chatworkAuthConfig } from './index';
+
+describe('Chatwork OAuth and Auth Configuration', () => {
+	it('defines correct authConfig linking account_id', () => {
+		expect(chatworkAuthConfig.api_key.account).toEqual(['account_id']);
+		expect(chatworkAuthConfig.oauth_2.account).toEqual(['account_id']);
+	});
+
+	it('configures OAuth endpoints and necessary scopes', () => {
+		const plugin = chatwork();
+		expect(plugin.oauthConfig).toBeDefined();
+		expect(plugin.oauthConfig?.providerName).toBe('Chatwork');
+		expect(plugin.oauthConfig?.authUrl).toBe(
+			'https://www.chatwork.com/packages/oauth2/login.php',
+		);
+		expect(plugin.oauthConfig?.tokenUrl).toBe(
+			'https://oauth.chatwork.com/token',
+		);
+
+		const expectedScopes = [
+			'users.profile.me:read',
+			'rooms.info:read',
+			'rooms.messages:read',
+			'rooms.members:read',
+			'rooms.messages:write',
+			'offline_access',
+		];
+
+		for (const scope of expectedScopes) {
+			expect(plugin.oauthConfig?.scopes).toContain(scope);
+		}
+	});
+
+	describe('keyBuilder', () => {
+		it('returns explicit option key for endpoints if provided', async () => {
+			const plugin = chatwork({ key: 'explicit-api-key' });
+			const ctx = {
+				keys: {
+					get_api_key: jest.fn(),
+					get_access_token: jest.fn(),
+					get_webhook_signature: jest.fn(),
+				},
+				authType: 'api_key',
+			};
+
+			const keyBuilder = plugin.keyBuilder as any;
+			expect(keyBuilder).toBeDefined();
+			const key = await keyBuilder(ctx, 'endpoint');
+			expect(key).toBe('explicit-api-key');
+		});
+
+		it('retrieves access_token for oauth_2 endpoints', async () => {
+			const plugin = chatwork();
+			const ctx = {
+				keys: {
+					get_api_key: jest.fn(),
+					get_access_token: jest.fn().mockResolvedValue('oauth-token-123'),
+					get_webhook_signature: jest.fn(),
+				},
+				authType: 'oauth_2',
+			};
+
+			const keyBuilder = plugin.keyBuilder as any;
+			expect(keyBuilder).toBeDefined();
+			const key = await keyBuilder(ctx, 'endpoint');
+			expect(key).toBe('oauth-token-123');
+		});
+
+		it('retrieves webhook secret from options or keys', async () => {
+			const pluginWithOptions = chatwork({ webhookSecret: 'secret-option' });
+			const ctx = {
+				keys: {
+					get_webhook_signature: jest.fn().mockResolvedValue('stored-secret'),
+				},
+			};
+
+			const keyBuilderWithOptions = pluginWithOptions.keyBuilder as any;
+			const key1 = await keyBuilderWithOptions(ctx, 'webhook');
+			expect(key1).toBe('secret-option');
+
+			const defaultPlugin = chatwork();
+			const defaultKeyBuilder = defaultPlugin.keyBuilder as any;
+			const key2 = await defaultKeyBuilder(ctx, 'webhook');
+			expect(key2).toBe('stored-secret');
+		});
+	});
+});

--- a/packages/chatwork/package.json
+++ b/packages/chatwork/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/chatwork",
+  "version": "0.1.0",
+  "description": "Chatwork plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "chatwork",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/chatwork/plugin-docs.yaml
+++ b/packages/chatwork/plugin-docs.yaml
@@ -1,0 +1,25 @@
+displayName: Chatwork
+description: Business chat and communication tool for team messaging, room management, and collaboration.
+recommendedAuth: oauth_2
+examples:
+  read:
+    path: rooms.list
+    title: List rooms
+  write:
+    path: messages.send
+    title: Send a message to a room
+    args:
+      room_id: 123456
+      body: Hello from Corsair!
+dbExample:
+  entity: rooms
+  note: Search synced rooms without hitting the Chatwork API.
+  data:
+    type: group
+  limit: 20
+exampleWebhook:
+  path: messages.created
+  note: React when someone posts a new message in a room.
+  after: |
+    const body = result.data?.webhook_event?.body;
+    console.log('New message received:', body);

--- a/packages/chatwork/schema.test.ts
+++ b/packages/chatwork/schema.test.ts
@@ -1,0 +1,20 @@
+import { ChatworkSchema } from './schema';
+
+describe('Chatwork schema', () => {
+	it('declares a semver version', () => {
+		expect(ChatworkSchema.version).toBeDefined();
+		expect(ChatworkSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof ChatworkSchema.entities).toBe('object');
+		expect(ChatworkSchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(ChatworkSchema.entities))).toBe(true);
+		for (const entity of Object.values(ChatworkSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/chatwork/schema/database.ts
+++ b/packages/chatwork/schema/database.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod';
+
+export const ChatworkAccount = z.object({
+	account_id: z.number(),
+	room_id: z.number().optional(),
+	name: z.string(),
+	chatwork_id: z.string().optional(),
+	organization_id: z.number().optional(),
+	organization_name: z.string().optional(),
+	department: z.string().optional(),
+	title: z.string().optional(),
+	url: z.string().optional(),
+	introduction: z.string().optional(),
+	mail: z.string().optional(),
+	tel_organization: z.string().optional(),
+	tel_extension: z.string().optional(),
+	tel_mobile: z.string().optional(),
+	skype: z.string().optional(),
+	facebook: z.string().optional(),
+	twitter: z.string().optional(),
+	avatar_image_url: z.string().optional(),
+	createdAt: z.coerce.date().nullable().optional(),
+});
+
+export const ChatworkRoom = z.object({
+	room_id: z.number(),
+	name: z.string(),
+	type: z.string(),
+	role: z.string().optional(),
+	sticky: z.boolean().optional(),
+	unread_num: z.number().optional(),
+	mention_num: z.number().optional(),
+	mytask_num: z.number().optional(),
+	message_num: z.number().optional(),
+	file_num: z.number().optional(),
+	task_num: z.number().optional(),
+	icon_path: z.string().optional(),
+	last_update_time: z.number().optional(),
+	description: z.string().optional(),
+	createdAt: z.coerce.date().nullable().optional(),
+});
+
+export const ChatworkMessage = z.object({
+	message_id: z.string(),
+	room_id: z.number().optional(),
+	account: z
+		.object({
+			account_id: z.number(),
+			name: z.string(),
+			avatar_image_url: z.string().optional(),
+		})
+		.optional(),
+	body: z.string(),
+	send_time: z.number(),
+	update_time: z.number().optional(),
+	createdAt: z.coerce.date().nullable().optional(),
+});
+
+export const ChatworkMember = z.object({
+	account_id: z.number(),
+	room_id: z.number().optional(),
+	role: z.string(),
+	name: z.string(),
+	chatwork_id: z.string().optional(),
+	organization_id: z.number().optional(),
+	organization_name: z.string().optional(),
+	department: z.string().optional(),
+	avatar_image_url: z.string().optional(),
+	createdAt: z.coerce.date().nullable().optional(),
+});
+
+export type ChatworkAccount = z.infer<typeof ChatworkAccount>;
+export type ChatworkRoom = z.infer<typeof ChatworkRoom>;
+export type ChatworkMessage = z.infer<typeof ChatworkMessage>;
+export type ChatworkMember = z.infer<typeof ChatworkMember>;

--- a/packages/chatwork/schema/index.ts
+++ b/packages/chatwork/schema/index.ts
@@ -1,0 +1,18 @@
+import {
+	ChatworkAccount,
+	ChatworkMember,
+	ChatworkMessage,
+	ChatworkRoom,
+} from './database';
+
+export const ChatworkSchema = {
+	version: '1.0.0',
+	entities: {
+		accounts: ChatworkAccount,
+		rooms: ChatworkRoom,
+		messages: ChatworkMessage,
+		members: ChatworkMember,
+	},
+} as const;
+
+export * from './database';

--- a/packages/chatwork/tsconfig.json
+++ b/packages/chatwork/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/chatwork/tsup.config.ts
+++ b/packages/chatwork/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/chatwork/webhooks.test.ts
+++ b/packages/chatwork/webhooks.test.ts
@@ -1,0 +1,335 @@
+import { createHmac } from 'node:crypto';
+import type { RawWebhookRequest, WebhookRequest } from 'corsair/core';
+import type { ChatworkContext } from './index';
+import {
+	createChatworkMatch,
+	MentionsWebhooks,
+	MessagesWebhooks,
+	matchChatworkTenantWebhook,
+	resolveChatworkOAuthWebhookTenantLink,
+	verifyChatworkWebhookSignature,
+} from './webhooks';
+import type {
+	MentionToMeWebhookPayload,
+	MessageCreatedWebhookPayload,
+	MessageUpdatedWebhookPayload,
+} from './webhooks/types';
+
+function testContext(key = 'dGVzdC1zZWNyZXQta2V5'): ChatworkContext {
+	return {
+		key,
+		$getAccountId: () => 'test-account-id',
+		options: {},
+		logEvent: jest.fn(),
+		db: {},
+	} as unknown as ChatworkContext;
+}
+
+// Helper to compute valid Chatwork signature given raw body and base64 secret
+function computeSignature(body: string, secretBase64: string): string {
+	const key = Buffer.from(secretBase64, 'base64');
+	return createHmac('sha256', key).update(body).digest('base64');
+}
+
+describe('Chatwork Webhooks Signature Verification', () => {
+	const secretBase64 = Buffer.from('my-super-secret-token').toString('base64');
+	const rawBody = JSON.stringify({
+		webhook_setting_id: '123',
+		webhook_event_type: 'message_created',
+		webhook_event_time: 1600000000,
+		webhook_event: {
+			message_id: 'msg-1',
+			room_id: 100,
+			account_id: 200,
+			body: 'Test',
+			send_time: 1600000000,
+		},
+	});
+
+	it('validates a correct HMAC-SHA256 signature with base64 decoded key', () => {
+		const validSig = computeSignature(rawBody, secretBase64);
+
+		const result = verifyChatworkWebhookSignature(
+			rawBody,
+			validSig,
+			secretBase64,
+		);
+
+		expect(result.valid).toBe(true);
+		expect(result.error).toBeUndefined();
+	});
+
+	it('rejects an invalid signature with length mismatch', () => {
+		const result = verifyChatworkWebhookSignature(
+			rawBody,
+			'short-invalid-sig',
+			secretBase64,
+		);
+
+		expect(result.valid).toBe(false);
+		expect(result.error).toBe('Signature length mismatch');
+	});
+
+	it('rejects an invalid signature of equal length', () => {
+		const validSig = computeSignature(rawBody, secretBase64);
+		// Same length but wrong characters
+		const tamperedSig = validSig.startsWith('A')
+			? `B${validSig.slice(1)}`
+			: `A${validSig.slice(1)}`;
+
+		const result = verifyChatworkWebhookSignature(
+			rawBody,
+			tamperedSig,
+			secretBase64,
+		);
+
+		expect(result.valid).toBe(false);
+		expect(result.error).toBe('Invalid webhook signature');
+	});
+
+	it('fails gracefully when signature is missing', () => {
+		const result = verifyChatworkWebhookSignature(rawBody, '', secretBase64);
+
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain('Missing x-chatworkwebhooksignature');
+	});
+
+	it('verifies signature via WebhookRequest object with headers', () => {
+		const validSig = computeSignature(rawBody, secretBase64);
+		const req: WebhookRequest<unknown> = {
+			payload: JSON.parse(rawBody),
+			headers: {
+				'x-chatworkwebhooksignature': validSig,
+			},
+			rawBody,
+		};
+
+		const result = verifyChatworkWebhookSignature(req, secretBase64);
+		expect(result.valid).toBe(true);
+	});
+});
+
+describe('Chatwork Webhook Matchers', () => {
+	it('matches message_created events correctly', () => {
+		const matcher = createChatworkMatch('message_created');
+		const req: RawWebhookRequest = {
+			headers: {},
+			body: JSON.stringify({ webhook_event_type: 'message_created' }),
+		};
+
+		expect(matcher(req)).toBe(true);
+	});
+
+	it('does not match differing event types', () => {
+		const matcher = createChatworkMatch('message_created');
+		const req: RawWebhookRequest = {
+			headers: {},
+			body: JSON.stringify({ webhook_event_type: 'message_updated' }),
+		};
+
+		expect(matcher(req)).toBe(false);
+	});
+});
+
+describe('Chatwork Webhook Handlers', () => {
+	const secretBase64 = Buffer.from('test-secret').toString('base64');
+	const ctx = testContext(secretBase64);
+
+	it('handles message_created webhook successfully', async () => {
+		const payload: MessageCreatedWebhookPayload = {
+			webhook_setting_id: 'setting-1',
+			webhook_event_type: 'message_created',
+			webhook_event_time: 1600000000,
+			webhook_event: {
+				message_id: 'msg-1',
+				room_id: 101,
+				account_id: 202,
+				body: 'New room message',
+				send_time: 1600000000,
+				update_time: 0,
+			},
+		};
+
+		const rawBody = JSON.stringify(payload);
+		const sig = computeSignature(rawBody, secretBase64);
+
+		const req: WebhookRequest<MessageCreatedWebhookPayload> = {
+			payload,
+			headers: { 'x-chatworkwebhooksignature': sig },
+			rawBody,
+		};
+
+		const response = await MessagesWebhooks.created.handler(ctx, req);
+
+		expect(response.success).toBe(true);
+		expect(response.data).toEqual(payload);
+	});
+
+	it('handles message_updated webhook successfully', async () => {
+		const payload: MessageUpdatedWebhookPayload = {
+			webhook_setting_id: 'setting-2',
+			webhook_event_type: 'message_updated',
+			webhook_event_time: 1600000010,
+			webhook_event: {
+				message_id: 'msg-1',
+				room_id: 101,
+				account_id: 202,
+				body: 'Updated room message',
+				send_time: 1600000000,
+				update_time: 1600000010,
+			},
+		};
+
+		const rawBody = JSON.stringify(payload);
+		const sig = computeSignature(rawBody, secretBase64);
+
+		const req: WebhookRequest<MessageUpdatedWebhookPayload> = {
+			payload,
+			headers: { 'x-chatworkwebhooksignature': sig },
+			rawBody,
+		};
+
+		const response = await MessagesWebhooks.updated.handler(ctx, req);
+
+		expect(response.success).toBe(true);
+		expect(response.data).toEqual(payload);
+	});
+
+	it('handles mention_to_me webhook successfully', async () => {
+		const payload: MentionToMeWebhookPayload = {
+			webhook_setting_id: 'setting-3',
+			webhook_event_type: 'mention_to_me',
+			webhook_event_time: 1600000020,
+			webhook_event: {
+				mention_id: 'men-1',
+				message_id: 'msg-99',
+				room_id: 101,
+				from_account_id: 303,
+				to_account_id: 404,
+				body: '[To:404] Hey look at this',
+				send_time: 1600000020,
+			},
+		};
+
+		const rawBody = JSON.stringify(payload);
+		const sig = computeSignature(rawBody, secretBase64);
+
+		const req: WebhookRequest<MentionToMeWebhookPayload> = {
+			payload,
+			headers: { 'x-chatworkwebhooksignature': sig },
+			rawBody,
+		};
+
+		const response = await MentionsWebhooks.toMe.handler(ctx, req);
+
+		expect(response.success).toBe(true);
+		expect(response.data).toEqual(payload);
+	});
+
+	it('rejects webhooks with invalid signature returning 401', async () => {
+		const payload: MessageCreatedWebhookPayload = {
+			webhook_setting_id: 'setting-1',
+			webhook_event_type: 'message_created',
+			webhook_event_time: 1600000000,
+			webhook_event: {
+				message_id: 'msg-1',
+				room_id: 101,
+				account_id: 202,
+				body: 'Hacked message',
+				send_time: 1600000000,
+			},
+		};
+
+		const req: WebhookRequest<MessageCreatedWebhookPayload> = {
+			payload,
+			headers: { 'x-chatworkwebhooksignature': 'bad-sig' },
+			rawBody: JSON.stringify(payload),
+		};
+
+		const response = await MessagesWebhooks.created.handler(ctx, req);
+
+		expect(response.success).toBe(false);
+		expect(response.statusCode).toBe(401);
+	});
+});
+
+describe('Chatwork Webhook Tenant Matcher', () => {
+	it('matches tenant by account_id in webhook_event', () => {
+		const req: RawWebhookRequest = {
+			headers: {},
+			body: {
+				webhook_event_type: 'message_created',
+				webhook_event: {
+					account_id: 12345,
+				},
+			},
+		};
+
+		const match = matchChatworkTenantWebhook(req);
+		expect(match).toEqual({ linkType: 'account_id', externalId: '12345' });
+	});
+
+	it('matches tenant by to_account_id in mention_to_me event', () => {
+		const req: RawWebhookRequest = {
+			headers: {},
+			body: {
+				webhook_event_type: 'mention_to_me',
+				webhook_event: {
+					to_account_id: 67890,
+				},
+			},
+		};
+
+		const match = matchChatworkTenantWebhook(req);
+		expect(match).toEqual({ linkType: 'account_id', externalId: '67890' });
+	});
+
+	it('returns null when no account_id is present', () => {
+		const req: RawWebhookRequest = {
+			headers: {},
+			body: { unknown: 'payload' },
+		};
+
+		const match = matchChatworkTenantWebhook(req);
+		expect(match).toBeNull();
+	});
+});
+
+describe('Chatwork OAuth Tenant Link Resolver', () => {
+	it('resolves externalId directly from tokens.account_id when available', async () => {
+		const tokens = {
+			access_token: 'fake-token',
+			token_type: 'Bearer',
+			account_id: 99999,
+		};
+
+		const result = await resolveChatworkOAuthWebhookTenantLink(tokens);
+		expect(result).toEqual({ linkType: 'account_id', externalId: '99999' });
+	});
+
+	it('fetches /me from Chatwork when token response omits account_id', async () => {
+		const originalFetch = global.fetch;
+		global.fetch = jest.fn().mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ account_id: 88888 }),
+		} as Response);
+
+		try {
+			const tokens = {
+				access_token: 'access-token-without-id',
+				token_type: 'Bearer',
+			};
+
+			const result = await resolveChatworkOAuthWebhookTenantLink(tokens);
+			expect(result).toEqual({ linkType: 'account_id', externalId: '88888' });
+			expect(global.fetch).toHaveBeenCalledWith(
+				'https://api.chatwork.com/v2/me',
+				expect.objectContaining({
+					headers: { Authorization: 'Bearer access-token-without-id' },
+				}),
+			);
+		} finally {
+			global.fetch = originalFetch;
+		}
+	});
+});

--- a/packages/chatwork/webhooks/index.ts
+++ b/packages/chatwork/webhooks/index.ts
@@ -1,0 +1,7 @@
+import * as MentionsWebhooks from './mentions';
+import * as MessagesWebhooks from './messages';
+
+export { MessagesWebhooks, MentionsWebhooks };
+export * from './oauth-tenant-link';
+export * from './tenant-matcher';
+export * from './types';

--- a/packages/chatwork/webhooks/mentions.ts
+++ b/packages/chatwork/webhooks/mentions.ts
@@ -1,0 +1,29 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ChatworkWebhooks } from '../index';
+import { createChatworkMatch, verifyChatworkWebhookSignature } from './types';
+
+export const toMe: ChatworkWebhooks['mentionToMe'] = {
+	match: createChatworkMatch('mention_to_me'),
+	handler: async (ctx, request) => {
+		const { valid, error } = verifyChatworkWebhookSignature(request, ctx.key);
+		if (!valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: error || 'Signature verification failed',
+			};
+		}
+
+		await logEventFromContext(
+			ctx,
+			'chatwork.webhook.mentionToMe',
+			{ ...request.payload },
+			'completed',
+		);
+
+		return {
+			success: true,
+			data: request.payload,
+		};
+	},
+};

--- a/packages/chatwork/webhooks/messages.ts
+++ b/packages/chatwork/webhooks/messages.ts
@@ -1,0 +1,55 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ChatworkWebhooks } from '../index';
+import { createChatworkMatch, verifyChatworkWebhookSignature } from './types';
+
+export const created: ChatworkWebhooks['messageCreated'] = {
+	match: createChatworkMatch('message_created'),
+	handler: async (ctx, request) => {
+		const { valid, error } = verifyChatworkWebhookSignature(request, ctx.key);
+		if (!valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: error || 'Signature verification failed',
+			};
+		}
+
+		await logEventFromContext(
+			ctx,
+			'chatwork.webhook.messageCreated',
+			{ ...request.payload },
+			'completed',
+		);
+
+		return {
+			success: true,
+			data: request.payload,
+		};
+	},
+};
+
+export const updated: ChatworkWebhooks['messageUpdated'] = {
+	match: createChatworkMatch('message_updated'),
+	handler: async (ctx, request) => {
+		const { valid, error } = verifyChatworkWebhookSignature(request, ctx.key);
+		if (!valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: error || 'Signature verification failed',
+			};
+		}
+
+		await logEventFromContext(
+			ctx,
+			'chatwork.webhook.messageUpdated',
+			{ ...request.payload },
+			'completed',
+		);
+
+		return {
+			success: true,
+			data: request.payload,
+		};
+	},
+};

--- a/packages/chatwork/webhooks/oauth-tenant-link.ts
+++ b/packages/chatwork/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,26 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { toExternalId } from 'corsair/core';
+
+export async function resolveChatworkOAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): Promise<WebhookTenantMatch | null> {
+	const externalId = toExternalId(tokens.account_id);
+	if (externalId) {
+		return { linkType: 'account_id', externalId };
+	}
+
+	const accessToken = tokens.access_token;
+	if (!accessToken) return null;
+
+	try {
+		const response = await fetch('https://api.chatwork.com/v2/me', {
+			headers: { Authorization: `Bearer ${accessToken}` },
+		});
+		if (!response.ok) return null;
+		const payload = (await response.json()) as { account_id?: number | string };
+		const fetchedId = toExternalId(payload.account_id);
+		return fetchedId ? { linkType: 'account_id', externalId: fetchedId } : null;
+	} catch {
+		return null;
+	}
+}

--- a/packages/chatwork/webhooks/tenant-matcher.ts
+++ b/packages/chatwork/webhooks/tenant-matcher.ts
@@ -1,0 +1,20 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+export function matchChatworkTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	const event = asRecord(body.webhook_event);
+	const externalId = firstString([
+		event?.account_id,
+		event?.to_account_id,
+		body.account_id,
+	]);
+
+	if (!externalId) return null;
+
+	return { linkType: 'account_id', externalId };
+}

--- a/packages/chatwork/webhooks/types.ts
+++ b/packages/chatwork/webhooks/types.ts
@@ -1,0 +1,183 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type {
+	CorsairWebhookMatcher,
+	RawWebhookRequest,
+	WebhookRequest,
+} from 'corsair/core';
+import { z } from 'zod';
+
+export const ChatworkBaseWebhookEnvelopeSchema = z.object({
+	webhook_setting_id: z.union([z.string(), z.number()]).transform(String),
+	webhook_event_type: z.string(),
+	webhook_event_time: z.number(),
+});
+
+export const MessageCreatedEventSchema = z.object({
+	message_id: z.string().describe('The unique message ID'),
+	room_id: z.number().describe('The room ID where the message was posted'),
+	account_id: z.number().describe('The account ID of the author'),
+	body: z.string().describe('The message body'),
+	send_time: z
+		.number()
+		.describe('Timestamp in Unix seconds when message was sent'),
+	update_time: z
+		.number()
+		.optional()
+		.describe('Timestamp in Unix seconds when message was updated (0 if not)'),
+});
+
+export const MessageCreatedWebhookPayloadSchema =
+	ChatworkBaseWebhookEnvelopeSchema.extend({
+		webhook_event_type: z.literal('message_created'),
+		webhook_event: MessageCreatedEventSchema,
+	});
+
+export const MessageUpdatedEventSchema = z.object({
+	message_id: z.string().describe('The unique message ID'),
+	room_id: z.number().describe('The room ID where the message was posted'),
+	account_id: z.number().describe('The account ID of the author'),
+	body: z.string().describe('The updated message body'),
+	send_time: z
+		.number()
+		.describe('Timestamp in Unix seconds when message was originally sent'),
+	update_time: z
+		.number()
+		.describe('Timestamp in Unix seconds when message was updated'),
+});
+
+export const MessageUpdatedWebhookPayloadSchema =
+	ChatworkBaseWebhookEnvelopeSchema.extend({
+		webhook_event_type: z.literal('message_updated'),
+		webhook_event: MessageUpdatedEventSchema,
+	});
+
+export const MentionToMeEventSchema = z.object({
+	mention_id: z
+		.union([z.string(), z.number()])
+		.transform(String)
+		.describe('The unique mention ID'),
+	message_id: z.string().describe('The message ID containing the mention'),
+	room_id: z.number().describe('The room ID where the mention occurred'),
+	account_id: z.number().optional().describe('The author account ID'),
+	from_account_id: z.number().describe('The account ID of the sender'),
+	to_account_id: z.number().describe('The account ID of the mentioned user'),
+	body: z.string().describe('The message body'),
+	send_time: z
+		.number()
+		.describe('Timestamp in Unix seconds when message was sent'),
+});
+
+export const MentionToMeWebhookPayloadSchema =
+	ChatworkBaseWebhookEnvelopeSchema.extend({
+		webhook_event_type: z.literal('mention_to_me'),
+		webhook_event: MentionToMeEventSchema,
+	});
+
+export const ChatworkWebhookPayloadSchema = z.union([
+	MessageCreatedWebhookPayloadSchema,
+	MessageUpdatedWebhookPayloadSchema,
+	MentionToMeWebhookPayloadSchema,
+]);
+
+export type MessageCreatedWebhookPayload = z.infer<
+	typeof MessageCreatedWebhookPayloadSchema
+>;
+export type MessageUpdatedWebhookPayload = z.infer<
+	typeof MessageUpdatedWebhookPayloadSchema
+>;
+export type MentionToMeWebhookPayload = z.infer<
+	typeof MentionToMeWebhookPayloadSchema
+>;
+export type ChatworkWebhookPayload = z.infer<
+	typeof ChatworkWebhookPayloadSchema
+>;
+
+export type ChatworkWebhookOutputs = {
+	messageCreated: MessageCreatedWebhookPayload;
+	messageUpdated: MessageUpdatedWebhookPayload;
+	mentionToMe: MentionToMeWebhookPayload;
+};
+
+function parseBody(body: unknown): Record<string, unknown> | null {
+	if (typeof body === 'string') {
+		try {
+			const parsed = JSON.parse(body);
+			return parsed !== null &&
+				typeof parsed === 'object' &&
+				!Array.isArray(parsed)
+				? (parsed as Record<string, unknown>)
+				: null;
+		} catch {
+			return null;
+		}
+	}
+	return body !== null && typeof body === 'object' && !Array.isArray(body)
+		? (body as Record<string, unknown>)
+		: null;
+}
+
+export function createChatworkMatch(eventType: string): CorsairWebhookMatcher {
+	return (request: RawWebhookRequest) => {
+		const parsedBody = parseBody(request.body);
+		return parsedBody !== null && parsedBody.webhook_event_type === eventType;
+	};
+}
+
+export function verifyChatworkWebhookSignature(
+	requestOrBody: WebhookRequest<unknown> | RawWebhookRequest | string | Buffer,
+	secretOrSignature: string,
+	secretIfBody?: string,
+): { valid: boolean; error?: string } {
+	let rawBody: string | Buffer;
+	let signature: string | undefined;
+	let secret: string;
+
+	if (typeof requestOrBody === 'string' || Buffer.isBuffer(requestOrBody)) {
+		rawBody = requestOrBody;
+		signature = secretOrSignature;
+		secret = secretIfBody ?? '';
+	} else {
+		secret = secretOrSignature;
+		const req = requestOrBody as RawWebhookRequest & { rawBody?: string };
+		const headers = req.headers ?? {};
+		const rawSig =
+			headers['x-chatworkwebhooksignature'] ??
+			headers['X-ChatWorkWebhookSignature'] ??
+			headers['x-chatwork-signature'];
+		signature = Array.isArray(rawSig) ? rawSig[0] : rawSig;
+
+		if (req.rawBody) {
+			rawBody = req.rawBody;
+		} else if (typeof req.body === 'string') {
+			rawBody = req.body;
+		} else {
+			rawBody = JSON.stringify(req.body ?? {});
+		}
+	}
+
+	if (!signature) {
+		return { valid: false, error: 'Missing x-chatworkwebhooksignature header' };
+	}
+	if (!secret) {
+		return { valid: false, error: 'Missing webhook secret' };
+	}
+
+	try {
+		const key = Buffer.from(secret, 'base64');
+		const hmac = createHmac('sha256', key);
+		hmac.update(rawBody);
+		const expectedSignature = hmac.digest('base64');
+
+		const sigBuf = Buffer.from(signature);
+		const expectedBuf = Buffer.from(expectedSignature);
+
+		if (sigBuf.length !== expectedBuf.length) {
+			return { valid: false, error: 'Signature length mismatch' };
+		}
+
+		const valid = timingSafeEqual(sigBuf, expectedBuf);
+		return { valid, error: valid ? undefined : 'Invalid webhook signature' };
+	} catch (e) {
+		return { valid: false, error: (e as Error).message };
+	}
+}

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -117,6 +117,7 @@ export const BaseProviders = [
 	'certifier',
 	'chatbotkit',
 	'chatfai',
+	'chatwork',
 	'chmeetings',
 	'circleci',
 	'clickhouse',
@@ -394,6 +395,7 @@ export const ProviderDisplayNames = {
 	certifier: 'Certifier',
 	chatbotkit: 'ChatBotKit',
 	chatfai: 'ChatFAI',
+	chatwork: 'Chatwork',
 	chmeetings: 'ChMeetings',
 	circleci: 'CircleCI',
 	clickhouse: 'Clickhouse',
@@ -678,6 +680,7 @@ export type AllProviders =
 	| 'certifier'
 	| 'chatbotkit'
 	| 'chatfai'
+	| 'chatwork'
 	| 'chmeetings'
 	| 'circleci'
 	| 'clickhouse'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2854,6 +2854,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/chatwork:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/chmeetings:
     devDependencies:
       '@jest/globals':


### PR DESCRIPTION
Fixes #1586

## Description
Adds the `@corsair-dev/chatwork` plugin with OAuth/API-key auth, seven endpoint implementations (account, rooms, messages, members), webhook handlers for message and mention events, local entity sync, schema definitions, tests, and generated docs.

## Checklist
- [x] Implemented plugin changes in `packages/chatwork`.
- [x] Added/updated tests for plugin endpoints and webhooks.
- [x] Added/updated plugin docs under `docs/plugins/chatwork`.

## Screenshots / Demos
![plugin demo placeholder](https://placehold.co/800x450/1a1a2e/eaeaea?text=Demo+video+pending+human+recording)

Human will replace with real recording before merge.

## Additional Notes
Live OAuth/demo recording still requires author-side capture in a real Chatwork environment before maintainer merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Chatwork as a supported integration.
  - Added API access for accounts, rooms, members, and messages.
  - Added OAuth 2.0 and API-key authentication options.
  - Added synchronization and searchable local data for accounts, rooms, members, and messages.
  - Added webhook support for message creation, updates, and mentions.
  - Added comprehensive Chatwork setup, API, database, and webhook documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->