### PR TITLE
fix(mcp): sandbox run_script in node:vm with membrane proxy

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -75,6 +75,7 @@
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
     "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.14",
     "@types/node": "^22.0.0",
     "tsup": "^8.0.1",
     "typescript": "^5.8.0"

--- a/packages/mcp/src/core/tools.test.ts
+++ b/packages/mcp/src/core/tools.test.ts
@@ -1,0 +1,104 @@
+import { buildCorsairToolDefs, runScriptInSandbox } from './tools.js';
+
+describe('MCP runScriptInSandbox', () => {
+	it('executes valid JavaScript and returns output', async () => {
+		const mockCorsair = {
+			slack: {
+				api: {
+					channels: {
+						list: async () => ({
+							channels: [{ id: 'C123', name: 'general' }],
+						}),
+					},
+				},
+			},
+		};
+
+		const code = `
+			const result = await corsair.slack.api.channels.list();
+			return result.channels[0].id;
+		`;
+
+		const output = await runScriptInSandbox(code, mockCorsair);
+		expect(output).toBe('C123');
+	});
+
+	it('blocks access to host process and globals', async () => {
+		const mockCorsair = {};
+		const code = `
+			return typeof process;
+		`;
+		const output = await runScriptInSandbox(code, mockCorsair);
+		expect(output).toBe('undefined');
+	});
+
+	it('blocks prototype / constructor escape on corsair membrane', async () => {
+		const mockCorsair = {
+			echo: (val: string) => val,
+		};
+
+		const code = `
+			return corsair.constructor;
+		`;
+		const output = await runScriptInSandbox(code, mockCorsair);
+		expect(output).toBeUndefined();
+	});
+
+	it('blocks constructor on methods and returned objects', async () => {
+		const mockCorsair = {
+			getData: async () => ({ secret: '123' }),
+		};
+
+		const code = `
+			const fnConstructor = corsair.getData.constructor;
+			const data = await corsair.getData();
+			return {
+				fnConstructor: typeof fnConstructor,
+				dataConstructor: typeof data.constructor,
+			};
+		`;
+		const output = (await runScriptInSandbox(code, mockCorsair)) as {
+			fnConstructor: string;
+			dataConstructor: string;
+		};
+		expect(output.fnConstructor).toBe('undefined');
+		expect(output.dataConstructor).toBe('undefined');
+	});
+
+	it('fails when attempting eval inside the sandbox', async () => {
+		const mockCorsair = {};
+		const code = `
+			return eval('1 + 1');
+		`;
+		await expect(runScriptInSandbox(code, mockCorsair)).rejects.toThrow();
+	});
+});
+
+describe('buildCorsairToolDefs run_script handler', () => {
+	it('runs script via handler and formats result', async () => {
+		const mockCorsair = {
+			math: {
+				add: async (a: number, b: number) => a + b,
+			},
+		};
+
+		const defs = buildCorsairToolDefs({
+			corsair: mockCorsair as any,
+		});
+
+		const runScriptDef = defs.find((d) => d.name === 'run_script');
+		expect(runScriptDef).toBeDefined();
+
+		const result = await runScriptDef!.handler({
+			code: 'return await corsair.math.add(2, 3);',
+		});
+
+		const firstContent = result.content[0];
+		expect(firstContent).toBeDefined();
+		expect(firstContent?.type).toBe('text');
+		if (firstContent && 'text' in firstContent) {
+			expect(firstContent.text).toBe('5');
+		}
+	});
+});
+

--- a/packages/mcp/src/core/tools.ts
+++ b/packages/mcp/src/core/tools.ts
@@ -1,3 +1,4 @@
+import * as vm from 'node:vm';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { AnyCorsairInstance } from 'corsair';
 import { listOperations, runReadonly } from 'corsair';
@@ -21,6 +22,100 @@ export type CorsairToolDef = {
 	shape: z.ZodRawShape;
 	handler: (args: Record<string, unknown>) => Promise<CallToolResult>;
 };
+
+const BLOCKED_KEYS = new Set<PropertyKey>([
+	'constructor',
+	'prototype',
+	'__proto__',
+]);
+
+export function harden(value: unknown, thisArg?: unknown): unknown {
+	if (value === null || value === undefined) return value;
+	const type = typeof value;
+	if (type === 'function') {
+		return hardenFunction(value as (...args: unknown[]) => unknown, thisArg);
+	}
+	if (type === 'object') return hardenObject(value as object);
+	return value;
+}
+
+function hardenObject(target: object): object {
+	return new Proxy(target, {
+		get(t, key) {
+			if (BLOCKED_KEYS.has(key)) return undefined;
+			return harden(Reflect.get(t, key, t), t);
+		},
+		getPrototypeOf: () => null,
+		setPrototypeOf: () => false,
+		defineProperty: () => false,
+		set: () => false,
+		deleteProperty: () => false,
+	});
+}
+
+function hardenFunction(
+	target: (...args: unknown[]) => unknown,
+	thisArg: unknown,
+): (...args: unknown[]) => unknown {
+	return new Proxy(target, {
+		apply: (fn, _thisArg, args) =>
+			hardenResult(Reflect.apply(fn, thisArg, args)),
+		construct() {
+			throw new Error('Script execution may not construct host objects');
+		},
+		get(fn, key) {
+			if (BLOCKED_KEYS.has(key)) return undefined;
+			return harden(Reflect.get(fn, key, fn), fn);
+		},
+		getPrototypeOf: () => null,
+		setPrototypeOf: () => false,
+		defineProperty: () => false,
+		set: () => false,
+		deleteProperty: () => false,
+	});
+}
+
+function hardenResult(result: unknown): unknown {
+	if (
+		result !== null &&
+		typeof result === 'object' &&
+		typeof (result as { then?: unknown }).then === 'function'
+	) {
+		return Promise.resolve(result as Promise<unknown>).then(
+			(value) => harden(value, undefined),
+			(error) => {
+				throw harden(error, undefined);
+			},
+		);
+	}
+	return harden(result, undefined);
+}
+
+const MCP_SCRIPT_TIMEOUT_MS = 30_000;
+
+export async function runScriptInSandbox(
+	code: string,
+	corsair: unknown,
+	timeoutMs = MCP_SCRIPT_TIMEOUT_MS,
+): Promise<unknown> {
+	const sandbox = Object.create(null) as Record<string, unknown>;
+	const context = vm.createContext(sandbox, {
+		name: 'corsair-mcp-sandbox',
+		codeGeneration: { strings: false, wasm: false },
+	});
+
+	const wrappedCode = `(async function(corsair) { ${code} })`;
+	const script = new vm.Script(wrappedCode, {
+		filename: 'corsair:mcp:script',
+	});
+
+	const fn = script.runInContext(context, {
+		timeout: timeoutMs,
+	}) as (c: unknown) => Promise<unknown>;
+
+	const hardenedCorsair = harden(corsair);
+	return await fn(hardenedCorsair);
+}
 
 export function buildCorsairToolDefs(
 	options: BaseMcpOptions,
@@ -87,12 +182,8 @@ export function buildCorsairToolDefs(
 			handler: async ({ code }) => {
 				const readonly = runOptions?.readonly || false;
 				try {
-					const fn = new Function(
-						'corsair',
-						`return (async () => { ${code} })()`,
-					);
 					const invoke = () =>
-						(fn as (c: unknown) => Promise<unknown>)(corsair);
+						runScriptInSandbox(code as string, corsair);
 					// When readonly is required, run the whole script inside a readonly
 					// scope that takes precedence over the developer's permission config.
 					// Any write/destructive endpoint throws and aborts the script.
@@ -107,3 +198,4 @@ export function buildCorsairToolDefs(
 
 	return defs;
 }
+

--- a/packages/mcp/tsconfig.build.json
+++ b/packages/mcp/tsconfig.build.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "emitDeclarationOnly": true,
     "outDir": "./dist"
-  }
+  },
+  "exclude": ["src/**/*.test.ts", "dist", "node_modules"]
 }

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["esnext", "dom"],
-    "types": ["node"],
+    "types": ["node", "jest"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "outDir": "./dist",


### PR DESCRIPTION
## Description

The MCP `run_script` tool previously used `new Function()` to execute model-generated JavaScript directly in the host Node.js process. This gave LLM-generated scripts unrestricted access to `process`, `globalThis`, `require`, dynamic `import()`, and all host globals — enabling sandbox escapes such as reading `process.env` (leaking API keys), accessing the filesystem via `import('node:fs')`, or executing arbitrary commands via `import('node:child_process')`.

This is also a direct violation of the repo's own rule in `AGENTS.md`: *"Never use `eval`/`new Function()` on generated content."*

This PR replaces the unisolated `new Function()` with a hardened `node:vm` sandbox + membrane proxy, matching the existing security pattern already used in `packages/corsair/workflows/execute.ts`.

### What changed:

- **`packages/mcp/src/core/tools.ts`** — Replaced `new Function('corsair', ...)` with `runScriptInSandbox()` using `node:vm`. Added `harden()` membrane proxy (ported from `workflows/execute.ts`) that blocks `constructor`/`prototype`/`__proto__` access. Sandbox uses `vm.createContext` with `codeGeneration: { strings: false, wasm: false }`, null-prototype global, and 30s timeout.
- **`packages/mcp/src/core/tools.test.ts`** *(new)* — 6 tests covering valid execution, host global blocking, membrane constructor blocking, eval blocking, and integration through `buildCorsairToolDefs`.
- **`packages/mcp/package.json`** — Added `@types/jest` to devDependencies.
- **`packages/mcp/tsconfig.json`** — Added `jest` to types.
- **`packages/mcp/tsconfig.build.json`** — Excluded `*.test.ts` from build declarations.

Fixes #1652 

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

N/A — no UI changes. Security fix is verified by unit tests.

## Additional Notes

- **No breaking changes.** The `run_script` tool's external behavior (input/output shape, readonly mode, error formatting) is identical. The only difference is scripts now execute in an isolated VM context instead of the host scope.
- **No new dependencies.** `node:vm` is a Node.js built-in module.
- **Pattern reuse.** The membrane proxy (`harden`, `hardenObject`, `hardenFunction`, `hardenResult`) and sandbox approach are consistent with the existing implementation in `packages/corsair/workflows/execute.ts`, which already uses this pattern for Hub-delivered workflow code.
- **Aligns with AGENTS.md.** The repo's agent guide explicitly states: *"Never auto-merge; never use `eval`/`new Function()` on generated content."* This PR brings the MCP package into compliance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved `run_script` execution with an isolated sandbox that blocks access to host globals, unsafe prototype or constructor escape attempts, dynamic code generation, and unauthorized object mutations.
  * Added a 30-second execution limit to prevent scripts from running indefinitely.

* **Reliability**
  * Added automated coverage for sandbox isolation, blocked operations, script execution, and tool result formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->