### PR TITLE
feat: configure Exist API client

### DIFF
--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -152,6 +152,7 @@ export const BaseProviders = [
 	'dynapictures',
 	'epicgames',
 	'exa',
+	'exist',
 	'facebook',
 	'faraday',
 	'figma',
@@ -429,6 +430,7 @@ export const ProviderDisplayNames = {
 	dynapictures: 'Dynapictures',
 	epicgames: 'Epic Games',
 	exa: 'Exa',
+	exist: 'Exist',
 	facebook: 'Facebook',
 	faraday: 'Faraday',
 	figma: 'Figma',
@@ -713,6 +715,7 @@ export type AllProviders =
 	| 'dynapictures'
 	| 'epicgames'
 	| 'exa'
+	| 'exist'
 	| 'facebook'
 	| 'faraday'
 	| 'figma'

--- a/packages/exist/client.ts
+++ b/packages/exist/client.ts
@@ -1,0 +1,60 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { request } from 'corsair/http';
+
+export class ExistAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly code?: string,
+	) {
+		super(message);
+		this.name = 'ExistAPIError';
+	}
+}
+
+// TODO: Update with your API base URL
+const EXIST_API_BASE = 'https://api.example.com';
+
+export async function makeExistRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	options: {
+		method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+		body?: Record<string, unknown>;
+		query?: Record<string, string | number | boolean | undefined>;
+	} = {},
+): Promise<T> {
+	const { method = 'GET', body, query } = options;
+
+	const config: OpenAPIConfig = {
+		BASE: EXIST_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: apiKey,
+		HEADERS: {
+			'Content-Type': 'application/json',
+			// TODO: Add authentication headers
+			// 'Authorization': \`Bearer \${apiKey}\`
+		},
+	};
+
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint,
+		body:
+			method === 'POST' || method === 'PUT' || method === 'PATCH'
+				? body
+				: undefined,
+		mediaType: 'application/json; charset=utf-8',
+		query: method === 'GET' ? query : undefined,
+	};
+
+	try {
+		return await request<T>(config, requestOptions);
+	} catch (error) {
+		if (error instanceof Error) {
+			throw new ExistAPIError(error.message);
+		}
+		throw new ExistAPIError('Unknown error');
+	}
+}

--- a/packages/exist/endpoints/example.ts
+++ b/packages/exist/endpoints/example.ts
@@ -1,0 +1,20 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ExistEndpoints } from '..';
+import { makeExistRequest } from '../client';
+import type { ExistEndpointOutputs } from './types';
+
+export const get: ExistEndpoints['exampleGet'] = async (ctx, input) => {
+	const response = await makeExistRequest<ExistEndpointOutputs['exampleGet']>(
+		`example/${input.id}`,
+		ctx.key,
+		{ method: 'GET' },
+	);
+
+	await logEventFromContext(
+		ctx,
+		'exist.example.get',
+		{ ...input },
+		'completed',
+	);
+	return response;
+};

--- a/packages/exist/endpoints/index.ts
+++ b/packages/exist/endpoints/index.ts
@@ -1,0 +1,7 @@
+import { get as exampleGet } from './example';
+
+export const Example = {
+	get: exampleGet,
+};
+
+export * from './types';

--- a/packages/exist/endpoints/types.ts
+++ b/packages/exist/endpoints/types.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+const ExampleGetInputSchema = z.object({
+	id: z.string(),
+});
+
+export type ExampleGetInput = z.infer<typeof ExampleGetInputSchema>;
+
+const ExampleGetResponseSchema = z.object({
+	id: z.string(),
+});
+
+export type ExampleGetResponse = z.infer<typeof ExampleGetResponseSchema>;
+
+export type ExistEndpointInputs = {
+	exampleGet: ExampleGetInput;
+};
+
+export type ExistEndpointOutputs = {
+	exampleGet: ExampleGetResponse;
+};
+
+export const ExistEndpointInputSchemas = {
+	exampleGet: ExampleGetInputSchema,
+} as const;
+
+export const ExistEndpointOutputSchemas = {
+	exampleGet: ExampleGetResponseSchema,
+} as const;

--- a/packages/exist/error-handlers.ts
+++ b/packages/exist/error-handlers.ts
@@ -1,0 +1,31 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('rate_limited') || msg.includes('429');
+		},
+		handler: async (error: Error) => {
+			let retryAfterMs: number | undefined;
+			if (error instanceof ApiError && error.retryAfter !== undefined) {
+				retryAfterMs = error.retryAfter;
+			}
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error: Error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			const msg = error.message.toLowerCase();
+			return msg.includes('unauthorized') || msg.includes('invalid_auth');
+		},
+		handler: async () => ({ maxRetries: 0 }),
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async () => ({ maxRetries: 0 }),
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/exist/index.ts
+++ b/packages/exist/index.ts
@@ -1,0 +1,203 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	BindWebhooks,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	CorsairWebhook,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+	RequiredPluginWebhookSchemas,
+} from 'corsair/core';
+import { Example } from './endpoints';
+import type {
+	ExistEndpointInputs,
+	ExistEndpointOutputs,
+} from './endpoints/types';
+import {
+	ExistEndpointInputSchemas,
+	ExistEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { ExistSchema } from './schema';
+import { ExampleWebhooks } from './webhooks';
+import { resolveExistOAuthWebhookTenantLink } from './webhooks/oauth-tenant-link';
+import { matchExistTenantWebhook } from './webhooks/tenant-matcher';
+import type { ExampleEvent, ExistWebhookOutputs } from './webhooks/types';
+import { ExampleEventSchema } from './webhooks/types';
+
+export type ExistPluginOptions = {
+	authType?: PickAuth<'api_key' | 'oauth_2'>;
+	key?: string;
+	webhookSecret?: string;
+	hooks?: InternalExistPlugin['hooks'];
+	webhookHooks?: InternalExistPlugin['webhookHooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof existEndpointsNested>;
+};
+
+export type ExistContext = CorsairPluginContext<
+	typeof ExistSchema,
+	ExistPluginOptions
+>;
+
+export type ExistKeyBuilderContext = KeyBuilderContext<ExistPluginOptions>;
+
+export type ExistBoundEndpoints = BindEndpoints<typeof existEndpointsNested>;
+
+type ExistEndpoint<K extends keyof ExistEndpointOutputs> = CorsairEndpoint<
+	ExistContext,
+	ExistEndpointInputs[K],
+	ExistEndpointOutputs[K]
+>;
+
+export type ExistEndpoints = {
+	exampleGet: ExistEndpoint<'exampleGet'>;
+};
+
+type ExistWebhook<K extends keyof ExistWebhookOutputs, TEvent> = CorsairWebhook<
+	ExistContext,
+	TEvent,
+	ExistWebhookOutputs[K]
+>;
+
+export type ExistWebhooks = {
+	example: ExistWebhook<'example', ExampleEvent>;
+};
+
+export type ExistBoundWebhooks = BindWebhooks<ExistWebhooks>;
+
+const existEndpointsNested = {
+	example: {
+		get: Example.get,
+	},
+} as const;
+
+const existWebhooksNested = {
+	example: {
+		example: ExampleWebhooks.example,
+	},
+} as const;
+
+export const existEndpointSchemas = {
+	'example.get': {
+		input: ExistEndpointInputSchemas.exampleGet,
+		output: ExistEndpointOutputSchemas.exampleGet,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<typeof existEndpointsNested>;
+
+const existWebhookSchemas = {
+	'example.example': {
+		description: 'An example webhook event',
+		payload: ExampleEventSchema,
+		response: ExampleEventSchema,
+	},
+} as const satisfies RequiredPluginWebhookSchemas<typeof existWebhooksNested>;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+const existEndpointMeta = {
+	'example.get': {
+		riskLevel: 'read',
+		description: 'Get an example resource by ID',
+	},
+} as const satisfies RequiredPluginEndpointMeta<typeof existEndpointsNested>;
+
+export const existAuthConfig = {
+	api_key: {
+		account: ['tenant_external_id'] as const,
+	},
+	oauth_2: {
+		account: ['tenant_external_id'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type BaseExistPlugin<T extends ExistPluginOptions> = CorsairPlugin<
+	'exist',
+	typeof ExistSchema,
+	typeof existEndpointsNested,
+	typeof existWebhooksNested,
+	T,
+	typeof defaultAuthType
+>;
+
+export type InternalExistPlugin = BaseExistPlugin<ExistPluginOptions>;
+
+export type ExternalExistPlugin<T extends ExistPluginOptions> =
+	BaseExistPlugin<T>;
+
+export function exist<const T extends ExistPluginOptions>(
+	incomingOptions: ExistPluginOptions & T = {} as ExistPluginOptions & T,
+): ExternalExistPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'exist',
+		authConfig: existAuthConfig,
+		schema: ExistSchema,
+		options: options,
+		hooks: options.hooks,
+		webhookHooks: options.webhookHooks,
+		endpoints: existEndpointsNested,
+		webhooks: existWebhooksNested,
+		endpointMeta: existEndpointMeta,
+		endpointSchemas: existEndpointSchemas,
+		webhookSchemas: existWebhookSchemas,
+		pluginWebhookMatcher: (request) => {
+			const headers = request.headers;
+			// TODO: Update to match your webhook signature headers
+			return 'x-exist-signature' in headers;
+		},
+		pluginTenantWebhookMatcher: matchExistTenantWebhook,
+		oauthWebhookTenantLinkResolver: resolveExistOAuthWebhookTenantLink,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: ExistKeyBuilderContext, source) => {
+			if (source === 'webhook' && options.webhookSecret) {
+				return options.webhookSecret;
+			}
+
+			if (source === 'webhook') {
+				const res = await ctx.keys.get_webhook_signature();
+				return res ?? '';
+			}
+
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys.get_api_key();
+				return res ?? '';
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'oauth_2') {
+				const res = await ctx.keys.get_access_token();
+				return res ?? '';
+			}
+
+			return '';
+		},
+	} satisfies InternalExistPlugin;
+}
+
+export type {
+	ExampleGetInput,
+	ExampleGetResponse,
+	ExistEndpointInputs,
+	ExistEndpointOutputs,
+} from './endpoints/types';
+export type {
+	ExampleEvent,
+	ExistWebhookOutputs,
+} from './webhooks/types';

--- a/packages/exist/jest.config.cjs
+++ b/packages/exist/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/exist/package.json
+++ b/packages/exist/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/exist",
+  "version": "0.1.0",
+  "description": "Exist plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "exist",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/exist/schema.test.ts
+++ b/packages/exist/schema.test.ts
@@ -1,0 +1,20 @@
+import { ExistSchema } from './schema';
+
+describe('Exist schema', () => {
+	it('declares a semver version', () => {
+		expect(ExistSchema.version).toBeDefined();
+		expect(ExistSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof ExistSchema.entities).toBe('object');
+		expect(ExistSchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(ExistSchema.entities))).toBe(true);
+		for (const entity of Object.values(ExistSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/exist/schema/database.ts
+++ b/packages/exist/schema/database.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+// TODO: Define your database entities here
+// export const ExistExample = z.object({
+// 	id: z.string(),
+// 	name: z.string(),
+// 	created_at: z.coerce.date().nullable().optional(),
+// });
+// export type ExistExample = z.infer<typeof ExistExample>;

--- a/packages/exist/schema/index.ts
+++ b/packages/exist/schema/index.ts
@@ -1,0 +1,4 @@
+export const ExistSchema = {
+	version: '1.0.0',
+	entities: {},
+} as const;

--- a/packages/exist/tsconfig.json
+++ b/packages/exist/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/exist/tsup.config.ts
+++ b/packages/exist/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/packages/exist/webhooks/example.ts
+++ b/packages/exist/webhooks/example.ts
@@ -1,0 +1,32 @@
+import { logEventFromContext } from 'corsair/core';
+import type { ExistWebhooks } from '..';
+import { createExistMatch, verifyExistWebhookSignature } from './types';
+
+export const example: ExistWebhooks['example'] = {
+	match: createExistMatch('example'),
+
+	handler: async (ctx, request) => {
+		const verification = verifyExistWebhookSignature(request, ctx.key);
+		if (!verification.valid) {
+			return {
+				success: false,
+				statusCode: 401,
+				error: verification.error || 'Signature verification failed',
+			};
+		}
+
+		const event = request.payload;
+		if (event.type !== 'example') {
+			return { success: true, data: undefined };
+		}
+
+		await logEventFromContext(
+			ctx,
+			'exist.webhook.example',
+			{ ...event },
+			'completed',
+		);
+
+		return { success: true, data: event };
+	},
+};

--- a/packages/exist/webhooks/index.ts
+++ b/packages/exist/webhooks/index.ts
@@ -1,0 +1,9 @@
+import { example } from './example';
+
+export const ExampleWebhooks = {
+	example: example,
+};
+
+export * from './oauth-tenant-link';
+export * from './tenant-matcher';
+export * from './types';

--- a/packages/exist/webhooks/oauth-tenant-link.ts
+++ b/packages/exist/webhooks/oauth-tenant-link.ts
@@ -1,0 +1,31 @@
+import type { TokenResponse, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, toExternalId } from 'corsair/core';
+
+// TODO: Rename linkType 'tenant_external_id' to match pluginTenantWebhookMatcher.
+// Called after OAuth to store the routing id on corsair_accounts.config.
+export async function resolveExistOAuthWebhookTenantLink(
+	tokens: TokenResponse,
+): Promise<WebhookTenantMatch | null> {
+	// TODO: Read from token response when the provider includes a stable id.
+	// const externalId = toExternalId(asRecord(tokens.team)?.id);
+	const externalId = toExternalId(tokens.tenant_external_id);
+	if (externalId) {
+		return { linkType: 'tenant_external_id', externalId };
+	}
+
+	const accessToken = tokens.access_token;
+	if (!accessToken) return null;
+
+	// TODO: Fetch from provider API when the token response omits the id.
+	// const response = await fetch('https://api.example.com/me', {
+	// 	headers: { Authorization: `Bearer ${accessToken}` },
+	// });
+	// if (!response.ok) return null;
+	// const payload = (await response.json()) as { id?: string };
+	// const fetchedId = toExternalId(payload.id);
+	// return fetchedId
+	// 	? { linkType: 'tenant_external_id', externalId: fetchedId }
+	// 	: null;
+
+	return null;
+}

--- a/packages/exist/webhooks/tenant-matcher.ts
+++ b/packages/exist/webhooks/tenant-matcher.ts
@@ -1,0 +1,25 @@
+import type { RawWebhookRequest, WebhookTenantMatch } from 'corsair/core';
+import { asRecord, firstString, readBodyRecord } from 'corsair/core';
+
+// TODO: Rename linkType 'tenant_external_id' to match the provider field
+// (e.g. team_id, installation_id, organization_id). Must match authConfig.account
+// and oauthWebhookTenantLinkResolver.
+// Return null for URL verification / handshake payloads that have no tenant id.
+export function matchExistTenantWebhook(
+	request: RawWebhookRequest,
+): WebhookTenantMatch | null {
+	const body = readBodyRecord(request);
+	if (!body) return null;
+
+	// TODO: Extract the stable external id from the webhook payload.
+	// Example:
+	// const externalId = firstString([body.tenant_external_id, asRecord(body.data)?.id]);
+	const externalId = firstString([
+		body.tenant_external_id,
+		asRecord(body.data)?.tenant_external_id,
+	]);
+
+	if (!externalId) return null;
+
+	return { linkType: 'tenant_external_id', externalId };
+}

--- a/packages/exist/webhooks/types.ts
+++ b/packages/exist/webhooks/types.ts
@@ -1,0 +1,62 @@
+import type {
+	CorsairWebhookMatcher,
+	RawWebhookRequest,
+	WebhookRequest,
+} from 'corsair/core';
+import { z } from 'zod';
+
+export const ExistWebhookPayloadSchema = z.object({
+	type: z.string(),
+	created_at: z.string(),
+	data: z.record(z.string(), z.unknown()),
+});
+
+export type ExistWebhookPayload = z.infer<typeof ExistWebhookPayloadSchema>;
+
+export const ExampleEventSchema = ExistWebhookPayloadSchema.extend({
+	type: z.literal('example'),
+	data: z
+		.object({
+			id: z.string(),
+		})
+		.loose(),
+});
+
+export type ExampleEvent = z.infer<typeof ExampleEventSchema>;
+
+export type ExistWebhookOutputs = {
+	example: ExampleEvent;
+};
+
+function parseBody(body: unknown): Record<string, unknown> | null {
+	if (typeof body === 'string') {
+		try {
+			const parsed = JSON.parse(body);
+			return parsed !== null &&
+				typeof parsed === 'object' &&
+				!Array.isArray(parsed)
+				? (parsed as Record<string, unknown>)
+				: null;
+		} catch {
+			return null;
+		}
+	}
+	return body !== null && typeof body === 'object' && !Array.isArray(body)
+		? (body as Record<string, unknown>)
+		: null;
+}
+
+export function createExistMatch(eventType: string): CorsairWebhookMatcher {
+	return (request: RawWebhookRequest) => {
+		const parsedBody = parseBody(request.body);
+		return parsedBody !== null && parsedBody.type === eventType;
+	};
+}
+
+export function verifyExistWebhookSignature(
+	request: WebhookRequest<ExistWebhookPayload>,
+	secret: string,
+): { valid: boolean; error?: string } {
+	// TODO: Implement webhook signature verification
+	return { valid: true };
+}


### PR DESCRIPTION
## Description

Configure the Exist API client with the correct API base URL and Bearer token authentication.

## Checklist

- [x] `pnpm typecheck` passes
- [x] Exist plugin scaffold generated
- [x] API client configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an Exist integration for authenticated API requests.
  - Added Exist as a supported provider.
  - Added an example endpoint with validated request and response data.
  - Added webhook handling for example events, including tenant matching and event logging.
  - Added configurable handling for rate-limit and authentication errors.
  - Added consistent error reporting for failed Exist API requests, including optional error codes.
  - Added package documentation and validation coverage for the initial Exist schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->