### PR TITLE
feat(gladia): add Gladia integration plugin

### DIFF
--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -163,6 +163,7 @@ export const BaseProviders = [
 	'gemini',
 	'github',
 	'gitlab',
+	'gladia',
 	'gmail',
 	'googleaddressvalidation',
 	'googleanalytics',
@@ -440,6 +441,7 @@ export const ProviderDisplayNames = {
 	gemini: 'Gemini',
 	github: 'GitHub',
 	gitlab: 'GitLab',
+	gladia: 'Gladia',
 	gmail: 'Gmail',
 	googleaddressvalidation: 'Google Address Validation',
 	googleanalytics: 'Google Analytics',
@@ -724,6 +726,7 @@ export type AllProviders =
 	| 'gemini'
 	| 'github'
 	| 'gitlab'
+	| 'gladia'
 	| 'gmail'
 	| 'googleaddressvalidation'
 	| 'googleanalytics'

--- a/packages/gladia/api.test.ts
+++ b/packages/gladia/api.test.ts
@@ -1,0 +1,203 @@
+import { logEventFromContext } from 'corsair/core';
+import { request } from 'corsair/http';
+import { GladiaAPIError } from './client';
+import type { GladiaContext } from './index';
+import { gladia } from './index';
+
+jest.mock('corsair/core', () => ({
+	...jest.requireActual('corsair/core'),
+	logEventFromContext: jest.fn(),
+}));
+
+jest.mock('corsair/http', () => ({
+	...jest.requireActual('corsair/http'),
+	request: jest.fn(),
+}));
+
+const mockRequest = request as jest.Mock;
+const mockLogEvent = logEventFromContext as jest.Mock;
+
+const mockCtx = {
+	key: 'test-api-key',
+	options: {},
+	logEvent: jest.fn(),
+	db: {},
+} as unknown as GladiaContext;
+
+const job = {
+	id: 'job-1',
+	status: 'done',
+	kind: 'pre-recorded',
+	custom_metadata: {},
+};
+
+describe('Gladia plugin shape', () => {
+	it('exposes the nine supported operations and no deprecated audio download', () => {
+		const plugin = gladia();
+		const paths = Object.entries(plugin.endpointMeta ?? {}).map(
+			([path]) => path,
+		);
+
+		expect(paths).toHaveLength(9);
+		expect(paths).toContain('upload.audioVideoFile');
+		expect(paths).toContain('preRecorded.deleteJob');
+		expect(paths.some((path) => path.toLowerCase().includes('audiofile'))).toBe(
+			false,
+		);
+		expect(plugin.webhooks).toEqual({});
+		expect(plugin.options?.authType).toBe('api_key');
+		expect(plugin.authConfig).toEqual({
+			api_key: { account: ['tenant_external_id'] },
+		});
+	});
+});
+
+describe('Gladia HTTP client and endpoints', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockLogEvent.mockReset();
+		mockRequest.mockResolvedValue(job);
+	});
+
+	it('uses the Gladia base URL and x-gladia-key header', async () => {
+		await gladia({
+			key: 'test-api-key',
+		}).endpoints!.live.getTranscriptionResult(mockCtx, { id: 'job/1' });
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.objectContaining({
+				BASE: 'https://api.gladia.io',
+				HEADERS: {
+					'x-gladia-key': 'test-api-key',
+					'Content-Type': 'application/json',
+				},
+			}),
+			expect.objectContaining({ method: 'GET', url: '/v2/live/job%2F1' }),
+		);
+	});
+
+	it('starts a pre-recorded job with a JSON body', async () => {
+		mockRequest.mockResolvedValue({
+			id: 'job-1',
+			result_url: 'https://api.gladia.io/v2/pre-recorded/job-1',
+		});
+		await gladia({
+			key: 'test-api-key',
+		}).endpoints!.preRecorded.initiateTranscription(mockCtx, {
+			audio_url: 'https://files.gladia.io/audio.wav',
+			language_config: { languages: ['en'] },
+		});
+
+		expect(mockRequest.mock.calls[0]?.[1]).toEqual(
+			expect.objectContaining({
+				method: 'POST',
+				url: '/v2/pre-recorded',
+				body: {
+					audio_url: 'https://files.gladia.io/audio.wav',
+					language_config: { languages: ['en'] },
+				},
+			}),
+		);
+	});
+
+	it('passes pagination and filters to both list endpoints', async () => {
+		const list = {
+			first: 'https://api.gladia.io/v2/live',
+			current: 'https://api.gladia.io/v2/live',
+			next: null,
+			items: [],
+		};
+		mockRequest.mockResolvedValue(list);
+		const input = { offset: 20, limit: 10, status: ['done'] as Array<'done'> };
+		await gladia({ key: 'test-api-key' }).endpoints!.live.listTranscriptionJobs(
+			mockCtx,
+			input,
+		);
+		await gladia({ key: 'test-api-key' }).endpoints!.preRecorded.listJobs(
+			mockCtx,
+			input,
+		);
+
+		expect(mockRequest.mock.calls.map((call) => call[1])).toEqual([
+			expect.objectContaining({ method: 'GET', url: '/v2/live', query: input }),
+			expect.objectContaining({
+				method: 'GET',
+				url: '/v2/pre-recorded',
+				query: input,
+			}),
+		]);
+	});
+
+	it('creates live sessions with a region query and returns the WebSocket URL', async () => {
+		const response = {
+			id: 'live-1',
+			created_at: '2026-01-01T00:00:00.000Z',
+			url: 'wss://api.gladia.io/v2/live?token=temporary',
+		};
+		mockRequest.mockResolvedValue(response);
+		await gladia({
+			key: 'test-api-key',
+		}).endpoints!.live.initiateTranscriptionSession(mockCtx, {
+			region: 'eu-west',
+			channels: 1,
+		});
+
+		expect(mockRequest.mock.calls[0]?.[1]).toEqual(
+			expect.objectContaining({
+				method: 'POST',
+				url: '/v2/live',
+				query: { region: 'eu-west' },
+				body: { channels: 1 },
+			}),
+		);
+	});
+
+	it('uploads audio as multipart form data', async () => {
+		mockRequest.mockResolvedValue({
+			audio_url: 'https://api.gladia.io/file/1',
+			audio_metadata: {},
+		});
+		const audio = new Blob(['audio'], { type: 'audio/wav' });
+		await gladia({ key: 'test-api-key' }).endpoints!.upload.audioVideoFile(
+			mockCtx,
+			{ audio, filename: 'sample.wav' },
+		);
+
+		const options = mockRequest.mock.calls[0]?.[1] as {
+			body: FormData;
+			url: string;
+		};
+		expect(options.url).toBe('/v2/upload');
+		expect(options.body).toBeInstanceOf(FormData);
+		expect(options.body.get('audio')).toBeInstanceOf(File);
+	});
+
+	it('maps delete operations to the documented routes', async () => {
+		mockRequest.mockResolvedValue(undefined);
+		await gladia({ key: 'test-api-key' }).endpoints!.live.deleteSession(
+			mockCtx,
+			{ id: 'live-1' },
+		);
+		await gladia({ key: 'test-api-key' }).endpoints!.preRecorded.deleteJob(
+			mockCtx,
+			{ id: 'pre-1' },
+		);
+
+		expect(mockRequest.mock.calls.map((call) => call[1])).toEqual([
+			expect.objectContaining({ method: 'DELETE', url: '/v2/live/live-1' }),
+			expect.objectContaining({
+				method: 'DELETE',
+				url: '/v2/pre-recorded/pre-1',
+			}),
+		]);
+	});
+
+	it('wraps transport failures with the provider error type', async () => {
+		mockRequest.mockRejectedValue(new Error('network unavailable'));
+		await expect(
+			gladia({ key: 'test-api-key' }).endpoints!.preRecorded.getJob(mockCtx, {
+				id: 'job-1',
+			}),
+		).rejects.toBeInstanceOf(GladiaAPIError);
+	});
+});

--- a/packages/gladia/api.test.ts
+++ b/packages/gladia/api.test.ts
@@ -2,7 +2,7 @@ import { logEventFromContext } from 'corsair/core';
 import { request } from 'corsair/http';
 import { GladiaAPIError } from './client';
 import type { GladiaContext } from './index';
-import { gladia } from './index';
+import { gladia, gladiaEndpointSchemas } from './index';
 
 jest.mock('corsair/core', () => ({
 	...jest.requireActual('corsair/core'),
@@ -19,10 +19,10 @@ const mockLogEvent = logEventFromContext as jest.Mock;
 
 const mockCtx = {
 	key: 'test-api-key',
-	options: {},
-	logEvent: jest.fn(),
-	db: {},
-} as unknown as GladiaContext;
+	$getAccountId: async () => 'test-account-id',
+	database: undefined,
+	endpoints: {},
+} as GladiaContext;
 
 const job = {
 	id: 'job-1',
@@ -49,6 +49,44 @@ describe('Gladia plugin shape', () => {
 		expect(plugin.authConfig).toEqual({
 			api_key: { account: ['tenant_external_id'] },
 		});
+	});
+});
+
+describe('Gladia live input bounds', () => {
+	const live =
+		gladiaEndpointSchemas['live.initiateTranscriptionSession']?.input;
+
+	it('rejects endpointing outside the 0.01 to 10 second range', () => {
+		expect(live!.safeParse({ endpointing: 0.001 }).success).toBe(false);
+		expect(live!.safeParse({ endpointing: 20 }).success).toBe(false);
+		expect(live!.safeParse({ endpointing: 0.05 }).success).toBe(true);
+	});
+
+	it('rejects maximum_duration_without_endpointing outside 5 to 60 seconds', () => {
+		expect(
+			live!.safeParse({ maximum_duration_without_endpointing: 1 }).success,
+		).toBe(false);
+		expect(
+			live!.safeParse({ maximum_duration_without_endpointing: 61 }).success,
+		).toBe(false);
+		expect(
+			live!.safeParse({ maximum_duration_without_endpointing: 30 }).success,
+		).toBe(true);
+	});
+
+	it('requires 8-bit audio for alaw and ulaw encodings', () => {
+		expect(
+			live!.safeParse({ encoding: 'wav/alaw', bit_depth: 16 }).success,
+		).toBe(false);
+		expect(
+			live!.safeParse({ encoding: 'wav/ulaw', bit_depth: 24 }).success,
+		).toBe(false);
+		expect(
+			live!.safeParse({ encoding: 'wav/alaw', bit_depth: 8 }).success,
+		).toBe(true);
+		expect(
+			live!.safeParse({ encoding: 'wav/pcm', bit_depth: 16 }).success,
+		).toBe(true);
 	});
 });
 
@@ -199,5 +237,26 @@ describe('Gladia HTTP client and endpoints', () => {
 				id: 'job-1',
 			}),
 		).rejects.toBeInstanceOf(GladiaAPIError);
+	});
+
+	it('rejects malformed inputs before they reach Gladia', async () => {
+		await expect(async () => {
+			await gladia({
+				key: 'test-api-key',
+			}).endpoints!.preRecorded.initiateTranscription(mockCtx, {
+				audio_url: 'not-a-url',
+			} as never);
+		}).rejects.toThrow(/input validation failed/);
+		expect(mockRequest).not.toHaveBeenCalled();
+	});
+
+	it('rejects responses that violate the advertised output contract', async () => {
+		mockRequest.mockResolvedValueOnce({ unexpected: true });
+		await expect(
+			gladia({ key: 'test-api-key' }).endpoints!.live.getTranscriptionResult(
+				mockCtx,
+				{ id: 'job-1' },
+			),
+		).rejects.toThrow(/gladia/i);
 	});
 });

--- a/packages/gladia/api.test.ts
+++ b/packages/gladia/api.test.ts
@@ -218,9 +218,7 @@ describe('Gladia HTTP client and endpoints', () => {
 	});
 
 	it('maps delete operations to the documented routes', async () => {
-		mockRequest.mockResolvedValue({
-			message: 'The pre recorded job has been successfully deleted',
-		});
+		mockRequest.mockResolvedValue(undefined);
 		await gladia({ key: 'test-api-key' }).endpoints!.live.deleteSession(
 			mockCtx,
 			{ id: 'live-1' },
@@ -237,6 +235,20 @@ describe('Gladia HTTP client and endpoints', () => {
 				url: '/v2/pre-recorded/pre-1',
 			}),
 		]);
+	});
+
+	it('accepts acknowledgement bodies on delete responses', async () => {
+		mockRequest.mockResolvedValueOnce({
+			message: 'The pre recorded job has been successfully deleted',
+		});
+		await expect(
+			gladia({ key: 'test-api-key' }).endpoints!.preRecorded.deleteJob(
+				mockCtx,
+				{ id: 'pre-1' },
+			),
+		).resolves.toEqual({
+			message: 'The pre recorded job has been successfully deleted',
+		});
 	});
 
 	it('rejects delete responses that are not acknowledgement objects', async () => {

--- a/packages/gladia/api.test.ts
+++ b/packages/gladia/api.test.ts
@@ -88,6 +88,13 @@ describe('Gladia live input bounds', () => {
 			live!.safeParse({ encoding: 'wav/pcm', bit_depth: 16 }).success,
 		).toBe(true);
 	});
+
+	it('rejects alaw and ulaw when bit_depth is omitted', () => {
+		expect(live!.safeParse({ encoding: 'wav/alaw' }).success).toBe(false);
+		expect(live!.safeParse({ encoding: 'wav/ulaw' }).success).toBe(false);
+		expect(live!.safeParse({ encoding: 'wav/pcm' }).success).toBe(true);
+		expect(live!.safeParse({}).success).toBe(true);
+	});
 });
 
 describe('Gladia HTTP client and endpoints', () => {
@@ -211,7 +218,9 @@ describe('Gladia HTTP client and endpoints', () => {
 	});
 
 	it('maps delete operations to the documented routes', async () => {
-		mockRequest.mockResolvedValue(undefined);
+		mockRequest.mockResolvedValue({
+			message: 'The pre recorded job has been successfully deleted',
+		});
 		await gladia({ key: 'test-api-key' }).endpoints!.live.deleteSession(
 			mockCtx,
 			{ id: 'live-1' },
@@ -228,6 +237,16 @@ describe('Gladia HTTP client and endpoints', () => {
 				url: '/v2/pre-recorded/pre-1',
 			}),
 		]);
+	});
+
+	it('rejects delete responses that are not acknowledgement objects', async () => {
+		mockRequest.mockResolvedValueOnce({ unexpected: true });
+		await expect(async () => {
+			await gladia({ key: 'test-api-key' }).endpoints!.preRecorded.deleteJob(
+				mockCtx,
+				{ id: 'pre-1' },
+			);
+		}).rejects.toThrow(/output validation failed/);
 	});
 
 	it('wraps transport failures with the provider error type', async () => {

--- a/packages/gladia/client.ts
+++ b/packages/gladia/client.ts
@@ -5,21 +5,27 @@ const GLADIA_API_BASE = 'https://api.gladia.io';
 
 export class GladiaAPIError extends Error {
 	public readonly status?: number;
+	// unknown is necessary because Gladia error payloads vary by endpoint; a closed error body union is infeasible because v2 does not publish one schema for failures
 	public readonly body?: unknown;
+	public readonly retryAfter?: number;
 
+	// unknown is necessary because the cause can be any thrown value from the transport; a closed error union is infeasible because fetch failures are untyped
 	constructor(message: string, cause?: unknown) {
 		super(message, cause instanceof Error ? { cause } : undefined);
 		this.name = 'GladiaAPIError';
 		if (cause instanceof ApiError) {
 			this.status = cause.status;
 			this.body = cause.body;
+			this.retryAfter = cause.retryAfter;
 		}
 	}
 }
 
 type GladiaRequestOptions = {
 	method?: 'GET' | 'POST' | 'DELETE';
+	// unknown is necessary because write bodies are operation-specific JSON bags; a closed union of nine payload shapes is infeasible because the transport is shared
 	body?: unknown;
+	// unknown is necessary because query values include nested filter records; a closed query-value union is infeasible because list filters are provider-defined
 	query?: Record<string, unknown>;
 };
 

--- a/packages/gladia/client.ts
+++ b/packages/gladia/client.ts
@@ -1,0 +1,81 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+
+const GLADIA_API_BASE = 'https://api.gladia.io';
+
+export class GladiaAPIError extends Error {
+	public readonly status?: number;
+	public readonly body?: unknown;
+
+	constructor(message: string, cause?: unknown) {
+		super(message, cause instanceof Error ? { cause } : undefined);
+		this.name = 'GladiaAPIError';
+		if (cause instanceof ApiError) {
+			this.status = cause.status;
+			this.body = cause.body;
+		}
+	}
+}
+
+type GladiaRequestOptions = {
+	method?: 'GET' | 'POST' | 'DELETE';
+	body?: unknown;
+	query?: Record<string, unknown>;
+};
+
+function config(
+	apiKey: string,
+	contentType = 'application/json',
+): OpenAPIConfig {
+	return {
+		BASE: GLADIA_API_BASE,
+		VERSION: '2',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		HEADERS: {
+			'x-gladia-key': apiKey,
+			...(contentType ? { 'Content-Type': contentType } : {}),
+		},
+	};
+}
+
+export async function makeGladiaRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	options: GladiaRequestOptions = {},
+): Promise<T> {
+	const { method = 'GET', body, query } = options;
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint,
+		body: method === 'POST' ? body : undefined,
+		query,
+		mediaType:
+			body === undefined ? undefined : 'application/json; charset=utf-8',
+	};
+	try {
+		return await request<T>(config(apiKey), requestOptions);
+	} catch (error) {
+		if (error instanceof Error) throw new GladiaAPIError(error.message, error);
+		throw new GladiaAPIError('Unknown Gladia API error');
+	}
+}
+
+export async function uploadGladiaFile<T>(
+	audio: Blob,
+	apiKey: string,
+	filename?: string,
+): Promise<T> {
+	const form = new FormData();
+	form.append('audio', audio, filename);
+	try {
+		return await request<T>(config(apiKey, ''), {
+			method: 'POST',
+			url: '/v2/upload',
+			body: form,
+		});
+	} catch (error) {
+		if (error instanceof Error) throw new GladiaAPIError(error.message, error);
+		throw new GladiaAPIError('Unknown Gladia API error');
+	}
+}

--- a/packages/gladia/endpoints/index.ts
+++ b/packages/gladia/endpoints/index.ts
@@ -1,0 +1,120 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeGladiaRequest, uploadGladiaFile } from '../client';
+import type {
+	GladiaContext,
+	GladiaEndpoints as GladiaEndpointTypes,
+} from '../index';
+import type { GladiaEndpointOutputs } from './types';
+
+const complete = async <T>(
+	ctx: GladiaContext,
+	operation: string,
+	input: Record<string, unknown>,
+	request: Promise<T>,
+): Promise<T> => {
+	const response = await request;
+	await logEventFromContext(ctx, operation, input, 'completed');
+	return response;
+};
+
+export const GladiaEndpoints: GladiaEndpointTypes = {
+	uploadAudioVideoFile: (ctx, input) =>
+		complete(
+			ctx,
+			'gladia.upload.audioVideoFile',
+			input,
+			uploadGladiaFile<GladiaEndpointOutputs['uploadAudioVideoFile']>(
+				input.audio,
+				ctx.key,
+				input.filename,
+			),
+		),
+	initiateLiveTranscriptionSession: (ctx, input) => {
+		const { region, ...body } = input;
+		return complete(
+			ctx,
+			'gladia.live.initiateTranscriptionSession',
+			input,
+			makeGladiaRequest<
+				GladiaEndpointOutputs['initiateLiveTranscriptionSession']
+			>('/v2/live', ctx.key, {
+				method: 'POST',
+				body,
+				query: region ? { region } : undefined,
+			}),
+		);
+	},
+	listLiveTranscriptionJobs: (ctx, input) =>
+		complete(
+			ctx,
+			'gladia.live.listTranscriptionJobs',
+			input,
+			makeGladiaRequest<GladiaEndpointOutputs['listLiveTranscriptionJobs']>(
+				'/v2/live',
+				ctx.key,
+				{ query: input },
+			),
+		),
+	getLiveTranscriptionResult: (ctx, input) =>
+		complete(
+			ctx,
+			'gladia.live.getTranscriptionResult',
+			input,
+			makeGladiaRequest<GladiaEndpointOutputs['getLiveTranscriptionResult']>(
+				`/v2/live/${encodeURIComponent(input.id)}`,
+				ctx.key,
+			),
+		),
+	deleteLiveSession: (ctx, input) =>
+		complete(
+			ctx,
+			'gladia.live.deleteSession',
+			input,
+			makeGladiaRequest('/v2/live/' + encodeURIComponent(input.id), ctx.key, {
+				method: 'DELETE',
+			}),
+		),
+	initiatePreRecordedTranscription: (ctx, input) =>
+		complete(
+			ctx,
+			'gladia.preRecorded.initiateTranscription',
+			input,
+			makeGladiaRequest<
+				GladiaEndpointOutputs['initiatePreRecordedTranscription']
+			>('/v2/pre-recorded', ctx.key, { method: 'POST', body: input }),
+		),
+	listPreRecordedJobs: (ctx, input) =>
+		complete(
+			ctx,
+			'gladia.preRecorded.listJobs',
+			input,
+			makeGladiaRequest<GladiaEndpointOutputs['listPreRecordedJobs']>(
+				'/v2/pre-recorded',
+				ctx.key,
+				{ query: input },
+			),
+		),
+	getPreRecordedJob: (ctx, input) =>
+		complete(
+			ctx,
+			'gladia.preRecorded.getJob',
+			input,
+			makeGladiaRequest<GladiaEndpointOutputs['getPreRecordedJob']>(
+				`/v2/pre-recorded/${encodeURIComponent(input.id)}`,
+				ctx.key,
+			),
+		),
+	deletePreRecordedJob: (ctx, input) =>
+		complete(
+			ctx,
+			'gladia.preRecorded.deleteJob',
+			input,
+			makeGladiaRequest(
+				'/v2/pre-recorded/' + encodeURIComponent(input.id),
+				ctx.key,
+				{ method: 'DELETE' },
+			),
+		),
+};
+
+export type { GladiaEndpointInputs, GladiaEndpointOutputs } from './types';

--- a/packages/gladia/endpoints/index.ts
+++ b/packages/gladia/endpoints/index.ts
@@ -4,11 +4,28 @@ import type {
 	GladiaContext,
 	GladiaEndpoints as GladiaEndpointTypes,
 } from '../index';
-import type { GladiaEndpointOutputs } from './types';
+import type { GladiaEndpointInputs, GladiaEndpointOutputs } from './types';
+import {
+	GladiaEndpointInputSchemas,
+	GladiaEndpointOutputSchemas,
+} from './types';
+
+class GladiaValidationError extends Error {
+	constructor(
+		public readonly kind: 'input' | 'output',
+		public readonly operation: string,
+		// unknown is necessary because Zod issue arrays are provider-agnostic; a closed issue union is infeasible because paths and codes vary by schema
+		public readonly issues: unknown,
+	) {
+		super(`[gladia] ${kind} validation failed for ${operation}: ${issues}`);
+		this.name = 'GladiaValidationError';
+	}
+}
 
 const complete = async <T>(
 	ctx: GladiaContext,
 	operation: string,
+	// unknown is necessary because event payloads record the raw caller input; a closed input union is infeasible because nine operations share this logger
 	input: Record<string, unknown>,
 	request: Promise<T>,
 ): Promise<T> => {
@@ -17,20 +34,47 @@ const complete = async <T>(
 	return response;
 };
 
+function parseInput<K extends keyof GladiaEndpointInputs>(
+	operation: K,
+	input: GladiaEndpointInputs[K],
+): GladiaEndpointInputs[K] {
+	const schema = GladiaEndpointInputSchemas[operation];
+	const parsed = schema.safeParse(input);
+	if (!parsed.success) {
+		throw new GladiaValidationError('input', String(operation), parsed.error);
+	}
+	return parsed.data as GladiaEndpointInputs[K];
+}
+
+function parseOutput<K extends keyof GladiaEndpointOutputs>(
+	operation: K,
+	response: GladiaEndpointOutputs[K],
+): GladiaEndpointOutputs[K] {
+	const schema = GladiaEndpointOutputSchemas[operation];
+	const parsed = schema.safeParse(response);
+	if (!parsed.success) {
+		throw new GladiaValidationError('output', String(operation), parsed.error);
+	}
+	return parsed.data as GladiaEndpointOutputs[K];
+}
+
 export const GladiaEndpoints: GladiaEndpointTypes = {
-	uploadAudioVideoFile: (ctx, input) =>
-		complete(
+	uploadAudioVideoFile: (ctx, input) => {
+		const parsed = parseInput('uploadAudioVideoFile', input);
+		return complete(
 			ctx,
 			'gladia.upload.audioVideoFile',
 			input,
 			uploadGladiaFile<GladiaEndpointOutputs['uploadAudioVideoFile']>(
-				input.audio,
+				parsed.audio,
 				ctx.key,
-				input.filename,
-			),
-		),
+				parsed.filename,
+			).then((response) => parseOutput('uploadAudioVideoFile', response)),
+		);
+	},
 	initiateLiveTranscriptionSession: (ctx, input) => {
-		const { region, ...body } = input;
+		const parsed = parseInput('initiateLiveTranscriptionSession', input);
+		const { region, ...body } = parsed;
 		return complete(
 			ctx,
 			'gladia.live.initiateTranscriptionSession',
@@ -41,80 +85,98 @@ export const GladiaEndpoints: GladiaEndpointTypes = {
 				method: 'POST',
 				body,
 				query: region ? { region } : undefined,
-			}),
+			}).then((response) =>
+				parseOutput('initiateLiveTranscriptionSession', response),
+			),
 		);
 	},
-	listLiveTranscriptionJobs: (ctx, input) =>
-		complete(
+	listLiveTranscriptionJobs: (ctx, input) => {
+		const parsed = parseInput('listLiveTranscriptionJobs', input);
+		return complete(
 			ctx,
 			'gladia.live.listTranscriptionJobs',
 			input,
 			makeGladiaRequest<GladiaEndpointOutputs['listLiveTranscriptionJobs']>(
 				'/v2/live',
 				ctx.key,
-				{ query: input },
-			),
-		),
-	getLiveTranscriptionResult: (ctx, input) =>
-		complete(
+				{ query: parsed },
+			).then((response) => parseOutput('listLiveTranscriptionJobs', response)),
+		);
+	},
+	getLiveTranscriptionResult: (ctx, input) => {
+		const parsed = parseInput('getLiveTranscriptionResult', input);
+		return complete(
 			ctx,
 			'gladia.live.getTranscriptionResult',
 			input,
 			makeGladiaRequest<GladiaEndpointOutputs['getLiveTranscriptionResult']>(
-				`/v2/live/${encodeURIComponent(input.id)}`,
+				`/v2/live/${encodeURIComponent(parsed.id)}`,
 				ctx.key,
-			),
-		),
-	deleteLiveSession: (ctx, input) =>
-		complete(
+			).then((response) => parseOutput('getLiveTranscriptionResult', response)),
+		);
+	},
+	deleteLiveSession: (ctx, input) => {
+		const parsed = parseInput('deleteLiveSession', input);
+		return complete(
 			ctx,
 			'gladia.live.deleteSession',
 			input,
-			makeGladiaRequest('/v2/live/' + encodeURIComponent(input.id), ctx.key, {
+			makeGladiaRequest('/v2/live/' + encodeURIComponent(parsed.id), ctx.key, {
 				method: 'DELETE',
 			}),
-		),
-	initiatePreRecordedTranscription: (ctx, input) =>
-		complete(
+		);
+	},
+	initiatePreRecordedTranscription: (ctx, input) => {
+		const parsed = parseInput('initiatePreRecordedTranscription', input);
+		return complete(
 			ctx,
 			'gladia.preRecorded.initiateTranscription',
 			input,
 			makeGladiaRequest<
 				GladiaEndpointOutputs['initiatePreRecordedTranscription']
-			>('/v2/pre-recorded', ctx.key, { method: 'POST', body: input }),
-		),
-	listPreRecordedJobs: (ctx, input) =>
-		complete(
+			>('/v2/pre-recorded', ctx.key, { method: 'POST', body: parsed }).then(
+				(response) => parseOutput('initiatePreRecordedTranscription', response),
+			),
+		);
+	},
+	listPreRecordedJobs: (ctx, input) => {
+		const parsed = parseInput('listPreRecordedJobs', input);
+		return complete(
 			ctx,
 			'gladia.preRecorded.listJobs',
 			input,
 			makeGladiaRequest<GladiaEndpointOutputs['listPreRecordedJobs']>(
 				'/v2/pre-recorded',
 				ctx.key,
-				{ query: input },
-			),
-		),
-	getPreRecordedJob: (ctx, input) =>
-		complete(
+				{ query: parsed },
+			).then((response) => parseOutput('listPreRecordedJobs', response)),
+		);
+	},
+	getPreRecordedJob: (ctx, input) => {
+		const parsed = parseInput('getPreRecordedJob', input);
+		return complete(
 			ctx,
 			'gladia.preRecorded.getJob',
 			input,
 			makeGladiaRequest<GladiaEndpointOutputs['getPreRecordedJob']>(
-				`/v2/pre-recorded/${encodeURIComponent(input.id)}`,
+				`/v2/pre-recorded/${encodeURIComponent(parsed.id)}`,
 				ctx.key,
-			),
-		),
-	deletePreRecordedJob: (ctx, input) =>
-		complete(
+			).then((response) => parseOutput('getPreRecordedJob', response)),
+		);
+	},
+	deletePreRecordedJob: (ctx, input) => {
+		const parsed = parseInput('deletePreRecordedJob', input);
+		return complete(
 			ctx,
 			'gladia.preRecorded.deleteJob',
 			input,
 			makeGladiaRequest(
-				'/v2/pre-recorded/' + encodeURIComponent(input.id),
+				'/v2/pre-recorded/' + encodeURIComponent(parsed.id),
 				ctx.key,
 				{ method: 'DELETE' },
 			),
-		),
+		);
+	},
 };
 
 export type { GladiaEndpointInputs, GladiaEndpointOutputs } from './types';

--- a/packages/gladia/endpoints/index.ts
+++ b/packages/gladia/endpoints/index.ts
@@ -121,9 +121,11 @@ export const GladiaEndpoints: GladiaEndpointTypes = {
 			ctx,
 			'gladia.live.deleteSession',
 			input,
-			makeGladiaRequest('/v2/live/' + encodeURIComponent(parsed.id), ctx.key, {
-				method: 'DELETE',
-			}),
+			makeGladiaRequest<GladiaEndpointOutputs['deleteLiveSession']>(
+				'/v2/live/' + encodeURIComponent(parsed.id),
+				ctx.key,
+				{ method: 'DELETE' },
+			).then((response) => parseOutput('deleteLiveSession', response)),
 		);
 	},
 	initiatePreRecordedTranscription: (ctx, input) => {
@@ -170,11 +172,11 @@ export const GladiaEndpoints: GladiaEndpointTypes = {
 			ctx,
 			'gladia.preRecorded.deleteJob',
 			input,
-			makeGladiaRequest(
+			makeGladiaRequest<GladiaEndpointOutputs['deletePreRecordedJob']>(
 				'/v2/pre-recorded/' + encodeURIComponent(parsed.id),
 				ctx.key,
 				{ method: 'DELETE' },
-			),
+			).then((response) => parseOutput('deletePreRecordedJob', response)),
 		);
 	},
 };

--- a/packages/gladia/endpoints/types.ts
+++ b/packages/gladia/endpoints/types.ts
@@ -146,11 +146,12 @@ const PreRecordedInitResponseSchema = z.object({
 	result_url: z.string().url(),
 });
 
-const DeleteAcknowledgementSchema = z
-	.object({
+const DeleteAcknowledgementSchema = z.union([
+	z.undefined(),
+	z.object({
 		message: z.string(),
-	})
-	.strict();
+	}),
+]);
 
 export type GladiaUploadAudioVideoFileInput = z.infer<typeof UploadInputSchema>;
 export type GladiaUploadAudioVideoFileResponse = z.infer<

--- a/packages/gladia/endpoints/types.ts
+++ b/packages/gladia/endpoints/types.ts
@@ -1,0 +1,215 @@
+import { z } from 'zod';
+
+const JsonRecordSchema = z.record(z.string(), z.unknown());
+const JsonRecordOptionalSchema = JsonRecordSchema.optional();
+const StatusSchema = z.enum(['queued', 'processing', 'done', 'error']);
+
+const FileMetadataSchema = z
+	.object({
+		id: z.string().optional(),
+		filename: z.string().optional(),
+		extension: z.string().optional(),
+		size: z.number().optional(),
+		audio_duration: z.number().optional(),
+		number_of_channels: z.number().optional(),
+		source: z.string().optional(),
+	})
+	.passthrough();
+
+const JobSchema = z
+	.object({
+		id: z.string(),
+		request_id: z.string().optional(),
+		version: z.number().optional(),
+		status: StatusSchema.optional(),
+		created_at: z.string().optional(),
+		completed_at: z.string().nullable().optional(),
+		kind: z.enum(['live', 'pre-recorded']).optional(),
+		custom_metadata: JsonRecordOptionalSchema,
+		error_code: z.number().nullable().optional(),
+		file: FileMetadataSchema.nullable().optional(),
+		request_params: JsonRecordSchema.nullable().optional(),
+		result: z.unknown().optional(),
+		post_session_metadata: JsonRecordOptionalSchema,
+	})
+	.passthrough();
+
+const JobListSchema = z.object({
+	first: z.string().url(),
+	current: z.string().url(),
+	next: z.string().url().nullable(),
+	items: z.array(JobSchema),
+});
+
+const ListInputSchema = z.object({
+	offset: z.number().int().nonnegative().optional(),
+	limit: z.number().int().positive().optional(),
+	date: z.string().optional(),
+	before_date: z.string().optional(),
+	after_date: z.string().optional(),
+	status: z.array(StatusSchema).optional(),
+	custom_metadata: JsonRecordOptionalSchema,
+});
+
+const IdInputSchema = z.object({ id: z.string().min(1) });
+const UploadInputSchema = z.object({
+	audio: z.custom<Blob>(
+		(value) => typeof Blob !== 'undefined' && value instanceof Blob,
+	),
+	filename: z.string().optional(),
+});
+const UploadResponseSchema = z.object({
+	audio_url: z.string().url(),
+	audio_metadata: FileMetadataSchema,
+});
+
+const LiveInputSchema = z.object({
+	region: z.enum(['us-west', 'eu-west']).optional(),
+	encoding: z.enum(['wav/pcm', 'wav/alaw', 'wav/ulaw']).optional(),
+	bit_depth: z
+		.union([z.literal(8), z.literal(16), z.literal(24), z.literal(32)])
+		.optional(),
+	sample_rate: z
+		.union([
+			z.literal(8000),
+			z.literal(16000),
+			z.literal(32000),
+			z.literal(44100),
+			z.literal(48000),
+		])
+		.optional(),
+	channels: z.number().int().min(1).max(8).optional(),
+	custom_metadata: JsonRecordOptionalSchema,
+	model: z.string().optional(),
+	endpointing: z.number().optional(),
+	maximum_duration_without_endpointing: z.number().optional(),
+	language_config: JsonRecordOptionalSchema,
+	pre_processing: JsonRecordOptionalSchema,
+	realtime_processing: JsonRecordOptionalSchema,
+	post_processing: JsonRecordOptionalSchema,
+	messages_config: JsonRecordOptionalSchema,
+	callback: z.boolean().optional(),
+	callback_config: JsonRecordOptionalSchema,
+});
+const LiveResponseSchema = z.object({
+	id: z.string(),
+	created_at: z.string(),
+	url: z.string().url(),
+});
+
+const PreRecordedInputSchema = z.object({
+	audio_url: z.string().url(),
+	custom_vocabulary: z.boolean().optional(),
+	custom_vocabulary_config: JsonRecordOptionalSchema,
+	callback_url: z.string().url().optional(),
+	callback: z.boolean().optional(),
+	callback_config: JsonRecordOptionalSchema,
+	subtitles: z.boolean().optional(),
+	subtitles_config: JsonRecordOptionalSchema,
+	diarization: z.boolean().optional(),
+	diarization_config: JsonRecordOptionalSchema,
+	translation: z.boolean().optional(),
+	translation_config: JsonRecordOptionalSchema,
+	summarization: z.boolean().optional(),
+	summarization_config: JsonRecordOptionalSchema,
+	named_entity_recognition: z.boolean().optional(),
+	custom_spelling: z.boolean().optional(),
+	custom_spelling_config: JsonRecordOptionalSchema,
+	sentiment_analysis: z.boolean().optional(),
+	audio_to_llm: z.boolean().optional(),
+	audio_to_llm_config: JsonRecordOptionalSchema,
+	pii_redaction: z.boolean().optional(),
+	pii_redaction_config: JsonRecordOptionalSchema,
+	custom_metadata: JsonRecordOptionalSchema,
+	sentences: z.boolean().optional(),
+	punctuation_enhanced: z.boolean().optional(),
+	language_config: JsonRecordOptionalSchema,
+	model: z.string().optional(),
+});
+const PreRecordedInitResponseSchema = z.object({
+	id: z.string(),
+	result_url: z.string().url(),
+});
+
+export type GladiaUploadAudioVideoFileInput = z.infer<typeof UploadInputSchema>;
+export type GladiaUploadAudioVideoFileResponse = z.infer<
+	typeof UploadResponseSchema
+>;
+export type GladiaInitiateLiveTranscriptionSessionInput = z.infer<
+	typeof LiveInputSchema
+>;
+export type GladiaInitiateLiveTranscriptionSessionResponse = z.infer<
+	typeof LiveResponseSchema
+>;
+export type GladiaListLiveTranscriptionJobsInput = z.infer<
+	typeof ListInputSchema
+>;
+export type GladiaListLiveTranscriptionJobsResponse = z.infer<
+	typeof JobListSchema
+>;
+export type GladiaGetLiveTranscriptionResultInput = z.infer<
+	typeof IdInputSchema
+>;
+export type GladiaGetLiveTranscriptionResultResponse = z.infer<
+	typeof JobSchema
+>;
+export type GladiaDeleteLiveSessionInput = z.infer<typeof IdInputSchema>;
+export type GladiaInitiatePreRecordedTranscriptionInput = z.infer<
+	typeof PreRecordedInputSchema
+>;
+export type GladiaInitiatePreRecordedTranscriptionResponse = z.infer<
+	typeof PreRecordedInitResponseSchema
+>;
+export type GladiaListPreRecordedJobsInput = z.infer<typeof ListInputSchema>;
+export type GladiaListPreRecordedJobsResponse = z.infer<typeof JobListSchema>;
+export type GladiaGetPreRecordedJobInput = z.infer<typeof IdInputSchema>;
+export type GladiaGetPreRecordedJobResponse = z.infer<typeof JobSchema>;
+export type GladiaDeletePreRecordedJobInput = z.infer<typeof IdInputSchema>;
+
+export type GladiaEndpointInputs = {
+	uploadAudioVideoFile: GladiaUploadAudioVideoFileInput;
+	initiateLiveTranscriptionSession: GladiaInitiateLiveTranscriptionSessionInput;
+	listLiveTranscriptionJobs: GladiaListLiveTranscriptionJobsInput;
+	getLiveTranscriptionResult: GladiaGetLiveTranscriptionResultInput;
+	deleteLiveSession: GladiaDeleteLiveSessionInput;
+	initiatePreRecordedTranscription: GladiaInitiatePreRecordedTranscriptionInput;
+	listPreRecordedJobs: GladiaListPreRecordedJobsInput;
+	getPreRecordedJob: GladiaGetPreRecordedJobInput;
+	deletePreRecordedJob: GladiaDeletePreRecordedJobInput;
+};
+
+export type GladiaEndpointOutputs = {
+	uploadAudioVideoFile: GladiaUploadAudioVideoFileResponse;
+	initiateLiveTranscriptionSession: GladiaInitiateLiveTranscriptionSessionResponse;
+	listLiveTranscriptionJobs: GladiaListLiveTranscriptionJobsResponse;
+	getLiveTranscriptionResult: GladiaGetLiveTranscriptionResultResponse;
+	deleteLiveSession: unknown;
+	initiatePreRecordedTranscription: GladiaInitiatePreRecordedTranscriptionResponse;
+	listPreRecordedJobs: GladiaListPreRecordedJobsResponse;
+	getPreRecordedJob: GladiaGetPreRecordedJobResponse;
+	deletePreRecordedJob: unknown;
+};
+
+export const GladiaEndpointInputSchemas = {
+	uploadAudioVideoFile: UploadInputSchema,
+	initiateLiveTranscriptionSession: LiveInputSchema,
+	listLiveTranscriptionJobs: ListInputSchema,
+	getLiveTranscriptionResult: IdInputSchema,
+	deleteLiveSession: IdInputSchema,
+	initiatePreRecordedTranscription: PreRecordedInputSchema,
+	listPreRecordedJobs: ListInputSchema,
+	getPreRecordedJob: IdInputSchema,
+	deletePreRecordedJob: IdInputSchema,
+} as const;
+
+export const GladiaEndpointOutputSchemas = {
+	uploadAudioVideoFile: UploadResponseSchema,
+	initiateLiveTranscriptionSession: LiveResponseSchema,
+	listLiveTranscriptionJobs: JobListSchema,
+	getLiveTranscriptionResult: JobSchema,
+	deleteLiveSession: z.unknown(),
+	initiatePreRecordedTranscription: PreRecordedInitResponseSchema,
+	listPreRecordedJobs: JobListSchema,
+	getPreRecordedJob: JobSchema,
+	deletePreRecordedJob: z.unknown(),
+} as const;

--- a/packages/gladia/endpoints/types.ts
+++ b/packages/gladia/endpoints/types.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 
-const JsonRecordSchema = z.record(z.string(), z.unknown());
+const JsonRecordSchema = z.record(
+	z.string(),
+	// unknown is necessary because Gladia accepts arbitrary JSON metadata values; a closed value union is infeasible because metadata keys are caller-defined
+	z.unknown(),
+);
 const JsonRecordOptionalSchema = JsonRecordSchema.optional();
 const StatusSchema = z.enum(['queued', 'processing', 'done', 'error']);
 
@@ -29,6 +33,7 @@ const JobSchema = z
 		error_code: z.number().nullable().optional(),
 		file: FileMetadataSchema.nullable().optional(),
 		request_params: JsonRecordSchema.nullable().optional(),
+		// unknown is necessary because transcription results differ by feature combination; a closed result union is infeasible because Gladia composes optional processing outputs
 		result: z.unknown().optional(),
 		post_session_metadata: JsonRecordOptionalSchema,
 	})
@@ -63,34 +68,45 @@ const UploadResponseSchema = z.object({
 	audio_metadata: FileMetadataSchema,
 });
 
-const LiveInputSchema = z.object({
-	region: z.enum(['us-west', 'eu-west']).optional(),
-	encoding: z.enum(['wav/pcm', 'wav/alaw', 'wav/ulaw']).optional(),
-	bit_depth: z
-		.union([z.literal(8), z.literal(16), z.literal(24), z.literal(32)])
-		.optional(),
-	sample_rate: z
-		.union([
-			z.literal(8000),
-			z.literal(16000),
-			z.literal(32000),
-			z.literal(44100),
-			z.literal(48000),
-		])
-		.optional(),
-	channels: z.number().int().min(1).max(8).optional(),
-	custom_metadata: JsonRecordOptionalSchema,
-	model: z.string().optional(),
-	endpointing: z.number().optional(),
-	maximum_duration_without_endpointing: z.number().optional(),
-	language_config: JsonRecordOptionalSchema,
-	pre_processing: JsonRecordOptionalSchema,
-	realtime_processing: JsonRecordOptionalSchema,
-	post_processing: JsonRecordOptionalSchema,
-	messages_config: JsonRecordOptionalSchema,
-	callback: z.boolean().optional(),
-	callback_config: JsonRecordOptionalSchema,
-});
+const LiveInputSchema = z
+	.object({
+		region: z.enum(['us-west', 'eu-west']).optional(),
+		encoding: z.enum(['wav/pcm', 'wav/alaw', 'wav/ulaw']).optional(),
+		bit_depth: z
+			.union([z.literal(8), z.literal(16), z.literal(24), z.literal(32)])
+			.optional(),
+		sample_rate: z
+			.union([
+				z.literal(8000),
+				z.literal(16000),
+				z.literal(32000),
+				z.literal(44100),
+				z.literal(48000),
+			])
+			.optional(),
+		channels: z.number().int().min(1).max(8).optional(),
+		custom_metadata: JsonRecordOptionalSchema,
+		model: z.string().optional(),
+		endpointing: z.number().min(0.01).max(10).optional(),
+		maximum_duration_without_endpointing: z.number().min(5).max(60).optional(),
+		language_config: JsonRecordOptionalSchema,
+		pre_processing: JsonRecordOptionalSchema,
+		realtime_processing: JsonRecordOptionalSchema,
+		post_processing: JsonRecordOptionalSchema,
+		messages_config: JsonRecordOptionalSchema,
+		callback: z.boolean().optional(),
+		callback_config: JsonRecordOptionalSchema,
+	})
+	.refine(
+		(value) =>
+			(value.encoding !== 'wav/alaw' && value.encoding !== 'wav/ulaw') ||
+			value.bit_depth === undefined ||
+			value.bit_depth === 8,
+		{
+			message: 'wav/alaw and wav/ulaw encodings require 8-bit audio',
+			path: ['bit_depth'],
+		},
+	);
 const LiveResponseSchema = z.object({
 	id: z.string(),
 	created_at: z.string(),
@@ -183,10 +199,12 @@ export type GladiaEndpointOutputs = {
 	initiateLiveTranscriptionSession: GladiaInitiateLiveTranscriptionSessionResponse;
 	listLiveTranscriptionJobs: GladiaListLiveTranscriptionJobsResponse;
 	getLiveTranscriptionResult: GladiaGetLiveTranscriptionResultResponse;
+	// unknown is necessary because Gladia deletes return 204 with no body; a closed response type is infeasible because there is no payload to model
 	deleteLiveSession: unknown;
 	initiatePreRecordedTranscription: GladiaInitiatePreRecordedTranscriptionResponse;
 	listPreRecordedJobs: GladiaListPreRecordedJobsResponse;
 	getPreRecordedJob: GladiaGetPreRecordedJobResponse;
+	// unknown is necessary because Gladia deletes return 204 with no body; a closed response type is infeasible because there is no payload to model
 	deletePreRecordedJob: unknown;
 };
 
@@ -207,9 +225,11 @@ export const GladiaEndpointOutputSchemas = {
 	initiateLiveTranscriptionSession: LiveResponseSchema,
 	listLiveTranscriptionJobs: JobListSchema,
 	getLiveTranscriptionResult: JobSchema,
+	// unknown is necessary because Gladia deletes return 204 with no body; a closed response type is infeasible because there is no payload to model
 	deleteLiveSession: z.unknown(),
 	initiatePreRecordedTranscription: PreRecordedInitResponseSchema,
 	listPreRecordedJobs: JobListSchema,
 	getPreRecordedJob: JobSchema,
+	// unknown is necessary because Gladia deletes return 204 with no body; a closed response type is infeasible because there is no payload to model
 	deletePreRecordedJob: z.unknown(),
 } as const;

--- a/packages/gladia/endpoints/types.ts
+++ b/packages/gladia/endpoints/types.ts
@@ -100,7 +100,6 @@ const LiveInputSchema = z
 	.refine(
 		(value) =>
 			(value.encoding !== 'wav/alaw' && value.encoding !== 'wav/ulaw') ||
-			value.bit_depth === undefined ||
 			value.bit_depth === 8,
 		{
 			message: 'wav/alaw and wav/ulaw encodings require 8-bit audio',
@@ -147,6 +146,12 @@ const PreRecordedInitResponseSchema = z.object({
 	result_url: z.string().url(),
 });
 
+const DeleteAcknowledgementSchema = z
+	.object({
+		message: z.string(),
+	})
+	.strict();
+
 export type GladiaUploadAudioVideoFileInput = z.infer<typeof UploadInputSchema>;
 export type GladiaUploadAudioVideoFileResponse = z.infer<
 	typeof UploadResponseSchema
@@ -180,7 +185,13 @@ export type GladiaListPreRecordedJobsInput = z.infer<typeof ListInputSchema>;
 export type GladiaListPreRecordedJobsResponse = z.infer<typeof JobListSchema>;
 export type GladiaGetPreRecordedJobInput = z.infer<typeof IdInputSchema>;
 export type GladiaGetPreRecordedJobResponse = z.infer<typeof JobSchema>;
+export type GladiaDeleteLiveSessionResponse = z.infer<
+	typeof DeleteAcknowledgementSchema
+>;
 export type GladiaDeletePreRecordedJobInput = z.infer<typeof IdInputSchema>;
+export type GladiaDeletePreRecordedJobResponse = z.infer<
+	typeof DeleteAcknowledgementSchema
+>;
 
 export type GladiaEndpointInputs = {
 	uploadAudioVideoFile: GladiaUploadAudioVideoFileInput;
@@ -199,13 +210,11 @@ export type GladiaEndpointOutputs = {
 	initiateLiveTranscriptionSession: GladiaInitiateLiveTranscriptionSessionResponse;
 	listLiveTranscriptionJobs: GladiaListLiveTranscriptionJobsResponse;
 	getLiveTranscriptionResult: GladiaGetLiveTranscriptionResultResponse;
-	// unknown is necessary because Gladia deletes return 204 with no body; a closed response type is infeasible because there is no payload to model
-	deleteLiveSession: unknown;
+	deleteLiveSession: GladiaDeleteLiveSessionResponse;
 	initiatePreRecordedTranscription: GladiaInitiatePreRecordedTranscriptionResponse;
 	listPreRecordedJobs: GladiaListPreRecordedJobsResponse;
 	getPreRecordedJob: GladiaGetPreRecordedJobResponse;
-	// unknown is necessary because Gladia deletes return 204 with no body; a closed response type is infeasible because there is no payload to model
-	deletePreRecordedJob: unknown;
+	deletePreRecordedJob: GladiaDeletePreRecordedJobResponse;
 };
 
 export const GladiaEndpointInputSchemas = {
@@ -225,11 +234,9 @@ export const GladiaEndpointOutputSchemas = {
 	initiateLiveTranscriptionSession: LiveResponseSchema,
 	listLiveTranscriptionJobs: JobListSchema,
 	getLiveTranscriptionResult: JobSchema,
-	// unknown is necessary because Gladia deletes return 204 with no body; a closed response type is infeasible because there is no payload to model
-	deleteLiveSession: z.unknown(),
+	deleteLiveSession: DeleteAcknowledgementSchema,
 	initiatePreRecordedTranscription: PreRecordedInitResponseSchema,
 	listPreRecordedJobs: JobListSchema,
 	getPreRecordedJob: JobSchema,
-	// unknown is necessary because Gladia deletes return 204 with no body; a closed response type is infeasible because there is no payload to model
-	deletePreRecordedJob: z.unknown(),
+	deletePreRecordedJob: DeleteAcknowledgementSchema,
 } as const;

--- a/packages/gladia/error-handlers.test.ts
+++ b/packages/gladia/error-handlers.test.ts
@@ -1,0 +1,59 @@
+import { ApiError } from 'corsair/http';
+import { GladiaAPIError } from './client';
+import { errorHandlers } from './error-handlers';
+
+function apiError(status: number, retryAfter?: number): ApiError {
+	return new ApiError(
+		{ method: 'GET', url: '/v2/live' },
+		{
+			url: 'https://api.gladia.io/v2/live',
+			ok: false,
+			status,
+			statusText: 'Error',
+			body: { message: 'Error' },
+		},
+		'Error',
+		retryAfter !== undefined ? { retryAfter } : undefined,
+	);
+}
+
+describe('Gladia error handlers', () => {
+	it('does not retry rate-limited requests because writes are billable', async () => {
+		const error = apiError(429, 2000);
+		expect(errorHandlers.RATE_LIMIT_ERROR.match(error)).toBe(true);
+		await expect(
+			errorHandlers.RATE_LIMIT_ERROR.handler(error),
+		).resolves.toEqual(
+			expect.objectContaining({
+				maxRetries: 0,
+				headersRetryAfterMs: 2000,
+			}),
+		);
+	});
+
+	it('preserves retryAfter on wrapped ApiError 429s', async () => {
+		const wrapped = new GladiaAPIError(
+			'Too Many Requests',
+			apiError(429, 3000),
+		);
+		expect(errorHandlers.RATE_LIMIT_ERROR.match(wrapped)).toBe(true);
+		await expect(
+			errorHandlers.RATE_LIMIT_ERROR.handler(wrapped),
+		).resolves.toEqual(
+			expect.objectContaining({
+				maxRetries: 0,
+				headersRetryAfterMs: 3000,
+			}),
+		);
+	});
+
+	it('does not retry auth failures from either error type', async () => {
+		const raw = apiError(401);
+		const wrapped = new GladiaAPIError('Unauthorized', apiError(401));
+		expect(errorHandlers.AUTH_ERROR.match(raw)).toBe(true);
+		expect(errorHandlers.AUTH_ERROR.match(wrapped)).toBe(true);
+		await expect(errorHandlers.AUTH_ERROR.handler()).resolves.toEqual({
+			maxRetries: 0,
+		});
+	});
+});

--- a/packages/gladia/error-handlers.ts
+++ b/packages/gladia/error-handlers.ts
@@ -1,0 +1,28 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+import { GladiaAPIError } from './client';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) =>
+			(error instanceof ApiError && error.status === 429) ||
+			(error instanceof GladiaAPIError && error.status === 429) ||
+			error.message.includes('429'),
+		handler: async (error: Error) => ({
+			maxRetries: 5,
+			headersRetryAfterMs:
+				error instanceof ApiError ? error.retryAfter : undefined,
+		}),
+	},
+	AUTH_ERROR: {
+		match: (error: Error) =>
+			(error instanceof ApiError && error.status === 401) ||
+			(error instanceof GladiaAPIError && error.status === 401) ||
+			error.message.toLowerCase().includes('gladia key'),
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/gladia/error-handlers.ts
+++ b/packages/gladia/error-handlers.ts
@@ -2,16 +2,21 @@ import type { CorsairErrorHandler } from 'corsair/core';
 import { ApiError } from 'corsair/http';
 import { GladiaAPIError } from './client';
 
+function retryAfterOf(error: Error): number | undefined {
+	if (error instanceof ApiError) return error.retryAfter;
+	if (error instanceof GladiaAPIError) return error.retryAfter;
+	return undefined;
+}
+
 export const errorHandlers = {
 	RATE_LIMIT_ERROR: {
 		match: (error: Error) =>
 			(error instanceof ApiError && error.status === 429) ||
 			(error instanceof GladiaAPIError && error.status === 429) ||
-			error.message.includes('429'),
+			error.message.toLowerCase().includes('429'),
 		handler: async (error: Error) => ({
-			maxRetries: 5,
-			headersRetryAfterMs:
-				error instanceof ApiError ? error.retryAfter : undefined,
+			maxRetries: 0,
+			headersRetryAfterMs: retryAfterOf(error),
 		}),
 	},
 	AUTH_ERROR: {

--- a/packages/gladia/index.ts
+++ b/packages/gladia/index.ts
@@ -1,0 +1,209 @@
+import type {
+	BindEndpoints,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+} from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
+import { GladiaEndpoints } from './endpoints';
+import type {
+	GladiaEndpointInputs,
+	GladiaEndpointOutputs,
+} from './endpoints/types';
+import {
+	GladiaEndpointInputSchemas,
+	GladiaEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { GladiaSchema } from './schema';
+
+export type GladiaPluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	hooks?: InternalGladiaPlugin['hooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof gladiaEndpointsNested>;
+};
+
+export type GladiaContext = CorsairPluginContext<
+	typeof GladiaSchema,
+	GladiaPluginOptions
+>;
+export type GladiaKeyBuilderContext = KeyBuilderContext<GladiaPluginOptions>;
+export type GladiaBoundEndpoints = BindEndpoints<typeof gladiaEndpointsNested>;
+
+type GladiaEndpoint<K extends keyof GladiaEndpointOutputs> = (
+	ctx: GladiaContext,
+	input: GladiaEndpointInputs[K],
+) => Promise<GladiaEndpointOutputs[K]>;
+
+export type GladiaEndpoints = {
+	uploadAudioVideoFile: GladiaEndpoint<'uploadAudioVideoFile'>;
+	initiateLiveTranscriptionSession: GladiaEndpoint<'initiateLiveTranscriptionSession'>;
+	listLiveTranscriptionJobs: GladiaEndpoint<'listLiveTranscriptionJobs'>;
+	getLiveTranscriptionResult: GladiaEndpoint<'getLiveTranscriptionResult'>;
+	deleteLiveSession: GladiaEndpoint<'deleteLiveSession'>;
+	initiatePreRecordedTranscription: GladiaEndpoint<'initiatePreRecordedTranscription'>;
+	listPreRecordedJobs: GladiaEndpoint<'listPreRecordedJobs'>;
+	getPreRecordedJob: GladiaEndpoint<'getPreRecordedJob'>;
+	deletePreRecordedJob: GladiaEndpoint<'deletePreRecordedJob'>;
+};
+
+const gladiaEndpointsNested = {
+	upload: { audioVideoFile: GladiaEndpoints.uploadAudioVideoFile },
+	live: {
+		initiateTranscriptionSession:
+			GladiaEndpoints.initiateLiveTranscriptionSession,
+		listTranscriptionJobs: GladiaEndpoints.listLiveTranscriptionJobs,
+		getTranscriptionResult: GladiaEndpoints.getLiveTranscriptionResult,
+		deleteSession: GladiaEndpoints.deleteLiveSession,
+	},
+	preRecorded: {
+		initiateTranscription: GladiaEndpoints.initiatePreRecordedTranscription,
+		listJobs: GladiaEndpoints.listPreRecordedJobs,
+		getJob: GladiaEndpoints.getPreRecordedJob,
+		deleteJob: GladiaEndpoints.deletePreRecordedJob,
+	},
+} as const;
+
+export const gladiaEndpointSchemas = {
+	'upload.audioVideoFile': {
+		input: GladiaEndpointInputSchemas.uploadAudioVideoFile,
+		output: GladiaEndpointOutputSchemas.uploadAudioVideoFile,
+	},
+	'live.initiateTranscriptionSession': {
+		input: GladiaEndpointInputSchemas.initiateLiveTranscriptionSession,
+		output: GladiaEndpointOutputSchemas.initiateLiveTranscriptionSession,
+	},
+	'live.listTranscriptionJobs': {
+		input: GladiaEndpointInputSchemas.listLiveTranscriptionJobs,
+		output: GladiaEndpointOutputSchemas.listLiveTranscriptionJobs,
+	},
+	'live.getTranscriptionResult': {
+		input: GladiaEndpointInputSchemas.getLiveTranscriptionResult,
+		output: GladiaEndpointOutputSchemas.getLiveTranscriptionResult,
+	},
+	'live.deleteSession': {
+		input: GladiaEndpointInputSchemas.deleteLiveSession,
+		output: GladiaEndpointOutputSchemas.deleteLiveSession,
+	},
+	'preRecorded.initiateTranscription': {
+		input: GladiaEndpointInputSchemas.initiatePreRecordedTranscription,
+		output: GladiaEndpointOutputSchemas.initiatePreRecordedTranscription,
+	},
+	'preRecorded.listJobs': {
+		input: GladiaEndpointInputSchemas.listPreRecordedJobs,
+		output: GladiaEndpointOutputSchemas.listPreRecordedJobs,
+	},
+	'preRecorded.getJob': {
+		input: GladiaEndpointInputSchemas.getPreRecordedJob,
+		output: GladiaEndpointOutputSchemas.getPreRecordedJob,
+	},
+	'preRecorded.deleteJob': {
+		input: GladiaEndpointInputSchemas.deletePreRecordedJob,
+		output: GladiaEndpointOutputSchemas.deletePreRecordedJob,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<
+	typeof gladiaEndpointsNested
+>;
+
+const gladiaEndpointMeta = {
+	'upload.audioVideoFile': {
+		riskLevel: 'write',
+		description: 'Upload an audio or video file for a pre-recorded job',
+	},
+	'live.initiateTranscriptionSession': {
+		riskLevel: 'write',
+		description:
+			'Create a live transcription session and return its WebSocket URL',
+	},
+	'live.listTranscriptionJobs': {
+		riskLevel: 'read',
+		description: 'List live transcription jobs with pagination and filters',
+	},
+	'live.getTranscriptionResult': {
+		riskLevel: 'read',
+		description: 'Retrieve a live transcription session result',
+	},
+	'live.deleteSession': {
+		riskLevel: 'destructive',
+		irreversible: true,
+		description: 'Permanently delete a live transcription session',
+	},
+	'preRecorded.initiateTranscription': {
+		riskLevel: 'write',
+		description: 'Start a pre-recorded transcription job',
+	},
+	'preRecorded.listJobs': {
+		riskLevel: 'read',
+		description:
+			'List pre-recorded transcription jobs with pagination and filters',
+	},
+	'preRecorded.getJob': {
+		riskLevel: 'read',
+		description: 'Retrieve a pre-recorded transcription job and result',
+	},
+	'preRecorded.deleteJob': {
+		riskLevel: 'destructive',
+		irreversible: true,
+		description: 'Permanently delete a pre-recorded transcription job',
+	},
+} as const satisfies RequiredPluginEndpointMeta<typeof gladiaEndpointsNested>;
+
+const defaultAuthType = 'api_key' as const;
+export const gladiaAuthConfig = {
+	api_key: { account: ['tenant_external_id'] as const },
+} as const satisfies PluginAuthConfig;
+
+export type BaseGladiaPlugin<T extends GladiaPluginOptions> = CorsairPlugin<
+	'gladia',
+	typeof GladiaSchema,
+	typeof gladiaEndpointsNested,
+	Record<string, never>,
+	T,
+	typeof defaultAuthType
+>;
+export type InternalGladiaPlugin = BaseGladiaPlugin<GladiaPluginOptions>;
+export type ExternalGladiaPlugin<T extends GladiaPluginOptions> =
+	BaseGladiaPlugin<T>;
+
+export function gladia<const T extends GladiaPluginOptions>(
+	incomingOptions: GladiaPluginOptions & T = {} as GladiaPluginOptions & T,
+): ExternalGladiaPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'gladia',
+		authConfig: gladiaAuthConfig,
+		schema: GladiaSchema,
+		options,
+		hooks: options.hooks,
+		endpoints: gladiaEndpointsNested,
+		webhooks: {},
+		endpointMeta: gladiaEndpointMeta,
+		endpointSchemas: gladiaEndpointSchemas,
+		pluginWebhookMatcher: undefined,
+		errorHandlers: { ...errorHandlers, ...options.errorHandlers },
+		keyBuilder: async (ctx: GladiaKeyBuilderContext, source) => {
+			if (source === 'endpoint' && options.key) return options.key;
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const key = await ctx.keys.get_api_key();
+				if (key) return key;
+			}
+			throw new AuthMissingError('gladia', 'api_key');
+		},
+	} satisfies InternalGladiaPlugin;
+}
+
+export type {
+	GladiaEndpointInputs,
+	GladiaEndpointOutputs,
+} from './endpoints/types';

--- a/packages/gladia/jest.config.cjs
+++ b/packages/gladia/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/gladia/package.json
+++ b/packages/gladia/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/gladia",
+  "version": "0.1.0",
+  "description": "Gladia plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "gladia",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/gladia/schema.test.ts
+++ b/packages/gladia/schema.test.ts
@@ -1,0 +1,20 @@
+import { GladiaSchema } from './schema';
+
+describe('Gladia schema', () => {
+	it('declares a semver version', () => {
+		expect(GladiaSchema.version).toBeDefined();
+		expect(GladiaSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof GladiaSchema.entities).toBe('object');
+		expect(GladiaSchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(GladiaSchema.entities))).toBe(true);
+		for (const entity of Object.values(GladiaSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/gladia/schema/index.ts
+++ b/packages/gladia/schema/index.ts
@@ -1,0 +1,4 @@
+export const GladiaSchema = {
+	version: '1.0.0',
+	entities: {},
+} as const;

--- a/packages/gladia/tsconfig.json
+++ b/packages/gladia/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/gladia/tsup.config.ts
+++ b/packages/gladia/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4165,6 +4165,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/gladia:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/gmail:
     devDependencies:
       '@types/jest':


### PR DESCRIPTION
## Description

Adds the Gladia speech-to-text integration plugin (`@corsair-dev/gladia`) for issue #1597. The plugin exposes nine operations across three groups — audio/video upload for pre-recorded jobs, live transcription sessions (create, list, get result, delete) returning a temporary WebSocket URL, and pre-recorded transcription jobs (create, list, get, delete) — authenticated via API key (`x-gladia-key`). Every endpoint validates its inputs and outputs with Zod schemas at runtime: malformed requests (e.g. an invalid `audio_url`) are rejected before reaching Gladia, live-session settings enforce provider bounds (`endpointing` 0.01–10s, `maximum_duration_without_endpointing` 5–60s, 8-bit audio required for `wav/alaw`/`wav/ulaw`), and responses that violate the advertised contract throw instead of passing through. Errors route through the plugin's error handlers: 429s surface the provider's `Retry-After` hint and never replay billable writes, and auth failures never retry. The deprecated `Get Transcription Audio File` operation is intentionally excluded.

Fixes #1597

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

https://github.com/user-attachments/assets/2417cbf7-ed59-4a27-b819-abd5cd95508b

## Additional Notes

- 18 tests pass across three suites (`api`, `error-handlers`, `schema`), covering request mapping, input/output validation, 429 no-replay behavior, `Retry-After` preservation, live-input bounds, and multipart upload.
- `pnpm run validate:plugins` passes.
- Registration limited to `packages/corsair/core/constants.ts` per R1 scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Gladia as a supported provider.
  - Added support for audio/video uploads, live transcription, and prerecorded transcription.
  - Added validation for transcription requests and responses.
  - Added authentication, structured error handling, and rate-limit awareness.
  - Added support for retrieving, listing, and deleting transcription sessions and jobs.
  - Deletion now supports responses with either an acknowledgement message or no response body.

- **Tests**
  - Added comprehensive coverage for Gladia operations, validation, schemas, authentication, uploads, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->