### PR TITLE
feat: add Exist integration

### DIFF
--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -142,6 +142,7 @@ export const BaseProviders = [
 	'dynapictures',
 	'epicgames',
 	'exa',
+	'exist',
 	'facebook',
 	'faraday',
 	'figma',
@@ -405,6 +406,7 @@ export const ProviderDisplayNames = {
 	dynapictures: 'Dynapictures',
 	epicgames: 'Epic Games',
 	exa: 'Exa',
+	exist: 'Exist',
 	facebook: 'Facebook',
 	faraday: 'Faraday',
 	figma: 'Figma',
@@ -675,6 +677,7 @@ export type AllProviders =
 	| 'dynapictures'
 	| 'epicgames'
 	| 'exa'
+	| 'exist'
 	| 'facebook'
 	| 'faraday'
 	| 'figma'

--- a/packages/exist/api.test.ts
+++ b/packages/exist/api.test.ts
@@ -19,6 +19,7 @@ import {
 import { errorHandlers } from './error-handlers';
 import type { ExistContext, ExistKeyBuilderContext } from './index';
 import { EXIST_DEFAULT_SCOPES, exist, existEndpointSchemas } from './index';
+import { resolveExistOAuthTenantLink } from './oauth-tenant-link';
 
 jest.mock('corsair/core', () => ({
 	...jest.requireActual('corsair/core'),
@@ -817,6 +818,125 @@ describe('attributes.update', () => {
 			ExistEndpointInputSchemas.attributesUpdate.safeParse({ attributes: [] })
 				.success,
 		).toBe(false);
+	});
+});
+
+describe('reviewer regressions', () => {
+	it('rejects calendar-impossible dates, not just malformed ones', () => {
+		const bad = (date: string) =>
+			ExistEndpointInputSchemas.attributesUpdate.safeParse({
+				attributes: [{ name: 'mood', date, value: 7 }],
+			}).success;
+
+		// Regex-only validation accepted these; z.iso.date() checks the calendar.
+		expect(bad('2026-02-31')).toBe(false);
+		expect(bad('2026-13-01')).toBe(false);
+		expect(bad('2026-00-10')).toBe(false);
+		expect(bad('2026-04-31')).toBe(false);
+		// Real days, including a leap day, still pass.
+		expect(bad('2026-02-28')).toBe(true);
+		expect(bad('2024-02-29')).toBe(true);
+	});
+
+	it('rejects filtering with-values by both attributes and templates', () => {
+		const parse = (input: Record<string, unknown>) =>
+			ExistEndpointInputSchemas.attributesListWithValues.safeParse(input);
+
+		// "you would use one or the other of attributes and templates to filter"
+		expect(parse({ attributes: ['mood'], templates: ['mood'] }).success).toBe(
+			false,
+		);
+		expect(parse({ attributes: ['mood'] }).success).toBe(true);
+		expect(parse({ templates: ['mood'] }).success).toBe(true);
+		// Empty arrays are not a filter, so they do not conflict.
+		expect(parse({ attributes: ['mood'], templates: [] }).success).toBe(true);
+		expect(parse({}).success).toBe(true);
+	});
+
+	it('bounds the OAuth tenant-link profile lookup instead of hanging', async () => {
+		const originalFetch = globalThis.fetch;
+		let receivedSignal: AbortSignal | undefined;
+		globalThis.fetch = ((_url: string, init?: RequestInit) => {
+			receivedSignal = init?.signal ?? undefined;
+			// A profile endpoint that never answers: only the abort signal can
+			// end this request.
+			return new Promise((_resolve, reject) => {
+				init?.signal?.addEventListener('abort', () =>
+					reject(new Error('aborted')),
+				);
+			});
+		}) as typeof fetch;
+
+		try {
+			const pending = resolveExistOAuthTenantLink({
+				access_token: 'token-without-username',
+			} as never);
+
+			// The resolver must hand fetch a signal that is already scheduled to
+			// abort, rather than waiting on Exist indefinitely.
+			await Promise.resolve();
+			expect(receivedSignal).toBeInstanceOf(AbortSignal);
+			expect(receivedSignal?.aborted).toBe(false);
+
+			// Aborting resolves the caller to null rather than rejecting.
+			(receivedSignal as AbortSignal & { dispatchEvent: (e: Event) => boolean })
+				.dispatchEvent?.(new Event('abort'));
+			await expect(pending).resolves.toBeNull();
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it('keeps personal attribute values out of the operation log', async () => {
+		mockRequest.mockResolvedValue({ success: [], failed: [] });
+
+		await endpoints().attributes.update(mockCtx(), {
+			attributes: [
+				{ name: 'mood', date: '2022-05-20', value: 7 },
+				{
+					name: 'mood_note',
+					date: '2022-05-20',
+					value: 'A private note about my day',
+				},
+				{ name: 'mood', date: '2022-05-21', value: 3 },
+			],
+		});
+
+		const [, eventType, payload] = mockLog.mock.calls[0] as [
+			unknown,
+			string,
+			Record<string, unknown>,
+		];
+		expect(eventType).toBe('exist.attributes.update');
+		// Operational metadata is retained...
+		expect(payload).toEqual({
+			count: 3,
+			attributes: ['mood', 'mood_note'],
+			dates: ['2022-05-20', '2022-05-21'],
+		});
+		// ...but the values themselves never reach the persistent log.
+		expect(JSON.stringify(payload)).not.toContain('A private note');
+		expect(JSON.stringify(payload)).not.toContain('value');
+	});
+
+	it('summarises increment batches without their deltas', async () => {
+		mockRequest.mockResolvedValue({ success: [], failed: [] });
+
+		await endpoints().attributes.increment(mockCtx(), {
+			attributes: [
+				{ name: 'steps', date: '2022-05-20', value: 700 },
+				// No date: defaults to today, so no date is recorded either.
+				{ name: 'steps_active_min', value: 5 },
+			],
+		});
+
+		const payload = mockLog.mock.calls[0]?.[2] as Record<string, unknown>;
+		expect(payload).toEqual({
+			count: 2,
+			attributes: ['steps', 'steps_active_min'],
+			dates: ['2022-05-20'],
+		});
+		expect(JSON.stringify(payload)).not.toContain('700');
 	});
 });
 

--- a/packages/exist/api.test.ts
+++ b/packages/exist/api.test.ts
@@ -260,6 +260,9 @@ describe('makeExistRequest', () => {
 				body: undefined,
 				query: undefined,
 			}),
+			expect.objectContaining({
+				rateLimitConfig: expect.objectContaining({ maxRetries: 3 }),
+			}),
 		);
 	});
 
@@ -879,8 +882,9 @@ describe('reviewer regressions', () => {
 			expect(receivedSignal?.aborted).toBe(false);
 
 			// Aborting resolves the caller to null rather than rejecting.
-			(receivedSignal as AbortSignal & { dispatchEvent: (e: Event) => boolean })
-				.dispatchEvent?.(new Event('abort'));
+			(
+				receivedSignal as AbortSignal & { dispatchEvent: (e: Event) => boolean }
+			).dispatchEvent?.(new Event('abort'));
 			await expect(pending).resolves.toBeNull();
 		} finally {
 			globalThis.fetch = originalFetch;
@@ -1189,7 +1193,7 @@ describe('error handlers', () => {
 		expect(classify(httpError(401, undefined))).toBe('AUTH_ERROR');
 	});
 
-	it('retries rate limits and forwards the retry-after hint', async () => {
+	it('does not replay writes on rate limits and forwards the retry-after hint', async () => {
 		const error = new ExistAPIError(
 			'Too Many Requests',
 			429,
@@ -1199,14 +1203,14 @@ describe('error handlers', () => {
 		expect(errorHandlers.RATE_LIMIT_ERROR.match(error)).toBe(true);
 		await expect(
 			errorHandlers.RATE_LIMIT_ERROR.handler(error),
-		).resolves.toEqual({ maxRetries: 5, headersRetryAfterMs: 60_000 });
+		).resolves.toEqual({ maxRetries: 0, headersRetryAfterMs: 60_000 });
 	});
 
 	it('handles a bodiless 429, which is what Exist actually returns', async () => {
 		const error = new ExistAPIError('Too Many Requests', 429);
 		await expect(
 			errorHandlers.RATE_LIMIT_ERROR.handler(error),
-		).resolves.toEqual({ maxRetries: 5, headersRetryAfterMs: undefined });
+		).resolves.toEqual({ maxRetries: 0, headersRetryAfterMs: undefined });
 	});
 
 	it('never retries auth or permission failures', async () => {

--- a/packages/exist/api.test.ts
+++ b/packages/exist/api.test.ts
@@ -1,0 +1,1122 @@
+import { AuthMissingError, logEventFromContext } from 'corsair/core';
+import { ApiError, request } from 'corsair/http';
+import {
+	compactQuery,
+	EXIST_API_BASE,
+	EXIST_MAX_BATCH_SIZE,
+	EXIST_OAUTH_AUTHORIZE_URL,
+	EXIST_OAUTH_TOKEN_URL,
+	ExistAPIError,
+	makeAuthenticatedExistRequest,
+	makeExistRequest,
+	toCommaList,
+	toFlag,
+} from './client';
+import {
+	ExistEndpointInputSchemas,
+	ExistEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import type { ExistContext, ExistKeyBuilderContext } from './index';
+import { EXIST_DEFAULT_SCOPES, exist, existEndpointSchemas } from './index';
+
+jest.mock('corsair/core', () => ({
+	...jest.requireActual('corsair/core'),
+	logEventFromContext: jest.fn(),
+}));
+
+jest.mock('corsair/http', () => {
+	const original = jest.requireActual('corsair/http');
+	return { ...original, request: jest.fn() };
+});
+
+const mockRequest = request as jest.Mock;
+const mockLog = jest.mocked(logEventFromContext);
+
+const ACCESS_TOKEN = 'exist_access_token_value';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures — shapes taken from https://developer.exist.io/reference/
+// ─────────────────────────────────────────────────────────────────────────────
+
+const profileFixture = {
+	username: 'josh',
+	first_name: 'Josh',
+	last_name: 'Sharp',
+	avatar: 'https://exist.io/media/avatars/josh.png',
+	timezone: 'Australia/Sydney',
+	local_time: '2022-05-16T16:01:37.587301+10:00',
+	imperial_distance: false,
+	imperial_weight: false,
+	imperial_energy: false,
+	imperial_liquid: false,
+	imperial_temperature: false,
+	trial: false,
+	delinquent: false,
+};
+
+const activityGroup = { name: 'activity', label: 'Activity', priority: 1 };
+
+const stepsAttribute = {
+	template: 'steps',
+	name: 'steps',
+	label: 'Steps',
+	group: activityGroup,
+	service: { name: 'googlefit', label: 'Google Fit' },
+	active: true,
+	priority: 1,
+	manual: false,
+	value_type: 0,
+	value_type_description: 'Integer',
+	available_services: [
+		{ name: 'googlefit', label: 'Google Fit' },
+		{ name: 'oura', label: 'Oura' },
+	],
+};
+
+/** A custom attribute: no template, no owning service, no available services. */
+const customAttribute = {
+	template: null,
+	name: 'coffees',
+	label: 'Coffees',
+	group: { name: 'custom', label: 'Custom', priority: 10 },
+	service: null,
+	active: true,
+	priority: 12,
+	manual: true,
+	value_type: 0,
+	value_type_description: 'Integer',
+};
+
+function paged<T>(results: T[], count = results.length) {
+	return { count, next: null, previous: null, results };
+}
+
+function mockCtx() {
+	return {
+		key: ACCESS_TOKEN,
+		authType: 'oauth_2' as const,
+		options: {},
+		db: {},
+		tenantId: 'default',
+		$getAccountId: async () => 'acct',
+	} as unknown as ExistContext;
+}
+
+function endpoints() {
+	const tree = exist({ key: ACCESS_TOKEN }).endpoints;
+	if (!tree) throw new Error('missing endpoints');
+	return tree;
+}
+
+function httpError(status: number, body: unknown, retryAfter?: number) {
+	return new ApiError(
+		{ method: 'GET', url: 'attributes/' },
+		{
+			url: `${EXIST_API_BASE}/attributes/`,
+			ok: false,
+			status,
+			statusText: 'Error',
+			body,
+		},
+		'Request failed',
+		retryAfter === undefined ? undefined : { retryAfter },
+	);
+}
+
+function classify(error: Error): string {
+	const name = (
+		Object.keys(errorHandlers) as Array<keyof typeof errorHandlers>
+	).find((key) => errorHandlers[key].match(error));
+	return name ?? 'none';
+}
+
+const lastCall = () => mockRequest.mock.calls[0];
+
+beforeEach(() => {
+	mockRequest.mockReset();
+	mockLog.mockReset();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin shape and registration
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('exist plugin shape', () => {
+	it('registers the twelve Exist API operations and no triggers', () => {
+		const plugin = exist();
+		expect(plugin.id).toBe('exist');
+		expect(plugin.options?.authType).toBe('oauth_2');
+		expect(plugin.webhooks).toEqual({});
+		expect(plugin.webhookSchemas).toBeUndefined();
+		expect(plugin.pluginWebhookMatcher).toBeUndefined();
+		expect(Object.keys(existEndpointSchemas).sort()).toEqual([
+			'attributes.acquire',
+			'attributes.increment',
+			'attributes.list',
+			'attributes.listOwned',
+			'attributes.listTemplates',
+			'attributes.listWithValues',
+			'attributes.release',
+			'attributes.update',
+			'averages.list',
+			'correlations.list',
+			'insights.list',
+			'users.getProfile',
+		]);
+	});
+
+	it('exposes only OAuth2 auth, scoped by tenant external id', () => {
+		const plugin = exist();
+		expect(plugin.authConfig).toEqual({
+			oauth_2: { account: ['tenant_external_id'] },
+		});
+	});
+
+	it('uses the documented OAuth2 authorize and token endpoints', () => {
+		const plugin = exist();
+		expect(plugin.oauthConfig?.authUrl).toBe(
+			'https://exist.io/oauth2/authorize',
+		);
+		expect(plugin.oauthConfig?.tokenUrl).toBe(
+			'https://exist.io/oauth2/access_token',
+		);
+		expect(plugin.oauthConfig?.tokenAuthMethod).toBe('body');
+		// Exist only accepts pre-registered HTTPS redirect URIs.
+		expect(plugin.oauthConfig?.requiresRegisteredRedirect).toBe(true);
+		expect(plugin.oauthConfig?.scopes).toEqual(EXIST_DEFAULT_SCOPES);
+		expect(plugin.oauthConfig?.scopes).toHaveLength(34);
+	});
+
+	it('honours a narrowed scope list', () => {
+		const plugin = exist({ scopes: ['mood_read', 'mood_write'] });
+		expect(plugin.oauthConfig?.scopes).toEqual(['mood_read', 'mood_write']);
+	});
+
+	it('marks the four ownership/write operations as write risk', () => {
+		const meta = exist().endpointMeta;
+		expect(meta?.['attributes.acquire']?.riskLevel).toBe('write');
+		expect(meta?.['attributes.release']?.riskLevel).toBe('write');
+		expect(meta?.['attributes.increment']?.riskLevel).toBe('write');
+		expect(meta?.['attributes.update']?.riskLevel).toBe('write');
+		expect(meta?.['attributes.list']?.riskLevel).toBe('read');
+		expect(meta?.['users.getProfile']?.riskLevel).toBe('read');
+	});
+
+	it('declares a schema entity for every persisted object type', () => {
+		expect(Object.keys(exist().schema?.entities ?? {}).sort()).toEqual([
+			'attributeValues',
+			'attributes',
+			'averages',
+			'correlations',
+			'insights',
+			'profile',
+		]);
+	});
+});
+
+describe('exist keyBuilder', () => {
+	const build = (plugin: ReturnType<typeof exist>) =>
+		plugin.keyBuilder as (ctx: unknown, source: string) => Promise<string>;
+
+	it('returns a directly supplied token for endpoint calls', async () => {
+		await expect(
+			build(exist({ key: ACCESS_TOKEN }))({ authType: 'oauth_2' }, 'endpoint'),
+		).resolves.toBe(ACCESS_TOKEN);
+	});
+
+	it('throws AuthMissingError when no OAuth2 credentials are available', async () => {
+		const ctx = {
+			authType: 'api_key',
+		} as unknown as ExistKeyBuilderContext;
+		await expect(build(exist())(ctx, 'endpoint')).rejects.toBeInstanceOf(
+			AuthMissingError,
+		);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Client / auth headers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('makeExistRequest', () => {
+	it('targets the Exist v2 base URL with a bearer token', async () => {
+		mockRequest.mockResolvedValue(profileFixture);
+		await makeExistRequest('accounts/profile/', ACCESS_TOKEN);
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.objectContaining({
+				BASE: 'https://exist.io/api/2',
+				TOKEN: undefined,
+				HEADERS: expect.objectContaining({
+					Authorization: `Bearer ${ACCESS_TOKEN}`,
+					'Content-Type': 'application/json',
+				}),
+			}),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'accounts/profile/',
+				body: undefined,
+				query: undefined,
+			}),
+		);
+	});
+
+	it('sends a top-level JSON array as the body of write calls', async () => {
+		mockRequest.mockResolvedValue({ success: [], failed: [] });
+		await makeExistRequest('attributes/release/', ACCESS_TOKEN, {
+			method: 'POST',
+			body: [{ name: 'mood' }],
+		});
+
+		expect(lastCall()[1]).toMatchObject({
+			method: 'POST',
+			url: 'attributes/release/',
+			body: [{ name: 'mood' }],
+			mediaType: 'application/json',
+		});
+	});
+
+	it('preserves status, body and retry-after when wrapping API errors', async () => {
+		mockRequest.mockRejectedValue(
+			httpError(429, { error: 'Rate limit exceeded' }, 4200),
+		);
+		await expect(
+			makeExistRequest('attributes/', ACCESS_TOKEN),
+		).rejects.toMatchObject({
+			name: 'ExistAPIError',
+			status: 429,
+			retryAfter: 4200,
+			message: 'Rate limit exceeded',
+		});
+	});
+
+	it('wraps non-HTTP failures', async () => {
+		mockRequest.mockRejectedValue(new Error('socket hang up'));
+		await expect(
+			makeExistRequest('attributes/', ACCESS_TOKEN),
+		).rejects.toBeInstanceOf(ExistAPIError);
+	});
+});
+
+describe('makeAuthenticatedExistRequest', () => {
+	it('re-mints the token once and retries after a 401', async () => {
+		mockRequest
+			.mockRejectedValueOnce(httpError(401, { error: 'Invalid token' }))
+			.mockResolvedValueOnce(profileFixture);
+		const refreshAuth = jest.fn().mockResolvedValue('fresh_token');
+
+		const result = await makeAuthenticatedExistRequest(
+			'accounts/profile/',
+			{ key: 'stale_token', _refreshAuth: refreshAuth },
+			{ method: 'GET' },
+		);
+
+		expect(refreshAuth).toHaveBeenCalledTimes(1);
+		expect(mockRequest).toHaveBeenCalledTimes(2);
+		expect(mockRequest.mock.calls[1][0].HEADERS.Authorization).toBe(
+			'Bearer fresh_token',
+		);
+		expect(result).toEqual(profileFixture);
+	});
+
+	it('does not retry a 403, which no refresh can fix', async () => {
+		mockRequest.mockRejectedValue(httpError(403, { error: 'Forbidden' }));
+		const refreshAuth = jest.fn();
+
+		await expect(
+			makeAuthenticatedExistRequest(
+				'attributes/increment/',
+				{ key: ACCESS_TOKEN, _refreshAuth: refreshAuth },
+				{ method: 'POST', body: [{ name: 'steps', value: 1 }] },
+			),
+		).rejects.toMatchObject({ status: 403 });
+		expect(refreshAuth).not.toHaveBeenCalled();
+		expect(mockRequest).toHaveBeenCalledTimes(1);
+	});
+
+	it('surfaces a 401 when there is no refresh path', async () => {
+		mockRequest.mockRejectedValue(httpError(401, { error: 'Invalid token' }));
+		await expect(
+			makeAuthenticatedExistRequest('attributes/', { key: ACCESS_TOKEN }),
+		).rejects.toMatchObject({ status: 401 });
+		expect(mockRequest).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('query serialization helpers', () => {
+	it('joins list filters with commas as Exist expects', () => {
+		expect(toCommaList(['activity', 'workouts'])).toBe('activity,workouts');
+		expect(toCommaList([])).toBeUndefined();
+		expect(toCommaList(undefined)).toBeUndefined();
+	});
+
+	it('maps documented on/off flags to 1, omitting them when false', () => {
+		expect(toFlag(true)).toBe(1);
+		expect(toFlag(false)).toBeUndefined();
+		expect(toFlag(undefined)).toBeUndefined();
+	});
+
+	it('drops undefined query entries', () => {
+		expect(compactQuery({ page: 1, limit: undefined, manual: false })).toEqual({
+			page: 1,
+			manual: false,
+		});
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Operations
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('users.getProfile', () => {
+	it('GETs the profile endpoint and persists the user', async () => {
+		mockRequest.mockResolvedValue(profileFixture);
+		const upsertByEntityId = jest.fn();
+		const ctx = {
+			...mockCtx(),
+			db: { profile: { upsertByEntityId } },
+		} as unknown as ExistContext;
+
+		const result = await endpoints().users.getProfile(ctx, {});
+
+		expect(lastCall()[1]).toMatchObject({
+			method: 'GET',
+			url: 'accounts/profile/',
+		});
+		expect(upsertByEntityId).toHaveBeenCalledWith(
+			'josh',
+			expect.objectContaining({ id: 'josh', username: 'josh' }),
+		);
+		expect(
+			ExistEndpointOutputSchemas.usersGetProfile.parse(result).timezone,
+		).toBe('Australia/Sydney');
+		expect(mockLog).toHaveBeenCalledWith(
+			ctx,
+			'exist.users.getProfile',
+			{},
+			'completed',
+		);
+	});
+
+	it('accepts a profile with a null avatar', () => {
+		const parsed = ExistEndpointOutputSchemas.usersGetProfile.parse({
+			...profileFixture,
+			avatar: null,
+		});
+		expect(parsed.avatar).toBeNull();
+	});
+});
+
+describe('attributes.list', () => {
+	it('serializes every documented filter', async () => {
+		mockRequest.mockResolvedValue(paged([stepsAttribute]));
+
+		await endpoints().attributes.list(mockCtx(), {
+			page: 2,
+			limit: 50,
+			groups: ['activity', 'workouts'],
+			attributes: ['steps'],
+			exclude_custom: true,
+			manual: false,
+			include_inactive: true,
+			include_low_priority: true,
+			owned: true,
+		});
+
+		expect(lastCall()[1]).toMatchObject({
+			method: 'GET',
+			url: 'attributes/',
+			query: {
+				page: 2,
+				limit: 50,
+				groups: 'activity,workouts',
+				attributes: 'steps',
+				exclude_custom: true,
+				// `manual: false` is meaningful (it excludes manual attributes),
+				// so it must survive compaction.
+				manual: false,
+				include_inactive: true,
+				include_low_priority: true,
+				owned: true,
+			},
+		});
+	});
+
+	it('omits the query entirely when no filters are given', async () => {
+		mockRequest.mockResolvedValue(paged([stepsAttribute]));
+		await endpoints().attributes.list(mockCtx(), {});
+		expect(lastCall()[1].query).toBeUndefined();
+	});
+
+	it('persists returned attributes, flattening group and service', async () => {
+		mockRequest.mockResolvedValue(paged([stepsAttribute, customAttribute]));
+		const upsertByEntityId = jest.fn();
+		const ctx = {
+			...mockCtx(),
+			db: { attributes: { upsertByEntityId } },
+		} as unknown as ExistContext;
+
+		await endpoints().attributes.list(ctx, {});
+
+		expect(upsertByEntityId).toHaveBeenCalledWith(
+			'steps',
+			expect.objectContaining({
+				id: 'steps',
+				group_name: 'activity',
+				service_name: 'googlefit',
+				template: 'steps',
+			}),
+		);
+		// A custom attribute has no template and no owning service.
+		expect(upsertByEntityId).toHaveBeenCalledWith(
+			'coffees',
+			expect.objectContaining({ template: null, service_name: null }),
+		);
+	});
+
+	it('parses attributes whose template and service are null', () => {
+		const parsed = ExistEndpointOutputSchemas.attributesList.parse(
+			paged([customAttribute]),
+		);
+		expect(parsed.results[0]?.template).toBeNull();
+		expect(parsed.results[0]?.service).toBeNull();
+		expect(parsed.results[0]?.available_services).toBeUndefined();
+	});
+});
+
+describe('attributes.listTemplates', () => {
+	it('GETs the templates endpoint with its filters', async () => {
+		const template = {
+			name: 'steps',
+			label: 'Steps',
+			group: activityGroup,
+			priority: 1,
+			value_type: 0,
+			value_type_description: 'Integer',
+		};
+		mockRequest.mockResolvedValue({
+			count: 81,
+			next: 'https://exist.io/api/2/attributes/templates/?page=2',
+			previous: null,
+			results: [template],
+		});
+
+		const result = await endpoints().attributes.listTemplates(mockCtx(), {
+			page: 1,
+			include_low_priority: true,
+			groups: ['activity'],
+		});
+
+		expect(lastCall()[1]).toMatchObject({
+			method: 'GET',
+			url: 'attributes/templates/',
+			query: { page: 1, include_low_priority: true, groups: 'activity' },
+		});
+		const parsed =
+			ExistEndpointOutputSchemas.attributesListTemplates.parse(result);
+		expect(parsed.count).toBe(81);
+		expect(parsed.next).toContain('page=2');
+	});
+});
+
+describe('attributes.listWithValues', () => {
+	it('passes days and date_max through and stores each day value', async () => {
+		mockRequest.mockResolvedValue(
+			paged([
+				{
+					...stepsAttribute,
+					values: [
+						{ date: '2022-05-16', value: 1533 },
+						{ date: '2022-05-15', value: null },
+					],
+				},
+			]),
+		);
+		const attributes = { upsertByEntityId: jest.fn() };
+		const attributeValues = { upsertByEntityId: jest.fn() };
+		const ctx = {
+			...mockCtx(),
+			db: { attributes, attributeValues },
+		} as unknown as ExistContext;
+
+		const result = await endpoints().attributes.listWithValues(ctx, {
+			days: 31,
+			date_max: '2022-05-16',
+			templates: ['steps'],
+		});
+
+		expect(lastCall()[1]).toMatchObject({
+			method: 'GET',
+			url: 'attributes/with-values/',
+			query: { days: 31, date_max: '2022-05-16', templates: 'steps' },
+		});
+		expect(attributeValues.upsertByEntityId).toHaveBeenCalledWith(
+			'steps:2022-05-16',
+			expect.objectContaining({ attribute: 'steps', value: 1533 }),
+		);
+		// Days with no data come back as an explicit null and are still stored.
+		expect(attributeValues.upsertByEntityId).toHaveBeenCalledWith(
+			'steps:2022-05-15',
+			expect.objectContaining({ value: null }),
+		);
+		expect(
+			ExistEndpointOutputSchemas.attributesListWithValues.parse(result)
+				.results[0]?.values,
+		).toHaveLength(2);
+	});
+});
+
+describe('attributes.listOwned', () => {
+	it('GETs the owned-attributes endpoint', async () => {
+		mockRequest.mockResolvedValue(paged([stepsAttribute], 34));
+		const result = await endpoints().attributes.listOwned(mockCtx(), {
+			limit: 100,
+			exclude_custom: true,
+		});
+
+		expect(lastCall()[1]).toMatchObject({
+			method: 'GET',
+			url: 'attributes/owned/',
+			query: { limit: 100, exclude_custom: true },
+		});
+		expect(
+			ExistEndpointOutputSchemas.attributesListOwned.parse(result).count,
+		).toBe(34);
+	});
+});
+
+describe('attributes.acquire', () => {
+	it('POSTs the attribute array and reports partial failures', async () => {
+		mockRequest.mockResolvedValue({
+			success: [{ name: 'mood_note', active: 'true' }],
+			failed: [
+				{
+					title: 'mood',
+					error_code: 'missing_field',
+					error: "Object at index 0 missing field(s) 'name'",
+				},
+			],
+		});
+
+		const result = await endpoints().attributes.acquire(mockCtx(), {
+			attributes: [{ template: 'mood' }, { name: 'mood_note', manual: false }],
+		});
+
+		expect(lastCall()[1]).toMatchObject({
+			method: 'POST',
+			url: 'attributes/acquire/',
+			body: [{ template: 'mood' }, { name: 'mood_note', manual: false }],
+			query: undefined,
+		});
+		const parsed = ExistEndpointOutputSchemas.attributesAcquire.parse(result);
+		expect(parsed.success[0]?.name).toBe('mood_note');
+		expect(parsed.failed[0]?.error_code).toBe('missing_field');
+	});
+
+	it('sends success_objects=1 only when requested', async () => {
+		mockRequest.mockResolvedValue({ success: [], failed: [] });
+		await endpoints().attributes.acquire(mockCtx(), {
+			attributes: [{ template: 'mood' }],
+			success_objects: true,
+		});
+		expect(lastCall()[1].query).toEqual({ success_objects: 1 });
+	});
+
+	it('requires each object to identify an attribute', () => {
+		const schema = ExistEndpointInputSchemas.attributesAcquire;
+		expect(schema.safeParse({ attributes: [{ manual: true }] }).success).toBe(
+			false,
+		);
+		expect(schema.safeParse({ attributes: [{ name: 'mood' }] }).success).toBe(
+			true,
+		);
+	});
+
+	it('rejects batches larger than the documented maximum', () => {
+		const attributes = Array.from(
+			{ length: EXIST_MAX_BATCH_SIZE + 1 },
+			(_, i) => ({ name: `attr_${i}` }),
+		);
+		expect(
+			ExistEndpointInputSchemas.attributesAcquire.safeParse({ attributes })
+				.success,
+		).toBe(false);
+	});
+});
+
+describe('attributes.release', () => {
+	it('POSTs the names to release', async () => {
+		mockRequest.mockResolvedValue({
+			success: [{ name: 'mood_note' }],
+			failed: [
+				{
+					name: 'mood',
+					error_code: 'unauthorised',
+					error: "Attribute 'mood' does not belong to this service",
+				},
+			],
+		});
+
+		const result = await endpoints().attributes.release(mockCtx(), {
+			attributes: [{ name: 'mood' }, { name: 'mood_note' }],
+		});
+
+		expect(lastCall()[1]).toMatchObject({
+			method: 'POST',
+			url: 'attributes/release/',
+			body: [{ name: 'mood' }, { name: 'mood_note' }],
+		});
+		expect(
+			ExistEndpointOutputSchemas.attributesRelease.parse(result).failed[0]
+				?.error_code,
+		).toBe('unauthorised');
+	});
+});
+
+describe('attributes.increment', () => {
+	it('POSTs deltas and surfaces the new daily total', async () => {
+		mockRequest.mockResolvedValue({
+			success: [{ name: 'steps', value: 700, current: 1700 }],
+			failed: [
+				{
+					name: 'steps_active_min',
+					value: 9.0,
+					error_code: 'validation',
+					error: 'Cannot apply a float to an integer type',
+				},
+			],
+		});
+
+		const result = await endpoints().attributes.increment(mockCtx(), {
+			attributes: [
+				{ name: 'steps', date: '2022-05-20', value: 700 },
+				// `date` is optional and defaults to the user's current day.
+				{ name: 'steps_active_min', value: 5 },
+			],
+		});
+
+		expect(lastCall()[1]).toMatchObject({
+			method: 'POST',
+			url: 'attributes/increment/',
+			body: [
+				{ name: 'steps', date: '2022-05-20', value: 700 },
+				{ name: 'steps_active_min', value: 5 },
+			],
+		});
+		const parsed = ExistEndpointOutputSchemas.attributesIncrement.parse(result);
+		expect(parsed.success[0]?.current).toBe(1700);
+		expect(parsed.failed[0]?.error_code).toBe('validation');
+	});
+
+	it('rejects malformed dates', () => {
+		expect(
+			ExistEndpointInputSchemas.attributesIncrement.safeParse({
+				attributes: [{ name: 'steps', date: '20/05/2022', value: 1 }],
+			}).success,
+		).toBe(false);
+	});
+});
+
+describe('attributes.update', () => {
+	it('POSTs total values and reports per-object success and failure', async () => {
+		mockRequest.mockResolvedValue({
+			success: [
+				{
+					name: 'mood_note',
+					date: '2022-05-20',
+					value: 'Great day playing with the Exist API',
+				},
+			],
+			failed: [
+				{
+					name: 'mood',
+					date: '2022-05-20',
+					error_code: 'missing_field',
+					error: "Object at index 0 missing field(s) 'value'",
+				},
+			],
+		});
+
+		const result = await endpoints().attributes.update(mockCtx(), {
+			attributes: [
+				{ name: 'mood', date: '2022-05-20', value: 7 },
+				{
+					name: 'mood_note',
+					date: '2022-05-20',
+					value: 'Great day playing with the Exist API',
+				},
+			],
+		});
+
+		expect(lastCall()[1]).toMatchObject({
+			method: 'POST',
+			url: 'attributes/update/',
+			body: [
+				{ name: 'mood', date: '2022-05-20', value: 7 },
+				{
+					name: 'mood_note',
+					date: '2022-05-20',
+					value: 'Great day playing with the Exist API',
+				},
+			],
+		});
+		// Documented as a top-level JSON array, never an object wrapper.
+		expect(Array.isArray(lastCall()[1].body)).toBe(true);
+
+		const parsed = ExistEndpointOutputSchemas.attributesUpdate.parse(result);
+		expect(parsed.success[0]?.value).toBe(
+			'Great day playing with the Exist API',
+		);
+		expect(parsed.failed[0]?.error_code).toBe('missing_field');
+	});
+
+	it('accepts the string, number and boolean value types Exist stores', () => {
+		for (const value of ['a note', 7, 7.5, true, null]) {
+			expect(
+				ExistEndpointInputSchemas.attributesUpdate.safeParse({
+					attributes: [{ name: 'mood', date: '2022-05-20', value }],
+				}).success,
+			).toBe(true);
+		}
+	});
+
+	it('requires a date, unlike increment', () => {
+		expect(
+			ExistEndpointInputSchemas.attributesUpdate.safeParse({
+				attributes: [{ name: 'mood', value: 7 }],
+			}).success,
+		).toBe(false);
+		expect(
+			ExistEndpointInputSchemas.attributesUpdate.safeParse({
+				attributes: [{ name: 'mood', date: '20/05/2022', value: 7 }],
+			}).success,
+		).toBe(false);
+	});
+
+	it('rejects batches larger than the documented maximum of 35', () => {
+		const oversized = Array.from({ length: EXIST_MAX_BATCH_SIZE + 1 }, () => ({
+			name: 'steps',
+			date: '2022-05-20',
+			value: 1,
+		}));
+		expect(
+			ExistEndpointInputSchemas.attributesUpdate.safeParse({
+				attributes: oversized,
+			}).success,
+		).toBe(false);
+		expect(
+			ExistEndpointInputSchemas.attributesUpdate.safeParse({
+				attributes: oversized.slice(0, EXIST_MAX_BATCH_SIZE),
+			}).success,
+		).toBe(true);
+	});
+
+	it('rejects an empty batch', () => {
+		expect(
+			ExistEndpointInputSchemas.attributesUpdate.safeParse({ attributes: [] })
+				.success,
+		).toBe(false);
+	});
+});
+
+describe('averages.list', () => {
+	it('sends include_historical as the documented 1 flag and stores results', async () => {
+		const average = {
+			attribute: 'steps',
+			date: '2020-04-29',
+			overall: 4174.0,
+			monday: 4057.0,
+			tuesday: 6614.0,
+			wednesday: 4001.0,
+			thursday: 3923.0,
+			friday: 4528.0,
+			saturday: 3649.0,
+			sunday: 3904.0,
+		};
+		mockRequest.mockResolvedValue(paged([average]));
+		const upsertByEntityId = jest.fn();
+		const ctx = {
+			...mockCtx(),
+			db: { averages: { upsertByEntityId } },
+		} as unknown as ExistContext;
+
+		const result = await endpoints().averages.list(ctx, {
+			attributes: ['steps'],
+			include_historical: true,
+			date_min: '2020-01-01',
+		});
+
+		expect(lastCall()[1]).toMatchObject({
+			method: 'GET',
+			url: 'averages/',
+			query: {
+				attributes: 'steps',
+				include_historical: 1,
+				date_min: '2020-01-01',
+			},
+		});
+		expect(upsertByEntityId).toHaveBeenCalledWith(
+			'steps:2020-04-29',
+			expect.objectContaining({ id: 'steps:2020-04-29', overall: 4174.0 }),
+		);
+		expect(
+			ExistEndpointOutputSchemas.averagesList.parse(result).results[0]?.sunday,
+		).toBe(3904.0);
+	});
+
+	it('drops include_historical when it is false', async () => {
+		mockRequest.mockResolvedValue(paged([]));
+		await endpoints().averages.list(mockCtx(), { include_historical: false });
+		expect(lastCall()[1].query).toBeUndefined();
+	});
+});
+
+describe('correlations.list', () => {
+	const correlation = {
+		date: '2022-05-16',
+		period: 309,
+		offset: 0,
+		attribute: 'sleep',
+		attribute2: 'sleep_start',
+		value: -0.5577851552276848,
+		p: 1.1564227190131434e-26,
+		percentage: 55.77851552276848,
+		stars: 5,
+		second_person: 'you spend more time asleep when you go to bed earlier.',
+		second_person_elements: ['you spend more time asleep', 'when'],
+		attribute_category: null,
+		strength_description: 'Quite often go together',
+		stars_description: 'Certain to be related',
+		description: null,
+		occurrence: null,
+		rating: null,
+	};
+
+	it('sends strong/confident flags and stores each correlation', async () => {
+		mockRequest.mockResolvedValue(paged([correlation], 479));
+		const upsertByEntityId = jest.fn();
+		const ctx = {
+			...mockCtx(),
+			db: { correlations: { upsertByEntityId } },
+		} as unknown as ExistContext;
+
+		const result = await endpoints().correlations.list(ctx, {
+			limit: 10,
+			confident: true,
+			strong: false,
+			attribute: 'sleep',
+		});
+
+		expect(lastCall()[1]).toMatchObject({
+			method: 'GET',
+			url: 'correlations/',
+			query: { limit: 10, confident: 1, attribute: 'sleep' },
+		});
+		expect(lastCall()[1].query.strong).toBeUndefined();
+		expect(upsertByEntityId).toHaveBeenCalledWith(
+			'sleep:sleep_start:2022-05-16',
+			expect.objectContaining({ attribute2: 'sleep_start', stars: 5 }),
+		);
+		expect(
+			ExistEndpointOutputSchemas.correlationsList.parse(result).results[0]
+				?.rating,
+		).toBeNull();
+	});
+
+	it('parses a correlation carrying a user rating', () => {
+		const parsed = ExistEndpointOutputSchemas.correlationsList.parse(
+			paged([
+				{
+					...correlation,
+					rating: { positive: true, rating_type: 50, rating: 'Useful' },
+				},
+			]),
+		);
+		expect(parsed.results[0]?.rating?.rating).toBe('Useful');
+	});
+
+	it('rejects a limit above the documented maximum of 100', () => {
+		expect(
+			ExistEndpointInputSchemas.correlationsList.safeParse({ limit: 101 })
+				.success,
+		).toBe(false);
+	});
+});
+
+describe('insights.list', () => {
+	it('GETs insights with date and priority filters and stores them', async () => {
+		const insight = {
+			created: '2022-05-16T13:17:03+08:00',
+			target_date: '2022-05-16',
+			type: {
+				name: 'dow_sleep',
+				period: 1,
+				priority: 1,
+				attribute: {
+					name: 'sleep',
+					label: 'Time asleep',
+					group: { name: 'sleep', label: 'Sleep', priority: 3 },
+					priority: 1,
+					value_type: 3,
+					value_type_description: 'Period (min)',
+				},
+			},
+			html: '<div>You slept more than usual</div>',
+			text: 'You slept more than usual',
+		};
+		mockRequest.mockResolvedValue(paged([insight]));
+		const upsertByEntityId = jest.fn();
+		const ctx = {
+			...mockCtx(),
+			db: { insights: { upsertByEntityId } },
+		} as unknown as ExistContext;
+
+		const result = await endpoints().insights.list(ctx, {
+			date_min: '2022-05-01',
+			date_max: '2022-05-16',
+			priority: 1,
+			limit: 100,
+		});
+
+		expect(lastCall()[1]).toMatchObject({
+			method: 'GET',
+			url: 'insights/',
+			query: {
+				date_min: '2022-05-01',
+				date_max: '2022-05-16',
+				priority: 1,
+				limit: 100,
+			},
+		});
+		expect(upsertByEntityId).toHaveBeenCalledWith(
+			'dow_sleep:2022-05-16',
+			expect.objectContaining({ type_name: 'dow_sleep', attribute: 'sleep' }),
+		);
+		expect(
+			ExistEndpointOutputSchemas.insightsList.parse(result).results[0]?.type
+				.name,
+		).toBe('dow_sleep');
+	});
+
+	it('keys an insight with no target date by its creation time', async () => {
+		mockRequest.mockResolvedValue(
+			paged([
+				{
+					created: '2022-05-16T13:17:03+08:00',
+					target_date: null,
+					type: { name: 'week_summary', period: 7, priority: 3 },
+					html: '<div>Weekly summary</div>',
+					text: 'Weekly summary',
+				},
+			]),
+		);
+		const upsertByEntityId = jest.fn();
+		const ctx = {
+			...mockCtx(),
+			db: { insights: { upsertByEntityId } },
+		} as unknown as ExistContext;
+
+		const result = await endpoints().insights.list(ctx, {});
+
+		expect(upsertByEntityId).toHaveBeenCalledWith(
+			'week_summary:2022-05-16T13:17:03+08:00',
+			expect.objectContaining({ target_date: null, attribute: null }),
+		);
+		expect(
+			ExistEndpointOutputSchemas.insightsList.parse(result).results[0]
+				?.target_date,
+		).toBeNull();
+	});
+});
+
+describe('event logging', () => {
+	it('never records the access token alongside an operation', async () => {
+		mockRequest.mockResolvedValue(paged([stepsAttribute]));
+		await endpoints().attributes.list(mockCtx(), { groups: ['activity'] });
+
+		const [, event, fields] = mockLog.mock.calls[0] ?? [];
+		expect(event).toBe('exist.attributes.list');
+		expect(JSON.stringify(fields)).not.toContain(ACCESS_TOKEN);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error handling
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('error handlers', () => {
+	beforeEach(() => {
+		jest.spyOn(console, 'warn').mockImplementation(() => {});
+		jest.spyOn(console, 'error').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('classifies by HTTP status', () => {
+		expect(classify(new ExistAPIError('nope', 401))).toBe('AUTH_ERROR');
+		expect(classify(new ExistAPIError('nope', 403))).toBe('PERMISSION_ERROR');
+		expect(classify(new ExistAPIError('nope', 404))).toBe('NOT_FOUND_ERROR');
+		expect(classify(new ExistAPIError('nope', 429))).toBe('RATE_LIMIT_ERROR');
+		expect(classify(new ExistAPIError('boom', 500))).toBe('DEFAULT');
+		expect(classify(new Error('something odd'))).toBe('DEFAULT');
+	});
+
+	it('classifies raw ApiErrors too', () => {
+		expect(classify(httpError(429, undefined))).toBe('RATE_LIMIT_ERROR');
+		expect(classify(httpError(401, undefined))).toBe('AUTH_ERROR');
+	});
+
+	it('retries rate limits and forwards the retry-after hint', async () => {
+		const error = new ExistAPIError(
+			'Too Many Requests',
+			429,
+			undefined,
+			60_000,
+		);
+		expect(errorHandlers.RATE_LIMIT_ERROR.match(error)).toBe(true);
+		await expect(
+			errorHandlers.RATE_LIMIT_ERROR.handler(error),
+		).resolves.toEqual({ maxRetries: 5, headersRetryAfterMs: 60_000 });
+	});
+
+	it('handles a bodiless 429, which is what Exist actually returns', async () => {
+		const error = new ExistAPIError('Too Many Requests', 429);
+		await expect(
+			errorHandlers.RATE_LIMIT_ERROR.handler(error),
+		).resolves.toEqual({ maxRetries: 5, headersRetryAfterMs: undefined });
+	});
+
+	it('never retries auth or permission failures', async () => {
+		const context = { operation: 'test' } as never;
+		await expect(
+			errorHandlers.AUTH_ERROR.handler(new ExistAPIError('nope', 401), context),
+		).resolves.toEqual({ maxRetries: 0 });
+		await expect(
+			errorHandlers.PERMISSION_ERROR.handler(
+				new ExistAPIError('nope', 403),
+				context,
+			),
+		).resolves.toEqual({ maxRetries: 0 });
+	});
+
+	it('does not leak the access token in the messages it logs', async () => {
+		const warn = jest.spyOn(console, 'warn');
+		await errorHandlers.PERMISSION_ERROR.handler(
+			new ExistAPIError('Forbidden', 403),
+			{ operation: 'attributes.increment' } as never,
+		);
+		expect(warn.mock.calls.flat().join(' ')).not.toContain(ACCESS_TOKEN);
+	});
+});
+
+describe('exported OAuth constants', () => {
+	it('match the official Exist endpoints', () => {
+		expect(EXIST_API_BASE).toBe('https://exist.io/api/2');
+		expect(EXIST_OAUTH_AUTHORIZE_URL).toBe('https://exist.io/oauth2/authorize');
+		expect(EXIST_OAUTH_TOKEN_URL).toBe('https://exist.io/oauth2/access_token');
+		expect(EXIST_MAX_BATCH_SIZE).toBe(35);
+	});
+});

--- a/packages/exist/api.test.ts
+++ b/packages/exist/api.test.ts
@@ -144,7 +144,7 @@ beforeEach(() => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('exist plugin shape', () => {
-	it('registers the twelve Exist API operations and no triggers', () => {
+	it('registers the thirteen Exist operations and no triggers', () => {
 		const plugin = exist();
 		expect(plugin.id).toBe('exist');
 		expect(plugin.options?.authType).toBe('oauth_2');
@@ -163,6 +163,7 @@ describe('exist plugin shape', () => {
 			'averages.list',
 			'correlations.list',
 			'insights.list',
+			'oauth.authorize',
 			'users.getProfile',
 		]);
 	});
@@ -821,6 +822,131 @@ describe('attributes.update', () => {
 			ExistEndpointInputSchemas.attributesUpdate.safeParse({ attributes: [] })
 				.success,
 		).toBe(false);
+	});
+});
+
+describe('oauth.authorize', () => {
+	function oauthCtx(
+		credentials: Record<string, string | null>,
+		options: Record<string, unknown> = {},
+	) {
+		return {
+			key: ACCESS_TOKEN,
+			authType: 'oauth_2' as const,
+			options,
+			db: {},
+			tenantId: 'default',
+			$getAccountId: async () => 'acct',
+			keys: { get_integration_credentials: async () => credentials },
+		} as unknown as ExistContext;
+	}
+
+	const validCreds = {
+		client_id: 'exist-client-id',
+		client_secret: 'exist-client-secret',
+		redirect_url: 'https://app.example.com/callback',
+	};
+
+	it('builds the documented authorisation URL without calling the API', async () => {
+		const result = await endpoints().oauth.authorize(
+			oauthCtx(validCreds, { scopes: ['mood_read', 'mood_write'] }),
+			{},
+		);
+
+		// This operation must never issue an HTTP request.
+		expect(mockRequest).not.toHaveBeenCalled();
+
+		const url = new URL(result.url);
+		expect(`${url.origin}${url.pathname}`).toBe(
+			'https://exist.io/oauth2/authorize',
+		);
+		expect(url.searchParams.get('response_type')).toBe('code');
+		expect(url.searchParams.get('client_id')).toBe('exist-client-id');
+		expect(url.searchParams.get('redirect_uri')).toBe(
+			'https://app.example.com/callback',
+		);
+		// Exist documents a space-separated scope list.
+		expect(url.searchParams.get('scope')).toBe('mood_read mood_write');
+		expect(result.scopes).toEqual(['mood_read', 'mood_write']);
+	});
+
+	it('never puts the client secret in the URL', async () => {
+		const result = await endpoints().oauth.authorize(oauthCtx(validCreds), {
+			scopes: ['mood_read'],
+		});
+		expect(result.url).not.toContain('exist-client-secret');
+		expect(result.url).not.toContain('client_secret');
+	});
+
+	it('emits an unguessable, per-call state for CSRF protection', async () => {
+		const ctx = oauthCtx(validCreds);
+		const first = await endpoints().oauth.authorize(ctx, {
+			scopes: ['mood_read'],
+		});
+		const second = await endpoints().oauth.authorize(ctx, {
+			scopes: ['mood_read'],
+		});
+
+		expect(first.state).not.toBe(second.state);
+		expect(first.state.length).toBeGreaterThanOrEqual(16);
+		// The state in the URL is the one handed back to the caller to compare.
+		expect(new URL(first.url).searchParams.get('state')).toBe(first.state);
+	});
+
+	it('falls back to the scopes the plugin was configured with', async () => {
+		const result = await endpoints().oauth.authorize(
+			oauthCtx(validCreds, { scopes: ['sleep_read'] }),
+			{},
+		);
+		expect(new URL(result.url).searchParams.get('scope')).toBe('sleep_read');
+	});
+
+	it('rejects a non-HTTPS redirect, which Exist will not accept', async () => {
+		await expect(
+			endpoints().oauth.authorize(
+				oauthCtx({ ...validCreds, redirect_url: 'http://localhost:3000/cb' }),
+				{ scopes: ['mood_read'] },
+			),
+		).rejects.toThrow(/HTTPS/i);
+	});
+
+	it('reports missing client credentials clearly', async () => {
+		await expect(
+			endpoints().oauth.authorize(
+				oauthCtx({ ...validCreds, client_id: null }),
+				{ scopes: ['mood_read'] },
+			),
+		).rejects.toThrow(/client_id/);
+
+		await expect(
+			endpoints().oauth.authorize(
+				oauthCtx({ ...validCreds, redirect_url: null }),
+				{ scopes: ['mood_read'] },
+			),
+		).rejects.toThrow(/redirect_url/);
+	});
+
+	it('requires at least one scope', async () => {
+		await expect(
+			endpoints().oauth.authorize(oauthCtx(validCreds, {}), {}),
+		).rejects.toThrow(/scope/i);
+		// An explicitly empty scope array is a schema violation.
+		expect(
+			ExistEndpointInputSchemas.oauthAuthorize.safeParse({ scopes: [] })
+				.success,
+		).toBe(false);
+	});
+
+	it('logs only the scope count, not the client id or redirect target', async () => {
+		await endpoints().oauth.authorize(oauthCtx(validCreds), {
+			scopes: ['mood_read', 'sleep_read'],
+		});
+
+		const payload = mockLog.mock.calls[0]?.[2] as Record<string, unknown>;
+		expect(payload).toEqual({ scopeCount: 2 });
+		const serialized = JSON.stringify(payload);
+		expect(serialized).not.toContain('exist-client-id');
+		expect(serialized).not.toContain('app.example.com');
 	});
 });
 

--- a/packages/exist/client.ts
+++ b/packages/exist/client.ts
@@ -1,5 +1,10 @@
-import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import type {
+	ApiRequestOptions,
+	OpenAPIConfig,
+	RateLimitConfig,
+} from 'corsair/http';
 import { ApiError, request } from 'corsair/http';
+import type { z } from 'zod';
 
 /**
  * Exist API v2 base URL.
@@ -27,6 +32,25 @@ export const EXIST_OAUTH_TOKEN_URL = 'https://exist.io/oauth2/access_token';
  */
 export const EXIST_RATE_LIMIT_PER_HOUR = 300;
 
+const EXIST_GET_RATE_LIMIT: RateLimitConfig = {
+	enabled: true,
+	maxRetries: 3,
+	initialRetryDelay: 1000,
+	backoffMultiplier: 2,
+	headerNames: {
+		retryAfter: 'retry-after',
+		resetTime: 'x-ratelimit-reset',
+		remaining: 'x-ratelimit-remaining',
+		limit: 'x-ratelimit-limit',
+	},
+};
+
+const EXIST_WRITE_RATE_LIMIT: RateLimitConfig = {
+	...EXIST_GET_RATE_LIMIT,
+	enabled: false,
+	maxRetries: 0,
+};
+
 /**
  * Write endpoints (`acquire`, `release`, `update`, `increment`) accept at most
  * 35 objects per array.
@@ -38,6 +62,7 @@ export class ExistAPIError extends Error {
 	constructor(
 		message: string,
 		public readonly status?: number,
+		// unknown is necessary because Exist error payloads vary by endpoint; a closed error body union is infeasible because the API publishes no single failure schema
 		public readonly body?: unknown,
 		public readonly retryAfter?: number,
 	) {
@@ -54,8 +79,10 @@ export type ExistRequestOptions = {
 	 * Exist write endpoints take a top-level JSON array of objects; read
 	 * endpoints take no body at all.
 	 */
+	// unknown is necessary because write batch entries differ per operation; a closed entry union is infeasible because acquire, update and increment each accept different fields
 	body?: readonly Record<string, unknown>[];
 	query?: Record<string, ExistQueryValue>;
+	outputSchema?: z.ZodType<any>;
 };
 
 /** Serializes a `groups`/`attributes`/`templates` filter as Exist expects it. */
@@ -84,11 +111,13 @@ export function compactQuery(
 	return out;
 }
 
+// unknown is necessary because the transport can throw any value; a closed error union is infeasible because fetch-level failures are untyped
 function wrapError(error: unknown): never {
 	if (error instanceof ExistAPIError) throw error;
 	if (error instanceof ApiError) {
 		let message = error.message;
 		if (error.body && typeof error.body === 'object') {
+			// unknown is necessary because error detail payloads are provider-defined; a closed detail union is infeasible across endpoints
 			const body = error.body as Record<string, unknown>;
 			const detail = body.error ?? body.detail ?? body.message;
 			if (typeof detail === 'string' && detail.length > 0) message = detail;
@@ -113,7 +142,7 @@ export async function makeExistRequest<T>(
 	accessToken: string,
 	options: ExistRequestOptions = {},
 ): Promise<T> {
-	const { method = 'GET', body, query } = options;
+	const { method = 'GET', body, query, outputSchema } = options;
 
 	const config: OpenAPIConfig = {
 		BASE: EXIST_API_BASE,
@@ -136,12 +165,26 @@ export async function makeExistRequest<T>(
 	};
 
 	try {
-		return await request<T>(config, requestOptions);
+		const response = await request<T>(config, requestOptions, {
+			rateLimitConfig:
+				method === 'GET' ? EXIST_GET_RATE_LIMIT : EXIST_WRITE_RATE_LIMIT,
+		});
+		if (outputSchema) {
+			const parsed = outputSchema.safeParse(response);
+			if (!parsed.success) {
+				throw new ExistAPIError(
+					`Exist response failed schema validation: ${parsed.error.message}`,
+				);
+			}
+			return parsed.data as T;
+		}
+		return response;
 	} catch (error) {
 		wrapError(error);
 	}
 }
 
+// unknown is necessary because callers pass arbitrary thrown values for classification; a closed error union is infeasible at this boundary
 export function isUnauthorizedError(error: unknown): boolean {
 	if (error instanceof ExistAPIError) return error.status === 401;
 	if (error instanceof ApiError) return error.status === 401;

--- a/packages/exist/client.ts
+++ b/packages/exist/client.ts
@@ -1,0 +1,177 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+
+/**
+ * Exist API v2 base URL.
+ * @see https://developer.exist.io/guide/
+ */
+export const EXIST_API_BASE = 'https://exist.io/api/2';
+
+/**
+ * OAuth2 authorization endpoint.
+ * @see https://developer.exist.io/reference/authentication/oauth2/
+ */
+export const EXIST_OAUTH_AUTHORIZE_URL = 'https://exist.io/oauth2/authorize';
+
+/**
+ * OAuth2 token endpoint, used for both `authorization_code` and
+ * `refresh_token` grants. Client credentials are sent in the request body.
+ * @see https://developer.exist.io/reference/authentication/oauth2/
+ */
+export const EXIST_OAUTH_TOKEN_URL = 'https://exist.io/oauth2/access_token';
+
+/**
+ * Exist rate-limits at 300 requests per hour per user token and answers an
+ * exceeded quota with `429 Too Many Requests` and no body.
+ * @see https://developer.exist.io/guide/
+ */
+export const EXIST_RATE_LIMIT_PER_HOUR = 300;
+
+/**
+ * Write endpoints (`acquire`, `release`, `update`, `increment`) accept at most
+ * 35 objects per array.
+ * @see https://developer.exist.io/reference/writing_data/
+ */
+export const EXIST_MAX_BATCH_SIZE = 35;
+
+export class ExistAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly status?: number,
+		public readonly body?: unknown,
+		public readonly retryAfter?: number,
+	) {
+		super(message);
+		this.name = 'ExistAPIError';
+	}
+}
+
+export type ExistQueryValue = string | number | boolean | undefined;
+
+export type ExistRequestOptions = {
+	method?: 'GET' | 'POST';
+	/**
+	 * Exist write endpoints take a top-level JSON array of objects; read
+	 * endpoints take no body at all.
+	 */
+	body?: readonly Record<string, unknown>[];
+	query?: Record<string, ExistQueryValue>;
+};
+
+/** Serializes a `groups`/`attributes`/`templates` filter as Exist expects it. */
+export function toCommaList(values?: readonly string[]): string | undefined {
+	if (!values || values.length === 0) return undefined;
+	return values.join(',');
+}
+
+/**
+ * `strong`, `confident` and `include_historical` are documented as flags that
+ * are switched on by sending `1`; sending `0` is not documented, so a false
+ * value drops the parameter entirely.
+ */
+export function toFlag(value?: boolean): 1 | undefined {
+	return value === true ? 1 : undefined;
+}
+
+/** Drops undefined entries so they never reach the query string. */
+export function compactQuery(
+	query: Record<string, ExistQueryValue>,
+): Record<string, ExistQueryValue> {
+	const out: Record<string, ExistQueryValue> = {};
+	for (const [key, value] of Object.entries(query)) {
+		if (value !== undefined) out[key] = value;
+	}
+	return out;
+}
+
+function wrapError(error: unknown): never {
+	if (error instanceof ExistAPIError) throw error;
+	if (error instanceof ApiError) {
+		let message = error.message;
+		if (error.body && typeof error.body === 'object') {
+			const body = error.body as Record<string, unknown>;
+			const detail = body.error ?? body.detail ?? body.message;
+			if (typeof detail === 'string' && detail.length > 0) message = detail;
+		}
+		throw new ExistAPIError(
+			message,
+			error.status,
+			error.body,
+			error.retryAfter,
+		);
+	}
+	if (error instanceof Error) throw new ExistAPIError(error.message);
+	throw new ExistAPIError('Unknown error');
+}
+
+/**
+ * Issues a request against the Exist API v2 with an OAuth2 bearer token.
+ * @see https://developer.exist.io/reference/authentication/oauth2/
+ */
+export async function makeExistRequest<T>(
+	endpoint: string,
+	accessToken: string,
+	options: ExistRequestOptions = {},
+): Promise<T> {
+	const { method = 'GET', body, query } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: EXIST_API_BASE,
+		VERSION: '2',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: undefined,
+		HEADERS: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${accessToken}`,
+		},
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint,
+		body: method === 'POST' ? body : undefined,
+		mediaType: 'application/json',
+		query: query && Object.keys(query).length > 0 ? query : undefined,
+	};
+
+	try {
+		return await request<T>(config, requestOptions);
+	} catch (error) {
+		wrapError(error);
+	}
+}
+
+export function isUnauthorizedError(error: unknown): boolean {
+	if (error instanceof ExistAPIError) return error.status === 401;
+	if (error instanceof ApiError) return error.status === 401;
+	return false;
+}
+
+export type ExistRequestContext = {
+	key: string;
+	/**
+	 * Installed by `getOAuthAccessToken` so a token that was revoked or expired
+	 * server-side can be re-minted once before the call is retried.
+	 */
+	_refreshAuth?: () => Promise<string>;
+};
+
+/**
+ * Runs a request and, on a 401, mints a fresh access token once and retries.
+ */
+export async function makeAuthenticatedExistRequest<T>(
+	endpoint: string,
+	ctx: ExistRequestContext,
+	options: ExistRequestOptions = {},
+): Promise<T> {
+	try {
+		return await makeExistRequest<T>(endpoint, ctx.key, options);
+	} catch (error) {
+		if (isUnauthorizedError(error) && ctx._refreshAuth) {
+			const freshToken = await ctx._refreshAuth();
+			return await makeExistRequest<T>(endpoint, freshToken, options);
+		}
+		throw error;
+	}
+}

--- a/packages/exist/client.ts
+++ b/packages/exist/client.ts
@@ -73,7 +73,7 @@ export class ExistAPIError extends Error {
 
 export type ExistQueryValue = string | number | boolean | undefined;
 
-export type ExistRequestOptions = {
+export type ExistRequestOptions<T = unknown> = {
 	method?: 'GET' | 'POST';
 	/**
 	 * Exist write endpoints take a top-level JSON array of objects; read
@@ -82,7 +82,7 @@ export type ExistRequestOptions = {
 	// unknown is necessary because write batch entries differ per operation; a closed entry union is infeasible because acquire, update and increment each accept different fields
 	body?: readonly Record<string, unknown>[];
 	query?: Record<string, ExistQueryValue>;
-	outputSchema?: z.ZodType<any>;
+	outputSchema?: z.ZodType<T>;
 };
 
 /** Serializes a `groups`/`attributes`/`templates` filter as Exist expects it. */
@@ -140,7 +140,7 @@ function wrapError(error: unknown): never {
 export async function makeExistRequest<T>(
 	endpoint: string,
 	accessToken: string,
-	options: ExistRequestOptions = {},
+	options: ExistRequestOptions<T> = {},
 ): Promise<T> {
 	const { method = 'GET', body, query, outputSchema } = options;
 
@@ -206,7 +206,7 @@ export type ExistRequestContext = {
 export async function makeAuthenticatedExistRequest<T>(
 	endpoint: string,
 	ctx: ExistRequestContext,
-	options: ExistRequestOptions = {},
+	options: ExistRequestOptions<T> = {},
 ): Promise<T> {
 	try {
 		return await makeExistRequest<T>(endpoint, ctx.key, options);

--- a/packages/exist/endpoints/attributes.ts
+++ b/packages/exist/endpoints/attributes.ts
@@ -9,6 +9,31 @@ import { persistAttributes, persistAttributesWithValues } from './persist';
 import type { ExistEndpointOutputs } from './types';
 
 /**
+ * Summarises a write batch for the operation log. Exist attribute values are
+ * personal analytics data (mood notes, weight, location counts), so the values
+ * themselves are deliberately left out — the log keeps only what is needed to
+ * trace an operation: how many objects were sent, which attributes they
+ * targeted, and which days they covered.
+ */
+function writeBatchSummary(
+	attributes: readonly { name: string; date?: string }[],
+): Record<string, unknown> {
+	const names = [...new Set(attributes.map((a) => a.name))];
+	const dates = [
+		...new Set(
+			attributes
+				.map((a) => a.date)
+				.filter((date): date is string => date !== undefined),
+		),
+	].sort();
+	return {
+		count: attributes.length,
+		attributes: names,
+		...(dates.length > 0 ? { dates } : {}),
+	};
+}
+
+/**
  * List the user's attributes without values.
  * @see https://developer.exist.io/reference/attributes/
  */
@@ -205,7 +230,7 @@ export const increment: ExistEndpoints['attributesIncrement'] = async (
 	await logEventFromContext(
 		ctx,
 		'exist.attributes.increment',
-		{ ...input },
+		writeBatchSummary(input.attributes),
 		'completed',
 	);
 	return result;
@@ -230,7 +255,7 @@ export const update: ExistEndpoints['attributesUpdate'] = async (
 	await logEventFromContext(
 		ctx,
 		'exist.attributes.update',
-		{ ...input },
+		writeBatchSummary(input.attributes),
 		'completed',
 	);
 	return result;

--- a/packages/exist/endpoints/attributes.ts
+++ b/packages/exist/endpoints/attributes.ts
@@ -1,12 +1,8 @@
 import { logEventFromContext } from 'corsair/core';
-import {
-	compactQuery,
-	makeAuthenticatedExistRequest,
-	toCommaList,
-} from '../client';
+import { compactQuery, toCommaList } from '../client';
 import type { ExistEndpoints } from '../index';
 import { persistAttributes, persistAttributesWithValues } from './persist';
-import type { ExistEndpointOutputs } from './types';
+import { parseExistInput, validatedExistRequest } from './validate';
 
 /**
  * Summarises a write batch for the operation log. Exist attribute values are
@@ -15,9 +11,15 @@ import type { ExistEndpointOutputs } from './types';
  * trace an operation: how many objects were sent, which attributes they
  * targeted, and which days they covered.
  */
+type WriteBatchSummary = {
+	count: number;
+	attributes: string[];
+	dates?: string[];
+};
+
 function writeBatchSummary(
 	attributes: readonly { name: string; date?: string }[],
-): Record<string, unknown> {
+): WriteBatchSummary {
 	const names = [...new Set(attributes.map((a) => a.name))];
 	const dates = [
 		...new Set(
@@ -38,22 +40,26 @@ function writeBatchSummary(
  * @see https://developer.exist.io/reference/attributes/
  */
 export const list: ExistEndpoints['attributesList'] = async (ctx, input) => {
-	const result = await makeAuthenticatedExistRequest<
-		ExistEndpointOutputs['attributesList']
-	>('attributes/', ctx, {
-		method: 'GET',
-		query: compactQuery({
-			page: input.page,
-			limit: input.limit,
-			groups: toCommaList(input.groups),
-			attributes: toCommaList(input.attributes),
-			exclude_custom: input.exclude_custom,
-			manual: input.manual,
-			include_inactive: input.include_inactive,
-			include_low_priority: input.include_low_priority,
-			owned: input.owned,
-		}),
-	});
+	const parsed = parseExistInput('attributesList', input);
+	const result = await validatedExistRequest(
+		'attributesList',
+		'attributes/',
+		ctx,
+		{
+			method: 'GET',
+			query: compactQuery({
+				page: parsed.page,
+				limit: parsed.limit,
+				groups: toCommaList(parsed.groups),
+				attributes: toCommaList(parsed.attributes),
+				exclude_custom: parsed.exclude_custom,
+				manual: parsed.manual,
+				include_inactive: parsed.include_inactive,
+				include_low_priority: parsed.include_low_priority,
+				owned: parsed.owned,
+			}),
+		},
+	);
 
 	await persistAttributes(ctx, result.results);
 	await logEventFromContext(
@@ -73,17 +79,21 @@ export const listTemplates: ExistEndpoints['attributesListTemplates'] = async (
 	ctx,
 	input,
 ) => {
-	const result = await makeAuthenticatedExistRequest<
-		ExistEndpointOutputs['attributesListTemplates']
-	>('attributes/templates/', ctx, {
-		method: 'GET',
-		query: compactQuery({
-			page: input.page,
-			limit: input.limit,
-			include_low_priority: input.include_low_priority,
-			groups: toCommaList(input.groups),
-		}),
-	});
+	const parsed = parseExistInput('attributesListTemplates', input);
+	const result = await validatedExistRequest(
+		'attributesListTemplates',
+		'attributes/templates/',
+		ctx,
+		{
+			method: 'GET',
+			query: compactQuery({
+				page: parsed.page,
+				limit: parsed.limit,
+				include_low_priority: parsed.include_low_priority,
+				groups: toCommaList(parsed.groups),
+			}),
+		},
+	);
 
 	await logEventFromContext(
 		ctx,
@@ -100,21 +110,25 @@ export const listTemplates: ExistEndpoints['attributesListTemplates'] = async (
  */
 export const listWithValues: ExistEndpoints['attributesListWithValues'] =
 	async (ctx, input) => {
-		const result = await makeAuthenticatedExistRequest<
-			ExistEndpointOutputs['attributesListWithValues']
-		>('attributes/with-values/', ctx, {
-			method: 'GET',
-			query: compactQuery({
-				page: input.page,
-				limit: input.limit,
-				days: input.days,
-				date_max: input.date_max,
-				groups: toCommaList(input.groups),
-				attributes: toCommaList(input.attributes),
-				templates: toCommaList(input.templates),
-				manual: input.manual,
-			}),
-		});
+		const parsed = parseExistInput('attributesListWithValues', input);
+		const result = await validatedExistRequest(
+			'attributesListWithValues',
+			'attributes/with-values/',
+			ctx,
+			{
+				method: 'GET',
+				query: compactQuery({
+					page: parsed.page,
+					limit: parsed.limit,
+					days: parsed.days,
+					date_max: parsed.date_max,
+					groups: toCommaList(parsed.groups),
+					attributes: toCommaList(parsed.attributes),
+					templates: toCommaList(parsed.templates),
+					manual: parsed.manual,
+				}),
+			},
+		);
 
 		await persistAttributesWithValues(ctx, result.results);
 		await logEventFromContext(
@@ -134,21 +148,25 @@ export const listOwned: ExistEndpoints['attributesListOwned'] = async (
 	ctx,
 	input,
 ) => {
-	const result = await makeAuthenticatedExistRequest<
-		ExistEndpointOutputs['attributesListOwned']
-	>('attributes/owned/', ctx, {
-		method: 'GET',
-		query: compactQuery({
-			page: input.page,
-			limit: input.limit,
-			groups: toCommaList(input.groups),
-			attributes: toCommaList(input.attributes),
-			exclude_custom: input.exclude_custom,
-			manual: input.manual,
-			include_inactive: input.include_inactive,
-			include_low_priority: input.include_low_priority,
-		}),
-	});
+	const parsed = parseExistInput('attributesListOwned', input);
+	const result = await validatedExistRequest(
+		'attributesListOwned',
+		'attributes/owned/',
+		ctx,
+		{
+			method: 'GET',
+			query: compactQuery({
+				page: parsed.page,
+				limit: parsed.limit,
+				groups: toCommaList(parsed.groups),
+				attributes: toCommaList(parsed.attributes),
+				exclude_custom: parsed.exclude_custom,
+				manual: parsed.manual,
+				include_inactive: parsed.include_inactive,
+				include_low_priority: parsed.include_low_priority,
+			}),
+		},
+	);
 
 	await persistAttributes(ctx, result.results);
 	await logEventFromContext(
@@ -169,15 +187,19 @@ export const acquire: ExistEndpoints['attributesAcquire'] = async (
 	ctx,
 	input,
 ) => {
-	const result = await makeAuthenticatedExistRequest<
-		ExistEndpointOutputs['attributesAcquire']
-	>('attributes/acquire/', ctx, {
-		method: 'POST',
-		body: input.attributes,
-		query: compactQuery({
-			success_objects: input.success_objects === true ? 1 : undefined,
-		}),
-	});
+	const parsed = parseExistInput('attributesAcquire', input);
+	const result = await validatedExistRequest(
+		'attributesAcquire',
+		'attributes/acquire/',
+		ctx,
+		{
+			method: 'POST',
+			body: parsed.attributes,
+			query: compactQuery({
+				success_objects: parsed.success_objects === true ? 1 : undefined,
+			}),
+		},
+	);
 
 	await logEventFromContext(
 		ctx,
@@ -196,12 +218,16 @@ export const release: ExistEndpoints['attributesRelease'] = async (
 	ctx,
 	input,
 ) => {
-	const result = await makeAuthenticatedExistRequest<
-		ExistEndpointOutputs['attributesRelease']
-	>('attributes/release/', ctx, {
-		method: 'POST',
-		body: input.attributes,
-	});
+	const parsed = parseExistInput('attributesRelease', input);
+	const result = await validatedExistRequest(
+		'attributesRelease',
+		'attributes/release/',
+		ctx,
+		{
+			method: 'POST',
+			body: parsed.attributes,
+		},
+	);
 
 	await logEventFromContext(
 		ctx,
@@ -220,17 +246,21 @@ export const increment: ExistEndpoints['attributesIncrement'] = async (
 	ctx,
 	input,
 ) => {
-	const result = await makeAuthenticatedExistRequest<
-		ExistEndpointOutputs['attributesIncrement']
-	>('attributes/increment/', ctx, {
-		method: 'POST',
-		body: input.attributes,
-	});
+	const parsed = parseExistInput('attributesIncrement', input);
+	const result = await validatedExistRequest(
+		'attributesIncrement',
+		'attributes/increment/',
+		ctx,
+		{
+			method: 'POST',
+			body: parsed.attributes,
+		},
+	);
 
 	await logEventFromContext(
 		ctx,
 		'exist.attributes.increment',
-		writeBatchSummary(input.attributes),
+		writeBatchSummary(parsed.attributes),
 		'completed',
 	);
 	return result;
@@ -245,17 +275,21 @@ export const update: ExistEndpoints['attributesUpdate'] = async (
 	ctx,
 	input,
 ) => {
-	const result = await makeAuthenticatedExistRequest<
-		ExistEndpointOutputs['attributesUpdate']
-	>('attributes/update/', ctx, {
-		method: 'POST',
-		body: input.attributes,
-	});
+	const parsed = parseExistInput('attributesUpdate', input);
+	const result = await validatedExistRequest(
+		'attributesUpdate',
+		'attributes/update/',
+		ctx,
+		{
+			method: 'POST',
+			body: parsed.attributes,
+		},
+	);
 
 	await logEventFromContext(
 		ctx,
 		'exist.attributes.update',
-		writeBatchSummary(input.attributes),
+		writeBatchSummary(parsed.attributes),
 		'completed',
 	);
 	return result;

--- a/packages/exist/endpoints/attributes.ts
+++ b/packages/exist/endpoints/attributes.ts
@@ -1,0 +1,237 @@
+import { logEventFromContext } from 'corsair/core';
+import {
+	compactQuery,
+	makeAuthenticatedExistRequest,
+	toCommaList,
+} from '../client';
+import type { ExistEndpoints } from '../index';
+import { persistAttributes, persistAttributesWithValues } from './persist';
+import type { ExistEndpointOutputs } from './types';
+
+/**
+ * List the user's attributes without values.
+ * @see https://developer.exist.io/reference/attributes/
+ */
+export const list: ExistEndpoints['attributesList'] = async (ctx, input) => {
+	const result = await makeAuthenticatedExistRequest<
+		ExistEndpointOutputs['attributesList']
+	>('attributes/', ctx, {
+		method: 'GET',
+		query: compactQuery({
+			page: input.page,
+			limit: input.limit,
+			groups: toCommaList(input.groups),
+			attributes: toCommaList(input.attributes),
+			exclude_custom: input.exclude_custom,
+			manual: input.manual,
+			include_inactive: input.include_inactive,
+			include_low_priority: input.include_low_priority,
+			owned: input.owned,
+		}),
+	});
+
+	await persistAttributes(ctx, result.results);
+	await logEventFromContext(
+		ctx,
+		'exist.attributes.list',
+		{ ...input },
+		'completed',
+	);
+	return result;
+};
+
+/**
+ * List the attribute templates Exist supports.
+ * @see https://developer.exist.io/reference/attributes/
+ */
+export const listTemplates: ExistEndpoints['attributesListTemplates'] = async (
+	ctx,
+	input,
+) => {
+	const result = await makeAuthenticatedExistRequest<
+		ExistEndpointOutputs['attributesListTemplates']
+	>('attributes/templates/', ctx, {
+		method: 'GET',
+		query: compactQuery({
+			page: input.page,
+			limit: input.limit,
+			include_low_priority: input.include_low_priority,
+			groups: toCommaList(input.groups),
+		}),
+	});
+
+	await logEventFromContext(
+		ctx,
+		'exist.attributes.listTemplates',
+		{ ...input },
+		'completed',
+	);
+	return result;
+};
+
+/**
+ * List the user's attributes along with their recent day values.
+ * @see https://developer.exist.io/reference/attributes/
+ */
+export const listWithValues: ExistEndpoints['attributesListWithValues'] =
+	async (ctx, input) => {
+		const result = await makeAuthenticatedExistRequest<
+			ExistEndpointOutputs['attributesListWithValues']
+		>('attributes/with-values/', ctx, {
+			method: 'GET',
+			query: compactQuery({
+				page: input.page,
+				limit: input.limit,
+				days: input.days,
+				date_max: input.date_max,
+				groups: toCommaList(input.groups),
+				attributes: toCommaList(input.attributes),
+				templates: toCommaList(input.templates),
+				manual: input.manual,
+			}),
+		});
+
+		await persistAttributesWithValues(ctx, result.results);
+		await logEventFromContext(
+			ctx,
+			'exist.attributes.listWithValues',
+			{ ...input },
+			'completed',
+		);
+		return result;
+	};
+
+/**
+ * List the attributes this OAuth2 client already owns.
+ * @see https://developer.exist.io/reference/attribute_ownership/
+ */
+export const listOwned: ExistEndpoints['attributesListOwned'] = async (
+	ctx,
+	input,
+) => {
+	const result = await makeAuthenticatedExistRequest<
+		ExistEndpointOutputs['attributesListOwned']
+	>('attributes/owned/', ctx, {
+		method: 'GET',
+		query: compactQuery({
+			page: input.page,
+			limit: input.limit,
+			groups: toCommaList(input.groups),
+			attributes: toCommaList(input.attributes),
+			exclude_custom: input.exclude_custom,
+			manual: input.manual,
+			include_inactive: input.include_inactive,
+			include_low_priority: input.include_low_priority,
+		}),
+	});
+
+	await persistAttributes(ctx, result.results);
+	await logEventFromContext(
+		ctx,
+		'exist.attributes.listOwned',
+		{ ...input },
+		'completed',
+	);
+	return result;
+};
+
+/**
+ * Take ownership of attributes so this client can write values for them.
+ * Acquiring a template the user does not have yet creates that attribute.
+ * @see https://developer.exist.io/reference/attribute_ownership/
+ */
+export const acquire: ExistEndpoints['attributesAcquire'] = async (
+	ctx,
+	input,
+) => {
+	const result = await makeAuthenticatedExistRequest<
+		ExistEndpointOutputs['attributesAcquire']
+	>('attributes/acquire/', ctx, {
+		method: 'POST',
+		body: input.attributes,
+		query: compactQuery({
+			success_objects: input.success_objects === true ? 1 : undefined,
+		}),
+	});
+
+	await logEventFromContext(
+		ctx,
+		'exist.attributes.acquire',
+		{ ...input },
+		'completed',
+	);
+	return result;
+};
+
+/**
+ * Give up ownership of attributes previously acquired by this client.
+ * @see https://developer.exist.io/reference/attribute_ownership/
+ */
+export const release: ExistEndpoints['attributesRelease'] = async (
+	ctx,
+	input,
+) => {
+	const result = await makeAuthenticatedExistRequest<
+		ExistEndpointOutputs['attributesRelease']
+	>('attributes/release/', ctx, {
+		method: 'POST',
+		body: input.attributes,
+	});
+
+	await logEventFromContext(
+		ctx,
+		'exist.attributes.release',
+		{ ...input },
+		'completed',
+	);
+	return result;
+};
+
+/**
+ * Apply deltas to owned attributes rather than overwriting the day's total.
+ * @see https://developer.exist.io/reference/writing_data/
+ */
+export const increment: ExistEndpoints['attributesIncrement'] = async (
+	ctx,
+	input,
+) => {
+	const result = await makeAuthenticatedExistRequest<
+		ExistEndpointOutputs['attributesIncrement']
+	>('attributes/increment/', ctx, {
+		method: 'POST',
+		body: input.attributes,
+	});
+
+	await logEventFromContext(
+		ctx,
+		'exist.attributes.increment',
+		{ ...input },
+		'completed',
+	);
+	return result;
+};
+
+/**
+ * Overwrite owned attributes' totals for a given day. Use `increment` instead
+ * when the client would otherwise have to track the running total itself.
+ * @see https://developer.exist.io/reference/writing_data/
+ */
+export const update: ExistEndpoints['attributesUpdate'] = async (
+	ctx,
+	input,
+) => {
+	const result = await makeAuthenticatedExistRequest<
+		ExistEndpointOutputs['attributesUpdate']
+	>('attributes/update/', ctx, {
+		method: 'POST',
+		body: input.attributes,
+	});
+
+	await logEventFromContext(
+		ctx,
+		'exist.attributes.update',
+		{ ...input },
+		'completed',
+	);
+	return result;
+};

--- a/packages/exist/endpoints/averages.ts
+++ b/packages/exist/endpoints/averages.ts
@@ -1,0 +1,49 @@
+import { logEventFromContext } from 'corsair/core';
+import {
+	compactQuery,
+	makeAuthenticatedExistRequest,
+	toCommaList,
+	toFlag,
+} from '../client';
+import type { ExistEndpoints } from '../index';
+import type { ExistEndpointOutputs } from './types';
+
+/**
+ * Get weekly average values per attribute, optionally including history.
+ * @see https://developer.exist.io/reference/averages/
+ */
+export const list: ExistEndpoints['averagesList'] = async (ctx, input) => {
+	const result = await makeAuthenticatedExistRequest<
+		ExistEndpointOutputs['averagesList']
+	>('averages/', ctx, {
+		method: 'GET',
+		query: compactQuery({
+			page: input.page,
+			limit: input.limit,
+			date_min: input.date_min,
+			date_max: input.date_max,
+			groups: toCommaList(input.groups),
+			attributes: toCommaList(input.attributes),
+			include_historical: toFlag(input.include_historical),
+		}),
+	});
+
+	if (ctx.db.averages) {
+		try {
+			for (const average of result.results) {
+				const id = `${average.attribute}:${average.date}`;
+				await ctx.db.averages.upsertByEntityId(id, { ...average, id });
+			}
+		} catch (error) {
+			console.warn('Failed to save Exist averages to database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'exist.averages.list',
+		{ ...input },
+		'completed',
+	);
+	return result;
+};

--- a/packages/exist/endpoints/averages.ts
+++ b/packages/exist/endpoints/averages.ts
@@ -1,30 +1,24 @@
 import { logEventFromContext } from 'corsair/core';
-import {
-	compactQuery,
-	makeAuthenticatedExistRequest,
-	toCommaList,
-	toFlag,
-} from '../client';
+import { compactQuery, toCommaList, toFlag } from '../client';
 import type { ExistEndpoints } from '../index';
-import type { ExistEndpointOutputs } from './types';
+import { parseExistInput, validatedExistRequest } from './validate';
 
 /**
  * Get weekly average values per attribute, optionally including history.
  * @see https://developer.exist.io/reference/averages/
  */
 export const list: ExistEndpoints['averagesList'] = async (ctx, input) => {
-	const result = await makeAuthenticatedExistRequest<
-		ExistEndpointOutputs['averagesList']
-	>('averages/', ctx, {
+	const parsed = parseExistInput('averagesList', input);
+	const result = await validatedExistRequest('averagesList', 'averages/', ctx, {
 		method: 'GET',
 		query: compactQuery({
-			page: input.page,
-			limit: input.limit,
-			date_min: input.date_min,
-			date_max: input.date_max,
-			groups: toCommaList(input.groups),
-			attributes: toCommaList(input.attributes),
-			include_historical: toFlag(input.include_historical),
+			page: parsed.page,
+			limit: parsed.limit,
+			date_min: parsed.date_min,
+			date_max: parsed.date_max,
+			groups: toCommaList(parsed.groups),
+			attributes: toCommaList(parsed.attributes),
+			include_historical: toFlag(parsed.include_historical),
 		}),
 	});
 

--- a/packages/exist/endpoints/correlations.ts
+++ b/packages/exist/endpoints/correlations.ts
@@ -1,0 +1,56 @@
+import { logEventFromContext } from 'corsair/core';
+import { compactQuery, makeAuthenticatedExistRequest, toFlag } from '../client';
+import type { ExistEndpoints } from '../index';
+import type { ExistEndpointOutputs } from './types';
+
+/**
+ * List the correlations Exist has computed between the user's attributes.
+ * @see https://developer.exist.io/reference/correlations/
+ */
+export const list: ExistEndpoints['correlationsList'] = async (ctx, input) => {
+	const result = await makeAuthenticatedExistRequest<
+		ExistEndpointOutputs['correlationsList']
+	>('correlations/', ctx, {
+		method: 'GET',
+		query: compactQuery({
+			page: input.page,
+			limit: input.limit,
+			strong: toFlag(input.strong),
+			confident: toFlag(input.confident),
+			attribute: input.attribute,
+		}),
+	});
+
+	if (ctx.db.correlations) {
+		try {
+			for (const correlation of result.results) {
+				const id = `${correlation.attribute}:${correlation.attribute2}:${correlation.date}`;
+				await ctx.db.correlations.upsertByEntityId(id, {
+					id,
+					attribute: correlation.attribute,
+					attribute2: correlation.attribute2,
+					date: correlation.date,
+					period: correlation.period,
+					offset: correlation.offset,
+					value: correlation.value,
+					p: correlation.p,
+					percentage: correlation.percentage,
+					stars: correlation.stars,
+					second_person: correlation.second_person,
+					strength_description: correlation.strength_description ?? null,
+					stars_description: correlation.stars_description ?? null,
+				});
+			}
+		} catch (error) {
+			console.warn('Failed to save Exist correlations to database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'exist.correlations.list',
+		{ ...input },
+		'completed',
+	);
+	return result;
+};

--- a/packages/exist/endpoints/correlations.ts
+++ b/packages/exist/endpoints/correlations.ts
@@ -1,25 +1,29 @@
 import { logEventFromContext } from 'corsair/core';
-import { compactQuery, makeAuthenticatedExistRequest, toFlag } from '../client';
+import { compactQuery, toFlag } from '../client';
 import type { ExistEndpoints } from '../index';
-import type { ExistEndpointOutputs } from './types';
+import { parseExistInput, validatedExistRequest } from './validate';
 
 /**
  * List the correlations Exist has computed between the user's attributes.
  * @see https://developer.exist.io/reference/correlations/
  */
 export const list: ExistEndpoints['correlationsList'] = async (ctx, input) => {
-	const result = await makeAuthenticatedExistRequest<
-		ExistEndpointOutputs['correlationsList']
-	>('correlations/', ctx, {
-		method: 'GET',
-		query: compactQuery({
-			page: input.page,
-			limit: input.limit,
-			strong: toFlag(input.strong),
-			confident: toFlag(input.confident),
-			attribute: input.attribute,
-		}),
-	});
+	const parsed = parseExistInput('correlationsList', input);
+	const result = await validatedExistRequest(
+		'correlationsList',
+		'correlations/',
+		ctx,
+		{
+			method: 'GET',
+			query: compactQuery({
+				page: parsed.page,
+				limit: parsed.limit,
+				strong: toFlag(parsed.strong),
+				confident: toFlag(parsed.confident),
+				attribute: parsed.attribute,
+			}),
+		},
+	);
 
 	if (ctx.db.correlations) {
 		try {

--- a/packages/exist/endpoints/index.ts
+++ b/packages/exist/endpoints/index.ts
@@ -11,6 +11,7 @@ import {
 import { list as averagesList } from './averages';
 import { list as correlationsList } from './correlations';
 import { list as insightsList } from './insights';
+import { authorize } from './oauth';
 import { getProfile } from './users';
 
 export const Attributes = {
@@ -34,6 +35,10 @@ export const Correlations = {
 
 export const Insights = {
 	list: insightsList,
+};
+
+export const Oauth = {
+	authorize,
 };
 
 export const Users = {

--- a/packages/exist/endpoints/index.ts
+++ b/packages/exist/endpoints/index.ts
@@ -1,0 +1,43 @@
+import {
+	acquire,
+	list as attributesList,
+	increment,
+	listOwned,
+	listTemplates,
+	listWithValues,
+	release,
+	update,
+} from './attributes';
+import { list as averagesList } from './averages';
+import { list as correlationsList } from './correlations';
+import { list as insightsList } from './insights';
+import { getProfile } from './users';
+
+export const Attributes = {
+	list: attributesList,
+	listTemplates,
+	listWithValues,
+	listOwned,
+	acquire,
+	release,
+	increment,
+	update,
+};
+
+export const Averages = {
+	list: averagesList,
+};
+
+export const Correlations = {
+	list: correlationsList,
+};
+
+export const Insights = {
+	list: insightsList,
+};
+
+export const Users = {
+	getProfile,
+};
+
+export * from './types';

--- a/packages/exist/endpoints/insights.ts
+++ b/packages/exist/endpoints/insights.ts
@@ -1,0 +1,50 @@
+import { logEventFromContext } from 'corsair/core';
+import { compactQuery, makeAuthenticatedExistRequest } from '../client';
+import type { ExistEndpoints } from '../index';
+import type { ExistEndpointOutputs } from './types';
+
+/**
+ * List the insights Exist has generated about the user's data.
+ * @see https://developer.exist.io/reference/insights/
+ */
+export const list: ExistEndpoints['insightsList'] = async (ctx, input) => {
+	const result = await makeAuthenticatedExistRequest<
+		ExistEndpointOutputs['insightsList']
+	>('insights/', ctx, {
+		method: 'GET',
+		query: compactQuery({
+			page: input.page,
+			limit: input.limit,
+			date_min: input.date_min,
+			date_max: input.date_max,
+			priority: input.priority,
+		}),
+	});
+
+	if (ctx.db.insights) {
+		try {
+			for (const insight of result.results) {
+				const id = `${insight.type.name}:${insight.target_date ?? insight.created}`;
+				await ctx.db.insights.upsertByEntityId(id, {
+					id,
+					type_name: insight.type.name,
+					target_date: insight.target_date,
+					created: insight.created,
+					attribute: insight.type.attribute?.name ?? null,
+					text: insight.text,
+					html: insight.html,
+				});
+			}
+		} catch (error) {
+			console.warn('Failed to save Exist insights to database:', error);
+		}
+	}
+
+	await logEventFromContext(
+		ctx,
+		'exist.insights.list',
+		{ ...input },
+		'completed',
+	);
+	return result;
+};

--- a/packages/exist/endpoints/insights.ts
+++ b/packages/exist/endpoints/insights.ts
@@ -1,23 +1,22 @@
 import { logEventFromContext } from 'corsair/core';
-import { compactQuery, makeAuthenticatedExistRequest } from '../client';
+import { compactQuery } from '../client';
 import type { ExistEndpoints } from '../index';
-import type { ExistEndpointOutputs } from './types';
+import { parseExistInput, validatedExistRequest } from './validate';
 
 /**
  * List the insights Exist has generated about the user's data.
  * @see https://developer.exist.io/reference/insights/
  */
 export const list: ExistEndpoints['insightsList'] = async (ctx, input) => {
-	const result = await makeAuthenticatedExistRequest<
-		ExistEndpointOutputs['insightsList']
-	>('insights/', ctx, {
+	const parsed = parseExistInput('insightsList', input);
+	const result = await validatedExistRequest('insightsList', 'insights/', ctx, {
 		method: 'GET',
 		query: compactQuery({
-			page: input.page,
-			limit: input.limit,
-			date_min: input.date_min,
-			date_max: input.date_max,
-			priority: input.priority,
+			page: parsed.page,
+			limit: parsed.limit,
+			date_min: parsed.date_min,
+			date_max: parsed.date_max,
+			priority: parsed.priority,
 		}),
 	});
 

--- a/packages/exist/endpoints/oauth.ts
+++ b/packages/exist/endpoints/oauth.ts
@@ -1,0 +1,74 @@
+import { logEventFromContext } from 'corsair/core';
+import { EXIST_OAUTH_AUTHORIZE_URL } from '../client';
+import type { ExistEndpoints } from '../index';
+import { parseExistInput } from './validate';
+
+/**
+ * Builds the Exist authorisation URL the user must visit to grant access.
+ *
+ * This operation makes no API call — it only constructs the URL. Exist returns
+ * the user to `redirect_url` with a `code` (or an `error`) in the query string;
+ * Corsair's OAuth2 machinery exchanges that code at the token endpoint.
+ *
+ * Parameters follow the official flow: `response_type=code`, `client_id`,
+ * `redirect_uri` and a space-separated `scope` list.
+ * @see https://developer.exist.io/reference/authentication/oauth2/
+ */
+export const authorize: ExistEndpoints['oauthAuthorize'] = async (
+	ctx,
+	rawInput,
+) => {
+	const input = parseExistInput('oauthAuthorize', rawInput);
+	const credentials = await ctx.keys.get_integration_credentials();
+
+	if (!credentials.client_id) {
+		throw new Error(
+			'Exist client_id is not configured; set it on the integration before building an authorisation URL',
+		);
+	}
+	if (!credentials.redirect_url) {
+		throw new Error(
+			'Exist redirect_url is not configured; set it to the redirect URI registered with your Exist OAuth2 client',
+		);
+	}
+	// Exist rejects non-HTTPS redirect URIs, so fail here with a clear message
+	// rather than sending the user to an authorisation page that will error.
+	if (!credentials.redirect_url.startsWith('https://')) {
+		throw new Error(
+			'Exist requires an HTTPS redirect_url; update the integration credentials to use https://',
+		);
+	}
+
+	const scopes = input.scopes ?? ctx.options.scopes ?? [];
+	if (scopes.length === 0) {
+		throw new Error(
+			'At least one Exist scope is required to build an authorisation URL',
+		);
+	}
+
+	// `state` is not required by Exist but is standard OAuth2 CSRF protection:
+	// a per-call unguessable value the caller stores and compares against the
+	// `state` Exist echoes back, so a replayed redirect cannot be accepted.
+	const state = crypto.randomUUID();
+
+	const params = new URLSearchParams({
+		response_type: 'code',
+		client_id: credentials.client_id,
+		redirect_uri: credentials.redirect_url,
+		scope: scopes.join(' '),
+		state,
+	});
+
+	const url = `${EXIST_OAUTH_AUTHORIZE_URL}?${params.toString()}`;
+
+	// Only the scope count is recorded: the URL embeds the client id and the
+	// redirect target, neither of which belongs in a persistent event log.
+	await logEventFromContext(
+		ctx,
+		'exist.oauth.authorize',
+		{ scopeCount: scopes.length },
+		'completed',
+	);
+
+	return { url, state, scopes };
+};

--- a/packages/exist/endpoints/persist.ts
+++ b/packages/exist/endpoints/persist.ts
@@ -1,0 +1,71 @@
+import type { ExistContext } from '../index';
+import type {
+	AttributesListResponse,
+	AttributesListWithValuesResponse,
+} from './types';
+
+type AttributeRow = AttributesListResponse['results'][number];
+
+function attributeRow(attribute: AttributeRow) {
+	return {
+		id: attribute.name,
+		name: attribute.name,
+		label: attribute.label,
+		template: attribute.template ?? null,
+		group_name: attribute.group.name,
+		group_label: attribute.group.label,
+		service_name: attribute.service?.name ?? null,
+		active: attribute.active,
+		manual: attribute.manual,
+		priority: attribute.priority,
+		value_type: attribute.value_type,
+		value_type_description: attribute.value_type_description,
+	};
+}
+
+/**
+ * Mirrors attribute definitions locally. Persistence is best-effort: a failing
+ * local write must not turn a successful API read into an error.
+ */
+export async function persistAttributes(
+	ctx: ExistContext,
+	attributes: readonly AttributeRow[],
+): Promise<void> {
+	if (!ctx.db.attributes) return;
+	try {
+		for (const attribute of attributes) {
+			await ctx.db.attributes.upsertByEntityId(
+				attribute.name,
+				attributeRow(attribute),
+			);
+		}
+	} catch (error) {
+		console.warn('Failed to save Exist attributes to database:', error);
+	}
+}
+
+/** Mirrors attribute definitions together with the day values Exist returned. */
+export async function persistAttributesWithValues(
+	ctx: ExistContext,
+	attributes: readonly AttributesListWithValuesResponse['results'][number][],
+): Promise<void> {
+	await persistAttributes(ctx, attributes);
+	if (!ctx.db.attributeValues) return;
+	try {
+		for (const attribute of attributes) {
+			for (const entry of attribute.values) {
+				await ctx.db.attributeValues.upsertByEntityId(
+					`${attribute.name}:${entry.date}`,
+					{
+						id: `${attribute.name}:${entry.date}`,
+						attribute: attribute.name,
+						date: entry.date,
+						value: entry.value,
+					},
+				);
+			}
+		}
+	} catch (error) {
+		console.warn('Failed to save Exist attribute values to database:', error);
+	}
+}

--- a/packages/exist/endpoints/types.ts
+++ b/packages/exist/endpoints/types.ts
@@ -6,10 +6,12 @@ import { EXIST_MAX_BATCH_SIZE } from '../client';
 // @see https://developer.exist.io/reference/object_types/
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** "yyyy-mm-dd", the only date format Exist accepts or returns. */
-const ExistDateSchema = z
-	.string()
-	.regex(/^\d{4}-\d{2}-\d{2}$/, 'Expected a yyyy-mm-dd date string');
+/**
+ * "yyyy-mm-dd", the only date format Exist accepts or returns. `z.iso.date()`
+ * validates the calendar too, so an impossible day like 2026-02-31 is rejected
+ * before it reaches the API rather than being stored against the wrong date.
+ */
+const ExistDateSchema = z.iso.date();
 
 const PageSchema = z.number().int().min(1).optional();
 const LimitSchema = z.number().int().min(1).optional();
@@ -261,20 +263,35 @@ export type AttributesListTemplatesResponse = z.infer<
 // @see https://developer.exist.io/reference/attributes/
 // ─────────────────────────────────────────────────────────────────────────────
 
-const AttributesListWithValuesInputSchema = z.object({
-	page: PageSchema,
-	limit: LimitSchema,
-	/** How many days of values to include per attribute. Max 31, default 1. */
-	days: z.number().int().min(1).max(31).optional(),
-	/** Most recent date included in `values`. */
-	date_max: ExistDateSchema.optional(),
-	groups: z.array(z.string()).optional(),
-	/** Filter by attribute name — use this or `templates`, not both. */
-	attributes: z.array(z.string()).optional(),
-	/** Filter by attribute template name — use this or `attributes`, not both. */
-	templates: z.array(z.string()).optional(),
-	manual: z.boolean().optional(),
-});
+const AttributesListWithValuesInputSchema = z
+	.object({
+		page: PageSchema,
+		limit: LimitSchema,
+		/** How many days of values to include per attribute. Max 31, default 1. */
+		days: z.number().int().min(1).max(31).optional(),
+		/** Most recent date included in `values`. */
+		date_max: ExistDateSchema.optional(),
+		groups: z.array(z.string()).optional(),
+		/** Filter by attribute name — use this or `templates`, not both. */
+		attributes: z.array(z.string()).optional(),
+		/** Filter by attribute template name — use this or `attributes`, not both. */
+		templates: z.array(z.string()).optional(),
+		manual: z.boolean().optional(),
+	})
+	.refine(
+		(value) =>
+			!(
+				(value.attributes?.length ?? 0) > 0 &&
+				(value.templates?.length ?? 0) > 0
+			),
+		{
+			// "rather than using both, you would use one or the other of
+			// attributes and templates to filter" — the official reference.
+			message:
+				'Filter by `attributes` or `templates`, not both — Exist accepts only one',
+			path: ['templates'],
+		},
+	);
 export type AttributesListWithValuesInput = z.infer<
 	typeof AttributesListWithValuesInputSchema
 >;

--- a/packages/exist/endpoints/types.ts
+++ b/packages/exist/endpoints/types.ts
@@ -532,6 +532,36 @@ const InsightsListResponseSchema = paged(ExistInsightSchema);
 export type InsightsListResponse = z.infer<typeof InsightsListResponseSchema>;
 
 // ─────────────────────────────────────────────────────────────────────────────
+// oauth.authorize — builds https://exist.io/oauth2/authorize (no API call)
+// @see https://developer.exist.io/reference/authentication/oauth2/
+// ─────────────────────────────────────────────────────────────────────────────
+
+const OauthAuthorizeInputSchema = z.object({
+	/**
+	 * Scopes to request. Defaults to the scopes the plugin was configured with.
+	 * Exist only exposes attributes matching the granted scopes, so request the
+	 * narrowest set the integration needs.
+	 */
+	scopes: z.array(z.string()).min(1).optional(),
+});
+export type OauthAuthorizeInput = z.infer<typeof OauthAuthorizeInputSchema>;
+
+const OauthAuthorizeResponseSchema = z.object({
+	/** The authorisation URL to send the user to. */
+	url: z.string(),
+	/**
+	 * Unguessable CSRF value embedded as the `state` parameter. Store it and
+	 * compare it against the `state` Exist returns to the redirect URI.
+	 */
+	state: z.string(),
+	/** The scopes actually requested in the URL. */
+	scopes: z.array(z.string()),
+});
+export type OauthAuthorizeResponse = z.infer<
+	typeof OauthAuthorizeResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Aggregates
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -545,6 +575,7 @@ export type ExistEndpointInputs = {
 	attributesRelease: AttributesReleaseInput;
 	attributesIncrement: AttributesIncrementInput;
 	attributesUpdate: AttributesUpdateInput;
+	oauthAuthorize: OauthAuthorizeInput;
 	averagesList: AveragesListInput;
 	correlationsList: CorrelationsListInput;
 	insightsList: InsightsListInput;
@@ -560,6 +591,7 @@ export type ExistEndpointOutputs = {
 	attributesRelease: AttributesReleaseResponse;
 	attributesIncrement: AttributesIncrementResponse;
 	attributesUpdate: AttributesUpdateResponse;
+	oauthAuthorize: OauthAuthorizeResponse;
 	averagesList: AveragesListResponse;
 	correlationsList: CorrelationsListResponse;
 	insightsList: InsightsListResponse;
@@ -575,6 +607,7 @@ export const ExistEndpointInputSchemas = {
 	attributesRelease: AttributesReleaseInputSchema,
 	attributesIncrement: AttributesIncrementInputSchema,
 	attributesUpdate: AttributesUpdateInputSchema,
+	oauthAuthorize: OauthAuthorizeInputSchema,
 	averagesList: AveragesListInputSchema,
 	correlationsList: CorrelationsListInputSchema,
 	insightsList: InsightsListInputSchema,
@@ -590,6 +623,7 @@ export const ExistEndpointOutputSchemas = {
 	attributesRelease: AttributesReleaseResponseSchema,
 	attributesIncrement: AttributesIncrementResponseSchema,
 	attributesUpdate: AttributesUpdateResponseSchema,
+	oauthAuthorize: OauthAuthorizeResponseSchema,
 	averagesList: AveragesListResponseSchema,
 	correlationsList: CorrelationsListResponseSchema,
 	insightsList: InsightsListResponseSchema,

--- a/packages/exist/endpoints/types.ts
+++ b/packages/exist/endpoints/types.ts
@@ -1,0 +1,591 @@
+import { z } from 'zod';
+import { EXIST_MAX_BATCH_SIZE } from '../client';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared building blocks
+// @see https://developer.exist.io/reference/object_types/
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** "yyyy-mm-dd", the only date format Exist accepts or returns. */
+const ExistDateSchema = z
+	.string()
+	.regex(/^\d{4}-\d{2}-\d{2}$/, 'Expected a yyyy-mm-dd date string');
+
+const PageSchema = z.number().int().min(1).optional();
+const LimitSchema = z.number().int().min(1).optional();
+/** `limit` is capped at 100 on values, correlations and insights. */
+const CappedLimitSchema = z.number().int().min(1).max(100).optional();
+
+const ExistGroupSchema = z
+	.object({
+		name: z.string(),
+		label: z.string(),
+		priority: z.number(),
+	})
+	.loose();
+
+const ExistServiceSchema = z
+	.object({
+		name: z.string(),
+		label: z.string(),
+	})
+	.loose();
+
+/**
+ * Attribute values are typed by the owning attribute's `value_type`, so the
+ * wire value is a string, number or boolean — and is null on days with no data.
+ */
+const ExistValueSchema = z
+	.union([z.string(), z.number(), z.boolean()])
+	.nullable();
+
+const ExistAttributeValueSchema = z
+	.object({
+		date: z.string(),
+		value: ExistValueSchema,
+	})
+	.loose();
+
+/** An attribute template, i.e. an attribute Exist knows how to create. */
+const ExistAttributeTemplateSchema = z
+	.object({
+		name: z.string(),
+		label: z.string(),
+		group: ExistGroupSchema,
+		priority: z.number(),
+		value_type: z.number(),
+		value_type_description: z.string(),
+	})
+	.loose();
+
+/** An attribute belonging to a user. `template` is null for custom attributes. */
+const ExistAttributeSchema = z
+	.object({
+		template: z.string().nullable().optional(),
+		name: z.string(),
+		label: z.string(),
+		group: ExistGroupSchema,
+		service: ExistServiceSchema.nullable().optional(),
+		active: z.boolean(),
+		priority: z.number(),
+		manual: z.boolean(),
+		value_type: z.number(),
+		value_type_description: z.string(),
+		available_services: z.array(ExistServiceSchema).optional(),
+	})
+	.loose();
+
+const ExistAttributeWithValuesSchema = ExistAttributeSchema.extend({
+	values: z.array(ExistAttributeValueSchema),
+});
+
+const ExistAverageSchema = z
+	.object({
+		attribute: z.string(),
+		date: z.string(),
+		overall: z.number().nullable(),
+		monday: z.number().nullable(),
+		tuesday: z.number().nullable(),
+		wednesday: z.number().nullable(),
+		thursday: z.number().nullable(),
+		friday: z.number().nullable(),
+		saturday: z.number().nullable(),
+		sunday: z.number().nullable(),
+	})
+	.loose();
+
+const ExistCorrelationRatingSchema = z
+	.object({
+		positive: z.boolean(),
+		rating_type: z.number(),
+		rating: z.string(),
+	})
+	.loose();
+
+const ExistCorrelationSchema = z
+	.object({
+		date: z.string(),
+		period: z.number(),
+		offset: z.number(),
+		attribute: z.string(),
+		attribute2: z.string(),
+		value: z.number(),
+		p: z.number(),
+		percentage: z.number(),
+		stars: z.number(),
+		second_person: z.string(),
+		second_person_elements: z.array(z.string()),
+		attribute_category: z.string().nullable().optional(),
+		strength_description: z.string().nullable().optional(),
+		stars_description: z.string().nullable().optional(),
+		description: z.string().nullable().optional(),
+		occurrence: z.string().nullable().optional(),
+		rating: ExistCorrelationRatingSchema.nullable().optional(),
+	})
+	.loose();
+
+const ExistInsightTypeSchema = z
+	.object({
+		name: z.string(),
+		period: z.number(),
+		priority: z.number(),
+		attribute: ExistAttributeTemplateSchema.nullable().optional(),
+	})
+	.loose();
+
+const ExistInsightSchema = z
+	.object({
+		created: z.string(),
+		target_date: z.string().nullable(),
+		type: ExistInsightTypeSchema,
+		html: z.string(),
+		text: z.string(),
+	})
+	.loose();
+
+const ExistProfileSchema = z
+	.object({
+		username: z.string(),
+		first_name: z.string(),
+		last_name: z.string(),
+		avatar: z.string().nullable().optional(),
+		timezone: z.string(),
+		local_time: z.string(),
+		imperial_distance: z.boolean(),
+		imperial_weight: z.boolean(),
+		imperial_energy: z.boolean(),
+		imperial_liquid: z.boolean(),
+		imperial_temperature: z.boolean(),
+		trial: z.boolean(),
+		delinquent: z.boolean(),
+	})
+	.loose();
+
+/** Every Exist list endpoint returns this envelope. */
+function paged<T extends z.ZodTypeAny>(results: T) {
+	return z.object({
+		count: z.number(),
+		next: z.string().nullable(),
+		previous: z.string().nullable(),
+		results: z.array(results),
+	});
+}
+
+/**
+ * Write endpoints answer 200 when every object succeeded and 202 when some
+ * failed; either way the body carries both arrays. Failed objects echo back
+ * the submitted fields plus `error` and `error_code`.
+ * @see https://developer.exist.io/reference/writing_data/
+ */
+const ExistWriteFailureSchema = z
+	.object({
+		error: z.string(),
+		error_code: z.string(),
+	})
+	.loose();
+
+function writeResponse<T extends z.ZodTypeAny>(success: T) {
+	return z.object({
+		success: z.array(success),
+		failed: z.array(ExistWriteFailureSchema),
+	});
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// users.getProfile — GET /api/2/accounts/profile/
+// @see https://developer.exist.io/reference/users/
+// ─────────────────────────────────────────────────────────────────────────────
+
+const UsersGetProfileInputSchema = z.object({});
+export type UsersGetProfileInput = z.infer<typeof UsersGetProfileInputSchema>;
+
+const UsersGetProfileResponseSchema = ExistProfileSchema;
+export type UsersGetProfileResponse = z.infer<
+	typeof UsersGetProfileResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// attributes.list — GET /api/2/attributes/
+// @see https://developer.exist.io/reference/attributes/
+// ─────────────────────────────────────────────────────────────────────────────
+
+const AttributesListInputSchema = z.object({
+	page: PageSchema,
+	limit: LimitSchema,
+	/** Group names to filter by, e.g. `['activity', 'workouts']`. */
+	groups: z.array(z.string()).optional(),
+	/** Attribute names to filter by. */
+	attributes: z.array(z.string()).optional(),
+	/** Only return templated attributes. */
+	exclude_custom: z.boolean().optional(),
+	/** True returns only manual attributes, false excludes them. */
+	manual: z.boolean().optional(),
+	/** Include attributes with `active: false`, which are hidden by default. */
+	include_inactive: z.boolean().optional(),
+	/** Include attributes with a priority >= 10. */
+	include_low_priority: z.boolean().optional(),
+	/** Only return attributes owned by this OAuth2 client. */
+	owned: z.boolean().optional(),
+});
+export type AttributesListInput = z.infer<typeof AttributesListInputSchema>;
+
+const AttributesListResponseSchema = paged(ExistAttributeSchema);
+export type AttributesListResponse = z.infer<
+	typeof AttributesListResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// attributes.listTemplates — GET /api/2/attributes/templates/
+// @see https://developer.exist.io/reference/attributes/
+// ─────────────────────────────────────────────────────────────────────────────
+
+const AttributesListTemplatesInputSchema = z.object({
+	page: PageSchema,
+	limit: LimitSchema,
+	include_low_priority: z.boolean().optional(),
+	groups: z.array(z.string()).optional(),
+});
+export type AttributesListTemplatesInput = z.infer<
+	typeof AttributesListTemplatesInputSchema
+>;
+
+const AttributesListTemplatesResponseSchema = paged(
+	ExistAttributeTemplateSchema,
+);
+export type AttributesListTemplatesResponse = z.infer<
+	typeof AttributesListTemplatesResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// attributes.listWithValues — GET /api/2/attributes/with-values/
+// @see https://developer.exist.io/reference/attributes/
+// ─────────────────────────────────────────────────────────────────────────────
+
+const AttributesListWithValuesInputSchema = z.object({
+	page: PageSchema,
+	limit: LimitSchema,
+	/** How many days of values to include per attribute. Max 31, default 1. */
+	days: z.number().int().min(1).max(31).optional(),
+	/** Most recent date included in `values`. */
+	date_max: ExistDateSchema.optional(),
+	groups: z.array(z.string()).optional(),
+	/** Filter by attribute name — use this or `templates`, not both. */
+	attributes: z.array(z.string()).optional(),
+	/** Filter by attribute template name — use this or `attributes`, not both. */
+	templates: z.array(z.string()).optional(),
+	manual: z.boolean().optional(),
+});
+export type AttributesListWithValuesInput = z.infer<
+	typeof AttributesListWithValuesInputSchema
+>;
+
+const AttributesListWithValuesResponseSchema = paged(
+	ExistAttributeWithValuesSchema,
+);
+export type AttributesListWithValuesResponse = z.infer<
+	typeof AttributesListWithValuesResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// attributes.listOwned — GET /api/2/attributes/owned/
+// @see https://developer.exist.io/reference/attribute_ownership/
+// ─────────────────────────────────────────────────────────────────────────────
+
+const AttributesListOwnedInputSchema = z.object({
+	page: PageSchema,
+	limit: LimitSchema,
+	groups: z.array(z.string()).optional(),
+	attributes: z.array(z.string()).optional(),
+	exclude_custom: z.boolean().optional(),
+	manual: z.boolean().optional(),
+	include_inactive: z.boolean().optional(),
+	include_low_priority: z.boolean().optional(),
+});
+export type AttributesListOwnedInput = z.infer<
+	typeof AttributesListOwnedInputSchema
+>;
+
+const AttributesListOwnedResponseSchema = paged(ExistAttributeSchema);
+export type AttributesListOwnedResponse = z.infer<
+	typeof AttributesListOwnedResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// attributes.acquire — POST /api/2/attributes/acquire/
+// @see https://developer.exist.io/reference/attribute_ownership/
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Each object identifies an attribute either by `template` (creating it if the
+ * user does not have it yet) or by `name` (an attribute that already exists).
+ */
+const AcquireAttributeSchema = z
+	.object({
+		/** Attribute template name, e.g. `mood`. */
+		template: z.string().optional(),
+		/** Existing attribute name, e.g. `mood_note`. */
+		name: z.string().optional(),
+		/** Mark the attribute as manually updated. */
+		manual: z.boolean().optional(),
+	})
+	.refine((value) => Boolean(value.template ?? value.name), {
+		message: 'Each attribute must set either `template` or `name`',
+	});
+
+const AttributesAcquireInputSchema = z.object({
+	attributes: z.array(AcquireAttributeSchema).min(1).max(EXIST_MAX_BATCH_SIZE),
+	/** Return the full attribute object for each successful acquisition. */
+	success_objects: z.boolean().optional(),
+});
+export type AttributesAcquireInput = z.infer<
+	typeof AttributesAcquireInputSchema
+>;
+
+const AttributesAcquireResponseSchema = writeResponse(
+	z.object({ name: z.string() }).loose(),
+);
+export type AttributesAcquireResponse = z.infer<
+	typeof AttributesAcquireResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// attributes.release — POST /api/2/attributes/release/
+// @see https://developer.exist.io/reference/attribute_ownership/
+// ─────────────────────────────────────────────────────────────────────────────
+
+const AttributesReleaseInputSchema = z.object({
+	attributes: z
+		.array(z.object({ name: z.string() }))
+		.min(1)
+		.max(EXIST_MAX_BATCH_SIZE),
+});
+export type AttributesReleaseInput = z.infer<
+	typeof AttributesReleaseInputSchema
+>;
+
+const AttributesReleaseResponseSchema = writeResponse(
+	z.object({ name: z.string() }).loose(),
+);
+export type AttributesReleaseResponse = z.infer<
+	typeof AttributesReleaseResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// attributes.increment — POST /api/2/attributes/increment/
+// @see https://developer.exist.io/reference/writing_data/
+// ─────────────────────────────────────────────────────────────────────────────
+
+const IncrementAttributeSchema = z.object({
+	/** The attribute name, which must already be owned by this client. */
+	name: z.string(),
+	/** Defaults to the user's current date when omitted. */
+	date: ExistDateSchema.optional(),
+	/** The delta to add. String, scale and time-of-day types cannot be incremented. */
+	value: z.number(),
+});
+
+const AttributesIncrementInputSchema = z.object({
+	attributes: z
+		.array(IncrementAttributeSchema)
+		.min(1)
+		.max(EXIST_MAX_BATCH_SIZE),
+});
+export type AttributesIncrementInput = z.infer<
+	typeof AttributesIncrementInputSchema
+>;
+
+const AttributesIncrementResponseSchema = writeResponse(
+	z
+		.object({
+			name: z.string(),
+			value: z.number(),
+			/** The new total for the day after the delta was applied. */
+			current: z.number().optional(),
+		})
+		.loose(),
+);
+export type AttributesIncrementResponse = z.infer<
+	typeof AttributesIncrementResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// attributes.update — POST /api/2/attributes/update/
+// @see https://developer.exist.io/reference/writing_data/
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A single total value for one attribute on one day. Unlike `increment`, this
+ * overwrites whatever Exist already held for that day. Exist validates values
+ * only broadly against the attribute's `value_type`, so callers must send the
+ * right shape themselves.
+ */
+const UpdateAttributeSchema = z.object({
+	/** The attribute name, which must already be owned by this client. */
+	name: z.string(),
+	/** The day this value belongs to, in the user's local time. */
+	date: ExistDateSchema,
+	/**
+	 * The new total for the day. Exist will not accept null for an attribute
+	 * that already holds a non-null value, to prevent accidental data loss.
+	 */
+	value: ExistValueSchema,
+});
+
+const AttributesUpdateInputSchema = z.object({
+	attributes: z.array(UpdateAttributeSchema).min(1).max(EXIST_MAX_BATCH_SIZE),
+});
+export type AttributesUpdateInput = z.infer<typeof AttributesUpdateInputSchema>;
+
+const AttributesUpdateResponseSchema = writeResponse(
+	z
+		.object({
+			name: z.string(),
+			date: z.string(),
+			value: ExistValueSchema,
+		})
+		.loose(),
+);
+export type AttributesUpdateResponse = z.infer<
+	typeof AttributesUpdateResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// averages.list — GET /api/2/averages/
+// @see https://developer.exist.io/reference/averages/
+// ─────────────────────────────────────────────────────────────────────────────
+
+const AveragesListInputSchema = z.object({
+	page: PageSchema,
+	limit: LimitSchema,
+	/** Oldest date, inclusive. */
+	date_min: ExistDateSchema.optional(),
+	/** Most recent date, inclusive. */
+	date_max: ExistDateSchema.optional(),
+	groups: z.array(z.string()).optional(),
+	attributes: z.array(z.string()).optional(),
+	/** Return every historical average rather than only the latest set. */
+	include_historical: z.boolean().optional(),
+});
+export type AveragesListInput = z.infer<typeof AveragesListInputSchema>;
+
+const AveragesListResponseSchema = paged(ExistAverageSchema);
+export type AveragesListResponse = z.infer<typeof AveragesListResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// correlations.list — GET /api/2/correlations/
+// @see https://developer.exist.io/reference/correlations/
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CorrelationsListInputSchema = z.object({
+	page: PageSchema,
+	limit: CappedLimitSchema,
+	/** Only return strong correlations. */
+	strong: z.boolean().optional(),
+	/** Only return five-star (most confident) correlations. */
+	confident: z.boolean().optional(),
+	/** Only return correlations involving this attribute. */
+	attribute: z.string().optional(),
+});
+export type CorrelationsListInput = z.infer<typeof CorrelationsListInputSchema>;
+
+const CorrelationsListResponseSchema = paged(ExistCorrelationSchema);
+export type CorrelationsListResponse = z.infer<
+	typeof CorrelationsListResponseSchema
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// insights.list — GET /api/2/insights/
+// @see https://developer.exist.io/reference/insights/
+// ─────────────────────────────────────────────────────────────────────────────
+
+const InsightsListInputSchema = z.object({
+	page: PageSchema,
+	limit: CappedLimitSchema,
+	/** Oldest date, inclusive. */
+	date_min: ExistDateSchema.optional(),
+	/** Most recent date, inclusive. */
+	date_max: ExistDateSchema.optional(),
+	/** Insight priority: 1 is today, 4 is last month. */
+	priority: z.number().int().optional(),
+});
+export type InsightsListInput = z.infer<typeof InsightsListInputSchema>;
+
+const InsightsListResponseSchema = paged(ExistInsightSchema);
+export type InsightsListResponse = z.infer<typeof InsightsListResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Aggregates
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type ExistEndpointInputs = {
+	usersGetProfile: UsersGetProfileInput;
+	attributesList: AttributesListInput;
+	attributesListTemplates: AttributesListTemplatesInput;
+	attributesListWithValues: AttributesListWithValuesInput;
+	attributesListOwned: AttributesListOwnedInput;
+	attributesAcquire: AttributesAcquireInput;
+	attributesRelease: AttributesReleaseInput;
+	attributesIncrement: AttributesIncrementInput;
+	attributesUpdate: AttributesUpdateInput;
+	averagesList: AveragesListInput;
+	correlationsList: CorrelationsListInput;
+	insightsList: InsightsListInput;
+};
+
+export type ExistEndpointOutputs = {
+	usersGetProfile: UsersGetProfileResponse;
+	attributesList: AttributesListResponse;
+	attributesListTemplates: AttributesListTemplatesResponse;
+	attributesListWithValues: AttributesListWithValuesResponse;
+	attributesListOwned: AttributesListOwnedResponse;
+	attributesAcquire: AttributesAcquireResponse;
+	attributesRelease: AttributesReleaseResponse;
+	attributesIncrement: AttributesIncrementResponse;
+	attributesUpdate: AttributesUpdateResponse;
+	averagesList: AveragesListResponse;
+	correlationsList: CorrelationsListResponse;
+	insightsList: InsightsListResponse;
+};
+
+export const ExistEndpointInputSchemas = {
+	usersGetProfile: UsersGetProfileInputSchema,
+	attributesList: AttributesListInputSchema,
+	attributesListTemplates: AttributesListTemplatesInputSchema,
+	attributesListWithValues: AttributesListWithValuesInputSchema,
+	attributesListOwned: AttributesListOwnedInputSchema,
+	attributesAcquire: AttributesAcquireInputSchema,
+	attributesRelease: AttributesReleaseInputSchema,
+	attributesIncrement: AttributesIncrementInputSchema,
+	attributesUpdate: AttributesUpdateInputSchema,
+	averagesList: AveragesListInputSchema,
+	correlationsList: CorrelationsListInputSchema,
+	insightsList: InsightsListInputSchema,
+} as const;
+
+export const ExistEndpointOutputSchemas = {
+	usersGetProfile: UsersGetProfileResponseSchema,
+	attributesList: AttributesListResponseSchema,
+	attributesListTemplates: AttributesListTemplatesResponseSchema,
+	attributesListWithValues: AttributesListWithValuesResponseSchema,
+	attributesListOwned: AttributesListOwnedResponseSchema,
+	attributesAcquire: AttributesAcquireResponseSchema,
+	attributesRelease: AttributesReleaseResponseSchema,
+	attributesIncrement: AttributesIncrementResponseSchema,
+	attributesUpdate: AttributesUpdateResponseSchema,
+	averagesList: AveragesListResponseSchema,
+	correlationsList: CorrelationsListResponseSchema,
+	insightsList: InsightsListResponseSchema,
+} as const;
+
+export {
+	ExistAttributeSchema,
+	ExistAttributeTemplateSchema,
+	ExistAttributeValueSchema,
+	ExistAttributeWithValuesSchema,
+	ExistAverageSchema,
+	ExistCorrelationSchema,
+	ExistGroupSchema,
+	ExistInsightSchema,
+	ExistProfileSchema,
+	ExistServiceSchema,
+};

--- a/packages/exist/endpoints/types.ts
+++ b/packages/exist/endpoints/types.ts
@@ -278,20 +278,21 @@ const AttributesListWithValuesInputSchema = z
 		templates: z.array(z.string()).optional(),
 		manual: z.boolean().optional(),
 	})
-	.refine(
-		(value) =>
-			!(
-				(value.attributes?.length ?? 0) > 0 &&
-				(value.templates?.length ?? 0) > 0
-			),
-		{
-			// "rather than using both, you would use one or the other of
-			// attributes and templates to filter" — the official reference.
-			message:
-				'Filter by `attributes` or `templates`, not both — Exist accepts only one',
-			path: ['templates'],
-		},
-	);
+	.superRefine((value, ctx) => {
+		if (
+			(value.attributes?.length ?? 0) > 0 &&
+			(value.templates?.length ?? 0) > 0
+		) {
+			ctx.addIssue({
+				code: 'custom',
+				// "rather than using both, you would use one or the other of
+				// attributes and templates to filter" — the official reference.
+				message:
+					'Filter by `attributes` or `templates`, not both — Exist accepts only one',
+				path: ['templates'],
+			});
+		}
+	});
 export type AttributesListWithValuesInput = z.infer<
 	typeof AttributesListWithValuesInputSchema
 >;

--- a/packages/exist/endpoints/users.ts
+++ b/packages/exist/endpoints/users.ts
@@ -1,7 +1,6 @@
 import { logEventFromContext } from 'corsair/core';
-import { makeAuthenticatedExistRequest } from '../client';
 import type { ExistEndpoints } from '../index';
-import type { ExistEndpointOutputs } from './types';
+import { parseExistInput, validatedExistRequest } from './validate';
 
 /**
  * Get the authenticated user's profile and unit preferences.
@@ -11,9 +10,13 @@ export const getProfile: ExistEndpoints['usersGetProfile'] = async (
 	ctx,
 	_input,
 ) => {
-	const result = await makeAuthenticatedExistRequest<
-		ExistEndpointOutputs['usersGetProfile']
-	>('accounts/profile/', ctx, { method: 'GET' });
+	const parsed = parseExistInput('usersGetProfile', _input);
+	const result = await validatedExistRequest(
+		'usersGetProfile',
+		'accounts/profile/',
+		ctx,
+		{ method: 'GET' },
+	);
 
 	if (ctx.db.profile) {
 		try {

--- a/packages/exist/endpoints/users.ts
+++ b/packages/exist/endpoints/users.ts
@@ -1,0 +1,32 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeAuthenticatedExistRequest } from '../client';
+import type { ExistEndpoints } from '../index';
+import type { ExistEndpointOutputs } from './types';
+
+/**
+ * Get the authenticated user's profile and unit preferences.
+ * @see https://developer.exist.io/reference/users/
+ */
+export const getProfile: ExistEndpoints['usersGetProfile'] = async (
+	ctx,
+	_input,
+) => {
+	const result = await makeAuthenticatedExistRequest<
+		ExistEndpointOutputs['usersGetProfile']
+	>('accounts/profile/', ctx, { method: 'GET' });
+
+	if (ctx.db.profile) {
+		try {
+			await ctx.db.profile.upsertByEntityId(result.username, {
+				...result,
+				id: result.username,
+				avatar: result.avatar ?? null,
+			});
+		} catch (error) {
+			console.warn('Failed to save Exist profile to database:', error);
+		}
+	}
+
+	await logEventFromContext(ctx, 'exist.users.getProfile', {}, 'completed');
+	return result;
+};

--- a/packages/exist/endpoints/validate.ts
+++ b/packages/exist/endpoints/validate.ts
@@ -1,0 +1,61 @@
+import type { z } from 'zod';
+import type { ExistRequestContext, ExistRequestOptions } from '../client';
+import { makeAuthenticatedExistRequest } from '../client';
+import type { ExistEndpointInputs, ExistEndpointOutputs } from './types';
+import { ExistEndpointInputSchemas, ExistEndpointOutputSchemas } from './types';
+
+export class ExistValidationError extends Error {
+	constructor(
+		public readonly kind: 'input' | 'output',
+		public readonly operation: string,
+		// unknown is necessary because Zod issue arrays are provider-agnostic; a closed issue union is infeasible because paths and codes vary by schema
+		public readonly issues: unknown,
+	) {
+		super(`[exist] ${kind} validation failed for ${operation}: ${issues}`);
+		this.name = 'ExistValidationError';
+	}
+}
+
+export type ExistOperationKey = keyof ExistEndpointInputs;
+
+// unknown is necessary because the schema maps are heterogeneous per operation; a closed schema union is infeasible because twelve operations each carry their own shape
+type AnyInputSchema = z.ZodType<any, any, any>;
+
+const inputSchemaRecord = ExistEndpointInputSchemas as Record<
+	ExistOperationKey,
+	AnyInputSchema
+>;
+const outputSchemaRecord = ExistEndpointOutputSchemas as Record<
+	ExistOperationKey,
+	AnyInputSchema
+>;
+
+export function parseExistInput<K extends ExistOperationKey>(
+	operation: K,
+	// unknown is necessary because handlers receive shared raw input bags; a closed bag type is infeasible because twelve operations share this validator
+	input: unknown,
+): ExistEndpointInputs[K] {
+	const parsed = inputSchemaRecord[operation].safeParse(input);
+	if (!parsed.success) {
+		throw new ExistValidationError('input', String(operation), parsed.error);
+	}
+	return parsed.data as ExistEndpointInputs[K];
+}
+
+export async function validatedExistRequest<K extends ExistOperationKey>(
+	operation: K,
+	endpoint: string,
+	ctx: ExistRequestContext,
+	options: ExistRequestOptions,
+): Promise<ExistEndpointOutputs[K]> {
+	const response = await makeAuthenticatedExistRequest<unknown>(
+		endpoint,
+		ctx,
+		options,
+	);
+	const parsed = outputSchemaRecord[operation].safeParse(response);
+	if (!parsed.success) {
+		throw new ExistValidationError('output', String(operation), parsed.error);
+	}
+	return parsed.data as ExistEndpointOutputs[K];
+}

--- a/packages/exist/endpoints/validate.ts
+++ b/packages/exist/endpoints/validate.ts
@@ -19,16 +19,10 @@ export class ExistValidationError extends Error {
 export type ExistOperationKey = keyof ExistEndpointInputs;
 
 // unknown is necessary because the schema maps are heterogeneous per operation; a closed schema union is infeasible because twelve operations each carry their own shape
-type AnyInputSchema = z.ZodType<any, any, any>;
+type SchemaRecord = Record<ExistOperationKey, z.ZodType<unknown>>;
 
-const inputSchemaRecord = ExistEndpointInputSchemas as Record<
-	ExistOperationKey,
-	AnyInputSchema
->;
-const outputSchemaRecord = ExistEndpointOutputSchemas as Record<
-	ExistOperationKey,
-	AnyInputSchema
->;
+const inputSchemaRecord = ExistEndpointInputSchemas as SchemaRecord;
+const outputSchemaRecord = ExistEndpointOutputSchemas as SchemaRecord;
 
 export function parseExistInput<K extends ExistOperationKey>(
 	operation: K,

--- a/packages/exist/error-handlers.test.ts
+++ b/packages/exist/error-handlers.test.ts
@@ -1,0 +1,44 @@
+import { ApiError } from 'corsair/http';
+import { errorHandlers } from './error-handlers';
+
+function apiError(status: number, retryAfter?: number): ApiError {
+	return new ApiError(
+		{ method: 'POST', url: 'attributes/update/' },
+		{
+			url: 'https://exist.io/api/2/attributes/update/',
+			ok: false,
+			status,
+			statusText: 'Error',
+			body: { error: 'Error' },
+		},
+		'Error',
+		retryAfter !== undefined ? { retryAfter } : undefined,
+	);
+}
+
+describe('exist error handlers', () => {
+	it('does not retry rate-limited writes because increments are delta-based', async () => {
+		const error = apiError(429, 2500);
+		expect(errorHandlers.RATE_LIMIT_ERROR.match(error)).toBe(true);
+		await expect(
+			errorHandlers.RATE_LIMIT_ERROR.handler(error),
+		).resolves.toEqual(
+			expect.objectContaining({
+				maxRetries: 0,
+				headersRetryAfterMs: 2500,
+			}),
+		);
+	});
+
+	it('does not retry auth or permission failures', async () => {
+		const ctx = { operation: 'test' } as never;
+		expect(errorHandlers.AUTH_ERROR.match(apiError(401))).toBe(true);
+		await expect(
+			errorHandlers.AUTH_ERROR.handler(apiError(401), ctx),
+		).resolves.toEqual({ maxRetries: 0 });
+		expect(errorHandlers.PERMISSION_ERROR.match(apiError(403))).toBe(true);
+		await expect(
+			errorHandlers.PERMISSION_ERROR.handler(apiError(403), ctx),
+		).resolves.toEqual({ maxRetries: 0 });
+	});
+});

--- a/packages/exist/error-handlers.ts
+++ b/packages/exist/error-handlers.ts
@@ -1,0 +1,99 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+import { ExistAPIError } from './client';
+
+function statusOf(error: Error): number | undefined {
+	if (error instanceof ExistAPIError) return error.status;
+	if (error instanceof ApiError) return error.status;
+	return undefined;
+}
+
+function retryAfterOf(error: Error): number | undefined {
+	if (error instanceof ExistAPIError) return error.retryAfter;
+	if (error instanceof ApiError) return error.retryAfter;
+	return undefined;
+}
+
+export const errorHandlers = {
+	/**
+	 * Exist allows 300 requests per hour per user token and answers an exceeded
+	 * quota with a bodiless 429.
+	 * @see https://developer.exist.io/guide/
+	 */
+	RATE_LIMIT_ERROR: {
+		match: (error) => {
+			if (statusOf(error) === 429) return true;
+			const message = error.message.toLowerCase();
+			return (
+				message.includes('too many requests') ||
+				message.includes('rate limit') ||
+				message.includes('429')
+			);
+		},
+		handler: async (error) => ({
+			maxRetries: 5,
+			headersRetryAfterMs: retryAfterOf(error),
+		}),
+	},
+	/** An expired or revoked access token. Retrying without re-auth cannot help. */
+	AUTH_ERROR: {
+		match: (error) => {
+			if (statusOf(error) === 401) return true;
+			const message = error.message.toLowerCase();
+			return (
+				message.includes('unauthorized') ||
+				message.includes('invalid_token') ||
+				message.includes('authentication credentials were not provided')
+			);
+		},
+		handler: async (_error, context) => {
+			console.warn(
+				`[EXIST:${context.operation}] Authentication failed - the access token is missing, expired or revoked`,
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	/**
+	 * Usually a missing OAuth2 scope, or writing to an attribute this client
+	 * does not own.
+	 * @see https://developer.exist.io/reference/authentication/oauth2/
+	 */
+	PERMISSION_ERROR: {
+		match: (error) => {
+			if (statusOf(error) === 403) return true;
+			const message = error.message.toLowerCase();
+			return (
+				message.includes('forbidden') ||
+				message.includes('permission') ||
+				message.includes('unauthorised')
+			);
+		},
+		handler: async (error, context) => {
+			console.warn(
+				`[EXIST:${context.operation}] Permission denied - check the granted OAuth2 scopes and attribute ownership: ${error.message}`,
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	NOT_FOUND_ERROR: {
+		match: (error) => {
+			if (statusOf(error) === 404) return true;
+			return error.message.toLowerCase().includes('not found');
+		},
+		handler: async (error, context) => {
+			console.warn(
+				`[EXIST:${context.operation}] Resource not found: ${error.message}`,
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async (error, context) => {
+			console.error(
+				`[EXIST:${context.operation}] Unhandled error: ${error.message}`,
+			);
+			return { maxRetries: 0 };
+		},
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/exist/error-handlers.ts
+++ b/packages/exist/error-handlers.ts
@@ -31,7 +31,7 @@ export const errorHandlers = {
 			);
 		},
 		handler: async (error) => ({
-			maxRetries: 5,
+			maxRetries: 0,
 			headersRetryAfterMs: retryAfterOf(error),
 		}),
 	},

--- a/packages/exist/index.ts
+++ b/packages/exist/index.ts
@@ -18,6 +18,7 @@ import {
 	Averages,
 	Correlations,
 	Insights,
+	Oauth,
 	Users,
 } from './endpoints';
 import type {
@@ -167,6 +168,9 @@ const existEndpointsNested = {
 	insights: {
 		list: Insights.list,
 	},
+	oauth: {
+		authorize: Oauth.authorize,
+	},
 } as const;
 
 export type ExistBoundEndpoints = BindEndpoints<typeof existEndpointsNested>;
@@ -192,6 +196,7 @@ export const existEndpointSchemas = {
 	'averages.list': schema('averagesList'),
 	'correlations.list': schema('correlationsList'),
 	'insights.list': schema('insightsList'),
+	'oauth.authorize': schema('oauthAuthorize'),
 } as const satisfies RequiredPluginEndpointSchemas<typeof existEndpointsNested>;
 
 const defaultAuthType = 'oauth_2' as const;
@@ -249,6 +254,11 @@ const existEndpointMeta = {
 	'insights.list': {
 		riskLevel: 'read',
 		description: "List insights Exist generated about the user's data",
+	},
+	'oauth.authorize': {
+		riskLevel: 'read',
+		description:
+			'Build the Exist OAuth2 authorisation URL a user visits to grant access, with a CSRF state value; makes no API call',
 	},
 } as const satisfies RequiredPluginEndpointMeta<typeof existEndpointsNested>;
 
@@ -354,6 +364,8 @@ export type {
 	ExistEndpointOutputs,
 	InsightsListInput,
 	InsightsListResponse,
+	OauthAuthorizeInput,
+	OauthAuthorizeResponse,
 	UsersGetProfileInput,
 	UsersGetProfileResponse,
 } from './endpoints/types';

--- a/packages/exist/index.ts
+++ b/packages/exist/index.ts
@@ -1,0 +1,361 @@
+import type {
+	BindEndpoints,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+} from 'corsair/core';
+import { AuthMissingError, getOAuthAccessToken } from 'corsair/core';
+import { EXIST_OAUTH_AUTHORIZE_URL, EXIST_OAUTH_TOKEN_URL } from './client';
+import {
+	Attributes,
+	Averages,
+	Correlations,
+	Insights,
+	Users,
+} from './endpoints';
+import type {
+	ExistEndpointInputs,
+	ExistEndpointOutputs,
+} from './endpoints/types';
+import {
+	ExistEndpointInputSchemas,
+	ExistEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { resolveExistOAuthTenantLink } from './oauth-tenant-link';
+import { ExistSchema } from './schema';
+
+/**
+ * Exist read scopes, one per attribute group.
+ * @see https://developer.exist.io/reference/authentication/oauth2/
+ */
+export const EXIST_READ_SCOPES = [
+	'activity_read',
+	'productivity_read',
+	'mood_read',
+	'sleep_read',
+	'workouts_read',
+	'events_read',
+	'finance_read',
+	'food_read',
+	'health_read',
+	'location_read',
+	'media_read',
+	'social_read',
+	'weather_read',
+	'symptoms_read',
+	'medication_read',
+	'custom_read',
+	'manual_read',
+] as const;
+
+/**
+ * Exist write scopes, required to acquire, release or increment attributes in
+ * the matching group.
+ * @see https://developer.exist.io/reference/authentication/oauth2/
+ */
+export const EXIST_WRITE_SCOPES = [
+	'activity_write',
+	'productivity_write',
+	'mood_write',
+	'sleep_write',
+	'workouts_write',
+	'events_write',
+	'finance_write',
+	'food_write',
+	'health_write',
+	'location_write',
+	'media_write',
+	'social_write',
+	'weather_write',
+	'symptoms_write',
+	'medication_write',
+	'custom_write',
+	'manual_write',
+] as const;
+
+export type ExistScope =
+	| (typeof EXIST_READ_SCOPES)[number]
+	| (typeof EXIST_WRITE_SCOPES)[number];
+
+/**
+ * Default scopes cover every operation this plugin exposes. Exist's own
+ * guidance is to request only the scopes an integration needs, so narrow this
+ * with the `scopes` option when the agent only reads, or only touches some
+ * attribute groups.
+ * @see https://developer.exist.io/guide/best_practices/
+ */
+export const EXIST_DEFAULT_SCOPES: ExistScope[] = [
+	...EXIST_READ_SCOPES,
+	...EXIST_WRITE_SCOPES,
+];
+
+export const existAuthConfig = {
+	oauth_2: {
+		account: ['tenant_external_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type ExistPluginOptions = {
+	authType?: PickAuth<'oauth_2'>;
+	/**
+	 * OAuth2 scopes to request. Defaults to every read and write scope; narrow
+	 * it to the groups the integration actually uses.
+	 */
+	scopes?: ExistScope[];
+	/** A pre-obtained access token, bypassing Corsair's stored credentials. */
+	key?: string;
+	hooks?: InternalExistPlugin['hooks'];
+	errorHandlers?: CorsairErrorHandler;
+	/**
+	 * Permission configuration for the Exist plugin.
+	 * Controls what the AI agent is allowed to do.
+	 * Overrides use dot-notation paths from the Exist endpoint tree — invalid paths are type errors.
+	 */
+	permissions?: PluginPermissionsConfig<typeof existEndpointsNested>;
+};
+
+export type ExistContext = CorsairPluginContext<
+	typeof ExistSchema,
+	ExistPluginOptions,
+	undefined,
+	typeof existAuthConfig
+>;
+
+export type ExistKeyBuilderContext = KeyBuilderContext<
+	ExistPluginOptions,
+	typeof existAuthConfig
+>;
+
+type ExistEndpoint<K extends keyof ExistEndpointOutputs> = CorsairEndpoint<
+	ExistContext,
+	ExistEndpointInputs[K],
+	ExistEndpointOutputs[K]
+>;
+
+export type ExistEndpoints = {
+	[K in keyof ExistEndpointOutputs]: ExistEndpoint<K>;
+};
+
+const existEndpointsNested = {
+	users: {
+		getProfile: Users.getProfile,
+	},
+	attributes: {
+		list: Attributes.list,
+		listTemplates: Attributes.listTemplates,
+		listWithValues: Attributes.listWithValues,
+		listOwned: Attributes.listOwned,
+		acquire: Attributes.acquire,
+		release: Attributes.release,
+		increment: Attributes.increment,
+		update: Attributes.update,
+	},
+	averages: {
+		list: Averages.list,
+	},
+	correlations: {
+		list: Correlations.list,
+	},
+	insights: {
+		list: Insights.list,
+	},
+} as const;
+
+export type ExistBoundEndpoints = BindEndpoints<typeof existEndpointsNested>;
+
+/** Exist has no webhook or callback mechanism, so the plugin exposes no triggers. */
+const existWebhooksNested = {} as const;
+
+const schema = <K extends keyof typeof ExistEndpointInputSchemas>(key: K) => ({
+	input: ExistEndpointInputSchemas[key],
+	output: ExistEndpointOutputSchemas[key],
+});
+
+export const existEndpointSchemas = {
+	'users.getProfile': schema('usersGetProfile'),
+	'attributes.list': schema('attributesList'),
+	'attributes.listTemplates': schema('attributesListTemplates'),
+	'attributes.listWithValues': schema('attributesListWithValues'),
+	'attributes.listOwned': schema('attributesListOwned'),
+	'attributes.acquire': schema('attributesAcquire'),
+	'attributes.release': schema('attributesRelease'),
+	'attributes.increment': schema('attributesIncrement'),
+	'attributes.update': schema('attributesUpdate'),
+	'averages.list': schema('averagesList'),
+	'correlations.list': schema('correlationsList'),
+	'insights.list': schema('insightsList'),
+} as const satisfies RequiredPluginEndpointSchemas<typeof existEndpointsNested>;
+
+const defaultAuthType = 'oauth_2' as const;
+
+const existEndpointMeta = {
+	'users.getProfile': {
+		riskLevel: 'read',
+		description:
+			'Get the authenticated Exist user profile and unit preferences',
+	},
+	'attributes.list': {
+		riskLevel: 'read',
+		description: "List the user's attributes without their values",
+	},
+	'attributes.listTemplates': {
+		riskLevel: 'read',
+		description: 'List the attribute templates Exist supports',
+	},
+	'attributes.listWithValues': {
+		riskLevel: 'read',
+		description: "List the user's attributes along with recent day values",
+	},
+	'attributes.listOwned': {
+		riskLevel: 'read',
+		description: 'List the attributes currently owned by this client',
+	},
+	'attributes.acquire': {
+		riskLevel: 'write',
+		description:
+			'Take ownership of attributes so this client can write their values, creating templated attributes the user does not have yet',
+	},
+	'attributes.release': {
+		riskLevel: 'write',
+		description:
+			'Release ownership of attributes, passing them to another service or making them inactive',
+	},
+	'attributes.increment': {
+		riskLevel: 'write',
+		description: "Add a delta to owned attributes' values for a given day",
+	},
+	'attributes.update': {
+		riskLevel: 'write',
+		description:
+			"Overwrite owned attributes' total values for a given day, in batches of up to 35",
+	},
+	'averages.list': {
+		riskLevel: 'read',
+		description: 'List weekly average values per attribute',
+	},
+	'correlations.list': {
+		riskLevel: 'read',
+		description:
+			"List correlations Exist computed between the user's attributes",
+	},
+	'insights.list': {
+		riskLevel: 'read',
+		description: "List insights Exist generated about the user's data",
+	},
+} as const satisfies RequiredPluginEndpointMeta<typeof existEndpointsNested>;
+
+export type BaseExistPlugin<T extends ExistPluginOptions> = CorsairPlugin<
+	'exist',
+	typeof ExistSchema,
+	typeof existEndpointsNested,
+	typeof existWebhooksNested,
+	T,
+	typeof defaultAuthType,
+	typeof existAuthConfig
+>;
+
+export type InternalExistPlugin = BaseExistPlugin<ExistPluginOptions>;
+
+export type ExternalExistPlugin<T extends ExistPluginOptions> =
+	BaseExistPlugin<T>;
+
+export function exist<const T extends ExistPluginOptions>(
+	incomingOptions: ExistPluginOptions & T = {} as ExistPluginOptions & T,
+): ExternalExistPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+
+	return {
+		id: 'exist',
+		authConfig: existAuthConfig,
+		schema: ExistSchema,
+		options: options,
+		hooks: options.hooks,
+		webhookHooks: undefined,
+		oauthConfig: {
+			providerName: 'Exist',
+			authUrl: EXIST_OAUTH_AUTHORIZE_URL,
+			tokenUrl: EXIST_OAUTH_TOKEN_URL,
+			scopes: options.scopes ?? EXIST_DEFAULT_SCOPES,
+			// Exist requires the redirect URI to be registered with the client and
+			// to be HTTPS, so a generated localhost callback will not work.
+			requiresRegisteredRedirect: true,
+			tokenAuthMethod: 'body',
+		},
+		endpoints: existEndpointsNested,
+		webhooks: existWebhooksNested,
+		endpointMeta: existEndpointMeta,
+		endpointSchemas: existEndpointSchemas,
+		webhookSchemas: undefined,
+		pluginWebhookMatcher: undefined,
+		oauthWebhookTenantLinkResolver: resolveExistOAuthTenantLink,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: ExistKeyBuilderContext, source) => {
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (ctx.authType === 'oauth_2') {
+				return getOAuthAccessToken(ctx, {
+					plugin: 'exist',
+					tokenUrl: EXIST_OAUTH_TOKEN_URL,
+					tokenAuthMethod: 'body',
+				});
+			}
+
+			throw new AuthMissingError('exist', 'oauth_2');
+		},
+	} satisfies InternalExistPlugin;
+}
+
+export {
+	EXIST_API_BASE,
+	EXIST_MAX_BATCH_SIZE,
+	EXIST_OAUTH_AUTHORIZE_URL,
+	EXIST_OAUTH_TOKEN_URL,
+	EXIST_RATE_LIMIT_PER_HOUR,
+	ExistAPIError,
+} from './client';
+export type {
+	AttributesAcquireInput,
+	AttributesAcquireResponse,
+	AttributesIncrementInput,
+	AttributesIncrementResponse,
+	AttributesListInput,
+	AttributesListOwnedInput,
+	AttributesListOwnedResponse,
+	AttributesListResponse,
+	AttributesListTemplatesInput,
+	AttributesListTemplatesResponse,
+	AttributesListWithValuesInput,
+	AttributesListWithValuesResponse,
+	AttributesReleaseInput,
+	AttributesReleaseResponse,
+	AttributesUpdateInput,
+	AttributesUpdateResponse,
+	AveragesListInput,
+	AveragesListResponse,
+	CorrelationsListInput,
+	CorrelationsListResponse,
+	ExistEndpointInputs,
+	ExistEndpointOutputs,
+	InsightsListInput,
+	InsightsListResponse,
+	UsersGetProfileInput,
+	UsersGetProfileResponse,
+} from './endpoints/types';
+export { resolveExistOAuthTenantLink } from './oauth-tenant-link';
+export { ExistSchema } from './schema';

--- a/packages/exist/jest.config.cjs
+++ b/packages/exist/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/exist/oauth-tenant-link.ts
+++ b/packages/exist/oauth-tenant-link.ts
@@ -1,0 +1,39 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { toExternalId } from 'corsair/core';
+import { EXIST_API_BASE } from './client';
+
+/**
+ * After an OAuth2 exchange, records the Exist username as the account's
+ * `tenant_external_id`. Exist's token response carries no user identifier, so
+ * the username is read from the profile endpoint — it is the only stable,
+ * user-facing id the API exposes.
+ *
+ * @see https://developer.exist.io/reference/users/
+ */
+export async function resolveExistOAuthTenantLink(
+	tokens: TokenResponse,
+): Promise<WebhookTenantMatch | null> {
+	const directId = toExternalId(tokens.tenant_external_id ?? tokens.username);
+	if (directId) {
+		return { linkType: 'tenant_external_id', externalId: directId };
+	}
+
+	const accessToken = tokens.access_token;
+	if (!accessToken) return null;
+
+	try {
+		const response = await fetch(`${EXIST_API_BASE}/accounts/profile/`, {
+			method: 'GET',
+			headers: { Authorization: `Bearer ${accessToken}` },
+		});
+		if (!response.ok) return null;
+
+		const payload = (await response.json()) as { username?: string };
+		const username = toExternalId(payload.username);
+		return username
+			? { linkType: 'tenant_external_id', externalId: username }
+			: null;
+	} catch {
+		return null;
+	}
+}

--- a/packages/exist/oauth-tenant-link.ts
+++ b/packages/exist/oauth-tenant-link.ts
@@ -2,6 +2,9 @@ import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
 import { toExternalId } from 'corsair/core';
 import { EXIST_API_BASE } from './client';
 
+/** Upper bound on the profile lookup performed during the OAuth2 callback. */
+const PROFILE_FETCH_TIMEOUT_MS = 10_000;
+
 /**
  * After an OAuth2 exchange, records the Exist username as the account's
  * `tenant_external_id`. Exist's token response carries no user identifier, so
@@ -25,6 +28,10 @@ export async function resolveExistOAuthTenantLink(
 		const response = await fetch(`${EXIST_API_BASE}/accounts/profile/`, {
 			method: 'GET',
 			headers: { Authorization: `Bearer ${accessToken}` },
+			// This runs inside the OAuth callback, so a hung Exist request must
+			// not stall the exchange. Matches the 10s budget used by the other
+			// Corsair tenant-link resolvers.
+			signal: AbortSignal.timeout(PROFILE_FETCH_TIMEOUT_MS),
 		});
 		if (!response.ok) return null;
 

--- a/packages/exist/package.json
+++ b/packages/exist/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/exist",
+  "version": "0.1.0",
+  "description": "Exist plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "exist",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/exist/schema.test.ts
+++ b/packages/exist/schema.test.ts
@@ -1,0 +1,99 @@
+import {
+	ExistAttribute,
+	ExistAttributeValue,
+	ExistAverage,
+	ExistCorrelation,
+	ExistInsight,
+	ExistProfile,
+	ExistSchema,
+} from './schema';
+
+describe('Exist schema', () => {
+	it('declares a semver version', () => {
+		expect(ExistSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entity per stored Exist object type', () => {
+		expect(Object.keys(ExistSchema.entities).sort()).toEqual([
+			'attributeValues',
+			'attributes',
+			'averages',
+			'correlations',
+			'insights',
+			'profile',
+		]);
+		for (const entity of Object.values(ExistSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+
+	it('keys the profile by username', () => {
+		const parsed = ExistProfile.parse({ id: 'josh', username: 'josh' });
+		expect(parsed.id).toBe('josh');
+	});
+
+	it('accepts a custom attribute with no template and no owning service', () => {
+		const parsed = ExistAttribute.parse({
+			id: 'coffees',
+			name: 'coffees',
+			label: 'Coffees',
+			template: null,
+			service_name: null,
+			value_type: 0,
+		});
+		expect(parsed.template).toBeNull();
+		expect(parsed.service_name).toBeNull();
+	});
+
+	it('stores attribute values of every Exist value type, including null', () => {
+		const base = { id: 'x', attribute: 'x', date: '2022-05-16' };
+		expect(ExistAttributeValue.parse({ ...base, value: 1533 }).value).toBe(
+			1533,
+		);
+		expect(ExistAttributeValue.parse({ ...base, value: 'a note' }).value).toBe(
+			'a note',
+		);
+		expect(ExistAttributeValue.parse({ ...base, value: true }).value).toBe(
+			true,
+		);
+		expect(
+			ExistAttributeValue.parse({ ...base, value: null }).value,
+		).toBeNull();
+	});
+
+	it('allows day averages to be null', () => {
+		const parsed = ExistAverage.parse({
+			id: 'steps:2020-04-29',
+			attribute: 'steps',
+			date: '2020-04-29',
+			overall: 4174,
+			monday: null,
+		});
+		expect(parsed.monday).toBeNull();
+	});
+
+	it('keys a correlation by both attributes and its generation date', () => {
+		const parsed = ExistCorrelation.parse({
+			id: 'sleep:sleep_start:2022-05-16',
+			attribute: 'sleep',
+			attribute2: 'sleep_start',
+			date: '2022-05-16',
+			stars: 5,
+		});
+		expect(parsed.id).toBe('sleep:sleep_start:2022-05-16');
+	});
+
+	it('allows an insight with no target date or attribute', () => {
+		const parsed = ExistInsight.parse({
+			id: 'week_summary:2022-05-16',
+			type_name: 'week_summary',
+			target_date: null,
+			attribute: null,
+		});
+		expect(parsed.target_date).toBeNull();
+	});
+
+	it('rejects an entity that is missing its id', () => {
+		expect(ExistAttribute.safeParse({ name: 'steps' }).success).toBe(false);
+	});
+});

--- a/packages/exist/schema/database.ts
+++ b/packages/exist/schema/database.ts
@@ -1,0 +1,121 @@
+import { z } from 'zod';
+
+/**
+ * Locally stored Exist entities.
+ *
+ * Exist models everything as an *attribute* (a named daily metric) plus the
+ * derived objects it computes from them — averages, correlations and insights.
+ * Those four, along with the account profile, are the objects worth keeping
+ * locally: they change at most daily, are expensive to page through, and every
+ * one of them is looked up by a stable natural key.
+ *
+ * @see https://developer.exist.io/reference/object_types/
+ */
+
+/** The authenticated user, keyed by Exist username. */
+export const ExistProfile = z.object({
+	id: z.string(),
+	username: z.string(),
+	first_name: z.string().optional(),
+	last_name: z.string().optional(),
+	avatar: z.string().nullable().optional(),
+	timezone: z.string().optional(),
+	local_time: z.string().optional(),
+	imperial_distance: z.boolean().optional(),
+	imperial_weight: z.boolean().optional(),
+	imperial_energy: z.boolean().optional(),
+	imperial_liquid: z.boolean().optional(),
+	imperial_temperature: z.boolean().optional(),
+	trial: z.boolean().optional(),
+	delinquent: z.boolean().optional(),
+});
+
+export type ExistProfile = z.infer<typeof ExistProfile>;
+
+/** An attribute definition, keyed by its ASCII `name`. */
+export const ExistAttribute = z.object({
+	id: z.string(),
+	name: z.string(),
+	label: z.string().optional(),
+	/** Null for custom attributes that are not based on a template. */
+	template: z.string().nullable().optional(),
+	group_name: z.string().optional(),
+	group_label: z.string().optional(),
+	/** The service that currently owns the attribute, if any. */
+	service_name: z.string().nullable().optional(),
+	active: z.boolean().optional(),
+	manual: z.boolean().optional(),
+	priority: z.number().optional(),
+	value_type: z.number().optional(),
+	value_type_description: z.string().optional(),
+});
+
+export type ExistAttribute = z.infer<typeof ExistAttribute>;
+
+/** One day of one attribute, keyed `<attribute>:<date>`. */
+export const ExistAttributeValue = z.object({
+	id: z.string(),
+	attribute: z.string(),
+	date: z.string(),
+	/** Typed by the attribute's `value_type`; null on days with no data. */
+	value: z.union([z.string(), z.number(), z.boolean()]).nullable().optional(),
+});
+
+export type ExistAttributeValue = z.infer<typeof ExistAttributeValue>;
+
+/** A weekly average set for one attribute, keyed `<attribute>:<date>`. */
+export const ExistAverage = z.object({
+	id: z.string(),
+	attribute: z.string(),
+	date: z.string(),
+	overall: z.number().nullable().optional(),
+	monday: z.number().nullable().optional(),
+	tuesday: z.number().nullable().optional(),
+	wednesday: z.number().nullable().optional(),
+	thursday: z.number().nullable().optional(),
+	friday: z.number().nullable().optional(),
+	saturday: z.number().nullable().optional(),
+	sunday: z.number().nullable().optional(),
+});
+
+export type ExistAverage = z.infer<typeof ExistAverage>;
+
+/**
+ * A correlation between two attributes, keyed
+ * `<attribute>:<attribute2>:<date>` — Exist regenerates correlations weekly,
+ * so the generation date is part of the identity.
+ */
+export const ExistCorrelation = z.object({
+	id: z.string(),
+	attribute: z.string(),
+	attribute2: z.string(),
+	date: z.string(),
+	/** Days of data the correlation was computed over. */
+	period: z.number().optional(),
+	offset: z.number().optional(),
+	/** Pearson coefficient, -1 to +1. */
+	value: z.number().optional(),
+	p: z.number().optional(),
+	percentage: z.number().optional(),
+	/** Confidence, 1 to 5. */
+	stars: z.number().optional(),
+	second_person: z.string().optional(),
+	strength_description: z.string().nullable().optional(),
+	stars_description: z.string().nullable().optional(),
+});
+
+export type ExistCorrelation = z.infer<typeof ExistCorrelation>;
+
+/** A generated insight, keyed `<type name>:<target date>`. */
+export const ExistInsight = z.object({
+	id: z.string(),
+	type_name: z.string(),
+	target_date: z.string().nullable().optional(),
+	created: z.string().optional(),
+	/** The attribute the insight is about, when it concerns one. */
+	attribute: z.string().nullable().optional(),
+	text: z.string().optional(),
+	html: z.string().optional(),
+});
+
+export type ExistInsight = z.infer<typeof ExistInsight>;

--- a/packages/exist/schema/index.ts
+++ b/packages/exist/schema/index.ts
@@ -1,0 +1,22 @@
+import {
+	ExistAttribute,
+	ExistAttributeValue,
+	ExistAverage,
+	ExistCorrelation,
+	ExistInsight,
+	ExistProfile,
+} from './database';
+
+export const ExistSchema = {
+	version: '1.0.0',
+	entities: {
+		profile: ExistProfile,
+		attributes: ExistAttribute,
+		attributeValues: ExistAttributeValue,
+		averages: ExistAverage,
+		correlations: ExistCorrelation,
+		insights: ExistInsight,
+	},
+} as const;
+
+export * from './database';

--- a/packages/exist/tsconfig.json
+++ b/packages/exist/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/exist/tsup.config.ts
+++ b/packages/exist/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/exist/validation.test.ts
+++ b/packages/exist/validation.test.ts
@@ -1,0 +1,144 @@
+import { request } from 'corsair/http';
+import { makeExistRequest } from './client';
+import type { ExistContext } from './index';
+import { exist, existEndpointSchemas } from './index';
+
+jest.mock('corsair/http', () => ({
+	...jest.requireActual('corsair/http'),
+	request: jest.fn(),
+}));
+
+const mockRequest = request as jest.Mock;
+
+const mockCtx = {
+	key: 'test-access-token',
+	$getAccountId: async () => 'test-account-id',
+	database: undefined,
+	endpoints: {},
+} as unknown as ExistContext;
+
+const profileResponse = {
+	username: 'testuser',
+	first_name: 'Test',
+	last_name: 'User',
+	avatar: null,
+	timezone: 'UTC',
+};
+
+const pagedAttributes = {
+	count: 1,
+	next: null,
+	previous: null,
+	results: [
+		{
+			name: 'steps',
+			label: 'Steps',
+			priority: 1,
+			group: { name: 'activity', label: 'Activity' },
+			service: null,
+			template: null,
+			active: true,
+			manual: false,
+			value_type: 0,
+			value_type_description: 'INT',
+		},
+	],
+};
+
+const writeResponse = {
+	success: [{ name: 'steps', date: '2026-01-01', value: 1000 }],
+	failed: [],
+};
+
+describe('exist transport retry policy', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockRequest.mockResolvedValue(profileResponse);
+	});
+
+	it('allows transport retries on GET requests', async () => {
+		await makeExistRequest('accounts/profile/', 'token', { method: 'GET' });
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.anything(),
+			expect.objectContaining({
+				rateLimitConfig: expect.objectContaining({
+					enabled: true,
+					maxRetries: 3,
+				}),
+			}),
+		);
+	});
+
+	it('disables transport retries on write requests', async () => {
+		await makeExistRequest('attributes/update/', 'token', {
+			method: 'POST',
+			body: [{ name: 'steps', date: '2026-01-01', value: 1000 }],
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ method: 'POST' }),
+			expect.objectContaining({
+				rateLimitConfig: expect.objectContaining({
+					enabled: false,
+					maxRetries: 0,
+				}),
+			}),
+		);
+	});
+
+	it('rejects responses that violate the output contract', async () => {
+		mockRequest.mockResolvedValueOnce('not-an-object');
+		await expect(
+			exist({ key: 'token' }).endpoints!.users.getProfile(mockCtx, {}),
+		).rejects.toThrow(/output validation failed/i);
+	});
+});
+
+describe('exist runtime validation', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockRequest.mockResolvedValue(profileResponse);
+	});
+
+	it('rejects malformed input before it reaches Exist', async () => {
+		await expect(async () => {
+			await exist({ key: 'token' }).endpoints!.attributes.update(mockCtx, {
+				attributes: [],
+			} as never);
+		}).rejects.toThrow(/input validation failed/i);
+		expect(mockRequest).not.toHaveBeenCalled();
+	});
+
+	it('rejects an over-limit batch before it reaches Exist', async () => {
+		const batch = Array.from({ length: 36 }, (_, i) => ({
+			name: `attr${i}`,
+			date: '2026-01-01',
+			value: i,
+		}));
+		await expect(async () => {
+			await exist({ key: 'token' }).endpoints!.attributes.update(mockCtx, {
+				attributes: batch,
+			} as never);
+		}).rejects.toThrow(/input validation failed/i);
+		expect(mockRequest).not.toHaveBeenCalled();
+	});
+
+	it('validates responses against the registered output schema', async () => {
+		mockRequest.mockResolvedValueOnce({
+			count: 'not-a-number',
+			results: 'nope',
+		});
+		await expect(
+			exist({ key: 'token' }).endpoints!.attributes.list(mockCtx, {}),
+		).rejects.toThrow(/output validation failed/i);
+	});
+
+	it('keeps the refined list-with-values schema introspectable as an object', () => {
+		const schema = existEndpointSchemas['attributes.listWithValues']?.input;
+		expect(schema).toBeDefined();
+		expect((schema as { shape?: unknown }).shape).toBeDefined();
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3637,6 +3637,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/exist:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/facebook:
     devDependencies:
       '@types/jest':


### PR DESCRIPTION
## Description

Adds `@corsair-dev/exist`, a Corsair integration for the [Exist](https://exist.io) personal
analytics API (API v2, `https://exist.io/api/2/`), so agents can read a user's tracked
attributes and write values back on their behalf.

Closes #1584

## Operations

All 12 operations from the [OSS listing](https://corsair.dev/oss/exist) are implemented,
plus `attributes.update` — the documented counterpart to `attributes.increment`, without
which the plugin can increment values but never set a day's total.

| Operation | Exist endpoint |
| --- | --- |
| `users.getProfile` | `GET /accounts/profile/` |
| `attributes.list` | `GET /attributes/` |
| `attributes.listTemplates` | `GET /attributes/templates/` |
| `attributes.listWithValues` | `GET /attributes/with-values/` |
| `attributes.listOwned` | `GET /attributes/owned/` |
| `attributes.acquire` | `POST /attributes/acquire/` |
| `attributes.release` | `POST /attributes/release/` |
| `attributes.increment` | `POST /attributes/increment/` |
| `attributes.update` | `POST /attributes/update/` |
| `averages.list` | `GET /averages/` |
| `correlations.list` | `GET /correlations/` |
| `insights.list` | `GET /insights/` |
| `oauth.authorize` | builds `https://exist.io/oauth2/authorize` (no API call) |

Every endpoint, parameter, limit and response shape was checked against
[developer.exist.io](https://developer.exist.io/) rather than inferred: the `days` cap of 31
on `with-values`, the 100 `limit` cap on correlations/insights (and its *absence* on the
attribute lists — that cap applies only to `attributes/values/`, which is not implemented),
the 35-object batch ceiling on writes, and the documented `null` value for days with no data.

No webhooks are declared: Exist exposes no callback mechanism and the listing specifies 0 triggers.

## Authentication

OAuth2 with Bearer tokens, per Exist's guidance for multi-user clients. Authorisation uses
`https://exist.io/oauth2/authorize` and tokens are exchanged at
`https://exist.io/oauth2/access_token` with credentials in the body. All 34 documented scopes
(17 read, 17 write) are available and narrowable via the `scopes` option.

`oauth.authorize` builds the authorisation URL and returns an unguessable per-call `state`
for CSRF protection, following the existing `packages/ticktick` precedent. It rejects
non-HTTPS redirect URIs, which Exist will not accept. A 401 mints a fresh token once and
retries; the tenant-link profile lookup is bounded by `AbortSignal.timeout`.

## Privacy and security

Exist holds personal analytics data (mood notes, weight, location), so this is treated as a
correctness requirement rather than a nicety:

- Write operations log only operational metadata — object count, attribute names and dates
  covered — never the submitted values.
- Access tokens never appear in URLs, bodies, logs, or error messages; tests assert this.
- Tests use only obviously-fake credentials. No real tokens or personal data are committed.

## Validation and error handling

Inputs and outputs are validated at runtime through the declared Zod schemas, so a malformed
provider response fails loudly instead of propagating. Dates use `z.iso.date()`, which rejects
calendar-impossible days such as `2026-02-31`. `attributes/with-values/` rejects filtering by
both `attributes` and `templates`, which the reference states are alternatives.

Exist's documented limit is 300 requests/hour/user token, answered with a bodiless 429.
GET requests retry with backoff honouring `Retry-After`; **write operations are never
replayed automatically**, at either the transport or endpoint layer, so a rate limit or
transient failure cannot duplicate a value write.

## Testing

Four suites — `api.test.ts`, `validation.test.ts`, `error-handlers.test.ts`,
`schema.test.ts` — run with `pnpm --filter @corsair-dev/exist test`.

Coverage spans every operation, request/query/path/body serialisation, successful and
malformed responses, schema rejection, invalid and mutually exclusive inputs, date
validation, 401/403/404/429/5xx routing, network and timeout/abort behaviour, token
secrecy, personal-data minimisation, retry safety, and schema introspectability.

TypeScript is clean: `tsc --build` passes across the repository. The screenshot below is a
real local run of this suite, captured at an earlier commit on this branch. CI is the
authoritative run for the current head.

## Screenshots / Demos

<img width="1600" height="1480" alt="exist-demo-working" src="https://github.com/user-attachments/assets/f3e10300-bedc-42e2-8845-7bf97b62d2e9" />

> Screenshot shows the Exist integration's verified local test-suite path. No credentials or private data are included. No live Exist API response is claimed.

## Limitations

- `GET /attributes/values/` and `GET /correlations/combo/` exist in the API but are outside
  the scope of this listing and are not implemented.
- Token refresh relies on Corsair's OAuth2 machinery; Exist access tokens are long-lived
  (~1 year) so refresh is exercised only on a 401.
