### PR TITLE
feat(zenserp): add integration plugin

### DIFF
--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -283,6 +283,7 @@ export const BaseProviders = [
 	'youcom',
 	'youtube',
 	'zendesk',
+	'zenserp',
 	'zohoinventory',
 	'zohomail',
 	'zoom',
@@ -560,6 +561,7 @@ export const ProviderDisplayNames = {
 	youcom: 'You.com',
 	youtube: 'YouTube',
 	zendesk: 'Zendesk',
+	zenserp: 'Zenserp',
 	zohoinventory: 'Zoho Inventory',
 	zohomail: 'Zoho Mail',
 	zoom: 'Zoom',
@@ -844,6 +846,7 @@ export type AllProviders =
 	| 'youcom'
 	| 'youtube'
 	| 'zendesk'
+	| 'zenserp'
 	| 'zohoinventory'
 	| 'zohomail'
 	| 'zoom'

--- a/packages/zenserp/api.test.ts
+++ b/packages/zenserp/api.test.ts
@@ -1,0 +1,86 @@
+import { getStatus } from './endpoints/account';
+import { list as listBatches } from './endpoints/batches';
+import {
+	listCountries,
+	listLanguages,
+	listLocations,
+	listSearchEngines,
+} from './endpoints/metadata';
+import { bing, google, reverseImage, yandex } from './endpoints/search';
+import { getProduct } from './endpoints/shopping';
+import { get as getTrends } from './endpoints/trends';
+
+const fetchMock = jest.spyOn(globalThis, 'fetch');
+const ctx = {
+	key: 'zenserp-test-key',
+	options: {},
+	$getAccountId: async () => 'test-account',
+} as never;
+
+function json(body: unknown): Response {
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}
+
+describe('Zenserp API operations', () => {
+	beforeEach(() => {
+		fetchMock.mockReset();
+		fetchMock.mockImplementation(async (input) => {
+			const url = String(input);
+			if (url.includes('/status')) return json({ remaining_requests: 1499 });
+			if (url.includes('/shopping'))
+				return json({ product: { product_id: 'p1', title: 'Keyboard' } });
+			if (url.includes('/trends'))
+				return json({ data: [{ keyword: 'corsair' }] });
+			if (url.includes('/batches')) return json({ data: [{ id: 'batch-1' }] });
+			if (url.includes('/gl'))
+				return json([{ name: 'United States', value: 'us' }]);
+			if (url.includes('/locations'))
+				return json([{ name: 'New York', country_code: 'us' }]);
+			if (url.includes('/search_engines'))
+				return json([{ name: 'Google', domain: 'google.com' }]);
+			if (url.includes('/hl')) return json([{ name: 'English', value: 'en' }]);
+			return json({ query: 'corsair', organic: [{ title: 'Corsair' }] });
+		});
+	});
+
+	afterAll(() => fetchMock.mockRestore());
+
+	it('calls and validates every catalog operation', async () => {
+		await google(ctx, { q: 'corsair' });
+		await bing(ctx, { q: 'corsair' });
+		await yandex(ctx, { q: 'corsair' });
+		await reverseImage(ctx, { imageUrl: 'https://example.com/image.png' });
+		await getProduct(ctx, { productId: 'p1' });
+		await getTrends(ctx, { keywords: ['corsair', 'agents'] });
+		const status = await getStatus(ctx, {});
+		await listBatches(ctx, { page: 1 });
+		await listCountries(ctx, {});
+		await listLocations(ctx, { q: 'New York' });
+		await listSearchEngines(ctx, {});
+		await listLanguages(ctx, {});
+
+		expect(fetchMock).toHaveBeenCalledTimes(12);
+		expect(status.remaining_requests).toBe(1499);
+		const calls = fetchMock.mock.calls.map(([input]) => String(input));
+		expect(calls[0]).toContain('/api/v2/search?q=corsair');
+		expect(calls[1]).toContain('search_engine=bing.com');
+		expect(calls[2]).toContain('search_engine=yandex.com');
+		expect(calls[3]).toContain(
+			'image_url=https%3A%2F%2Fexample.com%2Fimage.png',
+		);
+		expect(calls[4]).toContain('/api/v1/shopping?product_id=p1');
+		expect(calls[5]).toContain('keyword%5B%5D=corsair');
+		expect(calls[6]).toContain('/api/v2/status');
+		expect(calls[7]).toContain('/api/v1/batches?page=1');
+		expect(calls[8]).toContain('/api/v2/gl');
+		expect(calls[9]).toContain('/api/v2/locations?q=New%20York');
+		expect(calls[10]).toContain('/api/v2/search_engines');
+		expect(calls[11]).toContain('/api/v2/hl');
+		for (const [, init] of fetchMock.mock.calls) {
+			expect(new Headers(init?.headers).get('apikey')).toBe('zenserp-test-key');
+		}
+	});
+});

--- a/packages/zenserp/client.test.ts
+++ b/packages/zenserp/client.test.ts
@@ -1,4 +1,6 @@
 // Mocked transport coverage intentionally runs in Corsair's normal CI lane.
+
+import { makeZenserpRequest } from './client';
 import { getStatus } from './endpoints/account';
 import { list as listBatches } from './endpoints/batches';
 import {
@@ -7,7 +9,13 @@ import {
 	listLocations,
 	listSearchEngines,
 } from './endpoints/metadata';
-import { bing, google, reverseImage, yandex } from './endpoints/search';
+import {
+	bing,
+	google,
+	imageUrlForEvent,
+	reverseImage,
+	yandex,
+} from './endpoints/search';
 import { getProduct } from './endpoints/shopping';
 import { get as getTrends } from './endpoints/trends';
 import {
@@ -93,11 +101,12 @@ describe('Zenserp API operations', () => {
 		expect(calls[6]).toContain('/api/v2/status');
 		expect(calls[7]).toContain('/api/v1/batches?page=1');
 		expect(calls[8]).toContain('/api/v2/gl');
-		expect(calls[9]).toContain('/api/v2/locations?q=New%20York');
+		expect(calls[9]).toContain('/api/v2/locations?q=New+York');
 		expect(calls[10]).toContain('/api/v2/search_engines');
 		expect(calls[11]).toContain('/api/v2/hl');
 		for (const [, init] of fetchMock.mock.calls) {
 			expect(new Headers(init?.headers).get('apikey')).toBe('zenserp-test-key');
+			expect(init?.redirect).toBe('error');
 		}
 	});
 
@@ -105,5 +114,26 @@ describe('Zenserp API operations', () => {
 		expect(() => SearchResponseSchema.parse({})).toThrow();
 		expect(() => ShoppingProductResponseSchema.parse({})).toThrow();
 		expect(() => TrendsResponseSchema.parse({})).toThrow();
+	});
+
+	it('refuses redirects before forwarding the custom API key', async () => {
+		fetchMock.mockResolvedValueOnce(
+			new Response(null, {
+				status: 302,
+				headers: { Location: 'http://untrusted.example/collect' },
+			}),
+		);
+		await expect(
+			makeZenserpRequest('/api/v2/status', 'zenserp-test-key'),
+		).rejects.toMatchObject({ status: 302 });
+		expect(fetchMock.mock.calls[0]?.[1]?.redirect).toBe('error');
+	});
+
+	it('redacts query strings and fragments from image URLs before logging', () => {
+		expect(
+			imageUrlForEvent(
+				'https://images.example.com/photo.png?signature=secret#user-123',
+			),
+		).toBe('https://images.example.com/photo.png');
 	});
 });

--- a/packages/zenserp/client.test.ts
+++ b/packages/zenserp/client.test.ts
@@ -1,3 +1,4 @@
+// Mocked transport coverage intentionally runs in Corsair's normal CI lane.
 import { getStatus } from './endpoints/account';
 import { list as listBatches } from './endpoints/batches';
 import {

--- a/packages/zenserp/client.test.ts
+++ b/packages/zenserp/client.test.ts
@@ -43,7 +43,11 @@ describe('Zenserp API operations', () => {
 			if (url.includes('/search_engines'))
 				return json([{ name: 'Google', domain: 'google.com' }]);
 			if (url.includes('/hl')) return json([{ name: 'English', value: 'en' }]);
-			return json({ query: 'corsair', organic: [{ title: 'Corsair' }] });
+			return json({
+				query: { q: 'corsair' },
+				organic: [{ title: 'Corsair' }],
+				number_of_results: 1,
+			});
 		});
 	});
 

--- a/packages/zenserp/client.test.ts
+++ b/packages/zenserp/client.test.ts
@@ -10,6 +10,11 @@ import {
 import { bing, google, reverseImage, yandex } from './endpoints/search';
 import { getProduct } from './endpoints/shopping';
 import { get as getTrends } from './endpoints/trends';
+import {
+	SearchResponseSchema,
+	ShoppingProductResponseSchema,
+	TrendsResponseSchema,
+} from './endpoints/types';
 
 const fetchMock = jest.spyOn(globalThis, 'fetch');
 const ctx = {
@@ -32,9 +37,16 @@ describe('Zenserp API operations', () => {
 			const url = String(input);
 			if (url.includes('/status')) return json({ remaining_requests: 1499 });
 			if (url.includes('/shopping'))
-				return json({ product: { product_id: 'p1', title: 'Keyboard' } });
+				return json({
+					query: { product_id: 'p1' },
+					title: 'Keyboard',
+					description: 'Mechanical keyboard',
+				});
 			if (url.includes('/trends'))
-				return json({ data: [{ keyword: 'corsair' }] });
+				return json({
+					json: { corsair: { trends: {} } },
+					html: '<div>corsair</div>',
+				});
 			if (url.includes('/batches')) return json({ data: [{ id: 'batch-1' }] });
 			if (url.includes('/gl'))
 				return json([{ name: 'United States', value: 'us' }]);
@@ -87,5 +99,11 @@ describe('Zenserp API operations', () => {
 		for (const [, init] of fetchMock.mock.calls) {
 			expect(new Headers(init?.headers).get('apikey')).toBe('zenserp-test-key');
 		}
+	});
+
+	it('rejects empty successful payloads for data-bearing operations', () => {
+		expect(() => SearchResponseSchema.parse({})).toThrow();
+		expect(() => ShoppingProductResponseSchema.parse({})).toThrow();
+		expect(() => TrendsResponseSchema.parse({})).toThrow();
 	});
 });

--- a/packages/zenserp/client.ts
+++ b/packages/zenserp/client.ts
@@ -1,0 +1,33 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { request } from 'corsair/http';
+
+const ZENSERP_API_BASE = 'https://app.zenserp.com';
+
+export type ZenserpQuery = Record<
+	string,
+	string | number | boolean | readonly string[] | undefined
+>;
+
+export async function makeZenserpRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	query: ZenserpQuery = {},
+): Promise<T> {
+	if (!apiKey.trim()) throw new Error('Zenserp API key is required');
+
+	const config: OpenAPIConfig = {
+		BASE: ZENSERP_API_BASE,
+		VERSION: '2',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: undefined,
+		HEADERS: { Accept: 'application/json', apikey: apiKey },
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method: 'GET',
+		url: endpoint,
+		query,
+	};
+	return await request<T>(config, requestOptions);
+}

--- a/packages/zenserp/client.ts
+++ b/packages/zenserp/client.ts
@@ -1,33 +1,87 @@
-import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
-import { request } from 'corsair/http';
+import type { ApiRequestOptions } from 'corsair/http';
+import { ApiError } from 'corsair/http';
 
-const ZENSERP_API_BASE = 'https://app.zenserp.com';
+const ZENSERP_API_BASE = 'https://app.zenserp.com/';
+const REQUEST_TIMEOUT_MS = 45_000;
 
 export type ZenserpQuery = Record<
 	string,
 	string | number | boolean | readonly string[] | undefined
 >;
 
+function retryAfterMs(response: Response): number | undefined {
+	const value = response.headers.get('retry-after');
+	if (!value) return undefined;
+	const seconds = Number(value);
+	if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+	const date = Date.parse(value);
+	return Number.isNaN(date) ? undefined : Math.max(0, date - Date.now());
+}
+
+async function responseBody(response: Response): Promise<unknown> {
+	if (response.status === 204) return undefined;
+	const text = await response.text();
+	if (!text.trim()) return undefined;
+	const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
+	if (contentType.includes('json')) {
+		try {
+			return JSON.parse(text);
+		} catch {
+			return text;
+		}
+	}
+	return text;
+}
+
 export async function makeZenserpRequest<T>(
 	endpoint: string,
 	apiKey: string,
 	query: ZenserpQuery = {},
 ): Promise<T> {
-	if (!apiKey.trim()) throw new Error('Zenserp API key is required');
+	const normalizedKey = apiKey.trim();
+	if (!normalizedKey) throw new Error('Zenserp API key is required');
 
-	const config: OpenAPIConfig = {
-		BASE: ZENSERP_API_BASE,
-		VERSION: '2',
-		WITH_CREDENTIALS: false,
-		CREDENTIALS: 'omit',
-		TOKEN: undefined,
-		HEADERS: { Accept: 'application/json', apikey: apiKey },
-	};
+	const url = new URL(endpoint.replace(/^\/+/, ''), ZENSERP_API_BASE);
+	for (const [key, value] of Object.entries(query)) {
+		if (value === undefined) continue;
+		if (Array.isArray(value)) {
+			for (const item of value) url.searchParams.append(key, item);
+		} else {
+			url.searchParams.set(key, String(value));
+		}
+	}
 
 	const requestOptions: ApiRequestOptions = {
 		method: 'GET',
-		url: endpoint,
+		url: `${url.pathname}${url.search}`,
 		query,
 	};
-	return await request<T>(config, requestOptions);
+	const response = await fetch(url, {
+		method: 'GET',
+		headers: { Accept: 'application/json', apikey: normalizedKey },
+		redirect: 'error',
+		signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+	});
+	const body = await responseBody(response);
+
+	if (!response.ok) {
+		const providerMessage =
+			typeof body === 'object' && body !== null && 'error' in body
+				? String((body as { error: unknown }).error)
+				: response.statusText || `Zenserp request failed (${response.status})`;
+		throw new ApiError(
+			requestOptions,
+			{
+				url: url.toString(),
+				ok: false,
+				status: response.status,
+				statusText: response.statusText,
+				body,
+			},
+			providerMessage,
+			{ retryAfter: retryAfterMs(response) },
+		);
+	}
+
+	return body as T;
 }

--- a/packages/zenserp/endpoints/account.ts
+++ b/packages/zenserp/endpoints/account.ts
@@ -1,0 +1,21 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ZenserpEndpoints } from '..';
+import { makeZenserpRequest } from '../client';
+import { StatusInputSchema, StatusResponseSchema } from './types';
+
+export const getStatus: ZenserpEndpoints['accountGetStatus'] = async (
+	ctx,
+	rawInput,
+) => {
+	StatusInputSchema.parse(rawInput);
+	const response = StatusResponseSchema.parse(
+		await makeZenserpRequest<unknown>('/api/v2/status', ctx.key),
+	);
+	await logEventFromContext(
+		ctx,
+		'zenserp.account.getStatus',
+		{ remainingRequests: response.remaining_requests },
+		'completed',
+	);
+	return response;
+};

--- a/packages/zenserp/endpoints/batches.ts
+++ b/packages/zenserp/endpoints/batches.ts
@@ -1,0 +1,18 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ZenserpEndpoints } from '..';
+import { makeZenserpRequest } from '../client';
+import { BatchesResponseSchema, ListBatchesInputSchema } from './types';
+
+export const list: ZenserpEndpoints['batchesList'] = async (ctx, rawInput) => {
+	const input = ListBatchesInputSchema.parse(rawInput);
+	const response = BatchesResponseSchema.parse(
+		await makeZenserpRequest<unknown>('/api/v1/batches', ctx.key, input),
+	);
+	await logEventFromContext(
+		ctx,
+		'zenserp.batches.list',
+		{ page: input.page },
+		'completed',
+	);
+	return response;
+};

--- a/packages/zenserp/endpoints/index.ts
+++ b/packages/zenserp/endpoints/index.ts
@@ -1,0 +1,9 @@
+import * as Account from './account';
+import * as Batches from './batches';
+import * as Metadata from './metadata';
+import * as Search from './search';
+import * as Shopping from './shopping';
+import * as Trends from './trends';
+
+export { Account, Batches, Metadata, Search, Shopping, Trends };
+export * from './types';

--- a/packages/zenserp/endpoints/metadata.ts
+++ b/packages/zenserp/endpoints/metadata.ts
@@ -1,0 +1,79 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ZenserpEndpoints } from '..';
+import { makeZenserpRequest } from '../client';
+import {
+	CountriesResponseSchema,
+	LanguagesResponseSchema,
+	ListCountriesInputSchema,
+	ListLanguagesInputSchema,
+	ListLocationsInputSchema,
+	ListSearchEnginesInputSchema,
+	LocationsResponseSchema,
+	SearchEnginesResponseSchema,
+} from './types';
+
+export const listCountries: ZenserpEndpoints['metadataListCountries'] = async (
+	ctx,
+	rawInput,
+) => {
+	ListCountriesInputSchema.parse(rawInput);
+	const response = CountriesResponseSchema.parse(
+		await makeZenserpRequest<unknown>('/api/v2/gl', ctx.key),
+	);
+	await logEventFromContext(
+		ctx,
+		'zenserp.metadata.listCountries',
+		{ count: response.length },
+		'completed',
+	);
+	return response;
+};
+
+export const listLocations: ZenserpEndpoints['metadataListLocations'] = async (
+	ctx,
+	rawInput,
+) => {
+	const input = ListLocationsInputSchema.parse(rawInput);
+	const response = LocationsResponseSchema.parse(
+		await makeZenserpRequest<unknown>('/api/v2/locations', ctx.key, input),
+	);
+	await logEventFromContext(
+		ctx,
+		'zenserp.metadata.listLocations',
+		{ count: response.length },
+		'completed',
+	);
+	return response;
+};
+
+export const listSearchEngines: ZenserpEndpoints['metadataListSearchEngines'] =
+	async (ctx, rawInput) => {
+		ListSearchEnginesInputSchema.parse(rawInput);
+		const response = SearchEnginesResponseSchema.parse(
+			await makeZenserpRequest<unknown>('/api/v2/search_engines', ctx.key),
+		);
+		await logEventFromContext(
+			ctx,
+			'zenserp.metadata.listSearchEngines',
+			{ count: response.length },
+			'completed',
+		);
+		return response;
+	};
+
+export const listLanguages: ZenserpEndpoints['metadataListLanguages'] = async (
+	ctx,
+	rawInput,
+) => {
+	ListLanguagesInputSchema.parse(rawInput);
+	const response = LanguagesResponseSchema.parse(
+		await makeZenserpRequest<unknown>('/api/v2/hl', ctx.key),
+	);
+	await logEventFromContext(
+		ctx,
+		'zenserp.metadata.listLanguages',
+		{ count: response.length },
+		'completed',
+	);
+	return response;
+};

--- a/packages/zenserp/endpoints/search.ts
+++ b/packages/zenserp/endpoints/search.ts
@@ -1,0 +1,86 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ZenserpEndpoints } from '..';
+import { makeZenserpRequest } from '../client';
+import {
+	BingSearchInputSchema,
+	GoogleSearchInputSchema,
+	ReverseImageSearchInputSchema,
+	SearchResponseSchema,
+	YandexSearchInputSchema,
+} from './types';
+
+export const google: ZenserpEndpoints['searchGoogle'] = async (
+	ctx,
+	rawInput,
+) => {
+	const input = GoogleSearchInputSchema.parse(rawInput);
+	const response = SearchResponseSchema.parse(
+		await makeZenserpRequest<unknown>('/api/v2/search', ctx.key, input),
+	);
+	await logEventFromContext(
+		ctx,
+		'zenserp.search.google',
+		{ q: input.q },
+		'completed',
+	);
+	return response;
+};
+
+export const bing: ZenserpEndpoints['searchBing'] = async (ctx, rawInput) => {
+	const input = BingSearchInputSchema.parse(rawInput);
+	const response = SearchResponseSchema.parse(
+		await makeZenserpRequest<unknown>('/api/v2/search', ctx.key, {
+			...input,
+			search_engine: 'bing.com',
+		}),
+	);
+	await logEventFromContext(
+		ctx,
+		'zenserp.search.bing',
+		{ q: input.q },
+		'completed',
+	);
+	return response;
+};
+
+export const yandex: ZenserpEndpoints['searchYandex'] = async (
+	ctx,
+	rawInput,
+) => {
+	const input = YandexSearchInputSchema.parse(rawInput);
+	const response = SearchResponseSchema.parse(
+		await makeZenserpRequest<unknown>('/api/v2/search', ctx.key, {
+			...input,
+			search_engine: 'yandex.com',
+		}),
+	);
+	await logEventFromContext(
+		ctx,
+		'zenserp.search.yandex',
+		{ q: input.q },
+		'completed',
+	);
+	return response;
+};
+
+export const reverseImage: ZenserpEndpoints['searchReverseImage'] = async (
+	ctx,
+	rawInput,
+) => {
+	const input = ReverseImageSearchInputSchema.parse(rawInput);
+	const response = SearchResponseSchema.parse(
+		await makeZenserpRequest<unknown>('/api/v2/search', ctx.key, {
+			image_url: input.imageUrl,
+			location: input.location,
+			gl: input.gl,
+			hl: input.hl,
+		}),
+	);
+	await logEventFromContext(
+		ctx,
+		'zenserp.search.reverseImage',
+		{ imageUrl: input.imageUrl },
+		'completed',
+	);
+	return response;
+};

--- a/packages/zenserp/endpoints/search.ts
+++ b/packages/zenserp/endpoints/search.ts
@@ -9,6 +9,11 @@ import {
 	YandexSearchInputSchema,
 } from './types';
 
+export function imageUrlForEvent(imageUrl: string): string {
+	const url = new URL(imageUrl);
+	return `${url.origin}${url.pathname}`;
+}
+
 export const google: ZenserpEndpoints['searchGoogle'] = async (
 	ctx,
 	rawInput,
@@ -79,7 +84,7 @@ export const reverseImage: ZenserpEndpoints['searchReverseImage'] = async (
 	await logEventFromContext(
 		ctx,
 		'zenserp.search.reverseImage',
-		{ imageUrl: input.imageUrl },
+		{ imageUrl: imageUrlForEvent(input.imageUrl) },
 		'completed',
 	);
 	return response;

--- a/packages/zenserp/endpoints/shopping.ts
+++ b/packages/zenserp/endpoints/shopping.ts
@@ -1,0 +1,29 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ZenserpEndpoints } from '..';
+import { makeZenserpRequest } from '../client';
+import {
+	ShoppingProductInputSchema,
+	ShoppingProductResponseSchema,
+} from './types';
+
+export const getProduct: ZenserpEndpoints['shoppingGetProduct'] = async (
+	ctx,
+	rawInput,
+) => {
+	const input = ShoppingProductInputSchema.parse(rawInput);
+	const response = ShoppingProductResponseSchema.parse(
+		await makeZenserpRequest<unknown>('/api/v1/shopping', ctx.key, {
+			product_id: input.productId,
+			location: input.location,
+			gl: input.gl,
+			hl: input.hl,
+		}),
+	);
+	await logEventFromContext(
+		ctx,
+		'zenserp.shopping.getProduct',
+		{ productId: input.productId },
+		'completed',
+	);
+	return response;
+};

--- a/packages/zenserp/endpoints/trends.ts
+++ b/packages/zenserp/endpoints/trends.ts
@@ -1,0 +1,22 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ZenserpEndpoints } from '..';
+import { makeZenserpRequest } from '../client';
+import { TrendsInputSchema, TrendsResponseSchema } from './types';
+
+export const get: ZenserpEndpoints['trendsGet'] = async (ctx, rawInput) => {
+	const input = TrendsInputSchema.parse(rawInput);
+	const response = TrendsResponseSchema.parse(
+		await makeZenserpRequest<unknown>('/api/v1/trends', ctx.key, {
+			'keyword[]': input.keywords,
+			location: input.location,
+			timeframe: input.timeframe,
+		}),
+	);
+	await logEventFromContext(
+		ctx,
+		'zenserp.trends.get',
+		{ keywords: input.keywords },
+		'completed',
+	);
+	return response;
+};

--- a/packages/zenserp/endpoints/types.ts
+++ b/packages/zenserp/endpoints/types.ts
@@ -52,10 +52,16 @@ export const ListLocationsInputSchema = z.object({
 export const ListSearchEnginesInputSchema = EmptyInputSchema;
 export const ListLanguagesInputSchema = EmptyInputSchema;
 
+/**
+ * Search-engine and product payload fields vary by query and Google vertical.
+ * Stable envelope fields are validated explicitly below; documented dynamic
+ * result fields are preserved without asserting a shape the provider does not
+ * guarantee.
+ */
 const UnknownRecord = z.record(z.string(), z.unknown());
 export const SearchResponseSchema = z
 	.object({
-		query: UnknownRecord.optional(),
+		query: UnknownRecord,
 		organic: z.array(UnknownRecord).optional(),
 		paid: z.array(UnknownRecord).optional(),
 		images: z.array(UnknownRecord).optional(),
@@ -66,10 +72,18 @@ export const SearchResponseSchema = z
 	})
 	.loose();
 export const ShoppingProductResponseSchema = z
-	.object({ product: UnknownRecord.optional() })
+	.object({
+		query: UnknownRecord,
+		title: z.string(),
+		description: z.string().nullable().optional(),
+		image: z.string().url().optional(),
+		reviews: z.array(UnknownRecord).optional(),
+		specifications: z.array(UnknownRecord).optional(),
+		sellers: z.array(UnknownRecord).optional(),
+	})
 	.loose();
 export const TrendsResponseSchema = z
-	.object({ data: z.array(UnknownRecord).optional() })
+	.object({ json: UnknownRecord, html: z.string().optional() })
 	.loose();
 export const StatusResponseSchema = z
 	.object({ remaining_requests: z.number().int().min(0) })

--- a/packages/zenserp/endpoints/types.ts
+++ b/packages/zenserp/endpoints/types.ts
@@ -55,10 +55,13 @@ export const ListLanguagesInputSchema = EmptyInputSchema;
 const UnknownRecord = z.record(z.string(), z.unknown());
 export const SearchResponseSchema = z
 	.object({
-		query: z.string().optional(),
+		query: UnknownRecord.optional(),
 		organic: z.array(UnknownRecord).optional(),
 		paid: z.array(UnknownRecord).optional(),
 		images: z.array(UnknownRecord).optional(),
+		related_searches: z.array(UnknownRecord).optional(),
+		pagination: UnknownRecord.optional(),
+		number_of_results: z.number().optional(),
 		knowledge_graph: UnknownRecord.optional(),
 	})
 	.loose();

--- a/packages/zenserp/endpoints/types.ts
+++ b/packages/zenserp/endpoints/types.ts
@@ -1,0 +1,169 @@
+import { z } from 'zod';
+
+const NonEmptyString = z.string().trim().min(1);
+const EmptyInputSchema = z.object({}).strict();
+const SearchOptions = {
+	location: NonEmptyString.optional(),
+	hl: NonEmptyString.optional(),
+	gl: NonEmptyString.optional(),
+	device: z.enum(['desktop', 'tablet', 'mobile']).optional(),
+	num: z.number().int().min(1).max(100).optional(),
+	start: z.number().int().min(0).optional(),
+};
+
+export const GoogleSearchInputSchema = z.object({
+	q: NonEmptyString,
+	...SearchOptions,
+});
+export const BingSearchInputSchema = z.object({
+	q: NonEmptyString,
+	...SearchOptions,
+});
+export const YandexSearchInputSchema = z.object({
+	q: NonEmptyString,
+	...SearchOptions,
+});
+export const ReverseImageSearchInputSchema = z.object({
+	imageUrl: z.string().url(),
+	location: NonEmptyString.optional(),
+	gl: NonEmptyString.optional(),
+	hl: NonEmptyString.optional(),
+});
+export const ShoppingProductInputSchema = z.object({
+	productId: NonEmptyString,
+	location: NonEmptyString.optional(),
+	gl: NonEmptyString.optional(),
+	hl: NonEmptyString.optional(),
+});
+export const TrendsInputSchema = z.object({
+	keywords: z.array(NonEmptyString).min(1).max(5),
+	location: NonEmptyString.optional(),
+	timeframe: NonEmptyString.optional(),
+});
+export const StatusInputSchema = EmptyInputSchema;
+export const ListBatchesInputSchema = z.object({
+	page: z.number().int().min(1).optional(),
+	limit: z.number().int().min(1).max(100).optional(),
+});
+export const ListCountriesInputSchema = EmptyInputSchema;
+export const ListLocationsInputSchema = z.object({
+	q: NonEmptyString.optional(),
+});
+export const ListSearchEnginesInputSchema = EmptyInputSchema;
+export const ListLanguagesInputSchema = EmptyInputSchema;
+
+const UnknownRecord = z.record(z.string(), z.unknown());
+export const SearchResponseSchema = z
+	.object({
+		query: z.string().optional(),
+		organic: z.array(UnknownRecord).optional(),
+		paid: z.array(UnknownRecord).optional(),
+		images: z.array(UnknownRecord).optional(),
+		knowledge_graph: UnknownRecord.optional(),
+	})
+	.loose();
+export const ShoppingProductResponseSchema = z
+	.object({ product: UnknownRecord.optional() })
+	.loose();
+export const TrendsResponseSchema = z
+	.object({ data: z.array(UnknownRecord).optional() })
+	.loose();
+export const StatusResponseSchema = z
+	.object({ remaining_requests: z.number().int().min(0) })
+	.loose();
+export const BatchesResponseSchema = z.union([
+	z.array(UnknownRecord),
+	z.object({ data: z.array(UnknownRecord) }).loose(),
+]);
+export const CountriesResponseSchema = z.array(
+	z
+		.object({
+			name: z.string().optional(),
+			value: z.string().optional(),
+			code: z.string().optional(),
+		})
+		.loose(),
+);
+export const LocationsResponseSchema = z.array(
+	z
+		.object({
+			name: z.string().optional(),
+			canonical_name: z.string().optional(),
+			country_code: z.string().optional(),
+		})
+		.loose(),
+);
+export const SearchEnginesResponseSchema = z.array(
+	z
+		.object({ name: z.string().optional(), domain: z.string().optional() })
+		.loose(),
+);
+export const LanguagesResponseSchema = z.array(
+	z
+		.object({
+			name: z.string().optional(),
+			value: z.string().optional(),
+			code: z.string().optional(),
+		})
+		.loose(),
+);
+
+export type ZenserpEndpointInputs = {
+	searchGoogle: z.infer<typeof GoogleSearchInputSchema>;
+	searchBing: z.infer<typeof BingSearchInputSchema>;
+	searchYandex: z.infer<typeof YandexSearchInputSchema>;
+	searchReverseImage: z.infer<typeof ReverseImageSearchInputSchema>;
+	shoppingGetProduct: z.infer<typeof ShoppingProductInputSchema>;
+	trendsGet: z.infer<typeof TrendsInputSchema>;
+	accountGetStatus: z.infer<typeof StatusInputSchema>;
+	batchesList: z.infer<typeof ListBatchesInputSchema>;
+	metadataListCountries: z.infer<typeof ListCountriesInputSchema>;
+	metadataListLocations: z.infer<typeof ListLocationsInputSchema>;
+	metadataListSearchEngines: z.infer<typeof ListSearchEnginesInputSchema>;
+	metadataListLanguages: z.infer<typeof ListLanguagesInputSchema>;
+};
+
+export type ZenserpEndpointOutputs = {
+	searchGoogle: z.infer<typeof SearchResponseSchema>;
+	searchBing: z.infer<typeof SearchResponseSchema>;
+	searchYandex: z.infer<typeof SearchResponseSchema>;
+	searchReverseImage: z.infer<typeof SearchResponseSchema>;
+	shoppingGetProduct: z.infer<typeof ShoppingProductResponseSchema>;
+	trendsGet: z.infer<typeof TrendsResponseSchema>;
+	accountGetStatus: z.infer<typeof StatusResponseSchema>;
+	batchesList: z.infer<typeof BatchesResponseSchema>;
+	metadataListCountries: z.infer<typeof CountriesResponseSchema>;
+	metadataListLocations: z.infer<typeof LocationsResponseSchema>;
+	metadataListSearchEngines: z.infer<typeof SearchEnginesResponseSchema>;
+	metadataListLanguages: z.infer<typeof LanguagesResponseSchema>;
+};
+
+export const ZenserpEndpointInputSchemas = {
+	searchGoogle: GoogleSearchInputSchema,
+	searchBing: BingSearchInputSchema,
+	searchYandex: YandexSearchInputSchema,
+	searchReverseImage: ReverseImageSearchInputSchema,
+	shoppingGetProduct: ShoppingProductInputSchema,
+	trendsGet: TrendsInputSchema,
+	accountGetStatus: StatusInputSchema,
+	batchesList: ListBatchesInputSchema,
+	metadataListCountries: ListCountriesInputSchema,
+	metadataListLocations: ListLocationsInputSchema,
+	metadataListSearchEngines: ListSearchEnginesInputSchema,
+	metadataListLanguages: ListLanguagesInputSchema,
+} as const;
+
+export const ZenserpEndpointOutputSchemas = {
+	searchGoogle: SearchResponseSchema,
+	searchBing: SearchResponseSchema,
+	searchYandex: SearchResponseSchema,
+	searchReverseImage: SearchResponseSchema,
+	shoppingGetProduct: ShoppingProductResponseSchema,
+	trendsGet: TrendsResponseSchema,
+	accountGetStatus: StatusResponseSchema,
+	batchesList: BatchesResponseSchema,
+	metadataListCountries: CountriesResponseSchema,
+	metadataListLocations: LocationsResponseSchema,
+	metadataListSearchEngines: SearchEnginesResponseSchema,
+	metadataListLanguages: LanguagesResponseSchema,
+} as const;

--- a/packages/zenserp/error-handlers.ts
+++ b/packages/zenserp/error-handlers.ts
@@ -13,7 +13,7 @@ export const errorHandlers = {
 			if (error instanceof ApiError && error.retryAfter !== undefined) {
 				retryAfterMs = error.retryAfter;
 			}
-			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+			return { maxRetries: 0, headersRetryAfterMs: retryAfterMs };
 		},
 	},
 	AUTH_ERROR: {

--- a/packages/zenserp/error-handlers.ts
+++ b/packages/zenserp/error-handlers.ts
@@ -1,0 +1,39 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('429');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (
+				error instanceof ApiError &&
+				(error.status === 401 || error.status === 403)
+			)
+				return true;
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('unauthorized') ||
+				msg.includes('invalid_auth') ||
+				msg.includes('invalid api key')
+			);
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/zenserp/index.ts
+++ b/packages/zenserp/index.ts
@@ -1,0 +1,256 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+	RequiredPluginWebhookSchemas,
+} from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
+import {
+	Account,
+	Batches,
+	Metadata,
+	Search,
+	Shopping,
+	Trends,
+} from './endpoints';
+import type {
+	ZenserpEndpointInputs,
+	ZenserpEndpointOutputs,
+} from './endpoints/types';
+import {
+	ZenserpEndpointInputSchemas,
+	ZenserpEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { ZenserpSchema } from './schema';
+
+export type ZenserpPluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	hooks?: InternalZenserpPlugin['hooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof zenserpEndpointsNested>;
+};
+
+export type ZenserpContext = CorsairPluginContext<
+	typeof ZenserpSchema,
+	ZenserpPluginOptions
+>;
+export type ZenserpKeyBuilderContext = KeyBuilderContext<ZenserpPluginOptions>;
+export type ZenserpBoundEndpoints = BindEndpoints<
+	typeof zenserpEndpointsNested
+>;
+
+type ZenserpEndpoint<K extends keyof ZenserpEndpointOutputs> = CorsairEndpoint<
+	ZenserpContext,
+	ZenserpEndpointInputs[K],
+	ZenserpEndpointOutputs[K]
+>;
+
+export type ZenserpEndpoints = {
+	searchGoogle: ZenserpEndpoint<'searchGoogle'>;
+	searchBing: ZenserpEndpoint<'searchBing'>;
+	searchYandex: ZenserpEndpoint<'searchYandex'>;
+	searchReverseImage: ZenserpEndpoint<'searchReverseImage'>;
+	shoppingGetProduct: ZenserpEndpoint<'shoppingGetProduct'>;
+	trendsGet: ZenserpEndpoint<'trendsGet'>;
+	accountGetStatus: ZenserpEndpoint<'accountGetStatus'>;
+	batchesList: ZenserpEndpoint<'batchesList'>;
+	metadataListCountries: ZenserpEndpoint<'metadataListCountries'>;
+	metadataListLocations: ZenserpEndpoint<'metadataListLocations'>;
+	metadataListSearchEngines: ZenserpEndpoint<'metadataListSearchEngines'>;
+	metadataListLanguages: ZenserpEndpoint<'metadataListLanguages'>;
+};
+
+const zenserpEndpointsNested = {
+	search: {
+		google: Search.google,
+		bing: Search.bing,
+		yandex: Search.yandex,
+		reverseImage: Search.reverseImage,
+	},
+	shopping: { getProduct: Shopping.getProduct },
+	trends: { get: Trends.get },
+	account: { getStatus: Account.getStatus },
+	batches: { list: Batches.list },
+	metadata: {
+		listCountries: Metadata.listCountries,
+		listLocations: Metadata.listLocations,
+		listSearchEngines: Metadata.listSearchEngines,
+		listLanguages: Metadata.listLanguages,
+	},
+} as const;
+
+const zenserpWebhooksNested = {} as const;
+
+export const zenserpEndpointSchemas = {
+	'search.google': {
+		input: ZenserpEndpointInputSchemas.searchGoogle,
+		output: ZenserpEndpointOutputSchemas.searchGoogle,
+	},
+	'search.bing': {
+		input: ZenserpEndpointInputSchemas.searchBing,
+		output: ZenserpEndpointOutputSchemas.searchBing,
+	},
+	'search.yandex': {
+		input: ZenserpEndpointInputSchemas.searchYandex,
+		output: ZenserpEndpointOutputSchemas.searchYandex,
+	},
+	'search.reverseImage': {
+		input: ZenserpEndpointInputSchemas.searchReverseImage,
+		output: ZenserpEndpointOutputSchemas.searchReverseImage,
+	},
+	'shopping.getProduct': {
+		input: ZenserpEndpointInputSchemas.shoppingGetProduct,
+		output: ZenserpEndpointOutputSchemas.shoppingGetProduct,
+	},
+	'trends.get': {
+		input: ZenserpEndpointInputSchemas.trendsGet,
+		output: ZenserpEndpointOutputSchemas.trendsGet,
+	},
+	'account.getStatus': {
+		input: ZenserpEndpointInputSchemas.accountGetStatus,
+		output: ZenserpEndpointOutputSchemas.accountGetStatus,
+	},
+	'batches.list': {
+		input: ZenserpEndpointInputSchemas.batchesList,
+		output: ZenserpEndpointOutputSchemas.batchesList,
+	},
+	'metadata.listCountries': {
+		input: ZenserpEndpointInputSchemas.metadataListCountries,
+		output: ZenserpEndpointOutputSchemas.metadataListCountries,
+	},
+	'metadata.listLocations': {
+		input: ZenserpEndpointInputSchemas.metadataListLocations,
+		output: ZenserpEndpointOutputSchemas.metadataListLocations,
+	},
+	'metadata.listSearchEngines': {
+		input: ZenserpEndpointInputSchemas.metadataListSearchEngines,
+		output: ZenserpEndpointOutputSchemas.metadataListSearchEngines,
+	},
+	'metadata.listLanguages': {
+		input: ZenserpEndpointInputSchemas.metadataListLanguages,
+		output: ZenserpEndpointOutputSchemas.metadataListLanguages,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<
+	typeof zenserpEndpointsNested
+>;
+
+const zenserpWebhookSchemas =
+	{} as const satisfies RequiredPluginWebhookSchemas<
+		typeof zenserpWebhooksNested
+	>;
+
+const zenserpEndpointMeta = {
+	'search.google': {
+		riskLevel: 'read',
+		description: 'Search Google and return structured SERP data',
+	},
+	'search.bing': {
+		riskLevel: 'read',
+		description: 'Search Bing and return structured SERP data',
+	},
+	'search.yandex': {
+		riskLevel: 'read',
+		description: 'Search Yandex and return structured SERP data',
+	},
+	'search.reverseImage': {
+		riskLevel: 'read',
+		description: 'Run a Google reverse-image search for a public image URL',
+	},
+	'shopping.getProduct': {
+		riskLevel: 'read',
+		description: 'Retrieve Google Shopping product details',
+	},
+	'trends.get': {
+		riskLevel: 'read',
+		description: 'Retrieve Google Trends data for one or more keywords',
+	},
+	'account.getStatus': {
+		riskLevel: 'read',
+		description: 'Return the remaining request quota for the API key',
+	},
+	'batches.list': {
+		riskLevel: 'read',
+		description: 'List submitted Zenserp batches',
+	},
+	'metadata.listCountries': {
+		riskLevel: 'read',
+		description: 'List supported Google country parameters',
+	},
+	'metadata.listLocations': {
+		riskLevel: 'read',
+		description: 'List supported geolocation targets',
+	},
+	'metadata.listSearchEngines': {
+		riskLevel: 'read',
+		description: 'List supported search-engine domains',
+	},
+	'metadata.listLanguages': {
+		riskLevel: 'read',
+		description: 'List supported Google interface languages',
+	},
+} as const satisfies RequiredPluginEndpointMeta<typeof zenserpEndpointsNested>;
+
+const defaultAuthType: AuthTypes = 'api_key';
+
+export const zenserpAuthConfig = {
+	api_key: {},
+} as const satisfies PluginAuthConfig;
+
+export type BaseZenserpPlugin<T extends ZenserpPluginOptions> = CorsairPlugin<
+	'zenserp',
+	typeof ZenserpSchema,
+	typeof zenserpEndpointsNested,
+	typeof zenserpWebhooksNested,
+	T,
+	typeof defaultAuthType
+>;
+
+export type InternalZenserpPlugin = BaseZenserpPlugin<ZenserpPluginOptions>;
+export type ExternalZenserpPlugin<T extends ZenserpPluginOptions> =
+	BaseZenserpPlugin<T>;
+
+export function zenserp<const T extends ZenserpPluginOptions>(
+	incomingOptions: ZenserpPluginOptions & T = {} as ZenserpPluginOptions & T,
+): ExternalZenserpPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'zenserp',
+		authConfig: zenserpAuthConfig,
+		schema: ZenserpSchema,
+		options,
+		hooks: options.hooks,
+		webhookHooks: undefined,
+		endpoints: zenserpEndpointsNested,
+		webhooks: zenserpWebhooksNested,
+		endpointMeta: zenserpEndpointMeta,
+		endpointSchemas: zenserpEndpointSchemas,
+		webhookSchemas: zenserpWebhookSchemas,
+		pluginWebhookMatcher: undefined,
+		errorHandlers: { ...errorHandlers, ...options.errorHandlers },
+		keyBuilder: async (ctx: ZenserpKeyBuilderContext, source) => {
+			if (source === 'endpoint' && options.key) return options.key;
+			if (source === 'endpoint') {
+				const key = await ctx.keys.get_api_key();
+				if (key) return key;
+			}
+			throw new AuthMissingError('zenserp', 'api_key');
+		},
+	} satisfies InternalZenserpPlugin;
+}
+
+export * from './endpoints/types';
+export { ZenserpSchema } from './schema';

--- a/packages/zenserp/jest.config.cjs
+++ b/packages/zenserp/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/zenserp/package.json
+++ b/packages/zenserp/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/zenserp",
+  "version": "0.1.0",
+  "description": "Zenserp plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "zenserp",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/zenserp/schema.test.ts
+++ b/packages/zenserp/schema.test.ts
@@ -1,0 +1,20 @@
+import { ZenserpSchema } from './schema';
+
+describe('Zenserp schema', () => {
+	it('declares a semver version', () => {
+		expect(ZenserpSchema.version).toBeDefined();
+		expect(ZenserpSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof ZenserpSchema.entities).toBe('object');
+		expect(ZenserpSchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(ZenserpSchema.entities))).toBe(true);
+		for (const entity of Object.values(ZenserpSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/zenserp/schema/index.ts
+++ b/packages/zenserp/schema/index.ts
@@ -1,0 +1,4 @@
+export const ZenserpSchema = {
+	version: '1.0.0',
+	entities: {},
+} as const;

--- a/packages/zenserp/tsconfig.json
+++ b/packages/zenserp/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/zenserp/tsup.config.ts
+++ b/packages/zenserp/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7253,6 +7253,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/zenserp:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/zohoinventory:
     devDependencies:
       '@types/jest':


### PR DESCRIPTION
## Description

Adds a production-ready Zenserp plugin implementing all 12 operations from the Corsair OSS catalog. The plugin provides Google, Bing, Yandex, and reverse-image search; shopping product details; Google Trends; quota status; batch listing; and country, location, language, and search-engine metadata.

Authentication uses Zenserp's documented `apikey` header. Every operation has Zod input/output validation, read-risk metadata, event logging, and deterministic transport coverage. Live verification also corrected the provider's object-shaped query metadata.

Fixes #1607

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

[Zenserp live API demo (MP4)](https://github.com/shivangtanwar/corsair/raw/refs/heads/demo-assets/demos/zenserp-live-demo.mp4)

The recording shows authenticated quota checks and a real Google search executed through the plugin, with the live response validated by `SearchResponseSchema`. The API key is redacted.

## Additional Notes

Official API documentation: https://app.zenserp.com/documentation

Validated with package tests/build/typecheck, root lint/typecheck, `pnpm run validate:plugins`, and a live provider request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Zenserp as a supported provider.
  * Added Google, Bing, Yandex, and reverse image search.
  * Added shopping, trends, account status, batch, and metadata endpoints.
  * Added API key authentication, input validation, timeout handling, and rate-limit handling.
  * Added structured error reporting and response validation for supported data.
  * Protected API keys when following image-search requests.

* **Tests**
  * Added coverage for Zenserp requests, endpoints, schemas, and authentication headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->