### PR TITLE
feat: add Starton integration

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1587,6 +1587,14 @@
                 ]
               },
               {
+                "group": "Starton",
+                "pages": [
+                  "plugins/starton/overview",
+                  "plugins/starton/api",
+                  "plugins/starton/database"
+                ]
+              },
+              {
                 "group": "Strava",
                 "pages": [
                   "plugins/strava/overview",

--- a/docs/plugins/starton/api.mdx
+++ b/docs/plugins/starton/api.mdx
@@ -1,0 +1,585 @@
+---
+title: API
+description: "API reference for Starton: every `starton.api.*` operation with input and output types."
+---
+
+Every `starton.api.*` operation is listed below with parameter shapes and return types from the plugin Zod schemas.
+
+<Info>
+**New to Corsair?** See [API access](/concepts/api), [authentication](/concepts/auth), and [error handling](/concepts/error-handling).
+</Info>
+
+## Smart Contract
+
+### call
+
+`smartContract.call`
+
+Execute a state-changing function on a deployed smart contract
+
+**Risk:** `write`
+
+```ts
+await corsair.starton.api.smartContract.call({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `network` | `string` | Yes | Network of the smart contract, e.g. `polygon-mumbai`. List via GET /v3/network. |
+| `address` | `string` | Yes | Address of the deployed smart contract. |
+| `functionName` | `string` | Yes | Name of the contract function to execute. Must be state-changing; use smartContract.read for view functions. |
+| `params` | `object[]` | Yes | Function arguments, in the order the ABI declares them. |
+| `signerWallet` | `string` | Yes | Address of the KMS wallet that signs and pays for the transaction. |
+| `speed` | `low \| average \| fast \| fastest \| custom` | No | Gas speed. Defaults to `average`; use `custom` to supply customGas. |
+| `customGas` | `object` | No | Custom gas settings. Only used when speed is set to `custom`. |
+| `gasLimit` | `string` | No | Optional gas limit. |
+| `nonce` | `number` | No | Manual nonce. If set, the Starton relayer will not assign one automatically. |
+| `value` | `string` | No | Native-currency value sent with the call, in wei. |
+| `simulate` | `boolean` | No | Simulate only: estimates gas and does NOT broadcast a transaction. |
+
+<AccordionGroup>
+<Accordion title="params full type">
+
+```ts
+(
+  string | number | boolean | {
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="customGas full type">
+
+```ts
+{
+  gasPrice?: string,
+  maxFeePerGas?: string,
+  maxPriorityFeePerGas?: string
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `blockHash` | `string` | No | — |
+| `blockNumber` | `number` | No | — |
+| `chainId` | `number` | Yes | — |
+| `network` | `string` | Yes | — |
+| `data` | `string` | No | — |
+| `from` | `string` | Yes | — |
+| `gasLimit` | `string` | No | — |
+| `gasPrice` | `string` | No | — |
+| `maxFeePerGas` | `string` | No | — |
+| `maxPriorityFeePerGas` | `string` | No | — |
+| `metadata` | `object` | No | — |
+| `nonce` | `number` | No | — |
+| `type` | `number` | No | — |
+| `signerWallet` | `string` | Yes | — |
+| `publishedDate` | `string` | No | — |
+| `minedDate` | `string` | No | — |
+| `signedTransaction` | `string` | No | — |
+| `status` | `UNSIGNED \| ERROR_TX \| ERROR_PUBLISH \| PUBLISHED \| RECEIVED_BY_STARTON \| CREATED_BY_STARTON \| COULD_NOT_ESTIMATE_GAS_PRICE \| COULD_NOT_INCREASE_GAS_PRICE \| GAS_PRICE_ESTIMATED \| INVALID_GAS_PRICE \| REPLACEMENT_GAS_PRICE_UNDERPRICED \| COULD_NOT_ESTIMATE_GAS_LIMIT \| GAS_LIMIT_ESTIMATED \| EXECUTION_WILL_FAIL \| INVALID_ARGUMENT \| INSUFFICIENT_FUNDS \| INSUFFICIENT_FUNDS_AFTER_BROADCAST \| COULD_NOT_ASSIGN_NONCE \| COULD_NOT_UNSTUCK_NONCE \| NONCE_ASSIGNED \| NONCE_EXPIRED \| COULD_NOT_SIGN \| SIGNED \| SENT_TO_MEMPOOL \| COULD_NOT_BROADCAST \| ALREADY_KNOWN \| MINED \| CONFIRMED \| REPLACED \| FAILED \| MONITORING_IN_PROGRESS \| STUCK_BY_PREVIOUS_TRANSACTION \| MAX_GAS_PRICE_REACH \| GAS_PRICE_INCREASED \| NEW_TRANSACTION_HASH \| UNKNOWN \| MONITORING_INTERRUPTED` | Yes | — |
+| `state` | `SUCCESS \| PENDING \| MANUAL_ACTION_REQUIRED \| ERROR` | Yes | — |
+| `speed` | `low \| average \| fast \| fastest \| custom` | No | — |
+| `logs` | `object[]` | Yes | — |
+| `to` | `string` | No | — |
+| `transactionHash` | `string` | No | — |
+| `value` | `string` | Yes | — |
+| `automaticNonce` | `boolean` | Yes | — |
+| `isDeployTransaction` | `boolean` | Yes | — |
+| `projectId` | `string` | Yes | — |
+| `parentTransaction` | `string` | No | — |
+| `createdAt` | `string` | Yes | — |
+| `updatedAt` | `string` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="logs full type">
+
+```ts
+{
+  message: string,
+  type: UNSIGNED | ERROR_TX | ERROR_PUBLISH | PUBLISHED | RECEIVED_BY_STARTON | CREATED_BY_STARTON | COULD_NOT_ESTIMATE_GAS_PRICE | COULD_NOT_INCREASE_GAS_PRICE | GAS_PRICE_ESTIMATED | INVALID_GAS_PRICE | REPLACEMENT_GAS_PRICE_UNDERPRICED | COULD_NOT_ESTIMATE_GAS_LIMIT | GAS_LIMIT_ESTIMATED | EXECUTION_WILL_FAIL | INVALID_ARGUMENT | INSUFFICIENT_FUNDS | INSUFFICIENT_FUNDS_AFTER_BROADCAST | COULD_NOT_ASSIGN_NONCE | COULD_NOT_UNSTUCK_NONCE | NONCE_ASSIGNED | NONCE_EXPIRED | COULD_NOT_SIGN | SIGNED | SENT_TO_MEMPOOL | COULD_NOT_BROADCAST | ALREADY_KNOWN | MINED | CONFIRMED | REPLACED | FAILED | MONITORING_IN_PROGRESS | STUCK_BY_PREVIOUS_TRANSACTION | MAX_GAS_PRICE_REACH | GAS_PRICE_INCREASED | NEW_TRANSACTION_HASH | UNKNOWN | MONITORING_INTERRUPTED,
+  context?: {
+  },
+  createdAt: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### deployFromTemplate
+
+`smartContract.deployFromTemplate`
+
+Deploy a smart contract from a Starton-audited template (e.g. ERC20, ERC721)
+
+**Risk:** `write`
+
+```ts
+await corsair.starton.api.smartContract.deployFromTemplate({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `network` | `string` | Yes | Network of the smart contract, e.g. `polygon-mumbai`. List via GET /v3/network. |
+| `signerWallet` | `string` | Yes | Address of the KMS wallet that signs and pays for the transaction. |
+| `templateId` | `string` | Yes | Starton Library template to deploy, e.g. `ERC20_META_TRANSACTION`. List via GET /v3/smart-contract-template. |
+| `name` | `string` | Yes | Contract name on Starton (off-chain). Max 255 characters. |
+| `params` | `object[]` | Yes | Smart contract constructor parameters, in the order the template declares them. |
+| `description` | `string` | No | Contract description on Starton (off-chain). |
+| `gasLimit` | `string` | No | Optional gas limit. |
+| `speed` | `low \| average \| fast \| fastest \| custom` | No | Gas speed. Defaults to `average`; use `custom` to supply customGas. |
+| `customGas` | `object` | No | Custom gas settings. Only used when speed is set to `custom`. |
+| `nonce` | `number` | No | Manual nonce. If set, the Starton relayer will not assign one automatically. |
+| `value` | `string` | No | Native-currency value sent with the deployment, in wei. For payable constructors. |
+| `metadata` | `object` | No | Arbitrary JSON stored alongside the contract. |
+| `uiData` | `object` | No | Dashboard display metadata Starton stores with the contract. |
+| `simulate` | `boolean` | No | Simulate only: estimates gas and does NOT broadcast a transaction. |
+
+<AccordionGroup>
+<Accordion title="params full type">
+
+```ts
+(
+  string | number | boolean | {
+  }
+)[]
+```
+</Accordion>
+
+<Accordion title="customGas full type">
+
+```ts
+{
+  gasPrice?: string,
+  maxFeePerGas?: string,
+  maxPriorityFeePerGas?: string
+}
+```
+</Accordion>
+
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="uiData full type">
+
+```ts
+{
+  version: 1,
+  deployMethod: web3 | kms,
+  imported: boolean,
+  deployType?: string,
+  chainId?: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `smartContract` | `object` | Yes | — |
+| `transaction` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="smartContract full type">
+
+```ts
+{
+  id: string,
+  name: string,
+  description?: string | null,
+  network: string,
+  abi?: {
+  }[],
+  address: string,
+  params?: string[] | null,
+  compilationDetails?: {
+  } | null,
+  creationHash?: string | null,
+  status: UNSIGNED | ERROR_TX | ERROR_PUBLISH | PUBLISHED | RECEIVED_BY_STARTON | CREATED_BY_STARTON | COULD_NOT_ESTIMATE_GAS_PRICE | COULD_NOT_INCREASE_GAS_PRICE | GAS_PRICE_ESTIMATED | INVALID_GAS_PRICE | REPLACEMENT_GAS_PRICE_UNDERPRICED | COULD_NOT_ESTIMATE_GAS_LIMIT | GAS_LIMIT_ESTIMATED | EXECUTION_WILL_FAIL | INVALID_ARGUMENT | INSUFFICIENT_FUNDS | INSUFFICIENT_FUNDS_AFTER_BROADCAST | COULD_NOT_ASSIGN_NONCE | COULD_NOT_UNSTUCK_NONCE | NONCE_ASSIGNED | NONCE_EXPIRED | COULD_NOT_SIGN | SIGNED | SENT_TO_MEMPOOL | COULD_NOT_BROADCAST | ALREADY_KNOWN | MINED | CONFIRMED | REPLACED | FAILED | MONITORING_IN_PROGRESS | STUCK_BY_PREVIOUS_TRANSACTION | MAX_GAS_PRICE_REACH | GAS_PRICE_INCREASED | NEW_TRANSACTION_HASH | UNKNOWN | MONITORING_INTERRUPTED,
+  state: SUCCESS | PENDING | MANUAL_ACTION_REQUIRED | ERROR,
+  minedDate?: string | null,
+  blockNumber?: number | null,
+  templateId?: string | null,
+  projectId: string,
+  metadata?: {
+  } | null,
+  uiData?: {
+    version: 1,
+    deployMethod: web3 | kms,
+    imported: boolean,
+    deployType?: string,
+    chainId?: number
+  } | null,
+  createdAt: string,
+  updatedAt: string
+}
+```
+</Accordion>
+
+<Accordion title="transaction full type">
+
+```ts
+{
+  id: string,
+  blockHash?: string | null,
+  blockNumber?: number | null,
+  chainId: number,
+  network: string,
+  data?: string | null,
+  from: string,
+  gasLimit?: string | null,
+  gasPrice?: string | null,
+  maxFeePerGas?: string | null,
+  maxPriorityFeePerGas?: string | null,
+  metadata?: {
+  } | null,
+  nonce?: number | null,
+  type?: number | null,
+  signerWallet: string,
+  publishedDate?: string | null,
+  minedDate?: string | null,
+  signedTransaction?: string | null,
+  status: UNSIGNED | ERROR_TX | ERROR_PUBLISH | PUBLISHED | RECEIVED_BY_STARTON | CREATED_BY_STARTON | COULD_NOT_ESTIMATE_GAS_PRICE | COULD_NOT_INCREASE_GAS_PRICE | GAS_PRICE_ESTIMATED | INVALID_GAS_PRICE | REPLACEMENT_GAS_PRICE_UNDERPRICED | COULD_NOT_ESTIMATE_GAS_LIMIT | GAS_LIMIT_ESTIMATED | EXECUTION_WILL_FAIL | INVALID_ARGUMENT | INSUFFICIENT_FUNDS | INSUFFICIENT_FUNDS_AFTER_BROADCAST | COULD_NOT_ASSIGN_NONCE | COULD_NOT_UNSTUCK_NONCE | NONCE_ASSIGNED | NONCE_EXPIRED | COULD_NOT_SIGN | SIGNED | SENT_TO_MEMPOOL | COULD_NOT_BROADCAST | ALREADY_KNOWN | MINED | CONFIRMED | REPLACED | FAILED | MONITORING_IN_PROGRESS | STUCK_BY_PREVIOUS_TRANSACTION | MAX_GAS_PRICE_REACH | GAS_PRICE_INCREASED | NEW_TRANSACTION_HASH | UNKNOWN | MONITORING_INTERRUPTED,
+  state: SUCCESS | PENDING | MANUAL_ACTION_REQUIRED | ERROR,
+  speed?: low | average | fast | fastest | custom | null,
+  logs: {
+    message: string,
+    type: UNSIGNED | ERROR_TX | ERROR_PUBLISH | PUBLISHED | RECEIVED_BY_STARTON | CREATED_BY_STARTON | COULD_NOT_ESTIMATE_GAS_PRICE | COULD_NOT_INCREASE_GAS_PRICE | GAS_PRICE_ESTIMATED | INVALID_GAS_PRICE | REPLACEMENT_GAS_PRICE_UNDERPRICED | COULD_NOT_ESTIMATE_GAS_LIMIT | GAS_LIMIT_ESTIMATED | EXECUTION_WILL_FAIL | INVALID_ARGUMENT | INSUFFICIENT_FUNDS | INSUFFICIENT_FUNDS_AFTER_BROADCAST | COULD_NOT_ASSIGN_NONCE | COULD_NOT_UNSTUCK_NONCE | NONCE_ASSIGNED | NONCE_EXPIRED | COULD_NOT_SIGN | SIGNED | SENT_TO_MEMPOOL | COULD_NOT_BROADCAST | ALREADY_KNOWN | MINED | CONFIRMED | REPLACED | FAILED | MONITORING_IN_PROGRESS | STUCK_BY_PREVIOUS_TRANSACTION | MAX_GAS_PRICE_REACH | GAS_PRICE_INCREASED | NEW_TRANSACTION_HASH | UNKNOWN | MONITORING_INTERRUPTED,
+    context?: {
+    },
+    createdAt: string
+  }[],
+  to?: string | null,
+  transactionHash?: string | null,
+  value: string,
+  automaticNonce: boolean,
+  isDeployTransaction: boolean,
+  projectId: string,
+  parentTransaction?: string | null,
+  createdAt: string,
+  updatedAt: string
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### read
+
+`smartContract.read`
+
+Call a read-only function on a deployed smart contract without broadcasting a transaction
+
+**Risk:** `read`
+
+```ts
+await corsair.starton.api.smartContract.read({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `network` | `string` | Yes | Network of the smart contract, e.g. `polygon-mumbai`. List via GET /v3/network. |
+| `address` | `string` | Yes | Address of the deployed smart contract. |
+| `functionName` | `string` | Yes | Name of the read-only (view) contract function to call. |
+| `params` | `object[]` | Yes | Function arguments, in the order the ABI declares them. |
+
+<AccordionGroup>
+<Accordion title="params full type">
+
+```ts
+(
+  string | number | boolean | {
+  }
+)[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `response` | `object[]` | Yes | — |
+| `params` | `object[]` | Yes | — |
+| `functionName` | `string` | Yes | — |
+| `address` | `string` | Yes | — |
+| `network` | `string` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="response full type">
+
+```ts
+string | number | boolean | {
+} | any[]
+```
+</Accordion>
+
+<Accordion title="params full type">
+
+```ts
+(
+  string | number | boolean | {
+  }
+)[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Transaction
+
+### get
+
+`transaction.get`
+
+Retrieve a blockchain transaction by its Starton id
+
+**Risk:** `read`
+
+```ts
+await corsair.starton.api.transaction.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | Starton transaction id, as returned by smartContract.call or smartContract.deployFromTemplate. |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `id` | `string` | Yes | — |
+| `blockHash` | `string` | No | — |
+| `blockNumber` | `number` | No | — |
+| `chainId` | `number` | Yes | — |
+| `network` | `string` | Yes | — |
+| `data` | `string` | No | — |
+| `from` | `string` | Yes | — |
+| `gasLimit` | `string` | No | — |
+| `gasPrice` | `string` | No | — |
+| `maxFeePerGas` | `string` | No | — |
+| `maxPriorityFeePerGas` | `string` | No | — |
+| `metadata` | `object` | No | — |
+| `nonce` | `number` | No | — |
+| `type` | `number` | No | — |
+| `signerWallet` | `string` | Yes | — |
+| `publishedDate` | `string` | No | — |
+| `minedDate` | `string` | No | — |
+| `signedTransaction` | `string` | No | — |
+| `status` | `UNSIGNED \| ERROR_TX \| ERROR_PUBLISH \| PUBLISHED \| RECEIVED_BY_STARTON \| CREATED_BY_STARTON \| COULD_NOT_ESTIMATE_GAS_PRICE \| COULD_NOT_INCREASE_GAS_PRICE \| GAS_PRICE_ESTIMATED \| INVALID_GAS_PRICE \| REPLACEMENT_GAS_PRICE_UNDERPRICED \| COULD_NOT_ESTIMATE_GAS_LIMIT \| GAS_LIMIT_ESTIMATED \| EXECUTION_WILL_FAIL \| INVALID_ARGUMENT \| INSUFFICIENT_FUNDS \| INSUFFICIENT_FUNDS_AFTER_BROADCAST \| COULD_NOT_ASSIGN_NONCE \| COULD_NOT_UNSTUCK_NONCE \| NONCE_ASSIGNED \| NONCE_EXPIRED \| COULD_NOT_SIGN \| SIGNED \| SENT_TO_MEMPOOL \| COULD_NOT_BROADCAST \| ALREADY_KNOWN \| MINED \| CONFIRMED \| REPLACED \| FAILED \| MONITORING_IN_PROGRESS \| STUCK_BY_PREVIOUS_TRANSACTION \| MAX_GAS_PRICE_REACH \| GAS_PRICE_INCREASED \| NEW_TRANSACTION_HASH \| UNKNOWN \| MONITORING_INTERRUPTED` | Yes | — |
+| `state` | `SUCCESS \| PENDING \| MANUAL_ACTION_REQUIRED \| ERROR` | Yes | — |
+| `speed` | `low \| average \| fast \| fastest \| custom` | No | — |
+| `logs` | `object[]` | Yes | — |
+| `to` | `string` | No | — |
+| `transactionHash` | `string` | No | — |
+| `value` | `string` | Yes | — |
+| `automaticNonce` | `boolean` | Yes | — |
+| `isDeployTransaction` | `boolean` | Yes | — |
+| `projectId` | `string` | Yes | — |
+| `parentTransaction` | `string` | No | — |
+| `createdAt` | `string` | Yes | — |
+| `updatedAt` | `string` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="logs full type">
+
+```ts
+{
+  message: string,
+  type: UNSIGNED | ERROR_TX | ERROR_PUBLISH | PUBLISHED | RECEIVED_BY_STARTON | CREATED_BY_STARTON | COULD_NOT_ESTIMATE_GAS_PRICE | COULD_NOT_INCREASE_GAS_PRICE | GAS_PRICE_ESTIMATED | INVALID_GAS_PRICE | REPLACEMENT_GAS_PRICE_UNDERPRICED | COULD_NOT_ESTIMATE_GAS_LIMIT | GAS_LIMIT_ESTIMATED | EXECUTION_WILL_FAIL | INVALID_ARGUMENT | INSUFFICIENT_FUNDS | INSUFFICIENT_FUNDS_AFTER_BROADCAST | COULD_NOT_ASSIGN_NONCE | COULD_NOT_UNSTUCK_NONCE | NONCE_ASSIGNED | NONCE_EXPIRED | COULD_NOT_SIGN | SIGNED | SENT_TO_MEMPOOL | COULD_NOT_BROADCAST | ALREADY_KNOWN | MINED | CONFIRMED | REPLACED | FAILED | MONITORING_IN_PROGRESS | STUCK_BY_PREVIOUS_TRANSACTION | MAX_GAS_PRICE_REACH | GAS_PRICE_INCREASED | NEW_TRANSACTION_HASH | UNKNOWN | MONITORING_INTERRUPTED,
+  context?: {
+  },
+  createdAt: string
+}[]
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Wallet
+
+### create
+
+`wallet.create`
+
+Create a new KMS-managed blockchain wallet for the project
+
+**Risk:** `write`
+
+```ts
+await corsair.starton.api.wallet.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `kmsId` | `string` | Yes | Id of the Key Management System the wallet key is stored under. Required. List available KMS via GET /v3/kms. |
+| `name` | `string` | No | Wallet name on Starton (off-chain). |
+| `description` | `string` | No | Wallet description on Starton (off-chain). |
+| `metadata` | `object` | No | Arbitrary JSON stored alongside the wallet. |
+
+<AccordionGroup>
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `address` | `string` | Yes | — |
+| `providerKeyId` | `string` | Yes | — |
+| `kmsId` | `string` | Yes | — |
+| `name` | `string` | No | — |
+| `description` | `string` | No | — |
+| `metadata` | `object` | No | — |
+| `projectId` | `string` | Yes | — |
+| `createdAt` | `string` | Yes | — |
+| `updatedAt` | `string` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="metadata full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### list
+
+`wallet.list`
+
+List the KMS-managed wallets for the project (paginated)
+
+**Risk:** `read`
+
+```ts
+await corsair.starton.api.wallet.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `page` | `number` | No | Number of returned page. By default the returned page is the first. |
+| `limit` | `number` | No | Number of entities returned on each page. Defaults to 100, maximum 2500. |
+| `name` | `string` | No | Filter by wallet name. Letters, digits, -, _ and spaces only. |
+| `kmsId` | `string` | No | Filter by Key Management System id. |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `items` | `object[]` | Yes | — |
+| `meta` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="items full type">
+
+```ts
+{
+  address: string,
+  providerKeyId: string,
+  kmsId: string,
+  name?: string | null,
+  description?: string | null,
+  metadata?: {
+  } | null,
+  projectId: string,
+  createdAt: string,
+  updatedAt: string
+}[]
+```
+</Accordion>
+
+<Accordion title="meta full type">
+
+```ts
+{
+  itemCount: number,
+  totalItems?: number,
+  itemsPerPage: number,
+  totalPages?: number,
+  currentPage: number
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+

--- a/docs/plugins/starton/database.mdx
+++ b/docs/plugins/starton/database.mdx
@@ -1,0 +1,123 @@
+---
+title: Database
+description: "Starton local sync: searchable entities, `.search()` filters, and operators."
+---
+
+The Starton plugin syncs data locally. Use `corsair.starton.db.<entity>.search({ data, limit?, offset? })` with the filters listed per entity.
+
+<Info>
+**New to Corsair?** See [database operations](/concepts/database), [data synchronization](/concepts/integrations), and [multi-tenancy](/concepts/multi-tenancy).
+</Info>
+
+## Smart Contracts
+
+Path: `starton.db.smartContracts.search`
+
+```ts
+const rows = await corsair.starton.db.smartContracts.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `id` | `string` | equals, contains, startsWith, endsWith, in |
+| `name` | `string` | equals, contains, startsWith, endsWith, in |
+| `description` | `string` | equals, contains, startsWith, endsWith, in |
+| `network` | `string` | equals, contains, startsWith, endsWith, in |
+| `address` | `string` | equals, contains, startsWith, endsWith, in |
+| `creationHash` | `string` | equals, contains, startsWith, endsWith, in |
+| `minedDate` | `string` | equals, contains, startsWith, endsWith, in |
+| `blockNumber` | `number` | equals, gt, gte, lt, lte, in |
+| `templateId` | `string` | equals, contains, startsWith, endsWith, in |
+| `projectId` | `string` | equals, contains, startsWith, endsWith, in |
+| `createdAt` | `string` | equals, contains, startsWith, endsWith, in |
+| `updatedAt` | `string` | equals, contains, startsWith, endsWith, in |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+
+## Transactions
+
+Path: `starton.db.transactions.search`
+
+```ts
+const rows = await corsair.starton.db.transactions.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `id` | `string` | equals, contains, startsWith, endsWith, in |
+| `blockHash` | `string` | equals, contains, startsWith, endsWith, in |
+| `blockNumber` | `number` | equals, gt, gte, lt, lte, in |
+| `chainId` | `number` | equals, gt, gte, lt, lte, in |
+| `network` | `string` | equals, contains, startsWith, endsWith, in |
+| `data` | `string` | equals, contains, startsWith, endsWith, in |
+| `from` | `string` | equals, contains, startsWith, endsWith, in |
+| `gasLimit` | `string` | equals, contains, startsWith, endsWith, in |
+| `gasPrice` | `string` | equals, contains, startsWith, endsWith, in |
+| `maxFeePerGas` | `string` | equals, contains, startsWith, endsWith, in |
+| `maxPriorityFeePerGas` | `string` | equals, contains, startsWith, endsWith, in |
+| `nonce` | `number` | equals, gt, gte, lt, lte, in |
+| `type` | `number` | equals, gt, gte, lt, lte, in |
+| `signerWallet` | `string` | equals, contains, startsWith, endsWith, in |
+| `publishedDate` | `string` | equals, contains, startsWith, endsWith, in |
+| `minedDate` | `string` | equals, contains, startsWith, endsWith, in |
+| `signedTransaction` | `string` | equals, contains, startsWith, endsWith, in |
+| `to` | `string` | equals, contains, startsWith, endsWith, in |
+| `transactionHash` | `string` | equals, contains, startsWith, endsWith, in |
+| `value` | `string` | equals, contains, startsWith, endsWith, in |
+| `automaticNonce` | `boolean` | equals |
+| `isDeployTransaction` | `boolean` | equals |
+| `projectId` | `string` | equals, contains, startsWith, endsWith, in |
+| `parentTransaction` | `string` | equals, contains, startsWith, endsWith, in |
+| `createdAt` | `string` | equals, contains, startsWith, endsWith, in |
+| `updatedAt` | `string` | equals, contains, startsWith, endsWith, in |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+
+## Wallets
+
+Path: `starton.db.wallets.search`
+
+```ts
+const rows = await corsair.starton.db.wallets.search({
+    data: { /* filters below */ },
+    limit: 100,
+    offset: 0,
+});
+```
+
+### Searchable filters
+
+| Field | Type | Operators |
+|-------|------|-----------|
+| `entity_id` | `string` | equals, contains, startsWith, endsWith, in |
+| `address` | `string` | equals, contains, startsWith, endsWith, in |
+| `providerKeyId` | `string` | equals, contains, startsWith, endsWith, in |
+| `kmsId` | `string` | equals, contains, startsWith, endsWith, in |
+| `name` | `string` | equals, contains, startsWith, endsWith, in |
+| `description` | `string` | equals, contains, startsWith, endsWith, in |
+| `projectId` | `string` | equals, contains, startsWith, endsWith, in |
+| `createdAt` | `string` | equals, contains, startsWith, endsWith, in |
+| `updatedAt` | `string` | equals, contains, startsWith, endsWith, in |
+
+_Every `.search()` also accepts `limit` and `offset` for pagination. `.list()` is available on the same path without the `.search` suffix in code — see [database operations](/concepts/database)._
+
+---
+

--- a/docs/plugins/starton/overview.mdx
+++ b/docs/plugins/starton/overview.mdx
@@ -1,0 +1,131 @@
+---
+title: Overview
+description: "Starton plugin for Corsair — blockchain wallets, smart contract deployment/calls and transaction status"
+---
+
+Use **Starton** through Corsair: one client, typed API calls, local DB sync.
+
+**What you get:**
+
+- 6 typed API operations
+- 3 synced entities (`smartContracts`, `transactions`, `wallets`) for fast `.search()` / `.list()`
+
+## Setup
+
+<Steps>
+
+<Step title="Install">
+<CodeGroup>
+```bash npm
+npm install corsair @corsair-dev/starton
+```
+```bash yarn
+yarn add corsair @corsair-dev/starton
+```
+```bash pnpm
+pnpm install corsair @corsair-dev/starton
+```
+```bash bun
+bun add corsair @corsair-dev/starton
+```
+</CodeGroup>
+
+</Step>
+
+<Step title="Add the plugin">
+```ts corsair.ts
+import Database from 'better-sqlite3';
+import { createCorsair } from 'corsair';
+import { starton } from '@corsair-dev/starton';
+
+export const corsair = createCorsair({
+	plugins: [
+		starton(),
+	],
+	database: new Database('corsair.db'),
+	kek: process.env.CORSAIR_KEK!,
+	hub: {
+		projectApiKey: process.env.CORSAIR_API_KEY!,
+		signingSecret: process.env.CORSAIR_SIGNING_SECRET!,
+	},
+});
+```
+
+Multi-tenancy is the default — scope calls with `corsair.withTenant(id)`. See [Quick start](/quick-start) for KEK + Hub keys, and [Multi-tenancy](/concepts/multi-tenancy) for account isolation.
+
+</Step>
+
+<Step title="Choose authentication">
+<Tabs>
+<Tab title="API Key (Recommended)">
+
+No setup required yet. When you make your first request as a tenant, Corsair prompts for the API key.
+
+```ts
+starton()
+```
+
+More: [API Key](/concepts/api-key)
+
+</Tab>
+</Tabs>
+
+</Step>
+
+<Step title="Connect a tenant">
+Mint a connect link and send the tenant to it. Hub hosts the page and delivers the result to your app — see [Connect / OAuth](/management/connect).
+
+```ts
+const { connectUrl } = await corsair.manage.connect.createLink({
+	plugin: 'starton',
+	tenantId: 'acme',
+});
+// redirect the user's browser to connectUrl
+```
+
+</Step>
+
+</Steps>
+
+## Example API calls
+
+**`smartContract.read`**
+
+```ts
+const tenant = corsair.withTenant('acme');
+await tenant.starton.api.smartContract.read({});
+```
+
+
+**`smartContract.call`**
+
+```ts
+const tenant = corsair.withTenant('acme');
+await tenant.starton.api.smartContract.call({});
+```
+
+
+See the full list on the [API](/plugins/starton/api) page.
+
+## Query synced data
+
+Synced entities support `tenant.starton.db.<entity>.search()` and `.list()`: `smartContracts`, `transactions`, `wallets`.
+
+See [Database](/plugins/starton/database) for filters and operators.
+
+## What's next
+
+<CardGroup cols={2}>
+  <Card title="API reference" href="/plugins/starton/api">
+    Every `starton.api.*` operation with input and output types.
+  </Card>
+  <Card title="Database" href="/plugins/starton/database">
+    Synced entities, search filters, and operators.
+  </Card>
+  <Card title="Connect / OAuth" href="/management/connect">
+    createLink, Hub delivery, and tenant connect flows.
+  </Card>
+  <Card title="Use with agents" href="/mcp-adapters/mcp-adapters">
+    Expose this plugin's operations as MCP tools.
+  </Card>
+</CardGroup>

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -225,6 +225,7 @@ export const BaseProviders = [
 	'slack',
 	'sourcegraph',
 	'spotify',
+	'starton',
 	'strava',
 	'streamtime',
 	'stripe',
@@ -488,6 +489,7 @@ export const ProviderDisplayNames = {
 	slack: 'Slack',
 	sourcegraph: 'Sourcegraph',
 	spotify: 'Spotify',
+	starton: 'Starton',
 	strava: 'Strava',
 	streamtime: 'Streamtime',
 	stripe: 'Stripe',
@@ -758,6 +760,7 @@ export type AllProviders =
 	| 'slack'
 	| 'sourcegraph'
 	| 'spotify'
+	| 'starton'
 	| 'strava'
 	| 'streamtime'
 	| 'stripe'

--- a/packages/starton/api.test.ts
+++ b/packages/starton/api.test.ts
@@ -1,0 +1,940 @@
+import { AuthMissingError } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+import { encodeStartonPathSegment, makeStartonRequest } from './client';
+import { SmartContract, Transaction, Wallet } from './endpoints';
+import {
+	StartonEndpointInputSchemas,
+	StartonEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import type { StartonContext } from './index';
+import { starton, startonEndpointSchemas } from './index';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fetch mock — captures the outgoing request so we can assert URL / method /
+// headers / body without touching the real Starton API.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type CapturedRequest = {
+	url: string;
+	method: string;
+	headers: Record<string, string>;
+	body: string | undefined;
+};
+
+let captured: CapturedRequest | undefined;
+let nextResponseBody: unknown = {};
+let nextResponseStatus = 200;
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+	captured = undefined;
+	nextResponseBody = {};
+	nextResponseStatus = 200;
+	globalThis.fetch = (async (url: string | URL, init?: RequestInit) => {
+		const headers: Record<string, string> = {};
+		new Headers(init?.headers).forEach((value, key) => {
+			headers[key] = value;
+		});
+		captured = {
+			url: String(url),
+			method: init?.method ?? 'GET',
+			headers,
+			body: typeof init?.body === 'string' ? init.body : undefined,
+		};
+		return new Response(JSON.stringify(nextResponseBody), {
+			status: nextResponseStatus,
+			statusText: `status ${nextResponseStatus}`,
+			headers: { 'Content-Type': 'application/json' },
+		});
+	}) as typeof fetch;
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+const ctx = {
+	key: 'test-starton-api-key',
+	$getAccountId: async () => 'acct_test',
+	database: undefined,
+	endpoints: {},
+} as unknown as StartonContext;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Client / auth
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('makeStartonRequest', () => {
+	it('targets the v3 base URL and sends the API key as x-api-key', async () => {
+		await makeStartonRequest('v3/kms/wallet', 'test-starton-api-key', {
+			method: 'GET',
+		});
+
+		expect(captured?.url).toBe('https://api.starton.com/v3/kms/wallet');
+		expect(captured?.headers['x-api-key']).toBe('test-starton-api-key');
+	});
+
+	it('serializes JSON bodies for write requests', async () => {
+		await makeStartonRequest('v3/kms/wallet', 'k', {
+			method: 'POST',
+			body: { kmsId: 'kms_1', name: 'Treasury' },
+		});
+
+		expect(captured?.method).toBe('POST');
+		expect(captured?.headers['content-type']).toContain('application/json');
+		expect(JSON.parse(captured?.body ?? '{}')).toEqual({
+			kmsId: 'kms_1',
+			name: 'Treasury',
+		});
+	});
+
+	it('appends query params for list/filter requests', async () => {
+		await makeStartonRequest('v3/kms/wallet', 'k', {
+			method: 'GET',
+			query: { page: 0, limit: 20 },
+		});
+
+		expect(captured?.url).toContain('page=0');
+		expect(captured?.url).toContain('limit=20');
+	});
+
+	it('rejects path-traversal segments before building the URL', () => {
+		expect(() => encodeStartonPathSegment('..')).toThrow();
+		expect(() => encodeStartonPathSegment('')).toThrow();
+		expect(encodeStartonPathSegment('polygon-mumbai')).toBe('polygon-mumbai');
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint request shape (path + method + payload)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('endpoint request wiring', () => {
+	it('Wallet.create -> POST /v3/kms/wallet', async () => {
+		nextResponseBody = {
+			address: '0xabc',
+			providerKeyId: 'pk_1',
+			kmsId: 'kms_1',
+			projectId: 'proj_1',
+			createdAt: '2024-01-01T00:00:00.000Z',
+			updatedAt: '2024-01-01T00:00:00.000Z',
+		};
+		const res = await Wallet.create(ctx, { kmsId: 'kms_1', name: 'Treasury' });
+
+		expect(captured?.method).toBe('POST');
+		expect(captured?.url).toBe('https://api.starton.com/v3/kms/wallet');
+		expect(JSON.parse(captured?.body ?? '{}')).toEqual({
+			kmsId: 'kms_1',
+			name: 'Treasury',
+		});
+		expect(res.address).toBe('0xabc');
+	});
+
+	it('Wallet.list -> GET /v3/kms/wallet with pagination filters', async () => {
+		nextResponseBody = {
+			items: [{ address: '0xabc', providerKeyId: 'pk_1', kmsId: 'kms_1', projectId: 'p', createdAt: 'x', updatedAt: 'x' }],
+			meta: { itemCount: 1, itemsPerPage: 20, currentPage: 0 },
+		};
+		const res = await Wallet.list(ctx, { page: 0, limit: 20 });
+
+		expect(captured?.method).toBe('GET');
+		expect(captured?.url).toContain('https://api.starton.com/v3/kms/wallet?');
+		expect(captured?.url).toContain('page=0');
+		expect(captured?.url).toContain('limit=20');
+		expect(res.items).toHaveLength(1);
+	});
+
+	it('SmartContract.deployFromTemplate -> POST /v3/smart-contract/from-template', async () => {
+		nextResponseBody = {
+			smartContract: {
+				id: 'sc_1',
+				name: 'TestToken',
+				network: 'polygon-mumbai',
+				address: '0xdef',
+				status: 'PUBLISHED',
+				state: 'PENDING',
+				projectId: 'p',
+				createdAt: 'x',
+				updatedAt: 'x',
+			},
+			transaction: {
+				id: 'tx_1',
+				chainId: 80001,
+				network: 'polygon-mumbai',
+				from: '0x298',
+				signerWallet: '0x298',
+				status: 'PUBLISHED',
+				state: 'PENDING',
+				logs: [],
+				value: '0',
+				automaticNonce: true,
+				isDeployTransaction: true,
+				projectId: 'p',
+				createdAt: 'x',
+				updatedAt: 'x',
+			},
+		};
+		const res = await SmartContract.deployFromTemplate(ctx, {
+			network: 'polygon-mumbai',
+			signerWallet: '0x298e760768c8481780397eE28A127eAd584df4ee',
+			templateId: 'ERC20_MINT_META_TRANSACTION',
+			name: 'TestToken',
+			params: ['TestToken', 'TEST', '1000000000000000000000000'],
+		});
+
+		expect(captured?.method).toBe('POST');
+		expect(captured?.url).toBe(
+			'https://api.starton.com/v3/smart-contract/from-template',
+		);
+		expect(res.smartContract.id).toBe('sc_1');
+		expect(res.transaction.id).toBe('tx_1');
+	});
+
+	it('deployFromTemplate forwards `simulate` as a query param, not body', async () => {
+		nextResponseBody = {
+			smartContract: {
+				id: 'sc_1',
+				name: 'TestToken',
+				network: 'polygon-mumbai',
+				address: '0xdef',
+				status: 'PUBLISHED',
+				state: 'PENDING',
+				projectId: 'p',
+				createdAt: 'x',
+				updatedAt: 'x',
+			},
+			transaction: {
+				id: 'tx_1',
+				chainId: 80001,
+				network: 'polygon-mumbai',
+				from: '0x298',
+				signerWallet: '0x298',
+				status: 'PUBLISHED',
+				state: 'PENDING',
+				logs: [],
+				value: '0',
+				automaticNonce: true,
+				isDeployTransaction: true,
+				projectId: 'p',
+				createdAt: 'x',
+				updatedAt: 'x',
+			},
+		};
+		await SmartContract.deployFromTemplate(ctx, {
+			network: 'polygon-mumbai',
+			signerWallet: '0x298',
+			templateId: 'ERC20_MINT_META_TRANSACTION',
+			name: 'TestToken',
+			params: [],
+			simulate: true,
+		});
+
+		expect(captured?.url).toContain('simulate=true');
+		expect(JSON.parse(captured?.body ?? '{}').simulate).toBeUndefined();
+	});
+
+	it('SmartContract.call -> POST /v3/smart-contract/{network}/{address}/call', async () => {
+		nextResponseBody = {
+			id: 'tx_1',
+			chainId: 80001,
+			network: 'polygon-mumbai',
+			from: '0x298',
+			signerWallet: '0x298',
+			status: 'PUBLISHED',
+			state: 'PENDING',
+			logs: [],
+			value: '0',
+			automaticNonce: true,
+			isDeployTransaction: false,
+			projectId: 'p',
+			createdAt: 'x',
+			updatedAt: 'x',
+		};
+		const res = await SmartContract.call(ctx, {
+			network: 'polygon-mumbai',
+			address: '0x820f8728E32519b9C91B2406BF48AF80711aFecD',
+			functionName: 'mint',
+			params: ['0x298', '1000000000000000000'],
+			signerWallet: '0x298',
+		});
+
+		expect(captured?.method).toBe('POST');
+		expect(captured?.url).toContain(
+			'https://api.starton.com/v3/smart-contract/polygon-mumbai/0x820f8728E32519b9C91B2406BF48AF80711aFecD/call',
+		);
+		expect(res.id).toBe('tx_1');
+	});
+
+	it('SmartContract.read -> POST /v3/smart-contract/{network}/{address}/read', async () => {
+		nextResponseBody = {
+			response: '1000000000000000000',
+			params: ['0x298'],
+			functionName: 'balanceOf',
+			address: '0x820f8728E32519b9C91B2406BF48AF80711aFecD',
+			network: 'polygon-mumbai',
+		};
+		const res = await SmartContract.read(ctx, {
+			network: 'polygon-mumbai',
+			address: '0x820f8728E32519b9C91B2406BF48AF80711aFecD',
+			functionName: 'balanceOf',
+			params: ['0x298'],
+		});
+
+		expect(captured?.method).toBe('POST');
+		expect(captured?.url).toBe(
+			'https://api.starton.com/v3/smart-contract/polygon-mumbai/0x820f8728E32519b9C91B2406BF48AF80711aFecD/read',
+		);
+		expect(JSON.parse(captured?.body ?? '{}')).toEqual({
+			functionName: 'balanceOf',
+			params: ['0x298'],
+		});
+		expect(res.response).toBe('1000000000000000000');
+	});
+
+	it('Transaction.get -> GET /v3/transaction/{id}', async () => {
+		nextResponseBody = {
+			id: 'tx_1abfa87e04814cb7a669d614d1fe5f78',
+			chainId: 80001,
+			network: 'polygon-mumbai',
+			from: '0x298',
+			signerWallet: '0x298',
+			status: 'CONFIRMED',
+			state: 'SUCCESS',
+			logs: [],
+			value: '0',
+			automaticNonce: true,
+			isDeployTransaction: false,
+			projectId: 'p',
+			createdAt: 'x',
+			updatedAt: 'x',
+		};
+		const res = await Transaction.get(ctx, {
+			id: 'tx_1abfa87e04814cb7a669d614d1fe5f78',
+		});
+
+		expect(captured?.method).toBe('GET');
+		expect(captured?.url).toBe(
+			'https://api.starton.com/v3/transaction/tx_1abfa87e04814cb7a669d614d1fe5f78',
+		);
+		expect(res.status).toBe('CONFIRMED');
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Schema coverage — every declared endpoint has an input + output schema
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('schema coverage', () => {
+	const schemaKeys = Object.keys(startonEndpointSchemas);
+
+	it('declares 6 endpoints', () => {
+		expect(schemaKeys).toHaveLength(6);
+		expect(schemaKeys.sort()).toEqual([
+			'smartContract.call',
+			'smartContract.deployFromTemplate',
+			'smartContract.read',
+			'transaction.get',
+			'wallet.create',
+			'wallet.list',
+		]);
+	});
+
+	it('every endpoint schema entry has an input and output schema', () => {
+		const entries = startonEndpointSchemas as Record<
+			string,
+			{ input?: unknown; output?: unknown }
+		>;
+		for (const key of schemaKeys) {
+			expect(entries[key]?.input).toBeDefined();
+			expect(entries[key]?.output).toBeDefined();
+		}
+	});
+
+	it('input and output schema maps expose the same operation keys', () => {
+		expect(Object.keys(StartonEndpointInputSchemas).sort()).toEqual(
+			Object.keys(StartonEndpointOutputSchemas).sort(),
+		);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Input validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('input schema validation', () => {
+	it('requires kmsId to create a wallet', () => {
+		expect(
+			StartonEndpointInputSchemas.walletCreate.safeParse({ name: 'Treasury' })
+				.success,
+		).toBe(false);
+		expect(
+			StartonEndpointInputSchemas.walletCreate.safeParse({ kmsId: 'kms_1' })
+				.success,
+		).toBe(true);
+	});
+
+	it('caps wallet list page size at 2500 per the official spec', () => {
+		expect(
+			StartonEndpointInputSchemas.walletList.safeParse({ limit: 2500 }).success,
+		).toBe(true);
+		expect(
+			StartonEndpointInputSchemas.walletList.safeParse({ limit: 2501 }).success,
+		).toBe(false);
+	});
+
+	it('requires network, signerWallet, templateId, name and params to deploy from template', () => {
+		expect(
+			StartonEndpointInputSchemas.smartContractDeployFromTemplate.safeParse({
+				network: 'polygon-mumbai',
+				signerWallet: '0x298',
+				templateId: 'ERC20_MINT_META_TRANSACTION',
+				name: 'TestToken',
+			}).success,
+		).toBe(true);
+		expect(
+			StartonEndpointInputSchemas.smartContractDeployFromTemplate.safeParse({
+				network: 'polygon-mumbai',
+			}).success,
+		).toBe(false);
+	});
+
+	it('requires functionName, params and signerWallet to call a contract', () => {
+		expect(
+			StartonEndpointInputSchemas.smartContractCall.safeParse({
+				network: 'polygon-mumbai',
+				address: '0xabc',
+				functionName: 'mint',
+				params: [],
+				signerWallet: '0x298',
+			}).success,
+		).toBe(true);
+		expect(
+			StartonEndpointInputSchemas.smartContractCall.safeParse({
+				network: 'polygon-mumbai',
+				address: '0xabc',
+				functionName: 'mint',
+			}).success,
+		).toBe(false);
+	});
+
+	it('rejects a wallet-list name filter outside the spec pattern', () => {
+		expect(
+			StartonEndpointInputSchemas.walletList.safeParse({ name: 'Treasury 1' })
+				.success,
+		).toBe(true);
+		expect(
+			StartonEndpointInputSchemas.walletList.safeParse({ name: 'Treasury/../x' })
+				.success,
+		).toBe(false);
+	});
+
+	it('accepts the optional uiData block on a template deploy', () => {
+		const parsed =
+			StartonEndpointInputSchemas.smartContractDeployFromTemplate.safeParse({
+				network: 'polygon-mumbai',
+				signerWallet: '0x298',
+				templateId: 'ERC20_MINT_META_TRANSACTION',
+				name: 'TestToken',
+				params: [],
+				uiData: { version: '1', deployMethod: 'kms', imported: false },
+			});
+		expect(parsed.success).toBe(true);
+		expect(
+			StartonEndpointInputSchemas.smartContractDeployFromTemplate.safeParse({
+				network: 'polygon-mumbai',
+				signerWallet: '0x298',
+				templateId: 'ERC20_MINT_META_TRANSACTION',
+				name: 'TestToken',
+				params: [],
+				uiData: { version: '1', deployMethod: 'carrier-pigeon', imported: false },
+			}).success,
+		).toBe(false);
+	});
+
+	it('read does not require signerWallet (no transaction is broadcast)', () => {
+		expect(
+			StartonEndpointInputSchemas.smartContractRead.safeParse({
+				network: 'polygon-mumbai',
+				address: '0xabc',
+				functionName: 'balanceOf',
+				params: ['0x298'],
+			}).success,
+		).toBe(true);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Output validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('output schema validation', () => {
+	it('parses a representative Transaction and keeps unknown fields', () => {
+		const parsed = StartonEndpointOutputSchemas.transactionGet.parse({
+			id: 'tx_1',
+			chainId: 80001,
+			network: 'polygon-mumbai',
+			from: '0x298',
+			signerWallet: '0x298',
+			status: 'CONFIRMED',
+			state: 'SUCCESS',
+			logs: [],
+			value: '0',
+			automaticNonce: true,
+			isDeployTransaction: false,
+			projectId: 'p',
+			createdAt: 'x',
+			updatedAt: 'x',
+			someFutureField: true,
+		});
+		expect(parsed.id).toBe('tx_1');
+		expect((parsed as Record<string, unknown>).someFutureField).toBe(true);
+	});
+
+	it('parses the paginated wallet-list envelope', () => {
+		const parsed = StartonEndpointOutputSchemas.walletList.parse({
+			items: [
+				{
+					address: '0xabc',
+					providerKeyId: 'pk_1',
+					kmsId: 'kms_1',
+					projectId: 'p',
+					createdAt: 'x',
+					updatedAt: 'x',
+				},
+			],
+			meta: { itemCount: 1, itemsPerPage: 100, currentPage: 0 },
+		});
+		expect(parsed.items).toHaveLength(1);
+		expect(parsed.meta.itemCount).toBe(1);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin wiring
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('starton() plugin', () => {
+	it('exposes the plugin id, endpoint groups and matching meta', () => {
+		const plugin = starton({ key: 'test-starton-api-key' });
+		expect(plugin.id).toBe('starton');
+		expect(Object.keys(plugin.endpoints ?? {}).sort()).toEqual([
+			'smartContract',
+			'transaction',
+			'wallet',
+		]);
+		expect(Object.keys(plugin.endpointMeta ?? {}).sort()).toEqual(
+			Object.keys(startonEndpointSchemas).sort(),
+		);
+	});
+
+	it('has no webhooks — the Corsair listing declares 0 triggers', () => {
+		const plugin = starton();
+		expect(plugin.webhooks).toEqual({});
+	});
+
+	it('keyBuilder returns the configured key and throws when none is available', async () => {
+		const plugin = starton({ key: 'test-starton-api-key' });
+		const withKey = { authType: 'api_key' } as unknown as StartonContext;
+		await expect(
+			plugin.keyBuilder?.(withKey as never, 'endpoint'),
+		).resolves.toBe('test-starton-api-key');
+
+		const noKey = starton();
+		const emptyCtx = {
+			authType: 'api_key',
+			keys: { get_api_key: async () => undefined },
+		} as unknown as StartonContext;
+		await expect(
+			noKey.keyBuilder?.(emptyCtx as never, 'endpoint'),
+		).rejects.toBeInstanceOf(AuthMissingError);
+	});
+
+	it('marks write vs. read risk correctly', () => {
+		const meta = starton().endpointMeta as Record<
+			string,
+			{ riskLevel: string } | undefined
+		>;
+		expect(meta['wallet.create']?.riskLevel).toBe('write');
+		expect(meta['wallet.list']?.riskLevel).toBe('read');
+		expect(meta['smartContract.deployFromTemplate']?.riskLevel).toBe('write');
+		expect(meta['smartContract.call']?.riskLevel).toBe('write');
+		expect(meta['smartContract.read']?.riskLevel).toBe('read');
+		expect(meta['transaction.get']?.riskLevel).toBe('read');
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error handling
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('error handling', () => {
+	it('propagates a typed ApiError with the HTTP status preserved', async () => {
+		nextResponseStatus = 401;
+		nextResponseBody = {
+			statusCode: 401,
+			errorCode: 'NOT_AUTHENTICATED',
+			message: 'Not authenticated',
+		};
+
+		const err = await makeStartonRequest('v3/kms/wallet', 'bad_key', {
+			method: 'GET',
+		}).catch((e) => e);
+
+		expect(err).toBeInstanceOf(ApiError);
+		expect((err as ApiError).status).toBe(401);
+	});
+
+	it('routes a 401 to AUTH_ERROR with no retries', async () => {
+		nextResponseStatus = 401;
+		nextResponseBody = { errorCode: 'NOT_AUTHENTICATED' };
+		const err = (await makeStartonRequest('v3/kms/wallet', 'bad', {
+			method: 'GET',
+		}).catch((e) => e)) as Error;
+
+		expect(errorHandlers.AUTH_ERROR.match(err)).toBe(true);
+		await expect(errorHandlers.AUTH_ERROR.handler()).resolves.toEqual({
+			maxRetries: 0,
+		});
+	});
+
+	it('routes a 429 to RATE_LIMIT_ERROR with retries', async () => {
+		nextResponseStatus = 429;
+		nextResponseBody = { errorCode: 'THROTTLED' };
+		const err = (await makeStartonRequest('v3/kms/wallet', 'k', {
+			method: 'GET',
+		}).catch((e) => e)) as Error;
+
+		expect(errorHandlers.RATE_LIMIT_ERROR.match(err)).toBe(true);
+		const result = await errorHandlers.RATE_LIMIT_ERROR.handler(err);
+		expect(result.maxRetries).toBe(5);
+	});
+
+	it('routes a deterministic blockchain validation error (400) to the non-retryable handler', async () => {
+		nextResponseStatus = 400;
+		nextResponseBody = { errorCode: 'INSUFFICIENT_FUNDS' };
+		const err = (await makeStartonRequest(
+			'v3/smart-contract/polygon-mumbai/0xabc/call',
+			'k',
+			{ method: 'POST', body: {} },
+		).catch((e) => e)) as Error;
+
+		expect(errorHandlers.NOT_RETRYABLE_CLIENT_ERROR.match(err)).toBe(true);
+		await expect(
+			errorHandlers.NOT_RETRYABLE_CLIENT_ERROR.handler(),
+		).resolves.toEqual({ maxRetries: 0 });
+	});
+
+	it('routes a 5xx to SERVER_ERROR with limited retries', async () => {
+		nextResponseStatus = 500;
+		nextResponseBody = { errorCode: 'MICROSERVICE_NOT_RESPONDING' };
+		const err = (await makeStartonRequest('v3/transaction/tx_1', 'k', {
+			method: 'GET',
+		}).catch((e) => e)) as Error;
+
+		expect(errorHandlers.SERVER_ERROR.match(err)).toBe(true);
+		await expect(errorHandlers.SERVER_ERROR.handler()).resolves.toEqual({
+			maxRetries: 3,
+		});
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Request serialization details — what goes in the path, the query and the body
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TX_FIXTURE = {
+	id: 'tx_1',
+	chainId: 80001,
+	network: 'polygon-mumbai',
+	from: '0x298',
+	signerWallet: '0x298',
+	status: 'PUBLISHED',
+	state: 'PENDING',
+	logs: [],
+	value: '0',
+	automaticNonce: true,
+	isDeployTransaction: false,
+	projectId: 'p',
+	createdAt: 'x',
+	updatedAt: 'x',
+};
+
+describe('request serialization', () => {
+	it('Wallet.list sends no query string when no filters are supplied', async () => {
+		nextResponseBody = { items: [], meta: { itemCount: 0, itemsPerPage: 100, currentPage: 0 } };
+		await Wallet.list(ctx, {});
+
+		expect(captured?.url).toBe('https://api.starton.com/v3/kms/wallet');
+	});
+
+	it('Wallet.list forwards the name and kmsId filters from the official spec', async () => {
+		nextResponseBody = { items: [], meta: { itemCount: 0, itemsPerPage: 100, currentPage: 0 } };
+		await Wallet.list(ctx, { name: 'Treasury', kmsId: 'kms_1' });
+
+		expect(captured?.url).toContain('name=Treasury');
+		expect(captured?.url).toContain('kmsId=kms_1');
+	});
+
+	it('SmartContract.call keeps network/address in the path and simulate in the query, never in the body', async () => {
+		nextResponseBody = TX_FIXTURE;
+		await SmartContract.call(ctx, {
+			network: 'polygon-mumbai',
+			address: '0x820f8728E32519b9C91B2406BF48AF80711aFecD',
+			functionName: 'mint',
+			params: ['0x298', '1'],
+			signerWallet: '0x298',
+			speed: 'fast',
+			value: '0',
+			simulate: true,
+		});
+
+		expect(captured?.url).toBe(
+			'https://api.starton.com/v3/smart-contract/polygon-mumbai/0x820f8728E32519b9C91B2406BF48AF80711aFecD/call?simulate=true',
+		);
+
+		const body = JSON.parse(captured?.body ?? '{}');
+		expect(body).toEqual({
+			functionName: 'mint',
+			params: ['0x298', '1'],
+			signerWallet: '0x298',
+			speed: 'fast',
+			value: '0',
+		});
+		expect(body.network).toBeUndefined();
+		expect(body.address).toBeUndefined();
+		expect(body.simulate).toBeUndefined();
+	});
+
+	it('SmartContract.read sends no simulate query param (reads never broadcast)', async () => {
+		nextResponseBody = {
+			response: '1',
+			params: [],
+			functionName: 'totalSupply',
+			address: '0xabc',
+			network: 'polygon-mumbai',
+		};
+		await SmartContract.read(ctx, {
+			network: 'polygon-mumbai',
+			address: '0xabc',
+			functionName: 'totalSupply',
+			params: [],
+		});
+
+		expect(captured?.url).not.toContain('simulate');
+	});
+
+	it('percent-encodes caller-supplied path segments so they cannot escape the route', () => {
+		expect(encodeStartonPathSegment('0xabc/../../v3/kms/wallet')).toBe(
+			'0xabc%2F..%2F..%2Fv3%2Fkms%2Fwallet',
+		);
+		expect(() => encodeStartonPathSegment('.')).toThrow();
+	});
+
+	it('never puts the API key in the URL or the body', async () => {
+		nextResponseBody = TX_FIXTURE;
+		await Transaction.get(ctx, { id: 'tx_1' });
+
+		expect(captured?.url).not.toContain('test-starton-api-key');
+		expect(captured?.body ?? '').not.toContain('test-starton-api-key');
+		expect(captured?.headers['x-api-key']).toBe('test-starton-api-key');
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Response parsing — nullable/optional fields and malformed payloads
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('response parsing', () => {
+	it('accepts the nullable Wallet fields the spec marks nullable', () => {
+		const parsed = StartonEndpointOutputSchemas.walletCreate.parse({
+			address: '0xabc',
+			providerKeyId: 'pk_1',
+			kmsId: 'kms_1',
+			name: null,
+			description: null,
+			metadata: null,
+			projectId: 'p',
+			createdAt: '2024-01-01T00:00:00.000Z',
+			updatedAt: '2024-01-01T00:00:00.000Z',
+		});
+		expect(parsed.name).toBeNull();
+		expect(parsed.metadata).toBeNull();
+	});
+
+	it('accepts a Transaction whose optional blockchain fields are null (not yet mined)', () => {
+		const parsed = StartonEndpointOutputSchemas.transactionGet.parse({
+			...TX_FIXTURE,
+			blockHash: null,
+			blockNumber: null,
+			transactionHash: null,
+			minedDate: null,
+			nonce: null,
+			speed: null,
+			to: null,
+		});
+		expect(parsed.blockNumber).toBeNull();
+		expect(parsed.speed).toBeNull();
+	});
+
+	it('rejects a Transaction that is missing a spec-required field', () => {
+		const withoutLogs: Record<string, unknown> = { ...TX_FIXTURE };
+		delete withoutLogs.logs;
+		expect(
+			StartonEndpointOutputSchemas.transactionGet.safeParse(withoutLogs).success,
+		).toBe(false);
+	});
+
+	it('rejects a transaction status outside the official spec enum', () => {
+		expect(
+			StartonEndpointOutputSchemas.transactionGet.safeParse({
+				...TX_FIXTURE,
+				status: 'TOTALLY_MADE_UP',
+			}).success,
+		).toBe(false);
+	});
+
+	it('parses the deploy-from-template envelope (smartContract + transaction)', () => {
+		const parsed =
+			StartonEndpointOutputSchemas.smartContractDeployFromTemplate.parse({
+				smartContract: {
+					id: 'sc_1',
+					name: 'TestToken',
+					description: null,
+					network: 'polygon-mumbai',
+					abi: [{ type: 'function', name: 'mint' }],
+					address: '0xdef',
+					params: ['TestToken', 'TEST'],
+					compilationDetails: null,
+					creationHash: null,
+					status: 'PUBLISHED',
+					state: 'PENDING',
+					templateId: 'ERC20_MINT_META_TRANSACTION',
+					projectId: 'p',
+					createdAt: 'x',
+					updatedAt: 'x',
+				},
+				transaction: { ...TX_FIXTURE, isDeployTransaction: true },
+			});
+		expect(parsed.smartContract.templateId).toBe('ERC20_MINT_META_TRANSACTION');
+		expect(parsed.transaction.isDeployTransaction).toBe(true);
+	});
+
+	it('parses the uiData block the spec attaches to a smart contract', () => {
+		const parsed =
+			StartonEndpointOutputSchemas.smartContractDeployFromTemplate.parse({
+				smartContract: {
+					id: 'sc_1',
+					name: 'TestToken',
+					network: 'polygon-mumbai',
+					address: '0xdef',
+					status: 'PUBLISHED',
+					state: 'PENDING',
+					projectId: 'p',
+					createdAt: 'x',
+					updatedAt: 'x',
+					uiData: {
+						version: '1',
+						deployMethod: 'kms',
+						imported: false,
+						chainId: 80001,
+					},
+				},
+				transaction: TX_FIXTURE,
+			});
+		expect(parsed.smartContract.uiData?.deployMethod).toBe('kms');
+		expect(parsed.smartContract.uiData?.chainId).toBe(80001);
+	});
+
+	it('parses every shape the spec allows for a read response', () => {
+		const base = {
+			params: [],
+			functionName: 'f',
+			address: '0xabc',
+			network: 'polygon-mumbai',
+		};
+		for (const response of [
+			'1000',
+			42,
+			true,
+			['a', 'b'],
+			{ nested: 'value' },
+		]) {
+			expect(
+				StartonEndpointOutputSchemas.smartContractRead.safeParse({
+					...base,
+					response,
+				}).success,
+			).toBe(true);
+		}
+	});
+
+	it('parses a wallet-list page that reports the optional totals', () => {
+		const parsed = StartonEndpointOutputSchemas.walletList.parse({
+			items: [],
+			meta: {
+				itemCount: 0,
+				totalItems: 120,
+				itemsPerPage: 100,
+				totalPages: 2,
+				currentPage: 1,
+			},
+		});
+		expect(parsed.meta.totalPages).toBe(2);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Additional API error routing
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('error routing (403 / retry-after)', () => {
+	it('routes a 403 to AUTH_ERROR with no retries', async () => {
+		nextResponseStatus = 403;
+		nextResponseBody = { statusCode: 403, errorCode: 'FORBIDDEN' };
+		const err = (await makeStartonRequest('v3/kms/wallet', 'k', {
+			method: 'GET',
+		}).catch((e) => e)) as Error;
+
+		expect(err).toBeInstanceOf(ApiError);
+		expect((err as ApiError).status).toBe(403);
+		expect(errorHandlers.AUTH_ERROR.match(err)).toBe(true);
+		expect(errorHandlers.NOT_RETRYABLE_CLIENT_ERROR.match(err)).toBe(false);
+	});
+
+	it('routes a 404 COULD_NOT_FIND_RESOURCE to the non-retryable handler', async () => {
+		nextResponseStatus = 404;
+		nextResponseBody = { statusCode: 404, errorCode: 'COULD_NOT_FIND_RESOURCE' };
+		const err = (await makeStartonRequest('v3/transaction/nope', 'k', {
+			method: 'GET',
+		}).catch((e) => e)) as Error;
+
+		expect((err as ApiError).status).toBe(404);
+		expect(errorHandlers.NOT_RETRYABLE_CLIENT_ERROR.match(err)).toBe(true);
+		expect(errorHandlers.AUTH_ERROR.match(err)).toBe(false);
+	});
+
+	it('surfaces Retry-After from a 429 as headersRetryAfterMs', async () => {
+		const err = new ApiError(
+			{ method: 'GET', url: 'v3/kms/wallet' },
+			{ url: 'https://api.starton.com/v3/kms/wallet', ok: false, status: 429, statusText: 'Too Many Requests', body: {} },
+			'Too Many Requests',
+			{ retryAfter: 2000 },
+		);
+
+		expect(errorHandlers.RATE_LIMIT_ERROR.match(err)).toBe(true);
+		await expect(errorHandlers.RATE_LIMIT_ERROR.handler(err)).resolves.toEqual({
+			maxRetries: 5,
+			headersRetryAfterMs: 2000,
+		});
+	});
+
+	it('matches rate limiting by message when no typed ApiError is available', async () => {
+		expect(
+			errorHandlers.RATE_LIMIT_ERROR.match(new Error('Too Many Requests')),
+		).toBe(true);
+		expect(errorHandlers.AUTH_ERROR.match(new Error('Unauthorized'))).toBe(true);
+		expect(errorHandlers.DEFAULT.match()).toBe(true);
+	});
+});

--- a/packages/starton/api.test.ts
+++ b/packages/starton/api.test.ts
@@ -7,6 +7,10 @@ import {
 	StartonEndpointOutputSchemas,
 } from './endpoints/types';
 import { errorHandlers } from './error-handlers';
+import {
+	isNonIdempotentOperation,
+	NON_IDEMPOTENT_OPERATIONS,
+} from './idempotency';
 import type { StartonContext } from './index';
 import { starton, startonEndpointSchemas } from './index';
 
@@ -134,7 +138,16 @@ describe('endpoint request wiring', () => {
 
 	it('Wallet.list -> GET /v3/kms/wallet with pagination filters', async () => {
 		nextResponseBody = {
-			items: [{ address: '0xabc', providerKeyId: 'pk_1', kmsId: 'kms_1', projectId: 'p', createdAt: 'x', updatedAt: 'x' }],
+			items: [
+				{
+					address: '0xabc',
+					providerKeyId: 'pk_1',
+					kmsId: 'kms_1',
+					projectId: 'p',
+					createdAt: 'x',
+					updatedAt: 'x',
+				},
+			],
 			meta: { itemCount: 1, itemsPerPage: 20, currentPage: 0 },
 		};
 		const res = await Wallet.list(ctx, { page: 0, limit: 20 });
@@ -425,8 +438,9 @@ describe('input schema validation', () => {
 				.success,
 		).toBe(true);
 		expect(
-			StartonEndpointInputSchemas.walletList.safeParse({ name: 'Treasury/../x' })
-				.success,
+			StartonEndpointInputSchemas.walletList.safeParse({
+				name: 'Treasury/../x',
+			}).success,
 		).toBe(false);
 	});
 
@@ -448,7 +462,11 @@ describe('input schema validation', () => {
 				templateId: 'ERC20_MINT_META_TRANSACTION',
 				name: 'TestToken',
 				params: [],
-				uiData: { version: '1', deployMethod: 'carrier-pigeon', imported: false },
+				uiData: {
+					version: '1',
+					deployMethod: 'carrier-pigeon',
+					imported: false,
+				},
 			}).success,
 		).toBe(false);
 	});
@@ -634,7 +652,9 @@ describe('error handling', () => {
 		}).catch((e) => e)) as Error;
 
 		expect(errorHandlers.SERVER_ERROR.match(err)).toBe(true);
-		await expect(errorHandlers.SERVER_ERROR.handler()).resolves.toEqual({
+		await expect(
+			errorHandlers.SERVER_ERROR.handler(err, errorContext('transaction.get')),
+		).resolves.toEqual({
 			maxRetries: 3,
 		});
 	});
@@ -663,14 +683,20 @@ const TX_FIXTURE = {
 
 describe('request serialization', () => {
 	it('Wallet.list sends no query string when no filters are supplied', async () => {
-		nextResponseBody = { items: [], meta: { itemCount: 0, itemsPerPage: 100, currentPage: 0 } };
+		nextResponseBody = {
+			items: [],
+			meta: { itemCount: 0, itemsPerPage: 100, currentPage: 0 },
+		};
 		await Wallet.list(ctx, {});
 
 		expect(captured?.url).toBe('https://api.starton.com/v3/kms/wallet');
 	});
 
 	it('Wallet.list forwards the name and kmsId filters from the official spec', async () => {
-		nextResponseBody = { items: [], meta: { itemCount: 0, itemsPerPage: 100, currentPage: 0 } };
+		nextResponseBody = {
+			items: [],
+			meta: { itemCount: 0, itemsPerPage: 100, currentPage: 0 },
+		};
 		await Wallet.list(ctx, { name: 'Treasury', kmsId: 'kms_1' });
 
 		expect(captured?.url).toContain('name=Treasury');
@@ -779,10 +805,12 @@ describe('response parsing', () => {
 	});
 
 	it('rejects a Transaction that is missing a spec-required field', () => {
-		const withoutLogs: Record<string, unknown> = { ...TX_FIXTURE };
-		delete withoutLogs.logs;
+		// Omit the key entirely rather than setting it to undefined, so this
+		// asserts a genuinely absent required field.
+		const { logs: _logs, ...withoutLogs } = TX_FIXTURE;
 		expect(
-			StartonEndpointOutputSchemas.transactionGet.safeParse(withoutLogs).success,
+			StartonEndpointOutputSchemas.transactionGet.safeParse(withoutLogs)
+				.success,
 		).toBe(false);
 	});
 
@@ -905,7 +933,10 @@ describe('error routing (403 / retry-after)', () => {
 
 	it('routes a 404 COULD_NOT_FIND_RESOURCE to the non-retryable handler', async () => {
 		nextResponseStatus = 404;
-		nextResponseBody = { statusCode: 404, errorCode: 'COULD_NOT_FIND_RESOURCE' };
+		nextResponseBody = {
+			statusCode: 404,
+			errorCode: 'COULD_NOT_FIND_RESOURCE',
+		};
 		const err = (await makeStartonRequest('v3/transaction/nope', 'k', {
 			method: 'GET',
 		}).catch((e) => e)) as Error;
@@ -918,7 +949,13 @@ describe('error routing (403 / retry-after)', () => {
 	it('surfaces Retry-After from a 429 as headersRetryAfterMs', async () => {
 		const err = new ApiError(
 			{ method: 'GET', url: 'v3/kms/wallet' },
-			{ url: 'https://api.starton.com/v3/kms/wallet', ok: false, status: 429, statusText: 'Too Many Requests', body: {} },
+			{
+				url: 'https://api.starton.com/v3/kms/wallet',
+				ok: false,
+				status: 429,
+				statusText: 'Too Many Requests',
+				body: {},
+			},
 			'Too Many Requests',
 			{ retryAfter: 2000 },
 		);
@@ -934,7 +971,342 @@ describe('error routing (403 / retry-after)', () => {
 		expect(
 			errorHandlers.RATE_LIMIT_ERROR.match(new Error('Too Many Requests')),
 		).toBe(true);
-		expect(errorHandlers.AUTH_ERROR.match(new Error('Unauthorized'))).toBe(true);
+		expect(errorHandlers.AUTH_ERROR.match(new Error('Unauthorized'))).toBe(
+			true,
+		);
 		expect(errorHandlers.DEFAULT.match()).toBe(true);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Retry safety
+//
+// Starton exposes no idempotency key, and Corsair can replay a failed call at
+// two layers: `corsair/http` retries 429 internally, and the endpoint binder
+// re-invokes the whole endpoint whenever an error handler returns
+// `maxRetries > 0`. A replayed write would broadcast a second transaction, so
+// both layers must stay shut for the transaction-producing operations.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function errorContext(operation: string) {
+	return {
+		pluginId: 'starton',
+		operation,
+		input: {},
+		originalError: new Error('test'),
+	};
+}
+
+/** Count fetch attempts, optionally succeeding once the Nth attempt is reached. */
+function countingFetch(status: number, succeedOnAttempt?: number) {
+	let attempts = 0;
+	globalThis.fetch = (async () => {
+		attempts += 1;
+		const ok = succeedOnAttempt !== undefined && attempts >= succeedOnAttempt;
+		return new Response(JSON.stringify(ok ? TX_FIXTURE : { errorCode: 'X' }), {
+			status: ok ? 200 : status,
+			statusText: ok ? 'OK' : `status ${status}`,
+			headers: { 'Content-Type': 'application/json' },
+		});
+	}) as typeof fetch;
+	return () => attempts;
+}
+
+describe('retry safety: HTTP layer (429 replay)', () => {
+	it('does not replay smartContract.call — a replay would broadcast twice', async () => {
+		const attempts = countingFetch(429);
+
+		await SmartContract.call(ctx, {
+			network: 'polygon-mumbai',
+			address: '0xabc',
+			functionName: 'mint',
+			params: [],
+			signerWallet: '0x298',
+		}).catch(() => undefined);
+
+		expect(attempts()).toBe(1);
+	});
+
+	it('does not replay smartContract.deployFromTemplate', async () => {
+		const attempts = countingFetch(429);
+
+		await SmartContract.deployFromTemplate(ctx, {
+			network: 'polygon-mumbai',
+			signerWallet: '0x298',
+			templateId: 'ERC20_MINT_META_TRANSACTION',
+			name: 'TestToken',
+			params: [],
+		}).catch(() => undefined);
+
+		expect(attempts()).toBe(1);
+	});
+
+	it('does not replay wallet.create — a replay would provision a second wallet', async () => {
+		const attempts = countingFetch(429);
+
+		await Wallet.create(ctx, { kmsId: 'kms_1' }).catch(() => undefined);
+
+		expect(attempts()).toBe(1);
+	});
+
+	it('still replays a rate-limited read (the flag is scoped, not a blanket off-switch)', async () => {
+		const attempts = countingFetch(429, 2);
+
+		await Transaction.get(ctx, { id: 'tx_1' }).catch(() => undefined);
+
+		expect(attempts()).toBe(2);
+	});
+});
+
+describe('retry safety: binder layer (error-handler maxRetries)', () => {
+	it('withholds 5xx retries for every transaction-producing operation', async () => {
+		const err = new ApiError(
+			{ method: 'POST', url: 'v3/smart-contract/x/y/call' },
+			{
+				url: 'https://api.starton.com',
+				ok: false,
+				status: 502,
+				statusText: 'Bad Gateway',
+				body: {},
+			},
+			'Bad Gateway',
+		);
+
+		for (const operation of NON_IDEMPOTENT_OPERATIONS) {
+			await expect(
+				errorHandlers.SERVER_ERROR.handler(err, errorContext(operation)),
+			).resolves.toEqual({ maxRetries: 0 });
+		}
+	});
+
+	it('still retries 5xx for reads', async () => {
+		const err = new ApiError(
+			{ method: 'GET', url: 'v3/transaction/tx_1' },
+			{
+				url: 'https://api.starton.com',
+				ok: false,
+				status: 500,
+				statusText: 'Server Error',
+				body: {},
+			},
+			'Server Error',
+		);
+
+		for (const operation of [
+			'transaction.get',
+			'wallet.list',
+			'smartContract.read',
+		]) {
+			await expect(
+				errorHandlers.SERVER_ERROR.handler(err, errorContext(operation)),
+			).resolves.toEqual({ maxRetries: 3 });
+		}
+	});
+
+	it('withholds 429 retries for transaction-producing operations', async () => {
+		const err = new ApiError(
+			{ method: 'POST', url: 'v3/smart-contract/x/y/call' },
+			{
+				url: 'https://api.starton.com',
+				ok: false,
+				status: 429,
+				statusText: 'Too Many Requests',
+				body: {},
+			},
+			'Too Many Requests',
+			{ retryAfter: 1000 },
+		);
+
+		for (const operation of NON_IDEMPOTENT_OPERATIONS) {
+			await expect(
+				errorHandlers.RATE_LIMIT_ERROR.handler(err, errorContext(operation)),
+			).resolves.toEqual({ maxRetries: 0 });
+		}
+
+		await expect(
+			errorHandlers.RATE_LIMIT_ERROR.handler(err, errorContext('wallet.list')),
+		).resolves.toEqual({ maxRetries: 5, headersRetryAfterMs: 1000 });
+	});
+});
+
+describe('idempotency classification', () => {
+	it('classifies every declared operation, and only real operations', () => {
+		const declared = Object.keys(startonEndpointSchemas);
+
+		// No entry may reference an operation that does not exist — this catches a
+		// rename that would silently re-enable replay on a write.
+		for (const operation of NON_IDEMPOTENT_OPERATIONS) {
+			expect(declared).toContain(operation);
+		}
+
+		expect(declared.filter(isNonIdempotentOperation).sort()).toEqual([
+			'smartContract.call',
+			'smartContract.deployFromTemplate',
+			'wallet.create',
+		]);
+		expect(
+			declared.filter((op) => !isNonIdempotentOperation(op)).sort(),
+		).toEqual(['smartContract.read', 'transaction.get', 'wallet.list']);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Runtime response validation
+//
+// Corsair's endpoint binder does not validate against `endpointSchemas` — those
+// feed introspection (`zodToFormSchema`) only. Each endpoint therefore parses
+// the provider payload itself, so a malformed Starton response surfaces as an
+// error instead of being handed back as trustworthy typed data.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('runtime response validation', () => {
+	it('rejects a transaction response missing a spec-required field', async () => {
+		const { chainId: _chainId, ...incomplete } = TX_FIXTURE;
+		nextResponseBody = incomplete;
+
+		await expect(Transaction.get(ctx, { id: 'tx_1' })).rejects.toThrow();
+	});
+
+	it('rejects a transaction whose field has the wrong primitive type', async () => {
+		nextResponseBody = { ...TX_FIXTURE, chainId: '80001' };
+
+		await expect(Transaction.get(ctx, { id: 'tx_1' })).rejects.toThrow();
+	});
+
+	it('rejects a status outside the official enum rather than passing it through', async () => {
+		nextResponseBody = { ...TX_FIXTURE, status: 'NOT_A_REAL_STATUS' };
+
+		await expect(Transaction.get(ctx, { id: 'tx_1' })).rejects.toThrow();
+	});
+
+	it('rejects a wallet-list page with a malformed nested item', async () => {
+		nextResponseBody = {
+			items: [{ address: '0xabc' }],
+			meta: { itemCount: 1, itemsPerPage: 100, currentPage: 0 },
+		};
+
+		await expect(Wallet.list(ctx, {})).rejects.toThrow();
+	});
+
+	it('rejects an entirely unexpected response shape', async () => {
+		nextResponseBody = { unexpected: 'payload' };
+
+		await expect(Wallet.create(ctx, { kmsId: 'kms_1' })).rejects.toThrow();
+	});
+
+	it('rejects a deploy envelope missing the transaction half', async () => {
+		nextResponseBody = {
+			smartContract: {
+				id: 'sc_1',
+				name: 'TestToken',
+				network: 'polygon-mumbai',
+				address: '0xdef',
+				status: 'PUBLISHED',
+				state: 'PENDING',
+				projectId: 'p',
+				createdAt: 'x',
+				updatedAt: 'x',
+			},
+		};
+
+		await expect(
+			SmartContract.deployFromTemplate(ctx, {
+				network: 'polygon-mumbai',
+				signerWallet: '0x298',
+				templateId: 'ERC20_MINT_META_TRANSACTION',
+				name: 'TestToken',
+				params: [],
+			}),
+		).rejects.toThrow();
+	});
+
+	it('still accepts a valid response and preserves unknown forward-compatible fields', async () => {
+		nextResponseBody = { ...TX_FIXTURE, aFutureStartonField: 'kept' };
+
+		const result = await Transaction.get(ctx, { id: 'tx_1' });
+
+		expect(result.id).toBe('tx_1');
+		expect((result as Record<string, unknown>).aFutureStartonField).toBe(
+			'kept',
+		);
+	});
+
+	it('a malformed response is not retried (DEFAULT handler, no side-effect replay)', async () => {
+		const validationError = new Error('Invalid input');
+
+		expect(errorHandlers.DEFAULT.match()).toBe(true);
+		await expect(errorHandlers.DEFAULT.handler()).resolves.toEqual({
+			maxRetries: 0,
+		});
+		expect(errorHandlers.SERVER_ERROR.match(validationError)).toBe(false);
+		expect(errorHandlers.RATE_LIMIT_ERROR.match(validationError)).toBe(false);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Credential handling
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SECRET = 'test-starton-api-key';
+
+describe('credential secrecy', () => {
+	it('sends the key only as the x-api-key header, never in the URL or body', async () => {
+		nextResponseBody = TX_FIXTURE;
+
+		await SmartContract.call(ctx, {
+			network: 'polygon-mumbai',
+			address: '0xabc',
+			functionName: 'mint',
+			params: ['1'],
+			signerWallet: '0x298',
+		});
+
+		expect(captured?.headers['x-api-key']).toBe(SECRET);
+		expect(captured?.url).not.toContain(SECRET);
+		expect(captured?.body ?? '').not.toContain(SECRET);
+		expect(captured?.headers.authorization).toBeUndefined();
+	});
+
+	it('never leaks the key into a thrown provider error', async () => {
+		nextResponseStatus = 500;
+		nextResponseBody = { statusCode: 500, errorCode: 'UNKNOWN' };
+
+		const err = (await makeStartonRequest('v3/kms/wallet', SECRET, {
+			method: 'GET',
+		}).catch((e) => e)) as ApiError;
+
+		// Message, and every own enumerable property (url, request, body, ...).
+		const serialized = `${err.message} ${JSON.stringify(err, Object.getOwnPropertyNames(err))}`;
+		expect(serialized).not.toContain(SECRET);
+	});
+
+	it('never leaks the key into a thrown transport error', async () => {
+		globalThis.fetch = (async () => {
+			throw new Error('socket hang up');
+		}) as typeof fetch;
+
+		const err = (await makeStartonRequest('v3/kms/wallet', SECRET, {
+			method: 'GET',
+		}).catch((e) => e)) as Error;
+
+		const serialized = `${err.message} ${JSON.stringify(err, Object.getOwnPropertyNames(err))}`;
+		expect(serialized).not.toContain(SECRET);
+		expect(err).toBeInstanceOf(Error);
+	});
+
+	it('keeps the provider error useful (status and error code survive)', async () => {
+		nextResponseStatus = 400;
+		nextResponseBody = {
+			statusCode: 400,
+			errorCode: 'INSUFFICIENT_FUNDS',
+			message: 'Your funds are insufficient.',
+		};
+
+		const err = (await makeStartonRequest('v3/kms/wallet', SECRET, {
+			method: 'GET',
+		}).catch((e) => e)) as ApiError;
+
+		expect(err.status).toBe(400);
+		expect(JSON.stringify(err.body)).toContain('INSUFFICIENT_FUNDS');
 	});
 });

--- a/packages/starton/api.test.ts
+++ b/packages/starton/api.test.ts
@@ -9,7 +9,9 @@ import {
 import { errorHandlers } from './error-handlers';
 import {
 	isNonIdempotentOperation,
+	isRetryableOperation,
 	NON_IDEMPOTENT_OPERATIONS,
+	RETRY_SAFE_OPERATIONS,
 } from './idempotency';
 import type { StartonContext } from './index';
 import { starton, startonEndpointSchemas } from './index';
@@ -625,7 +627,12 @@ describe('error handling', () => {
 		}).catch((e) => e)) as Error;
 
 		expect(errorHandlers.RATE_LIMIT_ERROR.match(err)).toBe(true);
-		const result = await errorHandlers.RATE_LIMIT_ERROR.handler(err);
+		// A verified retry-safe operation — the handler now fails closed without
+		// one, which is covered separately below.
+		const result = await errorHandlers.RATE_LIMIT_ERROR.handler(
+			err,
+			errorContext('wallet.list'),
+		);
 		expect(result.maxRetries).toBe(5);
 	});
 
@@ -961,7 +968,9 @@ describe('error routing (403 / retry-after)', () => {
 		);
 
 		expect(errorHandlers.RATE_LIMIT_ERROR.match(err)).toBe(true);
-		await expect(errorHandlers.RATE_LIMIT_ERROR.handler(err)).resolves.toEqual({
+		await expect(
+			errorHandlers.RATE_LIMIT_ERROR.handler(err, errorContext('wallet.list')),
+		).resolves.toEqual({
 			maxRetries: 5,
 			headersRetryAfterMs: 2000,
 		});
@@ -1308,5 +1317,157 @@ describe('credential secrecy', () => {
 
 		expect(err.status).toBe(400);
 		expect(JSON.stringify(err.body)).toContain('INSUFFICIENT_FUNDS');
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fail-closed defaults
+//
+// Two review findings, both about defaulting to the unsafe branch:
+//   1. `replayable` defaulted to true, so a future non-GET endpoint that forgot
+//      `replayable: false` would be replayed after a 429.
+//   2. The retry handlers only withheld retries when an ErrorContext was
+//      present, so a missing or unrecognised operation fell through to
+//      retrying.
+// Both now default to "do not replay".
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('replayability defaults to the safe branch per HTTP method', () => {
+	it('GET defaults to replayable', async () => {
+		const attempts = countingFetch(429, 2);
+
+		await makeStartonRequest('v3/transaction/tx_1', 'k', {
+			method: 'GET',
+		}).catch(() => undefined);
+
+		expect(attempts()).toBe(2);
+	});
+
+	it.each(['POST', 'PUT', 'PATCH', 'DELETE'] as const)(
+		'%s defaults to non-replayable even without an explicit flag',
+		async (method) => {
+			const attempts = countingFetch(429);
+
+			await makeStartonRequest('v3/kms/wallet', 'k', {
+				method,
+				body: { kmsId: 'kms_1' },
+			}).catch(() => undefined);
+
+			expect(attempts()).toBe(1);
+		},
+	);
+
+	it('an explicit replayable: true still opts a non-GET into replay', async () => {
+		const attempts = countingFetch(429, 2);
+
+		await makeStartonRequest('v3/smart-contract/n/a/read', 'k', {
+			method: 'POST',
+			body: {},
+			replayable: true,
+		}).catch(() => undefined);
+
+		expect(attempts()).toBe(2);
+	});
+
+	it('an explicit replayable: false still overrides the GET default', async () => {
+		const attempts = countingFetch(429);
+
+		await makeStartonRequest('v3/kms/wallet', 'k', {
+			method: 'GET',
+			replayable: false,
+		}).catch(() => undefined);
+
+		expect(attempts()).toBe(1);
+	});
+
+	it('smartContract.read stays replayable through the endpoint', async () => {
+		const attempts = countingFetch(429, 2);
+
+		await SmartContract.read(ctx, {
+			network: 'polygon-mumbai',
+			address: '0xabc',
+			functionName: 'balanceOf',
+			params: [],
+		}).catch(() => undefined);
+
+		expect(attempts()).toBe(2);
+	});
+});
+
+describe('retry decision fails closed without a verified operation', () => {
+	const rateLimited = new ApiError(
+		{ method: 'POST', url: 'v3/smart-contract/x/y/call' },
+		{
+			url: 'https://api.starton.com',
+			ok: false,
+			status: 429,
+			statusText: 'Too Many Requests',
+			body: {},
+		},
+		'Too Many Requests',
+		{ retryAfter: 1000 },
+	);
+	const serverError = new ApiError(
+		{ method: 'POST', url: 'v3/smart-contract/x/y/call' },
+		{
+			url: 'https://api.starton.com',
+			ok: false,
+			status: 503,
+			statusText: 'Service Unavailable',
+			body: {},
+		},
+		'Service Unavailable',
+	);
+
+	it('withholds retries on both paths when context is absent', async () => {
+		await expect(
+			errorHandlers.RATE_LIMIT_ERROR.handler(rateLimited),
+		).resolves.toEqual({ maxRetries: 0 });
+		await expect(
+			errorHandlers.SERVER_ERROR.handler(serverError),
+		).resolves.toEqual({ maxRetries: 0 });
+	});
+
+	it('withholds retries on both paths for an unrecognised operation', async () => {
+		const unknown = errorContext('starton.someFutureOperation');
+
+		await expect(
+			errorHandlers.RATE_LIMIT_ERROR.handler(rateLimited, unknown),
+		).resolves.toEqual({ maxRetries: 0 });
+		await expect(
+			errorHandlers.SERVER_ERROR.handler(serverError, unknown),
+		).resolves.toEqual({ maxRetries: 0 });
+	});
+
+	it('still grants the documented limits to verified-safe operations', async () => {
+		for (const operation of RETRY_SAFE_OPERATIONS) {
+			await expect(
+				errorHandlers.RATE_LIMIT_ERROR.handler(
+					rateLimited,
+					errorContext(operation),
+				),
+			).resolves.toEqual({ maxRetries: 5, headersRetryAfterMs: 1000 });
+			await expect(
+				errorHandlers.SERVER_ERROR.handler(
+					serverError,
+					errorContext(operation),
+				),
+			).resolves.toEqual({ maxRetries: 3 });
+		}
+	});
+
+	it('the two classifications partition every declared operation exactly', () => {
+		const declared = Object.keys(startonEndpointSchemas);
+
+		// Nothing unclassified (would fail closed at runtime) and nothing in both.
+		for (const operation of declared) {
+			expect(
+				isRetryableOperation(operation) !== isNonIdempotentOperation(operation),
+			).toBe(true);
+		}
+		expect(
+			[...RETRY_SAFE_OPERATIONS, ...NON_IDEMPOTENT_OPERATIONS].sort(),
+		).toEqual(declared.sort());
+		expect(isRetryableOperation(undefined)).toBe(false);
 	});
 });

--- a/packages/starton/api.test.ts
+++ b/packages/starton/api.test.ts
@@ -1471,3 +1471,134 @@ describe('retry decision fails closed without a verified operation', () => {
 		expect(isRetryableOperation(undefined)).toBe(false);
 	});
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Runtime input validation
+//
+// Corsair's binder does not validate against `endpointSchemas` (they feed
+// introspection only), so each endpoint parses its own input. That rejects bad
+// arguments before any network call, applies the schema defaults, and — because
+// `z.object()` strips unknown keys — keeps caller-supplied extras out of the
+// request body and query string.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('runtime input validation', () => {
+	it('rejects a missing required field without issuing a request', async () => {
+		const attempts = countingFetch(200);
+
+		await expect(
+			Wallet.create(ctx, {} as unknown as Parameters<typeof Wallet.create>[1]),
+		).rejects.toThrow();
+		expect(attempts()).toBe(0);
+	});
+
+	it('rejects a wrong-typed field without issuing a request', async () => {
+		const attempts = countingFetch(200);
+
+		await expect(
+			Wallet.list(ctx, {
+				limit: 'twenty',
+			} as unknown as Parameters<typeof Wallet.list>[1]),
+		).rejects.toThrow();
+		expect(attempts()).toBe(0);
+	});
+
+	it('enforces the spec pagination ceiling before the request', async () => {
+		const attempts = countingFetch(200);
+
+		await expect(Wallet.list(ctx, { limit: 2501 })).rejects.toThrow();
+		expect(attempts()).toBe(0);
+	});
+
+	it('strips unknown keys out of a POST body', async () => {
+		nextResponseBody = {
+			address: '0xabc',
+			providerKeyId: 'pk_1',
+			kmsId: 'kms_1',
+			projectId: 'p',
+			createdAt: 'x',
+			updatedAt: 'x',
+		};
+
+		await Wallet.create(ctx, {
+			kmsId: 'kms_1',
+			name: 'Treasury',
+			// Not part of CreateWalletDto — must not be forwarded to Starton.
+			internalNote: 'do not send me',
+		} as unknown as Parameters<typeof Wallet.create>[1]);
+
+		const body = JSON.parse(captured?.body ?? '{}');
+		expect(body).toEqual({ kmsId: 'kms_1', name: 'Treasury' });
+		expect(captured?.body).not.toContain('do not send me');
+	});
+
+	it('strips unknown keys out of a query string', async () => {
+		nextResponseBody = {
+			items: [],
+			meta: { itemCount: 0, itemsPerPage: 100, currentPage: 0 },
+		};
+
+		await Wallet.list(ctx, {
+			limit: 5,
+			secretFilter: 'leak',
+		} as unknown as Parameters<typeof Wallet.list>[1]);
+
+		expect(captured?.url).toContain('limit=5');
+		expect(captured?.url).not.toContain('secretFilter');
+		expect(captured?.url).not.toContain('leak');
+	});
+
+	it('applies the schema default for `params` rather than omitting it', async () => {
+		nextResponseBody = {
+			response: '1',
+			params: [],
+			functionName: 'totalSupply',
+			address: '0xabc',
+			network: 'polygon-mumbai',
+		};
+
+		await SmartContract.read(ctx, {
+			network: 'polygon-mumbai',
+			address: '0xabc',
+			functionName: 'totalSupply',
+		} as unknown as Parameters<typeof SmartContract.read>[1]);
+
+		expect(JSON.parse(captured?.body ?? '{}')).toEqual({
+			functionName: 'totalSupply',
+			params: [],
+		});
+	});
+
+	it('keeps path/query fields out of the smartContract.call body after parsing', async () => {
+		nextResponseBody = TX_FIXTURE;
+
+		await SmartContract.call(ctx, {
+			network: 'polygon-mumbai',
+			address: '0xabc',
+			functionName: 'mint',
+			params: ['1'],
+			signerWallet: '0x298',
+			simulate: true,
+			bogus: 'nope',
+		} as unknown as Parameters<typeof SmartContract.call>[1]);
+
+		const body = JSON.parse(captured?.body ?? '{}');
+		expect(body).toEqual({
+			functionName: 'mint',
+			params: ['1'],
+			signerWallet: '0x298',
+		});
+		expect(captured?.url).toContain('simulate=true');
+		expect(captured?.body).not.toContain('bogus');
+	});
+
+	it('a validation failure is not retried (no side-effect replay)', async () => {
+		const zodish = new Error('Invalid input');
+
+		expect(errorHandlers.SERVER_ERROR.match(zodish)).toBe(false);
+		expect(errorHandlers.RATE_LIMIT_ERROR.match(zodish)).toBe(false);
+		await expect(errorHandlers.DEFAULT.handler()).resolves.toEqual({
+			maxRetries: 0,
+		});
+	});
+});

--- a/packages/starton/client.ts
+++ b/packages/starton/client.ts
@@ -43,8 +43,8 @@ export function encodeStartonPathSegment(value: string): string {
  * `corsair/http` retries a request internally when it sees HTTP 429 — three
  * extra attempts by default. That is correct for reads, but a rate-limited
  * write that Starton had already begun processing would be replayed, and
- * Starton offers no idempotency key to make that safe. Callers that broadcast
- * a blockchain transaction pass `replayable: false` to switch it off.
+ * Starton offers no idempotency key to make that safe, so replay defaults to
+ * off for every method except GET.
  */
 const NO_AUTOMATIC_REPLAY: RateLimitConfig = {
 	enabled: false,
@@ -64,9 +64,13 @@ export type StartonRequestOptions = {
 	body?: unknown;
 	query?: Record<string, string | number | boolean | undefined>;
 	/**
-	 * Whether this request may be re-sent automatically after a 429. Defaults to
-	 * `true`; set it to `false` for any call that can create a blockchain
-	 * transaction or otherwise duplicate a side effect.
+	 * Whether this request may be re-sent automatically after a 429.
+	 *
+	 * Defaults to `true` for GET and `false` for every other method, so a new
+	 * write endpoint is safe by default and has to opt in to replay explicitly.
+	 * Set it to `true` only for a non-GET request that provably has no side
+	 * effect — Starton's `read` endpoint is a POST purely because it takes the
+	 * function arguments in a body.
 	 */
 	replayable?: boolean;
 };
@@ -76,7 +80,10 @@ export async function makeStartonRequest<T>(
 	apiKey: string,
 	options: StartonRequestOptions = {},
 ): Promise<T> {
-	const { method = 'GET', body, query, replayable = true } = options;
+	const { method = 'GET', body, query } = options;
+	// Fail closed: anything that is not a GET is treated as a write unless the
+	// caller has explicitly established that replaying it is harmless.
+	const replayable = options.replayable ?? method === 'GET';
 
 	const config: OpenAPIConfig = {
 		BASE: STARTON_API_BASE,

--- a/packages/starton/client.ts
+++ b/packages/starton/client.ts
@@ -1,4 +1,8 @@
-import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import type {
+	ApiRequestOptions,
+	OpenAPIConfig,
+	RateLimitConfig,
+} from 'corsair/http';
 import { ApiError, request } from 'corsair/http';
 
 /**
@@ -35,10 +39,36 @@ export function encodeStartonPathSegment(value: string): string {
 	return encodeURIComponent(value);
 }
 
+/**
+ * `corsair/http` retries a request internally when it sees HTTP 429 — three
+ * extra attempts by default. That is correct for reads, but a rate-limited
+ * write that Starton had already begun processing would be replayed, and
+ * Starton offers no idempotency key to make that safe. Callers that broadcast
+ * a blockchain transaction pass `replayable: false` to switch it off.
+ */
+const NO_AUTOMATIC_REPLAY: RateLimitConfig = {
+	enabled: false,
+	maxRetries: 0,
+	initialRetryDelay: 0,
+	backoffMultiplier: 1,
+	headerNames: {
+		retryAfter: 'retry-after',
+		resetTime: 'x-ratelimit-reset',
+		remaining: 'x-ratelimit-remaining',
+		limit: 'x-ratelimit-limit',
+	},
+};
+
 export type StartonRequestOptions = {
 	method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 	body?: unknown;
 	query?: Record<string, string | number | boolean | undefined>;
+	/**
+	 * Whether this request may be re-sent automatically after a 429. Defaults to
+	 * `true`; set it to `false` for any call that can create a blockchain
+	 * transaction or otherwise duplicate a side effect.
+	 */
+	replayable?: boolean;
 };
 
 export async function makeStartonRequest<T>(
@@ -46,7 +76,7 @@ export async function makeStartonRequest<T>(
 	apiKey: string,
 	options: StartonRequestOptions = {},
 ): Promise<T> {
-	const { method = 'GET', body, query } = options;
+	const { method = 'GET', body, query, replayable = true } = options;
 
 	const config: OpenAPIConfig = {
 		BASE: STARTON_API_BASE,
@@ -68,7 +98,11 @@ export async function makeStartonRequest<T>(
 	};
 
 	try {
-		return await request<T>(config, requestOptions);
+		return await request<T>(
+			config,
+			requestOptions,
+			replayable ? undefined : { rateLimitConfig: NO_AUTOMATIC_REPLAY },
+		);
 	} catch (error) {
 		// Preserve ApiError so the plugin error handlers can inspect `status`
 		// and `retryAfter` (rate limiting, auth failures, blockchain errors).

--- a/packages/starton/client.ts
+++ b/packages/starton/client.ts
@@ -1,0 +1,83 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+
+/**
+ * Raised for failures that never reached Starton (transport errors, invalid
+ * path segments). HTTP failures surface as `ApiError` so the error handlers
+ * can read `status`, `body.errorCode` and the rate-limit headers.
+ */
+export class StartonAPIError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'StartonAPIError';
+	}
+}
+
+/**
+ * Starton REST API base (v3).
+ * https://github.com/starton-io/starton-openapi (servers[0].url)
+ */
+const STARTON_API_BASE = 'https://api.starton.com';
+
+/**
+ * Starton authenticates with an API key sent as the `x-api-key` header.
+ * https://github.com/starton-io/starton-openapi (components.securitySchemes.api-key)
+ */
+function buildHeaders(apiKey: string): Record<string, string> {
+	return { 'x-api-key': apiKey };
+}
+
+/** Reject traversal segments and encode caller-supplied path pieces (network, address, id). */
+export function encodeStartonPathSegment(value: string): string {
+	if (value === '.' || value === '..' || value.length === 0) {
+		throw new StartonAPIError('Invalid path segment');
+	}
+	return encodeURIComponent(value);
+}
+
+export type StartonRequestOptions = {
+	method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+	body?: unknown;
+	query?: Record<string, string | number | boolean | undefined>;
+};
+
+export async function makeStartonRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	options: StartonRequestOptions = {},
+): Promise<T> {
+	const { method = 'GET', body, query } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: STARTON_API_BASE,
+		VERSION: '3',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: undefined,
+		HEADERS: buildHeaders(apiKey),
+	};
+
+	const hasBody = body !== undefined && method !== 'GET';
+
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint,
+		query,
+		body: hasBody ? body : undefined,
+		mediaType: hasBody ? 'application/json; charset=utf-8' : undefined,
+	};
+
+	try {
+		return await request<T>(config, requestOptions);
+	} catch (error) {
+		// Preserve ApiError so the plugin error handlers can inspect `status`
+		// and `retryAfter` (rate limiting, auth failures, blockchain errors).
+		if (error instanceof ApiError) {
+			throw error;
+		}
+		if (error instanceof Error) {
+			throw new StartonAPIError(error.message);
+		}
+		throw new StartonAPIError('Unknown error');
+	}
+}

--- a/packages/starton/endpoints/index.ts
+++ b/packages/starton/endpoints/index.ts
@@ -1,6 +1,6 @@
-import { create, list } from './wallet';
 import { call, deployFromTemplate, read } from './smart-contract';
 import { get } from './transaction';
+import { create, list } from './wallet';
 
 export const Wallet = { create, list };
 

--- a/packages/starton/endpoints/index.ts
+++ b/packages/starton/endpoints/index.ts
@@ -1,0 +1,11 @@
+import { create, list } from './wallet';
+import { call, deployFromTemplate, read } from './smart-contract';
+import { get } from './transaction';
+
+export const Wallet = { create, list };
+
+export const SmartContract = { deployFromTemplate, call, read };
+
+export const Transaction = { get };
+
+export * from './types';

--- a/packages/starton/endpoints/smart-contract.ts
+++ b/packages/starton/endpoints/smart-contract.ts
@@ -1,11 +1,28 @@
 import { logEventFromContext } from 'corsair/core';
 import type { StartonEndpoints } from '..';
 import { encodeStartonPathSegment, makeStartonRequest } from '../client';
-import { StartonEndpointOutputSchemas } from './types';
+import {
+	StartonEndpointInputSchemas,
+	StartonEndpointOutputSchemas,
+} from './types';
 
+/**
+ * Deploy a smart contract from a Starton Library template (ERC20, ERC721, ...).
+ * Returns the created contract together with the deployment transaction; the
+ * transaction is asynchronous — poll `transaction.get` for its final state.
+ *
+ * Pass `simulate: true` to estimate gas without broadcasting.
+ *
+ * API: POST /v3/smart-contract/from-template?simulate=  (body:
+ * DeployFromTemplateDto) -> { smartContract, transaction }
+ */
 export const deployFromTemplate: StartonEndpoints['smartContractDeployFromTemplate'] =
 	async (ctx, input) => {
-		const { simulate, ...body } = input;
+		// Validate before the request: this rejects bad input without a network
+		// round trip, applies the documented `params` default, and strips unknown
+		// keys so only DeployFromTemplateDto fields reach Starton.
+		const { simulate, ...body } =
+			StartonEndpointInputSchemas.smartContractDeployFromTemplate.parse(input);
 		const response = await makeStartonRequest<unknown>(
 			'v3/smart-contract/from-template',
 			ctx.key,
@@ -21,20 +38,29 @@ export const deployFromTemplate: StartonEndpoints['smartContractDeployFromTempla
 			ctx,
 			'starton.smartContract.deployFromTemplate',
 			{
-				network: input.network,
-				templateId: input.templateId,
-				name: input.name,
+				network: body.network,
+				templateId: body.templateId,
+				name: body.name,
 			},
 			'completed',
 		);
 		return deployment;
 	};
 
+/**
+ * Execute a state-changing function on a deployed contract. Returns the relayer
+ * Transaction; it is asynchronous, so poll `transaction.get` for the final
+ * state. Pass `simulate: true` to estimate gas without broadcasting.
+ *
+ * API: POST /v3/smart-contract/{network}/{address}/call?simulate=
+ * (body: CallDto) -> Transaction
+ */
 export const call: StartonEndpoints['smartContractCall'] = async (
 	ctx,
 	input,
 ) => {
-	const { network, address, simulate, ...body } = input;
+	const { network, address, simulate, ...body } =
+		StartonEndpointInputSchemas.smartContractCall.parse(input);
 	const response = await makeStartonRequest<unknown>(
 		`v3/smart-contract/${encodeStartonPathSegment(network)}/${encodeStartonPathSegment(address)}/call`,
 		ctx.key,
@@ -46,17 +72,25 @@ export const call: StartonEndpoints['smartContractCall'] = async (
 	await logEventFromContext(
 		ctx,
 		'starton.smartContract.call',
-		{ network, address, functionName: input.functionName },
+		{ network, address, functionName: body.functionName },
 		'completed',
 	);
 	return transaction;
 };
 
+/**
+ * Call a read-only (view) function on a deployed contract. Returns the decoded
+ * value immediately; nothing is broadcast and no gas is spent.
+ *
+ * API: POST /v3/smart-contract/{network}/{address}/read
+ * (body: ReadDto) -> ReadSmartContractResponse
+ */
 export const read: StartonEndpoints['smartContractRead'] = async (
 	ctx,
 	input,
 ) => {
-	const { network, address, ...body } = input;
+	const { network, address, ...body } =
+		StartonEndpointInputSchemas.smartContractRead.parse(input);
 	const response = await makeStartonRequest<unknown>(
 		`v3/smart-contract/${encodeStartonPathSegment(network)}/${encodeStartonPathSegment(address)}/read`,
 		ctx.key,
@@ -68,7 +102,7 @@ export const read: StartonEndpoints['smartContractRead'] = async (
 	await logEventFromContext(
 		ctx,
 		'starton.smartContract.read',
-		{ network, address, functionName: input.functionName },
+		{ network, address, functionName: body.functionName },
 		'completed',
 	);
 	return result;

--- a/packages/starton/endpoints/smart-contract.ts
+++ b/packages/starton/endpoints/smart-contract.ts
@@ -1,0 +1,57 @@
+import { logEventFromContext } from 'corsair/core';
+import type { StartonEndpoints } from '..';
+import { encodeStartonPathSegment, makeStartonRequest } from '../client';
+import type { StartonTransaction } from '../schema/database';
+import type {
+	SmartContractDeployFromTemplateResponse,
+	SmartContractReadResponse,
+} from './types';
+
+export const deployFromTemplate: StartonEndpoints['smartContractDeployFromTemplate'] =
+	async (ctx, input) => {
+		const { simulate, ...body } = input;
+		const response = await makeStartonRequest<SmartContractDeployFromTemplateResponse>(
+			'v3/smart-contract/from-template',
+			ctx.key,
+			{ method: 'POST', body, query: { simulate } },
+		);
+		await logEventFromContext(
+			ctx,
+			'starton.smartContract.deployFromTemplate',
+			{ network: input.network, templateId: input.templateId, name: input.name },
+			'completed',
+		);
+		return response;
+	};
+
+export const call: StartonEndpoints['smartContractCall'] = async (ctx, input) => {
+	const { network, address, simulate, ...body } = input;
+	const response = await makeStartonRequest<StartonTransaction>(
+		`v3/smart-contract/${encodeStartonPathSegment(network)}/${encodeStartonPathSegment(address)}/call`,
+		ctx.key,
+		{ method: 'POST', body, query: { simulate } },
+	);
+	await logEventFromContext(
+		ctx,
+		'starton.smartContract.call',
+		{ network, address, functionName: input.functionName },
+		'completed',
+	);
+	return response;
+};
+
+export const read: StartonEndpoints['smartContractRead'] = async (ctx, input) => {
+	const { network, address, ...body } = input;
+	const response = await makeStartonRequest<SmartContractReadResponse>(
+		`v3/smart-contract/${encodeStartonPathSegment(network)}/${encodeStartonPathSegment(address)}/read`,
+		ctx.key,
+		{ method: 'POST', body },
+	);
+	await logEventFromContext(
+		ctx,
+		'starton.smartContract.read',
+		{ network, address, functionName: input.functionName },
+		'completed',
+	);
+	return response;
+};

--- a/packages/starton/endpoints/smart-contract.ts
+++ b/packages/starton/endpoints/smart-contract.ts
@@ -60,7 +60,9 @@ export const read: StartonEndpoints['smartContractRead'] = async (
 	const response = await makeStartonRequest<unknown>(
 		`v3/smart-contract/${encodeStartonPathSegment(network)}/${encodeStartonPathSegment(address)}/read`,
 		ctx.key,
-		{ method: 'POST', body },
+		// A POST only because Starton takes the call arguments in a body; it
+		// never broadcasts a transaction, so replaying it is harmless.
+		{ method: 'POST', body, replayable: true },
 	);
 	const result = StartonEndpointOutputSchemas.smartContractRead.parse(response);
 	await logEventFromContext(

--- a/packages/starton/endpoints/smart-contract.ts
+++ b/packages/starton/endpoints/smart-contract.ts
@@ -1,57 +1,73 @@
 import { logEventFromContext } from 'corsair/core';
 import type { StartonEndpoints } from '..';
 import { encodeStartonPathSegment, makeStartonRequest } from '../client';
-import type { StartonTransaction } from '../schema/database';
-import type {
-	SmartContractDeployFromTemplateResponse,
-	SmartContractReadResponse,
-} from './types';
+import { StartonEndpointOutputSchemas } from './types';
 
 export const deployFromTemplate: StartonEndpoints['smartContractDeployFromTemplate'] =
 	async (ctx, input) => {
 		const { simulate, ...body } = input;
-		const response = await makeStartonRequest<SmartContractDeployFromTemplateResponse>(
+		const response = await makeStartonRequest<unknown>(
 			'v3/smart-contract/from-template',
 			ctx.key,
-			{ method: 'POST', body, query: { simulate } },
+			// Deploys a contract on-chain — never replay it.
+			{ method: 'POST', body, query: { simulate }, replayable: false },
 		);
+		// Validate the provider payload before returning it as typed data.
+		const deployment =
+			StartonEndpointOutputSchemas.smartContractDeployFromTemplate.parse(
+				response,
+			);
 		await logEventFromContext(
 			ctx,
 			'starton.smartContract.deployFromTemplate',
-			{ network: input.network, templateId: input.templateId, name: input.name },
+			{
+				network: input.network,
+				templateId: input.templateId,
+				name: input.name,
+			},
 			'completed',
 		);
-		return response;
+		return deployment;
 	};
 
-export const call: StartonEndpoints['smartContractCall'] = async (ctx, input) => {
+export const call: StartonEndpoints['smartContractCall'] = async (
+	ctx,
+	input,
+) => {
 	const { network, address, simulate, ...body } = input;
-	const response = await makeStartonRequest<StartonTransaction>(
+	const response = await makeStartonRequest<unknown>(
 		`v3/smart-contract/${encodeStartonPathSegment(network)}/${encodeStartonPathSegment(address)}/call`,
 		ctx.key,
-		{ method: 'POST', body, query: { simulate } },
+		// Broadcasts a state-changing transaction — never replay it.
+		{ method: 'POST', body, query: { simulate }, replayable: false },
 	);
+	const transaction =
+		StartonEndpointOutputSchemas.smartContractCall.parse(response);
 	await logEventFromContext(
 		ctx,
 		'starton.smartContract.call',
 		{ network, address, functionName: input.functionName },
 		'completed',
 	);
-	return response;
+	return transaction;
 };
 
-export const read: StartonEndpoints['smartContractRead'] = async (ctx, input) => {
+export const read: StartonEndpoints['smartContractRead'] = async (
+	ctx,
+	input,
+) => {
 	const { network, address, ...body } = input;
-	const response = await makeStartonRequest<SmartContractReadResponse>(
+	const response = await makeStartonRequest<unknown>(
 		`v3/smart-contract/${encodeStartonPathSegment(network)}/${encodeStartonPathSegment(address)}/read`,
 		ctx.key,
 		{ method: 'POST', body },
 	);
+	const result = StartonEndpointOutputSchemas.smartContractRead.parse(response);
 	await logEventFromContext(
 		ctx,
 		'starton.smartContract.read',
 		{ network, address, functionName: input.functionName },
 		'completed',
 	);
-	return response;
+	return result;
 };

--- a/packages/starton/endpoints/transaction.ts
+++ b/packages/starton/endpoints/transaction.ts
@@ -1,11 +1,25 @@
 import { logEventFromContext } from 'corsair/core';
 import type { StartonEndpoints } from '..';
 import { encodeStartonPathSegment, makeStartonRequest } from '../client';
-import { StartonEndpointOutputSchemas } from './types';
+import {
+	StartonEndpointInputSchemas,
+	StartonEndpointOutputSchemas,
+} from './types';
 
+/**
+ * Fetch a relayer transaction by its Starton id, including its lifecycle
+ * `status`, coarse `state` (PENDING / SUCCESS / ERROR / MANUAL_ACTION_REQUIRED)
+ * and the `logs` trail. Use this to follow a `call` or `deployFromTemplate`
+ * through to confirmation.
+ *
+ * API: GET /v3/transaction/{id} -> Transaction
+ */
 export const get: StartonEndpoints['transactionGet'] = async (ctx, input) => {
+	// Validate before the request so a malformed id fails locally rather than
+	// being interpolated into the URL.
+	const { id } = StartonEndpointInputSchemas.transactionGet.parse(input);
 	const response = await makeStartonRequest<unknown>(
-		`v3/transaction/${encodeStartonPathSegment(input.id)}`,
+		`v3/transaction/${encodeStartonPathSegment(id)}`,
 		ctx.key,
 		{ method: 'GET' },
 	);
@@ -15,7 +29,7 @@ export const get: StartonEndpoints['transactionGet'] = async (ctx, input) => {
 	await logEventFromContext(
 		ctx,
 		'starton.transaction.get',
-		{ id: input.id, status: transaction.status },
+		{ id, status: transaction.status },
 		'completed',
 	);
 	return transaction;

--- a/packages/starton/endpoints/transaction.ts
+++ b/packages/starton/endpoints/transaction.ts
@@ -1,0 +1,19 @@
+import { logEventFromContext } from 'corsair/core';
+import type { StartonEndpoints } from '..';
+import { encodeStartonPathSegment, makeStartonRequest } from '../client';
+import type { StartonTransaction } from '../schema/database';
+
+export const get: StartonEndpoints['transactionGet'] = async (ctx, input) => {
+	const response = await makeStartonRequest<StartonTransaction>(
+		`v3/transaction/${encodeStartonPathSegment(input.id)}`,
+		ctx.key,
+		{ method: 'GET' },
+	);
+	await logEventFromContext(
+		ctx,
+		'starton.transaction.get',
+		{ id: input.id, status: response.status },
+		'completed',
+	);
+	return response;
+};

--- a/packages/starton/endpoints/transaction.ts
+++ b/packages/starton/endpoints/transaction.ts
@@ -1,19 +1,22 @@
 import { logEventFromContext } from 'corsair/core';
 import type { StartonEndpoints } from '..';
 import { encodeStartonPathSegment, makeStartonRequest } from '../client';
-import type { StartonTransaction } from '../schema/database';
+import { StartonEndpointOutputSchemas } from './types';
 
 export const get: StartonEndpoints['transactionGet'] = async (ctx, input) => {
-	const response = await makeStartonRequest<StartonTransaction>(
+	const response = await makeStartonRequest<unknown>(
 		`v3/transaction/${encodeStartonPathSegment(input.id)}`,
 		ctx.key,
 		{ method: 'GET' },
 	);
+	// Validate the provider payload before returning it as typed data.
+	const transaction =
+		StartonEndpointOutputSchemas.transactionGet.parse(response);
 	await logEventFromContext(
 		ctx,
 		'starton.transaction.get',
-		{ id: input.id, status: response.status },
+		{ id: input.id, status: transaction.status },
 		'completed',
 	);
-	return response;
+	return transaction;
 };

--- a/packages/starton/endpoints/types.ts
+++ b/packages/starton/endpoints/types.ts
@@ -1,0 +1,199 @@
+import { z } from 'zod';
+import {
+	StartonCustomGas,
+	StartonPaginationMeta,
+	StartonSmartContract,
+	StartonSmartContractUI,
+	StartonSpeed,
+	StartonTransaction,
+	StartonWallet,
+} from '../schema/database';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared primitives
+// ─────────────────────────────────────────────────────────────────────────────
+
+const JsonObject = z.record(z.string(), z.unknown());
+
+/** Smart contract constructor/function argument: string | number | boolean | object. */
+const ContractParam = z.union([
+	z.string(),
+	z.number(),
+	z.boolean(),
+	JsonObject,
+]);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wallet — POST/GET /v3/kms/wallet
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Official: components.schemas.CreateWalletDto
+ * `kmsId` is required — it identifies the Key Management System (e.g. the
+ * project's default Starton-managed KMS) the wallet's private key is stored
+ * under. Retrieve available KMS ids via the Starton dashboard or `GET /v3/kms`.
+ */
+const WalletCreateInputSchema = z.object({
+	kmsId: z.string(),
+	name: z.string().optional(),
+	description: z.string().optional(),
+	metadata: JsonObject.optional(),
+});
+export type WalletCreateInput = z.infer<typeof WalletCreateInputSchema>;
+
+/**
+ * Official: GET /v3/kms/wallet query parameters.
+ */
+const WalletListInputSchema = z.object({
+	page: z.number().int().min(0).optional(),
+	limit: z.number().int().min(1).max(2500).optional(),
+	/** Spec pattern: `^[\w\-\s]+$` — the API rejects other characters with a 400. */
+	name: z
+		.string()
+		.regex(/^[\w\-\s]+$/)
+		.optional(),
+	kmsId: z.string().optional(),
+});
+export type WalletListInput = z.infer<typeof WalletListInputSchema>;
+
+const WalletListResponseSchema = z.object({
+	items: z.array(StartonWallet),
+	meta: StartonPaginationMeta,
+});
+export type WalletListResponse = z.infer<typeof WalletListResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Smart Contract — POST /v3/smart-contract/from-template,
+// POST /v3/smart-contract/{network}/{address}/call,
+// POST /v3/smart-contract/{network}/{address}/read
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Official: components.schemas.DeployFromTemplateDto
+ */
+const SmartContractDeployFromTemplateInputSchema = z.object({
+	network: z.string(),
+	signerWallet: z.string(),
+	templateId: z.string(),
+	name: z.string().max(255),
+	params: z.array(ContractParam).default([]),
+	description: z.string().optional(),
+	gasLimit: z.string().optional(),
+	speed: StartonSpeed.optional(),
+	customGas: StartonCustomGas.optional(),
+	nonce: z.number().optional(),
+	value: z.string().optional(),
+	metadata: JsonObject.optional(),
+	uiData: StartonSmartContractUI.nullish(),
+	/** Estimate gas instead of broadcasting. */
+	simulate: z.boolean().optional(),
+});
+export type SmartContractDeployFromTemplateInput = z.infer<
+	typeof SmartContractDeployFromTemplateInputSchema
+>;
+
+const SmartContractDeployFromTemplateResponseSchema = z.object({
+	smartContract: StartonSmartContract,
+	transaction: StartonTransaction,
+});
+export type SmartContractDeployFromTemplateResponse = z.infer<
+	typeof SmartContractDeployFromTemplateResponseSchema
+>;
+
+/**
+ * Official: components.schemas.CallDto
+ */
+const SmartContractCallInputSchema = z.object({
+	network: z.string(),
+	address: z.string(),
+	functionName: z.string(),
+	params: z.array(ContractParam).default([]),
+	signerWallet: z.string(),
+	speed: StartonSpeed.optional(),
+	customGas: StartonCustomGas.optional(),
+	gasLimit: z.string().optional(),
+	nonce: z.number().optional(),
+	value: z.string().optional(),
+	/** Estimate gas instead of broadcasting. */
+	simulate: z.boolean().optional(),
+});
+export type SmartContractCallInput = z.infer<
+	typeof SmartContractCallInputSchema
+>;
+
+/**
+ * Official: components.schemas.ReadDto
+ */
+const SmartContractReadInputSchema = z.object({
+	network: z.string(),
+	address: z.string(),
+	functionName: z.string(),
+	params: z.array(ContractParam).default([]),
+});
+export type SmartContractReadInput = z.infer<
+	typeof SmartContractReadInputSchema
+>;
+
+/**
+ * Official: components.schemas.ReadSmartContractResponse
+ */
+const SmartContractReadResponseSchema = z.object({
+	response: z.union([
+		z.string(),
+		z.number(),
+		z.boolean(),
+		JsonObject,
+		z.array(z.unknown()),
+	]),
+	params: z.array(ContractParam),
+	functionName: z.string(),
+	address: z.string(),
+	network: z.string(),
+});
+export type SmartContractReadResponse = z.infer<
+	typeof SmartContractReadResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Transaction — GET /v3/transaction/{id}
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TransactionGetInputSchema = z.object({
+	id: z.string(),
+});
+export type TransactionGetInput = z.infer<typeof TransactionGetInputSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint schema maps
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const StartonEndpointInputSchemas = {
+	walletCreate: WalletCreateInputSchema,
+	walletList: WalletListInputSchema,
+	smartContractDeployFromTemplate: SmartContractDeployFromTemplateInputSchema,
+	smartContractCall: SmartContractCallInputSchema,
+	smartContractRead: SmartContractReadInputSchema,
+	transactionGet: TransactionGetInputSchema,
+} as const;
+
+export const StartonEndpointOutputSchemas = {
+	walletCreate: StartonWallet,
+	walletList: WalletListResponseSchema,
+	smartContractDeployFromTemplate:
+		SmartContractDeployFromTemplateResponseSchema,
+	smartContractCall: StartonTransaction,
+	smartContractRead: SmartContractReadResponseSchema,
+	transactionGet: StartonTransaction,
+} as const;
+
+export type StartonEndpointInputs = {
+	[K in keyof typeof StartonEndpointInputSchemas]: z.infer<
+		(typeof StartonEndpointInputSchemas)[K]
+	>;
+};
+
+export type StartonEndpointOutputs = {
+	[K in keyof typeof StartonEndpointOutputSchemas]: z.infer<
+		(typeof StartonEndpointOutputSchemas)[K]
+	>;
+};

--- a/packages/starton/endpoints/types.ts
+++ b/packages/starton/endpoints/types.ts
@@ -34,10 +34,19 @@ const ContractParam = z.union([
  * under. Retrieve available KMS ids via the Starton dashboard or `GET /v3/kms`.
  */
 const WalletCreateInputSchema = z.object({
-	kmsId: z.string(),
-	name: z.string().optional(),
-	description: z.string().optional(),
-	metadata: JsonObject.optional(),
+	kmsId: z
+		.string()
+		.describe(
+			'Id of the Key Management System the wallet key is stored under. Required. List available KMS via GET /v3/kms.',
+		),
+	name: z.string().optional().describe('Wallet name on Starton (off-chain).'),
+	description: z
+		.string()
+		.optional()
+		.describe('Wallet description on Starton (off-chain).'),
+	metadata: JsonObject.optional().describe(
+		'Arbitrary JSON stored alongside the wallet.',
+	),
 });
 export type WalletCreateInput = z.infer<typeof WalletCreateInputSchema>;
 
@@ -45,14 +54,30 @@ export type WalletCreateInput = z.infer<typeof WalletCreateInputSchema>;
  * Official: GET /v3/kms/wallet query parameters.
  */
 const WalletListInputSchema = z.object({
-	page: z.number().int().min(0).optional(),
-	limit: z.number().int().min(1).max(2500).optional(),
+	page: z
+		.number()
+		.int()
+		.min(0)
+		.optional()
+		.describe(
+			'Number of returned page. By default the returned page is the first.',
+		),
+	limit: z
+		.number()
+		.int()
+		.min(1)
+		.max(2500)
+		.optional()
+		.describe(
+			'Number of entities returned on each page. Defaults to 100, maximum 2500.',
+		),
 	/** Spec pattern: `^[\w\-\s]+$` — the API rejects other characters with a 400. */
 	name: z
 		.string()
 		.regex(/^[\w\-\s]+$/)
-		.optional(),
-	kmsId: z.string().optional(),
+		.optional()
+		.describe('Filter by wallet name. Letters, digits, -, _ and spaces only.'),
+	kmsId: z.string().optional().describe('Filter by Key Management System id.'),
 });
 export type WalletListInput = z.infer<typeof WalletListInputSchema>;
 
@@ -72,21 +97,66 @@ export type WalletListResponse = z.infer<typeof WalletListResponseSchema>;
  * Official: components.schemas.DeployFromTemplateDto
  */
 const SmartContractDeployFromTemplateInputSchema = z.object({
-	network: z.string(),
-	signerWallet: z.string(),
-	templateId: z.string(),
-	name: z.string().max(255),
-	params: z.array(ContractParam).default([]),
-	description: z.string().optional(),
-	gasLimit: z.string().optional(),
-	speed: StartonSpeed.optional(),
-	customGas: StartonCustomGas.optional(),
-	nonce: z.number().optional(),
-	value: z.string().optional(),
-	metadata: JsonObject.optional(),
-	uiData: StartonSmartContractUI.nullish(),
-	/** Estimate gas instead of broadcasting. */
-	simulate: z.boolean().optional(),
+	network: z
+		.string()
+		.describe(
+			'Network of the smart contract, e.g. `polygon-mumbai`. List via GET /v3/network.',
+		),
+	signerWallet: z
+		.string()
+		.describe(
+			'Address of the KMS wallet that signs and pays for the transaction.',
+		),
+	templateId: z
+		.string()
+		.describe(
+			'Starton Library template to deploy, e.g. `ERC20_META_TRANSACTION`. List via GET /v3/smart-contract-template.',
+		),
+	name: z
+		.string()
+		.max(255)
+		.describe('Contract name on Starton (off-chain). Max 255 characters.'),
+	params: z
+		.array(ContractParam)
+		.default([])
+		.describe(
+			'Smart contract constructor parameters, in the order the template declares them.',
+		),
+	description: z
+		.string()
+		.optional()
+		.describe('Contract description on Starton (off-chain).'),
+	gasLimit: z.string().optional().describe('Optional gas limit.'),
+	speed: StartonSpeed.optional().describe(
+		'Gas speed. Defaults to `average`; use `custom` to supply customGas.',
+	),
+	customGas: StartonCustomGas.optional().describe(
+		'Custom gas settings. Only used when speed is set to `custom`.',
+	),
+	nonce: z
+		.number()
+		.optional()
+		.describe(
+			'Manual nonce. If set, the Starton relayer will not assign one automatically.',
+		),
+	value: z
+		.string()
+		.optional()
+		.describe(
+			'Native-currency value sent with the deployment, in wei. For payable constructors.',
+		),
+	metadata: JsonObject.optional().describe(
+		'Arbitrary JSON stored alongside the contract.',
+	),
+	uiData: StartonSmartContractUI.nullish().describe(
+		'Dashboard display metadata Starton stores with the contract.',
+	),
+	simulate: z
+		.boolean()
+		.optional()
+		.describe(
+			'Simulate only: estimates gas and does NOT broadcast a transaction.',
+		),
 });
 export type SmartContractDeployFromTemplateInput = z.infer<
 	typeof SmartContractDeployFromTemplateInputSchema
@@ -104,18 +174,49 @@ export type SmartContractDeployFromTemplateResponse = z.infer<
  * Official: components.schemas.CallDto
  */
 const SmartContractCallInputSchema = z.object({
-	network: z.string(),
-	address: z.string(),
-	functionName: z.string(),
-	params: z.array(ContractParam).default([]),
-	signerWallet: z.string(),
-	speed: StartonSpeed.optional(),
-	customGas: StartonCustomGas.optional(),
-	gasLimit: z.string().optional(),
-	nonce: z.number().optional(),
-	value: z.string().optional(),
-	/** Estimate gas instead of broadcasting. */
-	simulate: z.boolean().optional(),
+	network: z
+		.string()
+		.describe(
+			'Network of the smart contract, e.g. `polygon-mumbai`. List via GET /v3/network.',
+		),
+	address: z.string().describe('Address of the deployed smart contract.'),
+	functionName: z
+		.string()
+		.describe(
+			'Name of the contract function to execute. Must be state-changing; use smartContract.read for view functions.',
+		),
+	params: z
+		.array(ContractParam)
+		.default([])
+		.describe('Function arguments, in the order the ABI declares them.'),
+	signerWallet: z
+		.string()
+		.describe(
+			'Address of the KMS wallet that signs and pays for the transaction.',
+		),
+	speed: StartonSpeed.optional().describe(
+		'Gas speed. Defaults to `average`; use `custom` to supply customGas.',
+	),
+	customGas: StartonCustomGas.optional().describe(
+		'Custom gas settings. Only used when speed is set to `custom`.',
+	),
+	gasLimit: z.string().optional().describe('Optional gas limit.'),
+	nonce: z
+		.number()
+		.optional()
+		.describe(
+			'Manual nonce. If set, the Starton relayer will not assign one automatically.',
+		),
+	value: z
+		.string()
+		.optional()
+		.describe('Native-currency value sent with the call, in wei.'),
+	simulate: z
+		.boolean()
+		.optional()
+		.describe(
+			'Simulate only: estimates gas and does NOT broadcast a transaction.',
+		),
 });
 export type SmartContractCallInput = z.infer<
 	typeof SmartContractCallInputSchema
@@ -125,10 +226,19 @@ export type SmartContractCallInput = z.infer<
  * Official: components.schemas.ReadDto
  */
 const SmartContractReadInputSchema = z.object({
-	network: z.string(),
-	address: z.string(),
-	functionName: z.string(),
-	params: z.array(ContractParam).default([]),
+	network: z
+		.string()
+		.describe(
+			'Network of the smart contract, e.g. `polygon-mumbai`. List via GET /v3/network.',
+		),
+	address: z.string().describe('Address of the deployed smart contract.'),
+	functionName: z
+		.string()
+		.describe('Name of the read-only (view) contract function to call.'),
+	params: z
+		.array(ContractParam)
+		.default([])
+		.describe('Function arguments, in the order the ABI declares them.'),
 });
 export type SmartContractReadInput = z.infer<
 	typeof SmartContractReadInputSchema
@@ -159,7 +269,11 @@ export type SmartContractReadResponse = z.infer<
 // ─────────────────────────────────────────────────────────────────────────────
 
 const TransactionGetInputSchema = z.object({
-	id: z.string(),
+	id: z
+		.string()
+		.describe(
+			'Starton transaction id, as returned by smartContract.call or smartContract.deployFromTemplate.',
+		),
 });
 export type TransactionGetInput = z.infer<typeof TransactionGetInputSchema>;
 

--- a/packages/starton/endpoints/wallet.ts
+++ b/packages/starton/endpoints/wallet.ts
@@ -1,30 +1,52 @@
 import { logEventFromContext } from 'corsair/core';
 import type { StartonEndpoints } from '..';
 import { makeStartonRequest } from '../client';
-import { StartonEndpointOutputSchemas } from './types';
+import {
+	StartonEndpointInputSchemas,
+	StartonEndpointOutputSchemas,
+} from './types';
 
+/**
+ * Create a KMS-managed wallet. Starton stores the private key in the given KMS
+ * and returns the wallet's public address.
+ *
+ * API: POST /v3/kms/wallet  (body: CreateWalletDto, `kmsId` required)
+ * Spec: https://github.com/starton-io/starton-openapi
+ */
 export const create: StartonEndpoints['walletCreate'] = async (ctx, input) => {
+	// Validate before the request: this rejects bad input without a network
+	// round trip and strips unknown keys, so only documented CreateWalletDto
+	// fields reach Starton.
+	const body = StartonEndpointInputSchemas.walletCreate.parse(input);
 	const response = await makeStartonRequest<unknown>(
 		'v3/kms/wallet',
 		ctx.key,
 		// Provisions a new wallet on every success — never replay it.
-		{ method: 'POST', body: input, replayable: false },
+		{ method: 'POST', body, replayable: false },
 	);
 	// Validate the provider payload before returning it as typed data.
 	const wallet = StartonEndpointOutputSchemas.walletCreate.parse(response);
 	await logEventFromContext(
 		ctx,
 		'starton.wallet.create',
-		{ kmsId: input.kmsId, name: input.name },
+		{ kmsId: body.kmsId, name: body.name },
 		'completed',
 	);
 	return wallet;
 };
 
+/**
+ * List the project's KMS-managed wallets. Paginated via `page`/`limit`
+ * (limit defaults to 100, maximum 2500); filterable by `name` and `kmsId`.
+ *
+ * API: GET /v3/kms/wallet  -> { items, meta }
+ */
 export const list: StartonEndpoints['walletList'] = async (ctx, input) => {
+	// Parsing also keeps unknown keys out of the query string.
+	const query = StartonEndpointInputSchemas.walletList.parse(input);
 	const response = await makeStartonRequest<unknown>('v3/kms/wallet', ctx.key, {
 		method: 'GET',
-		query: { ...input },
+		query: { ...query },
 	});
 	const page = StartonEndpointOutputSchemas.walletList.parse(response);
 	await logEventFromContext(

--- a/packages/starton/endpoints/wallet.ts
+++ b/packages/starton/endpoints/wallet.ts
@@ -1,35 +1,37 @@
 import { logEventFromContext } from 'corsair/core';
 import type { StartonEndpoints } from '..';
 import { makeStartonRequest } from '../client';
-import type { StartonWallet } from '../schema/database';
-import type { WalletListResponse } from './types';
+import { StartonEndpointOutputSchemas } from './types';
 
 export const create: StartonEndpoints['walletCreate'] = async (ctx, input) => {
-	const response = await makeStartonRequest<StartonWallet>(
+	const response = await makeStartonRequest<unknown>(
 		'v3/kms/wallet',
 		ctx.key,
-		{ method: 'POST', body: input },
+		// Provisions a new wallet on every success — never replay it.
+		{ method: 'POST', body: input, replayable: false },
 	);
+	// Validate the provider payload before returning it as typed data.
+	const wallet = StartonEndpointOutputSchemas.walletCreate.parse(response);
 	await logEventFromContext(
 		ctx,
 		'starton.wallet.create',
 		{ kmsId: input.kmsId, name: input.name },
 		'completed',
 	);
-	return response;
+	return wallet;
 };
 
 export const list: StartonEndpoints['walletList'] = async (ctx, input) => {
-	const response = await makeStartonRequest<WalletListResponse>(
-		'v3/kms/wallet',
-		ctx.key,
-		{ method: 'GET', query: { ...input } },
-	);
+	const response = await makeStartonRequest<unknown>('v3/kms/wallet', ctx.key, {
+		method: 'GET',
+		query: { ...input },
+	});
+	const page = StartonEndpointOutputSchemas.walletList.parse(response);
 	await logEventFromContext(
 		ctx,
 		'starton.wallet.list',
-		{ count: response.items?.length ?? 0 },
+		{ count: page.items.length },
 		'completed',
 	);
-	return response;
+	return page;
 };

--- a/packages/starton/endpoints/wallet.ts
+++ b/packages/starton/endpoints/wallet.ts
@@ -1,0 +1,35 @@
+import { logEventFromContext } from 'corsair/core';
+import type { StartonEndpoints } from '..';
+import { makeStartonRequest } from '../client';
+import type { StartonWallet } from '../schema/database';
+import type { WalletListResponse } from './types';
+
+export const create: StartonEndpoints['walletCreate'] = async (ctx, input) => {
+	const response = await makeStartonRequest<StartonWallet>(
+		'v3/kms/wallet',
+		ctx.key,
+		{ method: 'POST', body: input },
+	);
+	await logEventFromContext(
+		ctx,
+		'starton.wallet.create',
+		{ kmsId: input.kmsId, name: input.name },
+		'completed',
+	);
+	return response;
+};
+
+export const list: StartonEndpoints['walletList'] = async (ctx, input) => {
+	const response = await makeStartonRequest<WalletListResponse>(
+		'v3/kms/wallet',
+		ctx.key,
+		{ method: 'GET', query: { ...input } },
+	);
+	await logEventFromContext(
+		ctx,
+		'starton.wallet.list',
+		{ count: response.items?.length ?? 0 },
+		'completed',
+	);
+	return response;
+};

--- a/packages/starton/error-handlers.ts
+++ b/packages/starton/error-handlers.ts
@@ -1,11 +1,15 @@
-import type { CorsairErrorHandler } from 'corsair/core';
+import type { CorsairErrorHandler, ErrorContext } from 'corsair/core';
 import { ApiError } from 'corsair/http';
+import { isNonIdempotentOperation } from './idempotency';
 
 /**
  * Starton documents per-plan rate limits (Free 50 req/min, Developer 100
  * req/min, Business up to 10000 req/min) in the OpenAPI `info.description`,
  * but declares no 429 response on any individual path. We therefore route on
  * the HTTP status and honour `Retry-After` when the gateway sends one.
+ *
+ * Retries are withheld entirely for the operations that broadcast a blockchain
+ * transaction — see `./idempotency.ts` for why replaying those is unsafe.
  * https://github.com/starton-io/starton-openapi
  */
 export const errorHandlers = {
@@ -15,7 +19,14 @@ export const errorHandlers = {
 			const msg = error.message.toLowerCase();
 			return msg.includes('rate_limited') || msg.includes('too many requests');
 		},
-		handler: async (error: Error) => {
+		handler: async (error: Error, context?: ErrorContext) => {
+			// `corsair/http` already retried this request up to 3 times before the
+			// error surfaced here. Replaying a transaction-producing write on top of
+			// that could broadcast it twice, so those operations get no further
+			// attempts.
+			if (context && isNonIdempotentOperation(context.operation)) {
+				return { maxRetries: 0 };
+			}
 			let retryAfterMs: number | undefined;
 			if (error instanceof ApiError && error.retryAfter !== undefined) {
 				retryAfterMs = error.retryAfter;
@@ -55,8 +66,19 @@ export const errorHandlers = {
 	SERVER_ERROR: {
 		match: (error: Error) =>
 			error instanceof ApiError && error.status >= 500 && error.status < 600,
-		handler: async () => ({ maxRetries: 3 }),
+		// A 5xx is ambiguous: Starton may have accepted and broadcast the
+		// transaction before the response failed. Reads are replayed; writes that
+		// touch the chain are surfaced to the caller instead of being duplicated.
+		handler: async (_error: Error, context?: ErrorContext) => {
+			if (context && isNonIdempotentOperation(context.operation)) {
+				return { maxRetries: 0 };
+			}
+			return { maxRetries: 3 };
+		},
 	},
+	// Transport failures (DNS, socket reset, timeout) never reach a typed
+	// ApiError. They are ambiguous for every write, and Corsair's default is
+	// already no-retry, so the safe behaviour is simply to surface them.
 	DEFAULT: {
 		match: () => true,
 		handler: async () => ({ maxRetries: 0 }),

--- a/packages/starton/error-handlers.ts
+++ b/packages/starton/error-handlers.ts
@@ -1,6 +1,6 @@
 import type { CorsairErrorHandler, ErrorContext } from 'corsair/core';
 import { ApiError } from 'corsair/http';
-import { isNonIdempotentOperation } from './idempotency';
+import { isRetryableOperation } from './idempotency';
 
 /**
  * Starton documents per-plan rate limits (Free 50 req/min, Developer 100
@@ -8,8 +8,9 @@ import { isNonIdempotentOperation } from './idempotency';
  * but declares no 429 response on any individual path. We therefore route on
  * the HTTP status and honour `Retry-After` when the gateway sends one.
  *
- * Retries are withheld entirely for the operations that broadcast a blockchain
- * transaction — see `./idempotency.ts` for why replaying those is unsafe.
+ * Retries are granted only to operations on the verified retry-safe allowlist
+ * in `./idempotency.ts`; everything else — including an unrecognised operation
+ * or a missing error context — is surfaced to the caller instead of replayed.
  * https://github.com/starton-io/starton-openapi
  */
 export const errorHandlers = {
@@ -22,9 +23,10 @@ export const errorHandlers = {
 		handler: async (error: Error, context?: ErrorContext) => {
 			// `corsair/http` already retried this request up to 3 times before the
 			// error surfaced here. Replaying a transaction-producing write on top of
-			// that could broadcast it twice, so those operations get no further
-			// attempts.
-			if (context && isNonIdempotentOperation(context.operation)) {
+			// that could broadcast it twice, so only operations on the verified
+			// retry-safe allowlist get further attempts — an absent or unrecognised
+			// operation fails closed.
+			if (!isRetryableOperation(context?.operation)) {
 				return { maxRetries: 0 };
 			}
 			let retryAfterMs: number | undefined;
@@ -70,7 +72,7 @@ export const errorHandlers = {
 		// transaction before the response failed. Reads are replayed; writes that
 		// touch the chain are surfaced to the caller instead of being duplicated.
 		handler: async (_error: Error, context?: ErrorContext) => {
-			if (context && isNonIdempotentOperation(context.operation)) {
+			if (!isRetryableOperation(context?.operation)) {
 				return { maxRetries: 0 };
 			}
 			return { maxRetries: 3 };

--- a/packages/starton/error-handlers.ts
+++ b/packages/starton/error-handlers.ts
@@ -1,0 +1,64 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+
+/**
+ * Starton documents per-plan rate limits (Free 50 req/min, Developer 100
+ * req/min, Business up to 10000 req/min) in the OpenAPI `info.description`,
+ * but declares no 429 response on any individual path. We therefore route on
+ * the HTTP status and honour `Retry-After` when the gateway sends one.
+ * https://github.com/starton-io/starton-openapi
+ */
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('too many requests');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (
+				error instanceof ApiError &&
+				(error.status === 401 || error.status === 403)
+			)
+				return true;
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('not_authenticated') ||
+				msg.includes('unauthorized') ||
+				msg.includes('forbidden')
+			);
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	// Blockchain/validation errors (bad ABI args, insufficient funds, gas price
+	// issues, could-not-find-resource, ...) are deterministic per the Starton
+	// spec's documented error codes — never retryable.
+	NOT_RETRYABLE_CLIENT_ERROR: {
+		match: (error: Error) =>
+			error instanceof ApiError &&
+			error.status >= 400 &&
+			error.status < 500 &&
+			error.status !== 401 &&
+			error.status !== 403 &&
+			error.status !== 429,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	SERVER_ERROR: {
+		match: (error: Error) =>
+			error instanceof ApiError && error.status >= 500 && error.status < 600,
+		handler: async () => ({ maxRetries: 3 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/starton/idempotency.ts
+++ b/packages/starton/idempotency.ts
@@ -42,3 +42,32 @@ export const NON_IDEMPOTENT_OPERATIONS = new Set([
 export function isNonIdempotentOperation(operation: string): boolean {
 	return NON_IDEMPOTENT_OPERATIONS.has(operation);
 }
+
+/**
+ * Operations that are verified safe to re-issue after an ambiguous failure.
+ *
+ * This is a deliberate allowlist rather than "everything not in
+ * `NON_IDEMPOTENT_OPERATIONS`": an operation added later is not retryable
+ * until someone classifies it here, and an operation name that cannot be
+ * recognised at all (a rename, a typo, a caller that supplies no error
+ * context) is never retried.
+ */
+export const RETRY_SAFE_OPERATIONS = new Set([
+	// GET /v3/kms/wallet
+	'wallet.list',
+	// GET /v3/transaction/{id}
+	'transaction.get',
+	// POST /v3/smart-contract/{network}/{address}/read — a POST only because
+	// Starton takes the call arguments in a body; it broadcasts nothing.
+	'smartContract.read',
+]);
+
+/**
+ * True only when `operation` is a known, explicitly retry-safe operation.
+ *
+ * Returns false for an absent, unknown or unclassified operation so the retry
+ * decision fails closed.
+ */
+export function isRetryableOperation(operation: string | undefined): boolean {
+	return operation !== undefined && RETRY_SAFE_OPERATIONS.has(operation);
+}

--- a/packages/starton/idempotency.ts
+++ b/packages/starton/idempotency.ts
@@ -1,0 +1,44 @@
+/**
+ * Which Starton operations are safe to replay automatically.
+ *
+ * Starton's REST API exposes no idempotency key (there is no `Idempotency-Key`
+ * header or equivalent anywhere in the official OpenAPI specification), so a
+ * replayed write is a genuinely new write. For the operations that broadcast a
+ * blockchain transaction that means a retry can deploy a second contract or
+ * execute a contract call — and transfer value — a second time.
+ *
+ * Corsair can replay a failed operation at two independent layers:
+ *
+ *  1. `corsair/http`'s `request()` retries internally, but *only* when the
+ *     response is a rate limit (HTTP 429). See `async-core/request.ts`.
+ *  2. The endpoint binder re-invokes the entire endpoint function — issuing a
+ *     brand new HTTP request — whenever this plugin's error handler returns
+ *     `maxRetries > 0`. See `core/endpoints/bind.ts`.
+ *
+ * Both layers are disabled for the operations listed here. A 5xx or a dropped
+ * connection is *ambiguous*: Starton may already have accepted and broadcast
+ * the transaction before the response failed, so replaying is unsafe even
+ * though the error itself looks transient.
+ *
+ * https://github.com/starton-io/starton-openapi
+ */
+export const NON_IDEMPOTENT_OPERATIONS = new Set([
+	// POST /v3/kms/wallet — provisions a new KMS wallet each time it succeeds.
+	'wallet.create',
+	// POST /v3/smart-contract/from-template — deploys a contract on-chain.
+	'smartContract.deployFromTemplate',
+	// POST /v3/smart-contract/{network}/{address}/call — broadcasts a
+	// state-changing transaction and can transfer value.
+	'smartContract.call',
+]);
+
+/**
+ * True when replaying `operation` could produce a duplicate side effect.
+ *
+ * `wallet.list`, `transaction.get` and `smartContract.read` are all safe: the
+ * first two are GETs, and `read` is a POST only because Starton takes the
+ * function arguments in a body — it never broadcasts a transaction.
+ */
+export function isNonIdempotentOperation(operation: string): boolean {
+	return NON_IDEMPOTENT_OPERATIONS.has(operation);
+}

--- a/packages/starton/index.ts
+++ b/packages/starton/index.ts
@@ -1,0 +1,192 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+} from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
+import { SmartContract, Transaction, Wallet } from './endpoints';
+import type {
+	StartonEndpointInputs,
+	StartonEndpointOutputs,
+} from './endpoints/types';
+import {
+	StartonEndpointInputSchemas,
+	StartonEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { StartonSchema } from './schema';
+
+export type StartonPluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	/** Starton project API key. Overrides the account key store. */
+	key?: string;
+	hooks?: InternalStartonPlugin['hooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof startonEndpointsNested>;
+};
+
+export type StartonContext = CorsairPluginContext<
+	typeof StartonSchema,
+	StartonPluginOptions
+>;
+
+export type StartonKeyBuilderContext = KeyBuilderContext<StartonPluginOptions>;
+
+export type StartonBoundEndpoints = BindEndpoints<
+	typeof startonEndpointsNested
+>;
+
+type StartonEndpoint<K extends keyof StartonEndpointOutputs> = CorsairEndpoint<
+	StartonContext,
+	StartonEndpointInputs[K],
+	StartonEndpointOutputs[K]
+>;
+
+export type StartonEndpoints = {
+	[K in keyof StartonEndpointOutputs]: StartonEndpoint<K>;
+};
+
+const startonEndpointsNested = {
+	wallet: {
+		create: Wallet.create,
+		list: Wallet.list,
+	},
+	smartContract: {
+		deployFromTemplate: SmartContract.deployFromTemplate,
+		call: SmartContract.call,
+		read: SmartContract.read,
+	},
+	transaction: {
+		get: Transaction.get,
+	},
+} as const;
+
+export const startonEndpointSchemas = {
+	'wallet.create': {
+		input: StartonEndpointInputSchemas.walletCreate,
+		output: StartonEndpointOutputSchemas.walletCreate,
+	},
+	'wallet.list': {
+		input: StartonEndpointInputSchemas.walletList,
+		output: StartonEndpointOutputSchemas.walletList,
+	},
+	'smartContract.deployFromTemplate': {
+		input: StartonEndpointInputSchemas.smartContractDeployFromTemplate,
+		output: StartonEndpointOutputSchemas.smartContractDeployFromTemplate,
+	},
+	'smartContract.call': {
+		input: StartonEndpointInputSchemas.smartContractCall,
+		output: StartonEndpointOutputSchemas.smartContractCall,
+	},
+	'smartContract.read': {
+		input: StartonEndpointInputSchemas.smartContractRead,
+		output: StartonEndpointOutputSchemas.smartContractRead,
+	},
+	'transaction.get': {
+		input: StartonEndpointInputSchemas.transactionGet,
+		output: StartonEndpointOutputSchemas.transactionGet,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<
+	typeof startonEndpointsNested
+>;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const startonEndpointMeta = {
+	'wallet.create': {
+		riskLevel: 'write',
+		description: 'Create a new KMS-managed blockchain wallet for the project',
+	},
+	'wallet.list': {
+		riskLevel: 'read',
+		description: 'List the KMS-managed wallets for the project (paginated)',
+	},
+	'smartContract.deployFromTemplate': {
+		riskLevel: 'write',
+		description:
+			'Deploy a smart contract from a Starton-audited template (e.g. ERC20, ERC721)',
+	},
+	'smartContract.call': {
+		riskLevel: 'write',
+		description:
+			'Execute a state-changing function on a deployed smart contract',
+	},
+	'smartContract.read': {
+		riskLevel: 'read',
+		description:
+			'Call a read-only function on a deployed smart contract without broadcasting a transaction',
+	},
+	'transaction.get': {
+		riskLevel: 'read',
+		description: 'Retrieve a blockchain transaction by its Starton id',
+	},
+} as const satisfies RequiredPluginEndpointMeta<typeof startonEndpointsNested>;
+
+export type BaseStartonPlugin<T extends StartonPluginOptions> = CorsairPlugin<
+	'starton',
+	typeof StartonSchema,
+	typeof startonEndpointsNested,
+	Record<string, never>,
+	T,
+	typeof defaultAuthType
+>;
+
+export type InternalStartonPlugin = BaseStartonPlugin<StartonPluginOptions>;
+
+export type ExternalStartonPlugin<T extends StartonPluginOptions> =
+	BaseStartonPlugin<T>;
+
+export function starton<const T extends StartonPluginOptions>(
+	incomingOptions: StartonPluginOptions & T = {} as StartonPluginOptions & T,
+): ExternalStartonPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'starton',
+		schema: StartonSchema,
+		options,
+		hooks: options.hooks,
+		endpoints: startonEndpointsNested,
+		webhooks: {},
+		endpointMeta: startonEndpointMeta,
+		endpointSchemas: startonEndpointSchemas,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: StartonKeyBuilderContext, source) => {
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys.get_api_key();
+				if (!res) {
+					throw new AuthMissingError('starton', 'api_key');
+				}
+				return res;
+			}
+			throw new AuthMissingError('starton', 'api_key');
+		},
+	} satisfies InternalStartonPlugin;
+}
+
+export type {
+	StartonEndpointInputs,
+	StartonEndpointOutputs,
+} from './endpoints/types';
+export type {
+	StartonSmartContract,
+	StartonSmartContractUI,
+	StartonTransaction,
+	StartonWallet,
+} from './schema/database';

--- a/packages/starton/integration.test.ts
+++ b/packages/starton/integration.test.ts
@@ -1,0 +1,35 @@
+import { ApiError } from 'corsair/http';
+import { makeStartonRequest } from './client';
+import { StartonWallet } from './schema';
+
+const LIVE_ENABLED = process.env.STARTON_LIVE === '1';
+const LIVE_KEY = process.env.STARTON_API_KEY;
+const describeIfLive = LIVE_ENABLED ? describe : describe.skip;
+const describeIfKey = LIVE_ENABLED && LIVE_KEY ? describe : describe.skip;
+
+describeIfLive('Starton live REST v3', () => {
+	it('rejects an invalid API key on GET /v3/kms/wallet', async () => {
+		const err = await makeStartonRequest(
+			'v3/kms/wallet',
+			'invalid_starton_key',
+		).catch((error: unknown) => error);
+		expect(err).toBeInstanceOf(ApiError);
+		expect((err as ApiError).status).toBe(401);
+	});
+});
+
+describeIfKey('Starton live REST v3 (authenticated)', () => {
+	it('lists wallets', async () => {
+		const raw = await makeStartonRequest<{ items: unknown[] }>(
+			'v3/kms/wallet',
+			LIVE_KEY as string,
+			{ query: { limit: 1 } },
+		);
+		expect(Array.isArray(raw.items)).toBe(true);
+		if (raw.items[0] !== undefined) {
+			expect(StartonWallet.parse(raw.items[0]).address.length).toBeGreaterThan(
+				0,
+			);
+		}
+	});
+});

--- a/packages/starton/jest.config.cjs
+++ b/packages/starton/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/starton/package.json
+++ b/packages/starton/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@corsair-dev/starton",
+  "version": "0.1.0",
+  "description": "Starton plugin for Corsair — blockchain wallets, smart contract deployment/calls and transaction status",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "starton",
+    "web3",
+    "blockchain",
+    "smart-contract",
+    "wallet",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/starton/schema.test.ts
+++ b/packages/starton/schema.test.ts
@@ -1,0 +1,24 @@
+import { StartonSchema } from './schema';
+
+describe('Starton schema', () => {
+	it('declares a semver version', () => {
+		expect(StartonSchema.version).toBeDefined();
+		expect(StartonSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof StartonSchema.entities).toBe('object');
+		expect(StartonSchema.entities).not.toBeNull();
+		expect(Object.keys(StartonSchema.entities).sort()).toEqual([
+			'smartContracts',
+			'transactions',
+			'wallets',
+		]);
+		for (const entity of Object.values(StartonSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/starton/schema/database.ts
+++ b/packages/starton/schema/database.ts
@@ -1,0 +1,210 @@
+import { z } from 'zod';
+
+/**
+ * Shared transaction lifecycle status/state enums.
+ * Official: components.schemas.Transaction / SmartContract
+ * https://github.com/starton-io/starton-openapi
+ */
+export const StartonTransactionStatus = z.enum([
+	'UNSIGNED',
+	'ERROR_TX',
+	'ERROR_PUBLISH',
+	'PUBLISHED',
+	'RECEIVED_BY_STARTON',
+	'CREATED_BY_STARTON',
+	'COULD_NOT_ESTIMATE_GAS_PRICE',
+	'COULD_NOT_INCREASE_GAS_PRICE',
+	'GAS_PRICE_ESTIMATED',
+	'INVALID_GAS_PRICE',
+	'REPLACEMENT_GAS_PRICE_UNDERPRICED',
+	'COULD_NOT_ESTIMATE_GAS_LIMIT',
+	'GAS_LIMIT_ESTIMATED',
+	'EXECUTION_WILL_FAIL',
+	'INVALID_ARGUMENT',
+	'INSUFFICIENT_FUNDS',
+	'INSUFFICIENT_FUNDS_AFTER_BROADCAST',
+	'COULD_NOT_ASSIGN_NONCE',
+	'COULD_NOT_UNSTUCK_NONCE',
+	'NONCE_ASSIGNED',
+	'NONCE_EXPIRED',
+	'COULD_NOT_SIGN',
+	'SIGNED',
+	'SENT_TO_MEMPOOL',
+	'COULD_NOT_BROADCAST',
+	'ALREADY_KNOWN',
+	'MINED',
+	'CONFIRMED',
+	'REPLACED',
+	'FAILED',
+	'MONITORING_IN_PROGRESS',
+	'STUCK_BY_PREVIOUS_TRANSACTION',
+	'MAX_GAS_PRICE_REACH',
+	'GAS_PRICE_INCREASED',
+	'NEW_TRANSACTION_HASH',
+	'UNKNOWN',
+	'MONITORING_INTERRUPTED',
+]);
+export type StartonTransactionStatus = z.infer<typeof StartonTransactionStatus>;
+
+export const StartonTransactionState = z.enum([
+	'SUCCESS',
+	'PENDING',
+	'MANUAL_ACTION_REQUIRED',
+	'ERROR',
+]);
+export type StartonTransactionState = z.infer<typeof StartonTransactionState>;
+
+export const StartonSpeed = z.enum([
+	'low',
+	'average',
+	'fast',
+	'fastest',
+	'custom',
+]);
+export type StartonSpeed = z.infer<typeof StartonSpeed>;
+
+/**
+ * Official: components.schemas.CustomGasDto
+ */
+export const StartonCustomGas = z
+	.object({
+		gasPrice: z.string().optional(),
+		maxFeePerGas: z.string().optional(),
+		maxPriorityFeePerGas: z.string().optional(),
+	})
+	.loose();
+export type StartonCustomGas = z.infer<typeof StartonCustomGas>;
+
+/**
+ * Official: components.schemas.TransactionLog
+ */
+export const StartonTransactionLog = z
+	.object({
+		message: z.string(),
+		type: StartonTransactionStatus,
+		context: z.record(z.string(), z.unknown()).optional(),
+		createdAt: z.string(),
+	})
+	.loose();
+export type StartonTransactionLog = z.infer<typeof StartonTransactionLog>;
+
+/**
+ * Starton relayer Transaction object.
+ * Official: GET /v3/transaction/{id}
+ * https://github.com/starton-io/starton-openapi (components.schemas.Transaction)
+ */
+export const StartonTransaction = z
+	.object({
+		id: z.string(),
+		blockHash: z.string().nullable().optional(),
+		blockNumber: z.number().nullable().optional(),
+		chainId: z.number(),
+		network: z.string(),
+		data: z.string().nullable().optional(),
+		from: z.string(),
+		gasLimit: z.string().nullable().optional(),
+		gasPrice: z.string().nullable().optional(),
+		maxFeePerGas: z.string().nullable().optional(),
+		maxPriorityFeePerGas: z.string().nullable().optional(),
+		metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+		nonce: z.number().nullable().optional(),
+		type: z.number().nullable().optional(),
+		signerWallet: z.string(),
+		publishedDate: z.string().nullable().optional(),
+		minedDate: z.string().nullable().optional(),
+		signedTransaction: z.string().nullable().optional(),
+		status: StartonTransactionStatus,
+		state: StartonTransactionState,
+		speed: StartonSpeed.nullable().optional(),
+		logs: z.array(StartonTransactionLog),
+		to: z.string().nullable().optional(),
+		transactionHash: z.string().nullable().optional(),
+		value: z.string(),
+		automaticNonce: z.boolean(),
+		isDeployTransaction: z.boolean(),
+		projectId: z.string(),
+		parentTransaction: z.string().nullable().optional(),
+		createdAt: z.string(),
+		updatedAt: z.string(),
+	})
+	.loose();
+export type StartonTransaction = z.infer<typeof StartonTransaction>;
+
+/**
+ * Starton KMS-managed Wallet object.
+ * Official: GET/POST /v3/kms/wallet
+ * https://github.com/starton-io/starton-openapi (components.schemas.Wallet)
+ */
+export const StartonWallet = z
+	.object({
+		address: z.string(),
+		providerKeyId: z.string(),
+		kmsId: z.string(),
+		name: z.string().nullable().optional(),
+		description: z.string().nullable().optional(),
+		metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+		projectId: z.string(),
+		createdAt: z.string(),
+		updatedAt: z.string(),
+	})
+	.loose();
+export type StartonWallet = z.infer<typeof StartonWallet>;
+
+/**
+ * Dashboard/UI metadata Starton stores alongside a contract.
+ * Official: components.schemas.SmartContractUIDto
+ */
+export const StartonSmartContractUI = z
+	.object({
+		version: z.literal('1'),
+		deployMethod: z.enum(['web3', 'kms']),
+		imported: z.boolean(),
+		deployType: z.string().optional(),
+		chainId: z.number().optional(),
+	})
+	.loose();
+export type StartonSmartContractUI = z.infer<typeof StartonSmartContractUI>;
+
+/**
+ * Deployed/managed Smart Contract object.
+ * Official: GET /v3/smart-contract/{network}/{address}
+ * https://github.com/starton-io/starton-openapi (components.schemas.SmartContract)
+ */
+export const StartonSmartContract = z
+	.object({
+		id: z.string(),
+		name: z.string(),
+		description: z.string().nullable().optional(),
+		network: z.string(),
+		abi: z.array(z.record(z.string(), z.unknown())).optional(),
+		address: z.string(),
+		params: z.array(z.string()).nullable().optional(),
+		compilationDetails: z.record(z.string(), z.unknown()).nullable().optional(),
+		creationHash: z.string().nullable().optional(),
+		status: StartonTransactionStatus,
+		state: StartonTransactionState,
+		minedDate: z.string().nullable().optional(),
+		blockNumber: z.number().nullable().optional(),
+		templateId: z.string().nullable().optional(),
+		projectId: z.string(),
+		metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+		uiData: StartonSmartContractUI.nullable().optional(),
+		createdAt: z.string(),
+		updatedAt: z.string(),
+	})
+	.loose();
+export type StartonSmartContract = z.infer<typeof StartonSmartContract>;
+
+/**
+ * Official: components.schemas.PaginationData
+ */
+export const StartonPaginationMeta = z
+	.object({
+		itemCount: z.number(),
+		totalItems: z.number().optional(),
+		itemsPerPage: z.number(),
+		totalPages: z.number().optional(),
+		currentPage: z.number(),
+	})
+	.loose();
+export type StartonPaginationMeta = z.infer<typeof StartonPaginationMeta>;

--- a/packages/starton/schema/index.ts
+++ b/packages/starton/schema/index.ts
@@ -1,0 +1,27 @@
+import {
+	StartonSmartContract,
+	StartonTransaction,
+	StartonWallet,
+} from './database';
+
+export const StartonSchema = {
+	version: '1.0.0',
+	entities: {
+		wallets: StartonWallet,
+		smartContracts: StartonSmartContract,
+		transactions: StartonTransaction,
+	},
+} as const;
+
+export {
+	StartonCustomGas,
+	StartonPaginationMeta,
+	StartonSmartContract,
+	StartonSmartContractUI,
+	StartonSpeed,
+	StartonTransaction,
+	StartonTransactionLog,
+	StartonTransactionState,
+	StartonTransactionStatus,
+	StartonWallet,
+} from './database';

--- a/packages/starton/tsconfig.json
+++ b/packages/starton/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/starton/tsup.config.ts
+++ b/packages/starton/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5745,6 +5745,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/starton:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/strava:
     devDependencies:
       '@types/jest':


### PR DESCRIPTION
## Description

Adds a Corsair integration for the Starton Web3 API (`api.starton.com`, REST v3).

Closes #1496

### Operations (6)

| Operation | Route | Risk |
| --- | --- | --- |
| `wallet.create` | `POST /v3/kms/wallet` | write |
| `wallet.list` | `GET /v3/kms/wallet` (paginated) | read |
| `smartContract.deployFromTemplate` | `POST /v3/smart-contract/from-template` | write |
| `smartContract.call` | `POST /v3/smart-contract/{network}/{address}/call` | write |
| `smartContract.read` | `POST /v3/smart-contract/{network}/{address}/read` | read |
| `transaction.get` | `GET /v3/transaction/{id}` | read |

Matches the 6 operations / 0 triggers listed for Starton on the OSS page.

### Authentication

API key sent as the `x-api-key` header, per `components.securitySchemes.api-key`
in the official spec. The key is never placed in a URL, query string or body, and
is asserted absent from thrown provider and transport errors.

### Two engineering decisions worth reviewing

**Retry safety.** Starton exposes no idempotency key, and Corsair can replay a
call at two independent layers: `corsair/http` retries internally on HTTP 429,
and the endpoint binder re-invokes the whole endpoint whenever an error handler
returns `maxRetries > 0`. A 5xx is ambiguous — Starton may have accepted and
broadcast the transaction before the response failed — so replaying a write
could deploy a second contract or repeat a value transfer. Both layers are shut
for `wallet.create`, `smartContract.deployFromTemplate` and
`smartContract.call`; reads keep their retries. `replayable` defaults to `true`
for GET and `false` for every other method, so a write endpoint added later is
safe by default. The classification lives in `idempotency.ts` as an explicit
allowlist and is asserted to partition the declared operations exactly.

**Runtime validation.** `endpointSchemas` feed Corsair's introspection layer,
not the binder, so each endpoint parses its own input and output. Malformed
provider responses surface as errors rather than being returned as trusted typed
data, and unknown caller keys are stripped rather than forwarded to Starton.

### Validation

All exit 0, run off an iCloud-free checkout:

- `pnpm test` — 92 passed, 2 skipped (live, credential-gated), 94 total
- `tsc --noEmit` — clean
- `pnpm build` — clean
- `pnpm run validate:plugins` — `[SUCCESS] All plugins passed structural validation!`
- `pnpm run validate:docs` — clean
- `biome check .` — clean across 7092 files
- `git diff --check` — clean

All six operations were verified against the official
[starton-io/starton-openapi](https://github.com/starton-io/starton-openapi)
specification — method, path, path/query parameters, request DTO, required
fields, response schema, error codes and security scheme — including a
field-level audit of required vs. optional across every request and response
schema.

## Screenshots / Demos

A real ~42-second screen recording of the read-only `starton.wallet.list` path
is attached below:

https://github.com/user-attachments/assets/b30bfb9a-db81-4e2f-86f5-cfaa1b0b5367

It shows the test suite passing, then the actual Corsair integration
constructing and sending the request — `GET https://api.starton.com/v3/kms/wallet`
with `x-api-key` authentication — and the real provider response.

**No successful live API response is claimed or fabricated.** Starton's hosted
API currently returns **HTTP 530 / Cloudflare 1016** ("Origin DNS error"), so
the recording documents the real integration behaviour and the current upstream
outage rather than a working live call. `app.starton.com` (where an API key
would be generated) is also 530, `docs.starton.com` returns 402, and
`starton.com` does not respond at all, so no credential can be obtained either.

Full probe output, and a question for maintainers on how you would like R4
handled for an integration whose upstream provider went offline after the issue
was accepted, are in
[this comment](https://github.com/corsairdev/corsair/pull/1598#issuecomment-5573663730).

Everything that does not depend on the provider being reachable is verified
above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Starton integration for wallet, smart-contract, and transaction operations.
  - Added Starton authentication, input/output validation, database entities, and searchable records.
  - Added safe retry handling to prevent replaying operations that may create blockchain transactions.

- **Documentation**
  - Added Starton setup, API, database, and usage documentation.
  - Added Starton to the plugin navigation.

- **Bug Fixes**
  - Invalid inputs are rejected before requests are sent, and malformed responses are handled safely.
  - Improved credential protection by keeping API keys out of URLs, request bodies, and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->