### PR TITLE
feat(workable): add Workable plugin

### DIFF
--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -276,6 +276,7 @@ export const BaseProviders = [
 	'whatsapp',
 	'witai',
 	'wiza',
+	'workable',
 	'workday',
 	'workiom',
 	'worldnewsapi',
@@ -553,6 +554,7 @@ export const ProviderDisplayNames = {
 	whatsapp: 'WhatsApp',
 	witai: 'WitAi',
 	wiza: 'Wiza',
+	workable: 'Workable',
 	workday: 'Workday',
 	workiom: 'Workiom',
 	worldnewsapi: 'World News API',
@@ -837,6 +839,7 @@ export type AllProviders =
 	| 'whatsapp'
 	| 'witai'
 	| 'wiza'
+	| 'workable'
 	| 'workday'
 	| 'workiom'
 	| 'worldnewsapi'

--- a/packages/workable/client.test.ts
+++ b/packages/workable/client.test.ts
@@ -1,0 +1,115 @@
+import { WorkableAPIError } from './client';
+
+function readHeaders(init: RequestInit | undefined): Record<string, string> {
+	const raw = init?.headers;
+	if (!raw) return {};
+	if (raw instanceof Headers) return Object.fromEntries(raw.entries());
+	if (Array.isArray(raw)) return Object.fromEntries(raw);
+	return Object.fromEntries(Object.entries(raw as Record<string, string>));
+}
+
+describe('Workable client', () => {
+	const originalFetch = globalThis.fetch;
+	let calls: Array<{ url: string; init?: RequestInit }>;
+
+	beforeEach(() => {
+		calls = [];
+		globalThis.fetch = (async (url: string, init?: RequestInit) => {
+			calls.push({ url: String(url), init });
+			return new Response(JSON.stringify({ departments: [] }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}) as typeof fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	describe('credential validation', () => {
+		it('rejects a missing access token before issuing a request', async () => {
+			const { makeWorkableRequest } = await import('./client');
+			await expect(
+				makeWorkableRequest('/departments', '', 'example'),
+			).rejects.toBeInstanceOf(WorkableAPIError);
+			expect(calls).toHaveLength(0);
+		});
+
+		it('rejects a missing subdomain before issuing a request', async () => {
+			const { makeWorkableRequest } = await import('./client');
+			await expect(
+				makeWorkableRequest('/departments', 'token-123', ''),
+			).rejects.toBeInstanceOf(WorkableAPIError);
+			expect(calls).toHaveLength(0);
+		});
+
+		it.each([
+			['evil.com/', 'a slash'],
+			['host.other.com', 'a dot'],
+			['a b', 'a space'],
+		])(
+			'rejects a subdomain containing %s (%s) since it is interpolated into the hostname',
+			async (subdomain) => {
+				const { makeWorkableRequest } = await import('./client');
+				await expect(
+					makeWorkableRequest('/departments', 'token-123', subdomain),
+				).rejects.toBeInstanceOf(WorkableAPIError);
+				expect(calls).toHaveLength(0);
+			},
+		);
+
+		it('accepts a subdomain of letters, digits and hyphens', async () => {
+			const { makeWorkableRequest } = await import('./client');
+			await makeWorkableRequest('/departments', 'token-123', 'my-account-1');
+			expect(calls).toHaveLength(1);
+		});
+	});
+
+	describe('request shape', () => {
+		it('sends a Bearer token, not a query string', async () => {
+			const { makeWorkableRequest } = await import('./client');
+			await makeWorkableRequest('/departments', 'token-123', 'example');
+
+			expect(calls).toHaveLength(1);
+			const headers = readHeaders(calls[0]?.init);
+			const headerNames = Object.keys(headers).map((h) => h.toLowerCase());
+			expect(headerNames).toContain('authorization');
+			expect(headers.Authorization ?? headers.authorization).toBe(
+				'Bearer token-123',
+			);
+			expect(calls[0]?.url).not.toContain('token-123');
+		});
+
+		it('builds the subdomain-specific base URL', async () => {
+			const { makeWorkableRequest } = await import('./client');
+			await makeWorkableRequest('/departments', 'token-123', 'example');
+			expect(calls[0]?.url).toBe(
+				'https://example.workable.com/spi/v3/departments',
+			);
+		});
+	});
+
+	describe('public job-board request', () => {
+		it('sends no Authorization header and hits www.workable.com', async () => {
+			const { makeWorkablePublicRequest } = await import('./client');
+			await makeWorkablePublicRequest('example');
+			expect(calls).toHaveLength(1);
+			expect(calls[0]?.url).toBe(
+				'https://www.workable.com/api/accounts/example',
+			);
+			const headers = readHeaders(calls[0]?.init);
+			expect(Object.keys(headers).map((h) => h.toLowerCase())).not.toContain(
+				'authorization',
+			);
+		});
+
+		it('rejects a missing subdomain before issuing a request', async () => {
+			const { makeWorkablePublicRequest } = await import('./client');
+			await expect(makeWorkablePublicRequest('')).rejects.toBeInstanceOf(
+				WorkableAPIError,
+			);
+			expect(calls).toHaveLength(0);
+		});
+	});
+});

--- a/packages/workable/client.ts
+++ b/packages/workable/client.ts
@@ -1,0 +1,149 @@
+import type {
+	ApiRequestOptions,
+	OpenAPIConfig,
+	RateLimitConfig,
+} from 'corsair/http';
+import { request } from 'corsair/http';
+
+export class WorkableAPIError extends Error {
+	constructor(
+		message: string,
+		public readonly code?: string,
+	) {
+		super(message);
+		this.name = 'WorkableAPIError';
+	}
+}
+
+/**
+ * Workable hosts every account on its own subdomain, so the base URL cannot
+ * be a constant. The subdomain is the second half of the credential.
+ * @see https://workable.readme.io/reference/generate-an-access-token
+ */
+export function buildWorkableBaseUrl(subdomain: string): string {
+	return `https://${subdomain}.workable.com/spi/v3`;
+}
+
+/** Public job-board API - unauthenticated, hosted on www.workable.com rather than the tenant subdomain. */
+export const WORKABLE_PUBLIC_API_BASE = 'https://www.workable.com/api';
+
+/**
+ * Not publicly documented by Workable; retry generously on 429 and back off.
+ */
+const WORKABLE_RATE_LIMIT_CONFIG: RateLimitConfig = {
+	enabled: true,
+	maxRetries: 5,
+	initialRetryDelay: 1000,
+	backoffMultiplier: 2,
+	headerNames: {
+		retryAfter: 'Retry-After',
+	},
+};
+
+function assertCredentials(accessToken: string, subdomain: string): void {
+	if (!accessToken) {
+		throw new WorkableAPIError(
+			'An access token is required for the Workable integration',
+			'MISSING_ACCESS_TOKEN',
+		);
+	}
+	if (!subdomain) {
+		throw new WorkableAPIError(
+			'A Workable account subdomain is required - it is the subdomain of your account URL, https://<subdomain>.workable.com',
+			'MISSING_ACCOUNT',
+		);
+	}
+	if (!/^[a-zA-Z0-9-]+$/.test(subdomain)) {
+		throw new WorkableAPIError(
+			'The Workable account subdomain must contain only letters, numbers and hyphens',
+			'INVALID_ACCOUNT',
+		);
+	}
+}
+
+function buildConfig(accessToken: string, subdomain: string): OpenAPIConfig {
+	return {
+		BASE: buildWorkableBaseUrl(subdomain),
+		VERSION: 'v3',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: undefined,
+		HEADERS: {
+			'Content-Type': 'application/json',
+			Accept: 'application/json',
+			Authorization: `Bearer ${accessToken}`,
+		},
+	};
+}
+
+export async function makeWorkableRequest<T>(
+	endpoint: string,
+	accessToken: string,
+	subdomain: string,
+	options: {
+		method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+		body?: Record<string, unknown>;
+		query?: Record<string, string | number | boolean | undefined>;
+	} = {},
+): Promise<T> {
+	assertCredentials(accessToken, subdomain);
+	const { method = 'GET', body, query } = options;
+
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: endpoint,
+		body:
+			method === 'POST' || method === 'PUT' || method === 'PATCH'
+				? body
+				: undefined,
+		mediaType: 'application/json; charset=utf-8',
+		query,
+	};
+
+	return await request<T>(buildConfig(accessToken, subdomain), requestOptions, {
+		rateLimitConfig: WORKABLE_RATE_LIMIT_CONFIG,
+	});
+}
+
+/**
+ * Job-board listing for a given account subdomain. Documented as security-free
+ * in Workable's OpenAPI spec - no bearer token is sent or required.
+ * @see https://workable.readme.io/reference/jobs-1
+ */
+export async function makeWorkablePublicRequest<T>(
+	subdomain: string,
+	query?: Record<string, string | number | boolean | undefined>,
+): Promise<T> {
+	if (!subdomain) {
+		throw new WorkableAPIError(
+			'A Workable account subdomain is required to look up public jobs',
+			'MISSING_ACCOUNT',
+		);
+	}
+	if (!/^[a-zA-Z0-9-]+$/.test(subdomain)) {
+		throw new WorkableAPIError(
+			'The Workable account subdomain must contain only letters, numbers and hyphens',
+			'INVALID_ACCOUNT',
+		);
+	}
+
+	const requestOptions: ApiRequestOptions = {
+		method: 'GET',
+		url: `/accounts/${subdomain}`,
+		mediaType: 'application/json; charset=utf-8',
+		query,
+	};
+
+	return await request<T>(
+		{
+			BASE: WORKABLE_PUBLIC_API_BASE,
+			VERSION: 'v1',
+			WITH_CREDENTIALS: false,
+			CREDENTIALS: 'omit',
+			TOKEN: undefined,
+			HEADERS: { Accept: 'application/json' },
+		},
+		requestOptions,
+		{ rateLimitConfig: WORKABLE_RATE_LIMIT_CONFIG },
+	);
+}

--- a/packages/workable/endpoints.test.ts
+++ b/packages/workable/endpoints.test.ts
@@ -1,0 +1,274 @@
+import * as Accounts from './endpoints/accounts';
+import * as Candidates from './endpoints/candidates';
+import * as Departments from './endpoints/departments';
+import * as Employees from './endpoints/employees';
+import * as Jobs from './endpoints/jobs';
+import * as Members from './endpoints/members';
+import * as PublicJobs from './endpoints/public-jobs';
+import * as Reference from './endpoints/reference';
+import * as Subscriptions from './endpoints/subscriptions';
+
+jest.mock('corsair/core', () => ({
+	logEventFromContext: jest.fn().mockResolvedValue(undefined),
+	AuthMissingError: class AuthMissingError extends Error {
+		constructor(
+			public plugin: string,
+			public credential: string,
+			message?: string,
+		) {
+			super(message ?? `Missing ${credential} for ${plugin}`);
+		}
+	},
+}));
+
+type Ctx = Parameters<typeof Departments.list>[0];
+
+function makeStore() {
+	const rows = new Map<string, unknown>();
+	return {
+		rows,
+		upsertByEntityId: async (id: string, data: unknown) => {
+			rows.set(id, data);
+		},
+		deleteByEntityId: async (id: string) => {
+			rows.delete(id);
+		},
+	};
+}
+
+function makeCtx() {
+	const stores = {
+		departments: makeStore(),
+		employees: makeStore(),
+		members: makeStore(),
+		jobs: makeStore(),
+		candidates: makeStore(),
+	};
+	const ctx = {
+		key: 'test-token',
+		options: { account: 'example' },
+		keys: { get_account: async () => 'example' },
+		db: stores,
+	} as unknown as Ctx;
+	return { ctx, stores };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+	return new Response(status === 204 ? null : JSON.stringify(body), {
+		status,
+		headers: status === 204 ? {} : { 'Content-Type': 'application/json' },
+	});
+}
+
+describe('Workable endpoints', () => {
+	const originalFetch = globalThis.fetch;
+	let calls: Array<{ url: string; init?: RequestInit }>;
+
+	beforeEach(() => {
+		calls = [];
+		globalThis.fetch = (async (url: string, init?: RequestInit) => {
+			calls.push({ url: String(url), init });
+			return jsonResponse({});
+		}) as typeof fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	function respondWith(body: unknown, status = 200) {
+		globalThis.fetch = (async (url: string, init?: RequestInit) => {
+			calls.push({ url: String(url), init });
+			return jsonResponse(body, status);
+		}) as typeof fetch;
+	}
+
+	it('accounts.list / accounts.get', async () => {
+		const { ctx } = makeCtx();
+		respondWith({ accounts: [{ id: '1', subdomain: 'example' }] });
+		const list = await Accounts.list(ctx, {});
+		expect(list.accounts).toHaveLength(1);
+		expect(calls[0]?.url).toBe('https://example.workable.com/spi/v3/accounts');
+
+		respondWith({ id: '1', subdomain: 'example' });
+		const one = await Accounts.get(ctx, {});
+		expect(one.subdomain).toBe('example');
+		expect(calls.at(-1)?.url).toBe(
+			'https://example.workable.com/spi/v3/accounts/example',
+		);
+	});
+
+	it('departments: list/create/update/merge/delete round-trip through the cache', async () => {
+		const { ctx, stores } = makeCtx();
+
+		respondWith({ departments: [{ id: 'd1', name: 'Engineering' }] });
+		const listed = await Departments.list(ctx, {});
+		expect(listed.departments).toHaveLength(1);
+		expect(stores.departments.rows.get('d1')).toMatchObject({
+			name: 'Engineering',
+		});
+
+		respondWith({ id: 'd2', name: 'Sales', parent_id: null });
+		const created = await Departments.create(ctx, { name: 'Sales' });
+		expect(created.id).toBe('d2');
+		expect(calls.at(-1)?.init?.method).toBe('POST');
+
+		respondWith({ id: 'd2', name: 'Sales EU', parent_id: null });
+		const updated = await Departments.update(ctx, {
+			id: 'd2',
+			name: 'Sales EU',
+			parent_id: null,
+		});
+		expect(updated.name).toBe('Sales EU');
+		expect(calls.at(-1)?.init?.method).toBe('PUT');
+
+		respondWith({});
+		await Departments.merge(ctx, { id: 'd2', target_department_id: 'd1' });
+		expect(calls.at(-1)?.url).toContain('/departments/d2/merge');
+		expect(stores.departments.rows.has('d2')).toBe(false);
+
+		respondWith(null, 204);
+		await Departments.remove(ctx, { id: 'd1' });
+		expect(calls.at(-1)?.url).toContain('/departments/d1');
+		expect(calls.at(-1)?.init?.method).toBe('DELETE');
+	});
+
+	it('employees: list/get/create/update/uploadDocuments', async () => {
+		const { ctx } = makeCtx();
+
+		respondWith({ employees: [{ id: 'e1', firstname: 'Ada' }], totalCount: 1 });
+		const listed = await Employees.list(ctx, {});
+		expect(listed.totalCount).toBe(1);
+
+		respondWith({ id: 'e1', firstname: 'Ada' });
+		const one = await Employees.get(ctx, { id: 'e1' });
+		expect(one.id).toBe('e1');
+
+		respondWith({ id: 'e2', state: 'draft' });
+		const created = await Employees.create(ctx, {
+			state: 'draft',
+			employee: { firstname: 'Grace' },
+		});
+		expect(created.state).toBe('draft');
+		expect(calls.at(-1)?.init?.method).toBe('POST');
+
+		respondWith({ id: 'e2', state: 'published' });
+		const updated = await Employees.update(ctx, {
+			id: 'e2',
+			employee: { firstname: 'Grace' },
+		});
+		expect(updated.state).toBe('published');
+		expect(calls.at(-1)?.init?.method).toBe('PATCH');
+
+		respondWith({ success: true });
+		await Employees.uploadDocuments(ctx, {
+			id: 'e2',
+			documents: [{ url: 'https://example.com/f.pdf', name: 'contract.pdf' }],
+		});
+		expect(calls.at(-1)?.url).toContain('/employees/e2/documents');
+	});
+
+	it('members: list/invite/update/enable', async () => {
+		const { ctx } = makeCtx();
+
+		respondWith({ members: [{ id: 'm1', email: 'a@example.com' }] });
+		await Members.list(ctx, {});
+
+		respondWith({ id: 'm2', email: 'new@example.com', roles: ['ats.admin'] });
+		const invited = await Members.invite(ctx, {
+			email: 'new@example.com',
+			roles: ['ats.admin'],
+		});
+		expect(invited.id).toBe('m2');
+		expect(calls.at(-1)?.url).toContain('/members/invite');
+
+		respondWith({ id: 'm2', roles: ['ats.reviewer'] });
+		await Members.update(ctx, { id: 'm2', roles: ['ats.reviewer'] });
+		expect(calls.at(-1)?.init?.method).toBe('PUT');
+
+		respondWith(null, 204);
+		await Members.enable(ctx, { id: 'm2' });
+		expect(calls.at(-1)?.url).toContain('/members/m2/enable');
+	});
+
+	it('jobs.list and candidates.list persist into the cache', async () => {
+		const { ctx, stores } = makeCtx();
+
+		respondWith({ jobs: [{ id: 'j1', title: 'Engineer', shortcode: 'ENG1' }] });
+		const jobs = await Jobs.list(ctx, {});
+		expect(jobs.jobs?.[0]?.shortcode).toBe('ENG1');
+
+		respondWith({ candidates: [{ id: 'c1', email: 'cand@example.com' }] });
+		const candidates = await Candidates.list(ctx, {});
+		expect(candidates.candidates).toHaveLength(1);
+		expect(stores.candidates.rows.get('c1')).toBeDefined();
+	});
+
+	it('reference/config list endpoints hit the documented paths', async () => {
+		const { ctx } = makeCtx();
+		const cases: Array<[() => Promise<unknown>, string]> = [
+			[() => Reference.stagesList(ctx, {}), '/stages'],
+			[() => Reference.requisitionsList(ctx, {}), '/requisitions'],
+			[() => Reference.recruitersList(ctx, {}), '/recruiters'],
+			[() => Reference.legalEntitiesList(ctx, {}), '/legal_entities'],
+			[() => Reference.customAttributesList(ctx, {}), '/custom_attributes'],
+			[
+				() => Reference.disqualificationReasonsList(ctx, {}),
+				'/disqualification_reasons',
+			],
+			[() => Reference.permissionSetsList(ctx, {}), '/permission_sets'],
+			[() => Reference.employeeFieldsList(ctx, {}), '/employee_fields'],
+			[() => Reference.timeoffCategoriesList(ctx, {}), '/timeoff/categories'],
+			[() => Reference.timeoffBalancesList(ctx, {}), '/timeoff/balances'],
+			[() => Reference.workSchedulesList(ctx, {}), '/work_schedules'],
+			[() => Reference.eventsList(ctx, {}), '/events'],
+		];
+
+		for (const [call, expectedPath] of cases) {
+			respondWith({ items: [] });
+			await call();
+			expect(calls.at(-1)?.url).toBe(
+				`https://example.workable.com/spi/v3${expectedPath}`,
+			);
+		}
+	});
+
+	it('subscriptions: list/create/delete', async () => {
+		const { ctx } = makeCtx();
+
+		respondWith({ subscriptions: [] });
+		await Subscriptions.list(ctx, {});
+
+		respondWith({ id: 1, target: 'https://hooks.example.com' });
+		const created = await Subscriptions.create(ctx, {
+			target: 'https://hooks.example.com',
+			event: 'candidate_created',
+		});
+		expect(created.id).toBe(1);
+		expect(calls.at(-1)?.init?.method).toBe('POST');
+
+		respondWith({}, 200);
+		await Subscriptions.remove(ctx, { id: '1' });
+		expect(calls.at(-1)?.url).toContain('/subscriptions/1');
+		expect(calls.at(-1)?.init?.method).toBe('DELETE');
+	});
+
+	it('publicJobs.list hits the unauthenticated job-board API and needs no connected account', async () => {
+		const { ctx } = makeCtx();
+		respondWith({ name: 'Example Co', jobs: [] });
+		const result = await PublicJobs.list(ctx, { subdomain: 'other-co' });
+		expect(result.name).toBe('Example Co');
+		expect(calls.at(-1)?.url).toBe(
+			'https://www.workable.com/api/accounts/other-co',
+		);
+	});
+
+	it('publicJobs.list falls back to the connected account subdomain', async () => {
+		const { ctx } = makeCtx();
+		respondWith({ name: 'Example Co', jobs: [] });
+		await PublicJobs.list(ctx, {});
+		expect(calls.at(-1)?.url).toBe(
+			'https://www.workable.com/api/accounts/example',
+		);
+	});
+});

--- a/packages/workable/endpoints/accounts.ts
+++ b/packages/workable/endpoints/accounts.ts
@@ -1,0 +1,28 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeWorkableRequest } from '../client';
+import type { WorkableEndpoints } from '../index';
+import { resolveAccount } from './shared';
+import type { WorkableEndpointOutputs } from './types';
+
+export const list: WorkableEndpoints['accountsList'] = async (ctx) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['accountsList']
+	>('/accounts', ctx.key, account);
+	await logEventFromContext(ctx, 'workable.accounts.list', {}, 'completed');
+	return response;
+};
+
+export const get: WorkableEndpoints['accountsGet'] = async (ctx, input) => {
+	const account = input.subdomain ?? (await resolveAccount(ctx));
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['accountsGet']
+	>(`/accounts/${encodeURIComponent(account)}`, ctx.key, account);
+	await logEventFromContext(
+		ctx,
+		'workable.accounts.get',
+		{ subdomain: account },
+		'completed',
+	);
+	return response;
+};

--- a/packages/workable/endpoints/candidates.ts
+++ b/packages/workable/endpoints/candidates.ts
@@ -1,0 +1,38 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeWorkableRequest } from '../client';
+import type { WorkableEndpoints } from '../index';
+import { WorkableCandidate } from '../schema/database';
+import { persistRows } from './persist';
+import { compactQuery, resolveAccount } from './shared';
+import type { WorkableEndpointOutputs } from './types';
+
+export const list: WorkableEndpoints['candidatesList'] = async (ctx, input) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['candidatesList']
+	>('/candidates', ctx.key, account, {
+		query: compactQuery({
+			email: input.email,
+			shortcode: input.shortcode,
+			stage: input.stage,
+			limit: input.limit,
+			since_id: input.since_id,
+			max_id: input.max_id,
+			created_after: input.created_after,
+			updated_after: input.updated_after,
+		}),
+	});
+	await persistRows(
+		ctx.db.candidates,
+		WorkableCandidate,
+		response.candidates,
+		'candidate',
+	);
+	await logEventFromContext(
+		ctx,
+		'workable.candidates.list',
+		{ shortcode: input.shortcode, stage: input.stage },
+		'completed',
+	);
+	return response;
+};

--- a/packages/workable/endpoints/departments.ts
+++ b/packages/workable/endpoints/departments.ts
@@ -1,0 +1,119 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeWorkableRequest } from '../client';
+import type { WorkableEndpoints } from '../index';
+import { WorkableDepartment } from '../schema/database';
+import { evictRow, persistRow, persistRows } from './persist';
+import { compactBody, resolveAccount } from './shared';
+import type { WorkableEndpointOutputs } from './types';
+
+export const list: WorkableEndpoints['departmentsList'] = async (ctx) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['departmentsList']
+	>('/departments', ctx.key, account);
+	await persistRows(
+		ctx.db.departments,
+		WorkableDepartment,
+		response.departments,
+		'department',
+	);
+	await logEventFromContext(ctx, 'workable.departments.list', {}, 'completed');
+	return response;
+};
+
+export const create: WorkableEndpoints['departmentsCreate'] = async (
+	ctx,
+	input,
+) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['departmentsCreate']
+	>('/departments', ctx.key, account, {
+		method: 'POST',
+		body: compactBody({ name: input.name, parent_id: input.parent_id }),
+	});
+	await persistRow(
+		ctx.db.departments,
+		WorkableDepartment,
+		response,
+		'department',
+	);
+	await logEventFromContext(
+		ctx,
+		'workable.departments.create',
+		{ name: input.name },
+		'completed',
+	);
+	return response;
+};
+
+export const update: WorkableEndpoints['departmentsUpdate'] = async (
+	ctx,
+	input,
+) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['departmentsUpdate']
+	>('/departments', ctx.key, account, {
+		method: 'PUT',
+		body: { id: input.id, name: input.name, parent_id: input.parent_id },
+	});
+	await persistRow(
+		ctx.db.departments,
+		WorkableDepartment,
+		response,
+		'department',
+	);
+	await logEventFromContext(
+		ctx,
+		'workable.departments.update',
+		{ id: input.id },
+		'completed',
+	);
+	return response;
+};
+
+export const merge: WorkableEndpoints['departmentsMerge'] = async (
+	ctx,
+	input,
+) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['departmentsMerge']
+	>(`/departments/${encodeURIComponent(input.id)}/merge`, ctx.key, account, {
+		method: 'POST',
+		body: compactBody({
+			target_department_id: input.target_department_id,
+			force: input.force,
+		}),
+	});
+	await evictRow(ctx.db.departments, input.id, 'department');
+	await logEventFromContext(
+		ctx,
+		'workable.departments.merge',
+		{ id: input.id, target_department_id: input.target_department_id },
+		'completed',
+	);
+	return response;
+};
+
+export const remove: WorkableEndpoints['departmentsDelete'] = async (
+	ctx,
+	input,
+) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['departmentsDelete']
+	>(`/departments/${encodeURIComponent(input.id)}`, ctx.key, account, {
+		method: 'DELETE',
+		query: { force: input.force ? 'DELETE' : undefined },
+	});
+	await evictRow(ctx.db.departments, input.id, 'department');
+	await logEventFromContext(
+		ctx,
+		'workable.departments.delete',
+		{ id: input.id },
+		'completed',
+	);
+	return response ?? {};
+};

--- a/packages/workable/endpoints/employees.ts
+++ b/packages/workable/endpoints/employees.ts
@@ -1,0 +1,124 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeWorkableRequest } from '../client';
+import type { WorkableEndpoints } from '../index';
+import { WorkableEmployee } from '../schema/database';
+import { persistRow, persistRows } from './persist';
+import { compactBody, compactQuery, resolveAccount } from './shared';
+import type { WorkableEndpointOutputs } from './types';
+
+export const list: WorkableEndpoints['employeesList'] = async (ctx, input) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['employeesList']
+	>('/employees', ctx.key, account, {
+		query: compactQuery({
+			limit: input.limit,
+			offset: input.offset,
+			query: input.query,
+			order_by: input.order_by,
+			member_id: input.member_id,
+		}),
+	});
+	await persistRows(
+		ctx.db.employees,
+		WorkableEmployee,
+		response.employees,
+		'employee',
+	);
+	await logEventFromContext(
+		ctx,
+		'workable.employees.list',
+		{ limit: input.limit, offset: input.offset },
+		'completed',
+	);
+	return response;
+};
+
+export const get: WorkableEndpoints['employeesGet'] = async (ctx, input) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['employeesGet']
+	>(`/employees/${encodeURIComponent(input.id)}`, ctx.key, account, {
+		query: compactQuery({ member_id: input.member_id }),
+	});
+	await persistRow(ctx.db.employees, WorkableEmployee, response, 'employee');
+	await logEventFromContext(
+		ctx,
+		'workable.employees.get',
+		{ id: input.id },
+		'completed',
+	);
+	return response;
+};
+
+export const create: WorkableEndpoints['employeesCreate'] = async (
+	ctx,
+	input,
+) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['employeesCreate']
+	>('/employees', ctx.key, account, {
+		method: 'POST',
+		body: compactBody({
+			state: input.state,
+			member_id: input.member_id,
+			employee: input.employee,
+		}),
+	});
+	await persistRow(ctx.db.employees, WorkableEmployee, response, 'employee');
+	await logEventFromContext(
+		ctx,
+		'workable.employees.create',
+		{ state: input.state },
+		'completed',
+	);
+	return response;
+};
+
+export const update: WorkableEndpoints['employeesUpdate'] = async (
+	ctx,
+	input,
+) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['employeesUpdate']
+	>(`/employees/${encodeURIComponent(input.id)}`, ctx.key, account, {
+		method: 'PATCH',
+		body: compactBody({ member_id: input.member_id, employee: input.employee }),
+	});
+	await persistRow(ctx.db.employees, WorkableEmployee, response, 'employee');
+	await logEventFromContext(
+		ctx,
+		'workable.employees.update',
+		{ id: input.id },
+		'completed',
+	);
+	return response;
+};
+
+export const uploadDocuments: WorkableEndpoints['employeesUploadDocuments'] =
+	async (ctx, input) => {
+		const account = await resolveAccount(ctx);
+		const response = await makeWorkableRequest<
+			WorkableEndpointOutputs['employeesUploadDocuments']
+		>(
+			`/employees/${encodeURIComponent(input.id)}/documents`,
+			ctx.key,
+			account,
+			{
+				method: 'POST',
+				body: compactBody({
+					member_id: input.member_id,
+					documents: input.documents,
+				}),
+			},
+		);
+		await logEventFromContext(
+			ctx,
+			'workable.employees.upload_documents',
+			{ id: input.id, count: input.documents.length },
+			'completed',
+		);
+		return response;
+	};

--- a/packages/workable/endpoints/jobs.ts
+++ b/packages/workable/endpoints/jobs.ts
@@ -1,0 +1,32 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeWorkableRequest } from '../client';
+import type { WorkableEndpoints } from '../index';
+import { WorkableJob } from '../schema/database';
+import { persistRows } from './persist';
+import { compactQuery, resolveAccount } from './shared';
+import type { WorkableEndpointOutputs } from './types';
+
+export const list: WorkableEndpoints['jobsList'] = async (ctx, input) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['jobsList']
+	>('/jobs', ctx.key, account, {
+		query: compactQuery({
+			limit: input.limit,
+			state: input.state,
+			created_after: input.created_after,
+			updated_after: input.updated_after,
+			since_id: input.since_id,
+			max_id: input.max_id,
+			include_fields: input.include_fields,
+		}),
+	});
+	await persistRows(ctx.db.jobs, WorkableJob, response.jobs, 'job');
+	await logEventFromContext(
+		ctx,
+		'workable.jobs.list',
+		{ state: input.state },
+		'completed',
+	);
+	return response;
+};

--- a/packages/workable/endpoints/members.ts
+++ b/packages/workable/endpoints/members.ts
@@ -1,0 +1,98 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeWorkableRequest } from '../client';
+import type { WorkableEndpoints } from '../index';
+import { WorkableMember } from '../schema/database';
+import { persistRow, persistRows } from './persist';
+import { compactBody, compactQuery, resolveAccount } from './shared';
+import type { WorkableEndpointOutputs } from './types';
+
+export const list: WorkableEndpoints['membersList'] = async (ctx, input) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['membersList']
+	>('/members', ctx.key, account, {
+		query: compactQuery({
+			limit: input.limit,
+			since_id: input.since_id,
+			max_id: input.max_id,
+			role: input.role,
+			shortcode: input.shortcode,
+			email: input.email,
+			name: input.name,
+			status: input.status,
+		}),
+	});
+	await persistRows(ctx.db.members, WorkableMember, response.members, 'member');
+	await logEventFromContext(ctx, 'workable.members.list', {}, 'completed');
+	return response;
+};
+
+export const invite: WorkableEndpoints['membersInvite'] = async (
+	ctx,
+	input,
+) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['membersInvite']
+	>('/members/invite', ctx.key, account, {
+		method: 'POST',
+		body: compactBody({
+			email: input.email,
+			roles: input.roles,
+			member_id: input.member_id,
+			collaboration_rules: input.collaboration_rules,
+		}),
+	});
+	await persistRow(ctx.db.members, WorkableMember, response, 'member');
+	await logEventFromContext(
+		ctx,
+		'workable.members.invite',
+		{ email: input.email },
+		'completed',
+	);
+	return response;
+};
+
+export const update: WorkableEndpoints['membersUpdate'] = async (
+	ctx,
+	input,
+) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['membersUpdate']
+	>('/members', ctx.key, account, {
+		method: 'PUT',
+		body: compactBody({
+			id: input.id,
+			roles: input.roles,
+			collaboration_rules: input.collaboration_rules,
+		}),
+	});
+	await persistRow(ctx.db.members, WorkableMember, response, 'member');
+	await logEventFromContext(
+		ctx,
+		'workable.members.update',
+		{ id: input.id },
+		'completed',
+	);
+	return response;
+};
+
+export const enable: WorkableEndpoints['membersEnable'] = async (
+	ctx,
+	input,
+) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['membersEnable']
+	>(`/members/${encodeURIComponent(input.id)}/enable`, ctx.key, account, {
+		method: 'POST',
+	});
+	await logEventFromContext(
+		ctx,
+		'workable.members.enable',
+		{ id: input.id },
+		'completed',
+	);
+	return response ?? {};
+};

--- a/packages/workable/endpoints/persist.ts
+++ b/packages/workable/endpoints/persist.ts
@@ -1,0 +1,82 @@
+import type { z } from 'zod';
+
+/**
+ * Cache helpers for the local Workable mirror.
+ *
+ * A row is validated against its entity schema before it is written, so an
+ * unrecognised row is skipped rather than stored as something later reads
+ * cannot interpret. Writes are best-effort: a plugin call must not fail
+ * because the local mirror could not be written.
+ */
+const WRITE_CONCURRENCY = 16;
+
+type Store = {
+	upsertByEntityId(entityId: string, data: never): Promise<unknown>;
+	deleteByEntityId?(entityId: string): Promise<unknown>;
+};
+
+export async function persistRow(
+	store: Store | undefined,
+	schema: z.ZodType,
+	row: unknown,
+	entityName: string,
+): Promise<void> {
+	if (!store || row === null || row === undefined) return;
+
+	const parsed = schema.safeParse(row);
+	if (!parsed.success) {
+		console.warn(
+			`[WORKABLE] Skipped caching a ${entityName} row that did not match the entity schema: ${parsed.error.issues
+				.map((i) => `${i.path.join('.')}: ${i.message}`)
+				.join('; ')}`,
+		);
+		return;
+	}
+
+	const data = parsed.data as Record<string, unknown>;
+	const entityId = data.id;
+	if (typeof entityId !== 'string' || entityId.length === 0) {
+		console.warn(
+			`[WORKABLE] Skipped caching a ${entityName} row with no usable id`,
+		);
+		return;
+	}
+
+	try {
+		await store.upsertByEntityId(entityId, data as never);
+	} catch (error) {
+		console.warn(`[WORKABLE] Failed to cache ${entityName}:`, error);
+	}
+}
+
+export async function persistRows(
+	store: Store | undefined,
+	schema: z.ZodType,
+	rows: unknown,
+	entityName: string,
+): Promise<void> {
+	if (!store || !Array.isArray(rows) || rows.length === 0) return;
+
+	for (let i = 0; i < rows.length; i += WRITE_CONCURRENCY) {
+		const batch = rows.slice(i, i + WRITE_CONCURRENCY);
+		await Promise.all(
+			batch.map((row) => persistRow(store, schema, row, entityName)),
+		);
+	}
+}
+
+export async function evictRow(
+	store: Store | undefined,
+	entityId: string,
+	entityName: string,
+): Promise<void> {
+	if (!store?.deleteByEntityId || !entityId) return;
+	try {
+		await store.deleteByEntityId(entityId);
+	} catch (error) {
+		console.warn(
+			`[WORKABLE] Failed to evict ${entityName} ${entityId} from the cache:`,
+			error,
+		);
+	}
+}

--- a/packages/workable/endpoints/public-jobs.ts
+++ b/packages/workable/endpoints/public-jobs.ts
@@ -1,0 +1,36 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeWorkablePublicRequest } from '../client';
+import type { WorkableEndpoints } from '../index';
+import { compactQuery } from './shared';
+import type { WorkableEndpointOutputs } from './types';
+
+/**
+ * Unauthenticated job-board listing. Falls back to the connected account's
+ * subdomain when the caller doesn't name one, since a lot of callers will
+ * just want "our own" public postings - but unlike every other endpoint in
+ * this plugin, a subdomain can also be passed explicitly to look up any
+ * Workable-hosted careers page, connected or not.
+ */
+export const list: WorkableEndpoints['publicJobsList'] = async (ctx, input) => {
+	const subdomain =
+		input.subdomain ??
+		ctx.options?.account ??
+		(await ctx.keys?.get_account?.()) ??
+		'';
+	if (!subdomain) {
+		throw new Error(
+			'workable.publicJobs.list requires a subdomain, either explicitly or via a connected Workable account',
+		);
+	}
+
+	const response = await makeWorkablePublicRequest<
+		WorkableEndpointOutputs['publicJobsList']
+	>(subdomain, compactQuery({ details: input.details }));
+	await logEventFromContext(
+		ctx,
+		'workable.public_jobs.list',
+		{ subdomain },
+		'completed',
+	);
+	return response;
+};

--- a/packages/workable/endpoints/reference.ts
+++ b/packages/workable/endpoints/reference.ts
@@ -1,0 +1,205 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeWorkableRequest } from '../client';
+import type { WorkableEndpoints } from '../index';
+import { compactQuery, resolveAccount } from './shared';
+import type { WorkableEndpointOutputs } from './types';
+
+/**
+ * Read-only reference/configuration data (pipeline stages, requisitions,
+ * recruiters, legal entities, custom attributes, disqualification reasons,
+ * permission sets, employee fields, timeoff categories/balances, work
+ * schedules, scheduled events). None of these are cached locally - they're
+ * account configuration or point-in-time data, not entities this plugin
+ * creates or updates, so there's nothing to keep a local mirror in sync for.
+ */
+
+export const stagesList: WorkableEndpoints['stagesList'] = async (ctx) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['stagesList']
+	>('/stages', ctx.key, account);
+	await logEventFromContext(ctx, 'workable.stages.list', {}, 'completed');
+	return response;
+};
+
+export const requisitionsList: WorkableEndpoints['requisitionsList'] = async (
+	ctx,
+	input,
+) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['requisitionsList']
+	>('/requisitions', ctx.key, account, {
+		query: compactQuery({
+			limit: input.limit,
+			since_id: input.since_id,
+			max_id: input.max_id,
+		}),
+	});
+	await logEventFromContext(ctx, 'workable.requisitions.list', {}, 'completed');
+	return response;
+};
+
+export const recruitersList: WorkableEndpoints['recruitersList'] = async (
+	ctx,
+	input,
+) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['recruitersList']
+	>('/recruiters', ctx.key, account, {
+		query: compactQuery({ shortcode: input.shortcode }),
+	});
+	await logEventFromContext(ctx, 'workable.recruiters.list', {}, 'completed');
+	return response;
+};
+
+export const legalEntitiesList: WorkableEndpoints['legalEntitiesList'] = async (
+	ctx,
+) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['legalEntitiesList']
+	>('/legal_entities', ctx.key, account);
+	await logEventFromContext(
+		ctx,
+		'workable.legal_entities.list',
+		{},
+		'completed',
+	);
+	return response;
+};
+
+export const customAttributesList: WorkableEndpoints['customAttributesList'] =
+	async (ctx) => {
+		const account = await resolveAccount(ctx);
+		const response = await makeWorkableRequest<
+			WorkableEndpointOutputs['customAttributesList']
+		>('/custom_attributes', ctx.key, account);
+		await logEventFromContext(
+			ctx,
+			'workable.custom_attributes.list',
+			{},
+			'completed',
+		);
+		return response;
+	};
+
+export const disqualificationReasonsList: WorkableEndpoints['disqualificationReasonsList'] =
+	async (ctx) => {
+		const account = await resolveAccount(ctx);
+		const response = await makeWorkableRequest<
+			WorkableEndpointOutputs['disqualificationReasonsList']
+		>('/disqualification_reasons', ctx.key, account);
+		await logEventFromContext(
+			ctx,
+			'workable.disqualification_reasons.list',
+			{},
+			'completed',
+		);
+		return response;
+	};
+
+export const permissionSetsList: WorkableEndpoints['permissionSetsList'] =
+	async (ctx) => {
+		const account = await resolveAccount(ctx);
+		const response = await makeWorkableRequest<
+			WorkableEndpointOutputs['permissionSetsList']
+		>('/permission_sets', ctx.key, account);
+		await logEventFromContext(
+			ctx,
+			'workable.permission_sets.list',
+			{},
+			'completed',
+		);
+		return response;
+	};
+
+export const employeeFieldsList: WorkableEndpoints['employeeFieldsList'] =
+	async (ctx) => {
+		const account = await resolveAccount(ctx);
+		const response = await makeWorkableRequest<
+			WorkableEndpointOutputs['employeeFieldsList']
+		>('/employee_fields', ctx.key, account);
+		await logEventFromContext(
+			ctx,
+			'workable.employee_fields.list',
+			{},
+			'completed',
+		);
+		return response;
+	};
+
+export const timeoffCategoriesList: WorkableEndpoints['timeoffCategoriesList'] =
+	async (ctx) => {
+		const account = await resolveAccount(ctx);
+		const response = await makeWorkableRequest<
+			WorkableEndpointOutputs['timeoffCategoriesList']
+		>('/timeoff/categories', ctx.key, account);
+		await logEventFromContext(
+			ctx,
+			'workable.timeoff_categories.list',
+			{},
+			'completed',
+		);
+		return response;
+	};
+
+export const timeoffBalancesList: WorkableEndpoints['timeoffBalancesList'] =
+	async (ctx, input) => {
+		const account = await resolveAccount(ctx);
+		const response = await makeWorkableRequest<
+			WorkableEndpointOutputs['timeoffBalancesList']
+		>('/timeoff/balances', ctx.key, account, {
+			query: compactQuery({ employee_id: input.employee_id }),
+		});
+		await logEventFromContext(
+			ctx,
+			'workable.timeoff_balances.list',
+			{},
+			'completed',
+		);
+		return response;
+	};
+
+export const workSchedulesList: WorkableEndpoints['workSchedulesList'] = async (
+	ctx,
+) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['workSchedulesList']
+	>('/work_schedules', ctx.key, account);
+	await logEventFromContext(
+		ctx,
+		'workable.work_schedules.list',
+		{},
+		'completed',
+	);
+	return response;
+};
+
+export const eventsList: WorkableEndpoints['eventsList'] = async (
+	ctx,
+	input,
+) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['eventsList']
+	>('/events', ctx.key, account, {
+		query: compactQuery({
+			type: input.type,
+			limit: input.limit,
+			start_date: input.start_date,
+			end_date: input.end_date,
+			candidate_id: input.candidate_id,
+			shortcode: input.shortcode,
+			member_id: input.member_id,
+			context: input.context,
+			include_cancelled: input.include_cancelled,
+			since_id: input.since_id,
+			max_id: input.max_id,
+		}),
+	});
+	await logEventFromContext(ctx, 'workable.events.list', {}, 'completed');
+	return response;
+};

--- a/packages/workable/endpoints/shared.ts
+++ b/packages/workable/endpoints/shared.ts
@@ -1,0 +1,61 @@
+import { AuthMissingError } from 'corsair/core';
+
+/** Strips keys whose value is `undefined` so they don't get serialised as literal "undefined". */
+export function compactQuery(
+	query: Record<string, string | number | boolean | undefined>,
+): Record<string, string | number | boolean | undefined> {
+	const out: Record<string, string | number | boolean | undefined> = {};
+	for (const [key, value] of Object.entries(query)) {
+		if (value !== undefined) out[key] = value;
+	}
+	return out;
+}
+
+export function compactBody(
+	body: Record<string, unknown>,
+): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(body)) {
+		if (value !== undefined) out[key] = value;
+	}
+	return out;
+}
+
+/**
+ * Resolves the account subdomain - the second half of the Workable
+ * credential, https://<subdomain>.workable.com.
+ *
+ * Raises rather than returning an empty string so a missing subdomain
+ * surfaces as the configuration gap it is, instead of a confusing transport
+ * error against `https://.workable.com`.
+ */
+export async function resolveAccount(ctx: {
+	options?: { account?: string };
+	keys?: { get_account?: () => Promise<string | null | undefined> };
+}): Promise<string> {
+	const account =
+		ctx.options?.account ?? (await ctx.keys?.get_account?.()) ?? '';
+
+	if (!account) {
+		throw new AuthMissingError(
+			'workable',
+			'account',
+			'[auth-missing:workable:account]: a Workable account subdomain is required - it is the subdomain of your account URL, https://<subdomain>.workable.com',
+		);
+	}
+
+	return account;
+}
+
+/** Shared `limit`/`since_id`/`max_id` cursor pagination used by jobs, candidates, members, events. */
+export function buildCursorPaginationQuery(input: {
+	limit?: number;
+	since_id?: string;
+	max_id?: string;
+}): Record<string, string | number | boolean | undefined> {
+	return compactQuery({
+		limit: input.limit,
+		since_id: input.since_id,
+		max_id: input.max_id,
+	});
+}

--- a/packages/workable/endpoints/subscriptions.ts
+++ b/packages/workable/endpoints/subscriptions.ts
@@ -1,0 +1,62 @@
+import { logEventFromContext } from 'corsair/core';
+import { makeWorkableRequest } from '../client';
+import type { WorkableEndpoints } from '../index';
+import { compactBody, resolveAccount } from './shared';
+import type { WorkableEndpointOutputs } from './types';
+
+export const list: WorkableEndpoints['subscriptionsList'] = async (ctx) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['subscriptionsList']
+	>('/subscriptions', ctx.key, account);
+	await logEventFromContext(
+		ctx,
+		'workable.subscriptions.list',
+		{},
+		'completed',
+	);
+	return response;
+};
+
+export const create: WorkableEndpoints['subscriptionsCreate'] = async (
+	ctx,
+	input,
+) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['subscriptionsCreate']
+	>('/subscriptions', ctx.key, account, {
+		method: 'POST',
+		body: compactBody({
+			target: input.target,
+			event: input.event,
+			args: input.args,
+		}),
+	});
+	await logEventFromContext(
+		ctx,
+		'workable.subscriptions.create',
+		{ event: input.event, target: input.target },
+		'completed',
+	);
+	return response;
+};
+
+export const remove: WorkableEndpoints['subscriptionsDelete'] = async (
+	ctx,
+	input,
+) => {
+	const account = await resolveAccount(ctx);
+	const response = await makeWorkableRequest<
+		WorkableEndpointOutputs['subscriptionsDelete']
+	>(`/subscriptions/${encodeURIComponent(input.id)}`, ctx.key, account, {
+		method: 'DELETE',
+	});
+	await logEventFromContext(
+		ctx,
+		'workable.subscriptions.delete',
+		{ id: input.id },
+		'completed',
+	);
+	return response ?? {};
+};

--- a/packages/workable/endpoints/types.ts
+++ b/packages/workable/endpoints/types.ts
@@ -1,0 +1,304 @@
+import { z } from 'zod';
+import {
+	WorkableCandidate,
+	WorkableDepartment,
+	WorkableEmployee,
+	WorkableJob,
+	WorkableMember,
+} from '../schema/database';
+
+const EmptyInputSchema = z.object({});
+
+const NonEmptyString = z.string().trim().min(1);
+
+const MemberRoleSchema = z.enum([
+	'ats.admin',
+	'ats.simple',
+	'ats.reviewer',
+	'hris.admin',
+	'hris.employee',
+	'hris.limited',
+	'workable.superadmin',
+]);
+
+/** Generic list envelope for reference/config endpoints whose row shape Workable doesn't
+ * document in detail (custom attributes, disqualification reasons, permission sets, etc).
+ * Loose so a plugin call doesn't fail parsing when the account has custom configuration. */
+function listEnvelope(key: string) {
+	return z
+		.object({ [key]: z.array(z.record(z.string(), z.unknown())) })
+		.loose();
+}
+
+const WorkableAccount = z
+	.object({
+		id: z.string().optional(),
+		name: z.string().optional(),
+		subdomain: z.string().optional(),
+		website_url: z.string().optional(),
+	})
+	.catchall(z.unknown());
+
+const SuccessResponseSchema = z
+	.object({
+		message: z.string().optional(),
+		success: z.boolean().optional(),
+	})
+	.loose();
+
+export const WorkableEndpointInputSchemas = {
+	// accounts
+	accountsList: EmptyInputSchema,
+	accountsGet: z.object({ subdomain: NonEmptyString.optional() }),
+
+	// departments
+	departmentsList: EmptyInputSchema,
+	departmentsCreate: z.object({
+		name: NonEmptyString,
+		parent_id: z.string().nullable().optional(),
+	}),
+	departmentsUpdate: z.object({
+		id: NonEmptyString,
+		name: NonEmptyString,
+		parent_id: z.string().nullable(),
+	}),
+	departmentsMerge: z.object({
+		id: NonEmptyString,
+		target_department_id: NonEmptyString,
+		force: z.boolean().optional(),
+	}),
+	departmentsDelete: z.object({
+		id: NonEmptyString,
+		force: z.boolean().optional(),
+	}),
+
+	// employees
+	employeesList: z.object({
+		limit: z.number().int().positive().max(100).optional(),
+		offset: z.number().int().nonnegative().optional(),
+		query: z.string().optional(),
+		order_by: z.string().optional(),
+		member_id: z.string().optional(),
+	}),
+	employeesGet: z.object({
+		id: NonEmptyString,
+		member_id: z.string().optional(),
+	}),
+	employeesCreate: z.object({
+		state: z.enum(['draft', 'published']),
+		member_id: z.string().optional(),
+		employee: z.record(z.string(), z.unknown()),
+	}),
+	employeesUpdate: z.object({
+		id: NonEmptyString,
+		member_id: z.string().optional(),
+		employee: z.record(z.string(), z.unknown()),
+	}),
+	employeesUploadDocuments: z.object({
+		id: NonEmptyString,
+		member_id: z.string().optional(),
+		documents: z.array(z.object({ url: z.url(), name: NonEmptyString })).min(1),
+	}),
+
+	// employee fields
+	employeeFieldsList: EmptyInputSchema,
+
+	// members
+	membersList: z.object({
+		limit: z.number().int().positive().max(100).optional(),
+		since_id: z.string().optional(),
+		max_id: z.string().optional(),
+		role: z.string().optional(),
+		shortcode: z.string().optional(),
+		email: z.string().optional(),
+		name: z.string().optional(),
+		status: z.enum(['active', 'inactive', 'all']).optional(),
+	}),
+	membersInvite: z.object({
+		email: z.string().email(),
+		roles: z.array(MemberRoleSchema).min(1),
+		member_id: z.string().optional(),
+		collaboration_rules: z.array(z.record(z.string(), z.unknown())).optional(),
+	}),
+	membersUpdate: z.object({
+		id: NonEmptyString,
+		roles: z.array(MemberRoleSchema).min(1),
+		collaboration_rules: z.array(z.record(z.string(), z.unknown())).optional(),
+	}),
+	membersEnable: z.object({ id: NonEmptyString }),
+
+	// jobs
+	jobsList: z.object({
+		limit: z.number().int().positive().max(100).optional(),
+		state: z.enum(['draft', 'published', 'archived', 'closed']).optional(),
+		created_after: z.string().optional(),
+		updated_after: z.string().optional(),
+		since_id: z.string().optional(),
+		max_id: z.string().optional(),
+		include_fields: z.string().optional(),
+	}),
+
+	// candidates
+	candidatesList: z.object({
+		email: z.string().optional(),
+		shortcode: z.string().optional(),
+		stage: z.string().optional(),
+		limit: z.number().int().positive().max(100).optional(),
+		since_id: z.string().optional(),
+		max_id: z.string().optional(),
+		created_after: z.string().optional(),
+		updated_after: z.string().optional(),
+	}),
+
+	// stages
+	stagesList: EmptyInputSchema,
+
+	// requisitions
+	requisitionsList: z.object({
+		limit: z.number().int().positive().max(100).optional(),
+		since_id: z.string().optional(),
+		max_id: z.string().optional(),
+	}),
+
+	// recruiters
+	recruitersList: z.object({ shortcode: z.string().optional() }),
+
+	// legal entities
+	legalEntitiesList: EmptyInputSchema,
+
+	// custom attributes
+	customAttributesList: EmptyInputSchema,
+
+	// disqualification reasons
+	disqualificationReasonsList: EmptyInputSchema,
+
+	// permission sets
+	permissionSetsList: EmptyInputSchema,
+
+	// timeoff
+	timeoffCategoriesList: EmptyInputSchema,
+	timeoffBalancesList: z.object({ employee_id: z.string().optional() }),
+
+	// work schedules
+	workSchedulesList: EmptyInputSchema,
+
+	// events
+	eventsList: z.object({
+		type: z.enum(['call', 'interview', 'meeting']).optional(),
+		limit: z.number().int().positive().max(100).optional(),
+		start_date: z.string().optional(),
+		end_date: z.string().optional(),
+		candidate_id: z.string().optional(),
+		shortcode: z.string().optional(),
+		member_id: z.string().optional(),
+		context: z.enum(['user', 'team', 'all']).optional(),
+		include_cancelled: z.boolean().optional(),
+		since_id: z.string().optional(),
+		max_id: z.string().optional(),
+	}),
+
+	// subscriptions
+	subscriptionsList: EmptyInputSchema,
+	subscriptionsCreate: z.object({
+		target: z.url(),
+		event: z.enum([
+			'candidate_created',
+			'candidate_moved',
+			'employee_created',
+			'employee_updated',
+			'employee_published',
+			'onboarding_completed',
+			'timeoff_updated',
+		]),
+		args: z
+			.object({
+				account_id: z.string().optional(),
+				job_shortcode: z.string().optional(),
+				stage_slug: z.string().optional(),
+			})
+			.optional(),
+	}),
+	subscriptionsDelete: z.object({ id: NonEmptyString }),
+
+	// public (unauthenticated) job board
+	publicJobsList: z.object({
+		subdomain: NonEmptyString.optional(),
+		details: z.boolean().optional(),
+	}),
+} as const;
+
+export const WorkableEndpointOutputSchemas = {
+	accountsList: z.object({ accounts: z.array(WorkableAccount) }).loose(),
+	accountsGet: WorkableAccount,
+
+	departmentsList: z
+		.object({ departments: z.array(WorkableDepartment) })
+		.loose(),
+	departmentsCreate: WorkableDepartment,
+	departmentsUpdate: WorkableDepartment,
+	departmentsMerge: SuccessResponseSchema,
+	departmentsDelete: SuccessResponseSchema,
+
+	employeesList: z
+		.object({
+			employees: z.array(WorkableEmployee),
+			totalCount: z.number().optional(),
+		})
+		.loose(),
+	employeesGet: WorkableEmployee,
+	employeesCreate: WorkableEmployee,
+	employeesUpdate: WorkableEmployee,
+	employeesUploadDocuments: SuccessResponseSchema,
+
+	employeeFieldsList: listEnvelope('employee_fields'),
+
+	membersList: z.object({ members: z.array(WorkableMember) }).loose(),
+	membersInvite: WorkableMember,
+	membersUpdate: WorkableMember,
+	membersEnable: SuccessResponseSchema,
+
+	jobsList: z.object({ jobs: z.array(WorkableJob) }).loose(),
+
+	candidatesList: z
+		.object({
+			candidates: z.array(WorkableCandidate),
+			paging: z.record(z.string(), z.unknown()).optional(),
+		})
+		.loose(),
+
+	stagesList: listEnvelope('stages'),
+	requisitionsList: listEnvelope('requisitions'),
+	recruitersList: listEnvelope('recruiters'),
+	legalEntitiesList: listEnvelope('legal_entities'),
+	customAttributesList: listEnvelope('custom_attributes'),
+	disqualificationReasonsList: listEnvelope('disqualification_reasons'),
+	permissionSetsList: listEnvelope('permission_sets'),
+	timeoffCategoriesList: listEnvelope('categories'),
+	timeoffBalancesList: listEnvelope('balances'),
+	workSchedulesList: listEnvelope('work_schedules'),
+	eventsList: listEnvelope('events'),
+
+	subscriptionsList: listEnvelope('subscriptions'),
+	subscriptionsCreate: z.record(z.string(), z.unknown()),
+	subscriptionsDelete: SuccessResponseSchema,
+
+	publicJobsList: z
+		.object({
+			name: z.string().optional(),
+			description: z.string().optional(),
+			jobs: z.array(z.record(z.string(), z.unknown())).optional(),
+		})
+		.loose(),
+} as const;
+
+export type WorkableEndpointInputs = {
+	[K in keyof typeof WorkableEndpointInputSchemas]: z.infer<
+		(typeof WorkableEndpointInputSchemas)[K]
+	>;
+};
+
+export type WorkableEndpointOutputs = {
+	[K in keyof typeof WorkableEndpointOutputSchemas]: z.infer<
+		(typeof WorkableEndpointOutputSchemas)[K]
+	>;
+};

--- a/packages/workable/error-handlers.ts
+++ b/packages/workable/error-handlers.ts
@@ -1,0 +1,138 @@
+import type { CorsairErrorHandler } from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
+import { ApiError } from 'corsair/http';
+
+/**
+ * Corsair replays the whole endpoint call on retry. Workable has no
+ * idempotency-key header, so a transport failure on a write cannot be told
+ * apart from "the write already landed" - these are never retried after one.
+ */
+export const NON_IDEMPOTENT_OPERATIONS: ReadonlySet<string> = new Set([
+	'departmentsCreate',
+	'departmentsUpdate',
+	'departmentsMerge',
+	'departmentsDelete',
+	'employeesCreate',
+	'employeesUpdate',
+	'employeesUploadDocuments',
+	'membersInvite',
+	'membersUpdate',
+	'membersEnable',
+	'subscriptionsCreate',
+	'subscriptionsDelete',
+]);
+
+function isNonIdempotent(operation: string): boolean {
+	return NON_IDEMPOTENT_OPERATIONS.has(operation);
+}
+
+export const errorHandlers = {
+	CONFIGURATION_ERROR: {
+		match: (error) => {
+			if (error instanceof AuthMissingError) return true;
+			const code = (error as { code?: string }).code;
+			return (
+				code === 'MISSING_ACCESS_TOKEN' ||
+				code === 'MISSING_ACCOUNT' ||
+				code === 'INVALID_ACCOUNT'
+			);
+		},
+		handler: async (error, context) => {
+			console.error(
+				`[WORKABLE:${context.operation}] Configuration error: ${error.message}`,
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	/** Not publicly documented by Workable; retry generously on 429. */
+	RATE_LIMIT_ERROR: {
+		match: (error) => {
+			if (error instanceof ApiError && error.status === 429) return true;
+			const message = error.message.toLowerCase();
+			return (
+				message.includes('too many requests') || message.includes('rate limit')
+			);
+		},
+		handler: async (error) => {
+			const retryAfterMs =
+				error instanceof ApiError ? error.retryAfter : undefined;
+			return { maxRetries: 5, headersRetryAfterMs: retryAfterMs };
+		},
+	},
+	AUTH_ERROR: {
+		match: (error) => {
+			if (error instanceof ApiError && error.status === 401) return true;
+			return error.message.toLowerCase().includes('unauthorized');
+		},
+		handler: async (error, context) => {
+			console.warn(
+				`[WORKABLE:${context.operation}] Authentication failed - check the access token generated under Settings > Integrations`,
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	PERMISSION_ERROR: {
+		match: (error) => error instanceof ApiError && error.status === 403,
+		handler: async (error, context) => {
+			console.warn(
+				`[WORKABLE:${context.operation}] Permission denied - the access token is likely missing a required scope: ${error.message}`,
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	NOT_FOUND_ERROR: {
+		match: (error) => error instanceof ApiError && error.status === 404,
+		handler: async (error, context) => {
+			console.warn(
+				`[WORKABLE:${context.operation}] Resource not found: ${error.message}`,
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	VALIDATION_ERROR: {
+		match: (error) =>
+			error instanceof ApiError &&
+			(error.status === 400 || error.status === 422),
+		handler: async (error, context) => {
+			console.warn(
+				`[WORKABLE:${context.operation}] Invalid request: ${error.message}`,
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	NETWORK_ERROR: {
+		match: (error) => {
+			const message = error.message.toLowerCase();
+			return (
+				message.includes('network') ||
+				message.includes('connection') ||
+				message.includes('econnrefused') ||
+				message.includes('enotfound') ||
+				message.includes('etimedout') ||
+				message.includes('fetch failed') ||
+				message.includes('aborted')
+			);
+		},
+		handler: async (error, context) => {
+			if (isNonIdempotent(context.operation)) {
+				console.warn(
+					`[WORKABLE:${context.operation}] Network error on a write operation - not retried, since Workable offers no idempotency key: ${error.message}`,
+				);
+				return { maxRetries: 0 };
+			}
+			console.warn(
+				`[WORKABLE:${context.operation}] Network error: ${error.message}`,
+			);
+			return { maxRetries: 3 };
+		},
+	},
+	DEFAULT: {
+		match: () => true,
+		handler: async (error, context) => {
+			console.error(
+				`[WORKABLE:${context.operation}] Unhandled error: ${error.message}`,
+			);
+			return { maxRetries: 0 };
+		},
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/workable/index.ts
+++ b/packages/workable/index.ts
@@ -1,0 +1,498 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	CorsairEndpoint,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+	RequiredPluginEndpointSchemas,
+} from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
+import * as Accounts from './endpoints/accounts';
+import * as Candidates from './endpoints/candidates';
+import * as Departments from './endpoints/departments';
+import * as Employees from './endpoints/employees';
+import * as Jobs from './endpoints/jobs';
+import * as Members from './endpoints/members';
+import * as PublicJobs from './endpoints/public-jobs';
+import * as Reference from './endpoints/reference';
+import * as Subscriptions from './endpoints/subscriptions';
+import type {
+	WorkableEndpointInputs,
+	WorkableEndpointOutputs,
+} from './endpoints/types';
+import {
+	WorkableEndpointInputSchemas,
+	WorkableEndpointOutputSchemas,
+} from './endpoints/types';
+import { errorHandlers } from './error-handlers';
+import { WorkableSchema } from './schema';
+
+/**
+ * Workable's public API is bearer-token only - there is no OAuth 2.0
+ * authorize/token flow (tokens are generated manually under Settings >
+ * Integrations, scoped to a subdomain). `api_key` is therefore the only
+ * authType this plugin supports; see the integration issue (#1660) for the
+ * corsair.dev/oss listing correction.
+ */
+export type WorkablePluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	/**
+	 * The account subdomain - the first segment of
+	 * `https://<subdomain>.workable.com`. Workable hosts every account on its
+	 * own subdomain and it cannot be derived from the access token, so it is
+	 * required alongside it, the same way ActiveCampaign's account slug is.
+	 */
+	account?: string;
+	hooks?: InternalWorkablePlugin['hooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof workableEndpointsNested>;
+};
+
+/**
+ * Declaring `account: ['account']` generates `ctx.keys.get_account()`, which
+ * is how the subdomain half of the credential reaches an endpoint when it is
+ * not passed as a plugin option.
+ */
+export const workableAuthConfig = {
+	api_key: {
+		account: ['account'] as const,
+	},
+} as const satisfies PluginAuthConfig;
+
+export type WorkableContext = CorsairPluginContext<
+	typeof WorkableSchema,
+	WorkablePluginOptions,
+	undefined,
+	typeof workableAuthConfig
+>;
+
+export type WorkableKeyBuilderContext = KeyBuilderContext<
+	WorkablePluginOptions,
+	typeof workableAuthConfig
+>;
+
+export type WorkableBoundEndpoints = BindEndpoints<
+	typeof workableEndpointsNested
+>;
+
+type WorkableEndpoint<K extends keyof WorkableEndpointOutputs> =
+	CorsairEndpoint<
+		WorkableContext,
+		WorkableEndpointInputs[K],
+		WorkableEndpointOutputs[K]
+	>;
+
+export type WorkableEndpoints = {
+	accountsList: WorkableEndpoint<'accountsList'>;
+	accountsGet: WorkableEndpoint<'accountsGet'>;
+	departmentsList: WorkableEndpoint<'departmentsList'>;
+	departmentsCreate: WorkableEndpoint<'departmentsCreate'>;
+	departmentsUpdate: WorkableEndpoint<'departmentsUpdate'>;
+	departmentsMerge: WorkableEndpoint<'departmentsMerge'>;
+	departmentsDelete: WorkableEndpoint<'departmentsDelete'>;
+	employeesList: WorkableEndpoint<'employeesList'>;
+	employeesGet: WorkableEndpoint<'employeesGet'>;
+	employeesCreate: WorkableEndpoint<'employeesCreate'>;
+	employeesUpdate: WorkableEndpoint<'employeesUpdate'>;
+	employeesUploadDocuments: WorkableEndpoint<'employeesUploadDocuments'>;
+	employeeFieldsList: WorkableEndpoint<'employeeFieldsList'>;
+	membersList: WorkableEndpoint<'membersList'>;
+	membersInvite: WorkableEndpoint<'membersInvite'>;
+	membersUpdate: WorkableEndpoint<'membersUpdate'>;
+	membersEnable: WorkableEndpoint<'membersEnable'>;
+	jobsList: WorkableEndpoint<'jobsList'>;
+	candidatesList: WorkableEndpoint<'candidatesList'>;
+	stagesList: WorkableEndpoint<'stagesList'>;
+	requisitionsList: WorkableEndpoint<'requisitionsList'>;
+	recruitersList: WorkableEndpoint<'recruitersList'>;
+	legalEntitiesList: WorkableEndpoint<'legalEntitiesList'>;
+	customAttributesList: WorkableEndpoint<'customAttributesList'>;
+	disqualificationReasonsList: WorkableEndpoint<'disqualificationReasonsList'>;
+	permissionSetsList: WorkableEndpoint<'permissionSetsList'>;
+	timeoffCategoriesList: WorkableEndpoint<'timeoffCategoriesList'>;
+	timeoffBalancesList: WorkableEndpoint<'timeoffBalancesList'>;
+	workSchedulesList: WorkableEndpoint<'workSchedulesList'>;
+	eventsList: WorkableEndpoint<'eventsList'>;
+	subscriptionsList: WorkableEndpoint<'subscriptionsList'>;
+	subscriptionsCreate: WorkableEndpoint<'subscriptionsCreate'>;
+	subscriptionsDelete: WorkableEndpoint<'subscriptionsDelete'>;
+	publicJobsList: WorkableEndpoint<'publicJobsList'>;
+};
+
+const workableEndpointsNested = {
+	accounts: { list: Accounts.list, get: Accounts.get },
+	departments: {
+		list: Departments.list,
+		create: Departments.create,
+		update: Departments.update,
+		merge: Departments.merge,
+		delete: Departments.remove,
+	},
+	employees: {
+		list: Employees.list,
+		get: Employees.get,
+		create: Employees.create,
+		update: Employees.update,
+		uploadDocuments: Employees.uploadDocuments,
+	},
+	employeeFields: { list: Reference.employeeFieldsList },
+	members: {
+		list: Members.list,
+		invite: Members.invite,
+		update: Members.update,
+		enable: Members.enable,
+	},
+	jobs: { list: Jobs.list },
+	candidates: { list: Candidates.list },
+	stages: { list: Reference.stagesList },
+	requisitions: { list: Reference.requisitionsList },
+	recruiters: { list: Reference.recruitersList },
+	legalEntities: { list: Reference.legalEntitiesList },
+	customAttributes: { list: Reference.customAttributesList },
+	disqualificationReasons: { list: Reference.disqualificationReasonsList },
+	permissionSets: { list: Reference.permissionSetsList },
+	timeoffCategories: { list: Reference.timeoffCategoriesList },
+	timeoffBalances: { list: Reference.timeoffBalancesList },
+	workSchedules: { list: Reference.workSchedulesList },
+	events: { list: Reference.eventsList },
+	subscriptions: {
+		list: Subscriptions.list,
+		create: Subscriptions.create,
+		delete: Subscriptions.remove,
+	},
+	publicJobs: { list: PublicJobs.list },
+} as const;
+
+const workableEndpointSchemas = {
+	'accounts.list': {
+		input: WorkableEndpointInputSchemas.accountsList,
+		output: WorkableEndpointOutputSchemas.accountsList,
+	},
+	'accounts.get': {
+		input: WorkableEndpointInputSchemas.accountsGet,
+		output: WorkableEndpointOutputSchemas.accountsGet,
+	},
+	'departments.list': {
+		input: WorkableEndpointInputSchemas.departmentsList,
+		output: WorkableEndpointOutputSchemas.departmentsList,
+	},
+	'departments.create': {
+		input: WorkableEndpointInputSchemas.departmentsCreate,
+		output: WorkableEndpointOutputSchemas.departmentsCreate,
+	},
+	'departments.update': {
+		input: WorkableEndpointInputSchemas.departmentsUpdate,
+		output: WorkableEndpointOutputSchemas.departmentsUpdate,
+	},
+	'departments.merge': {
+		input: WorkableEndpointInputSchemas.departmentsMerge,
+		output: WorkableEndpointOutputSchemas.departmentsMerge,
+	},
+	'departments.delete': {
+		input: WorkableEndpointInputSchemas.departmentsDelete,
+		output: WorkableEndpointOutputSchemas.departmentsDelete,
+	},
+	'employees.list': {
+		input: WorkableEndpointInputSchemas.employeesList,
+		output: WorkableEndpointOutputSchemas.employeesList,
+	},
+	'employees.get': {
+		input: WorkableEndpointInputSchemas.employeesGet,
+		output: WorkableEndpointOutputSchemas.employeesGet,
+	},
+	'employees.create': {
+		input: WorkableEndpointInputSchemas.employeesCreate,
+		output: WorkableEndpointOutputSchemas.employeesCreate,
+	},
+	'employees.update': {
+		input: WorkableEndpointInputSchemas.employeesUpdate,
+		output: WorkableEndpointOutputSchemas.employeesUpdate,
+	},
+	'employees.uploadDocuments': {
+		input: WorkableEndpointInputSchemas.employeesUploadDocuments,
+		output: WorkableEndpointOutputSchemas.employeesUploadDocuments,
+	},
+	'employeeFields.list': {
+		input: WorkableEndpointInputSchemas.employeeFieldsList,
+		output: WorkableEndpointOutputSchemas.employeeFieldsList,
+	},
+	'members.list': {
+		input: WorkableEndpointInputSchemas.membersList,
+		output: WorkableEndpointOutputSchemas.membersList,
+	},
+	'members.invite': {
+		input: WorkableEndpointInputSchemas.membersInvite,
+		output: WorkableEndpointOutputSchemas.membersInvite,
+	},
+	'members.update': {
+		input: WorkableEndpointInputSchemas.membersUpdate,
+		output: WorkableEndpointOutputSchemas.membersUpdate,
+	},
+	'members.enable': {
+		input: WorkableEndpointInputSchemas.membersEnable,
+		output: WorkableEndpointOutputSchemas.membersEnable,
+	},
+	'jobs.list': {
+		input: WorkableEndpointInputSchemas.jobsList,
+		output: WorkableEndpointOutputSchemas.jobsList,
+	},
+	'candidates.list': {
+		input: WorkableEndpointInputSchemas.candidatesList,
+		output: WorkableEndpointOutputSchemas.candidatesList,
+	},
+	'stages.list': {
+		input: WorkableEndpointInputSchemas.stagesList,
+		output: WorkableEndpointOutputSchemas.stagesList,
+	},
+	'requisitions.list': {
+		input: WorkableEndpointInputSchemas.requisitionsList,
+		output: WorkableEndpointOutputSchemas.requisitionsList,
+	},
+	'recruiters.list': {
+		input: WorkableEndpointInputSchemas.recruitersList,
+		output: WorkableEndpointOutputSchemas.recruitersList,
+	},
+	'legalEntities.list': {
+		input: WorkableEndpointInputSchemas.legalEntitiesList,
+		output: WorkableEndpointOutputSchemas.legalEntitiesList,
+	},
+	'customAttributes.list': {
+		input: WorkableEndpointInputSchemas.customAttributesList,
+		output: WorkableEndpointOutputSchemas.customAttributesList,
+	},
+	'disqualificationReasons.list': {
+		input: WorkableEndpointInputSchemas.disqualificationReasonsList,
+		output: WorkableEndpointOutputSchemas.disqualificationReasonsList,
+	},
+	'permissionSets.list': {
+		input: WorkableEndpointInputSchemas.permissionSetsList,
+		output: WorkableEndpointOutputSchemas.permissionSetsList,
+	},
+	'timeoffCategories.list': {
+		input: WorkableEndpointInputSchemas.timeoffCategoriesList,
+		output: WorkableEndpointOutputSchemas.timeoffCategoriesList,
+	},
+	'timeoffBalances.list': {
+		input: WorkableEndpointInputSchemas.timeoffBalancesList,
+		output: WorkableEndpointOutputSchemas.timeoffBalancesList,
+	},
+	'workSchedules.list': {
+		input: WorkableEndpointInputSchemas.workSchedulesList,
+		output: WorkableEndpointOutputSchemas.workSchedulesList,
+	},
+	'events.list': {
+		input: WorkableEndpointInputSchemas.eventsList,
+		output: WorkableEndpointOutputSchemas.eventsList,
+	},
+	'subscriptions.list': {
+		input: WorkableEndpointInputSchemas.subscriptionsList,
+		output: WorkableEndpointOutputSchemas.subscriptionsList,
+	},
+	'subscriptions.create': {
+		input: WorkableEndpointInputSchemas.subscriptionsCreate,
+		output: WorkableEndpointOutputSchemas.subscriptionsCreate,
+	},
+	'subscriptions.delete': {
+		input: WorkableEndpointInputSchemas.subscriptionsDelete,
+		output: WorkableEndpointOutputSchemas.subscriptionsDelete,
+	},
+	'publicJobs.list': {
+		input: WorkableEndpointInputSchemas.publicJobsList,
+		output: WorkableEndpointOutputSchemas.publicJobsList,
+	},
+} as const satisfies RequiredPluginEndpointSchemas<
+	typeof workableEndpointsNested
+>;
+
+const workableEndpointMeta = {
+	'accounts.list': {
+		riskLevel: 'read',
+		description:
+			'List all Workable accounts accessible to the authenticated token',
+	},
+	'accounts.get': {
+		riskLevel: 'read',
+		description: 'Get account metadata by subdomain',
+	},
+	'departments.list': {
+		riskLevel: 'read',
+		description: 'List all departments',
+	},
+	'departments.create': {
+		riskLevel: 'write',
+		description: 'Create a department',
+	},
+	'departments.update': {
+		riskLevel: 'write',
+		description: "Update a department's name or parent",
+	},
+	'departments.merge': {
+		riskLevel: 'write',
+		description: 'Merge a department into another department',
+	},
+	'departments.delete': {
+		riskLevel: 'destructive',
+		description: 'Delete a department',
+	},
+	'employees.list': { riskLevel: 'read', description: 'List/search employees' },
+	'employees.get': {
+		riskLevel: 'read',
+		description: 'Get a specific employee by ID',
+	},
+	'employees.create': {
+		riskLevel: 'write',
+		description: 'Create an employee in draft or published state',
+	},
+	'employees.update': {
+		riskLevel: 'write',
+		description: "Update an employee's details",
+	},
+	'employees.uploadDocuments': {
+		riskLevel: 'write',
+		description: 'Upload documents for an employee',
+	},
+	'employeeFields.list': {
+		riskLevel: 'read',
+		description: 'List employee field definitions',
+	},
+	'members.list': { riskLevel: 'read', description: 'List account members' },
+	'members.invite': {
+		riskLevel: 'write',
+		description: 'Invite a new member by email',
+	},
+	'members.update': {
+		riskLevel: 'write',
+		description: "Update a member's roles or collaboration rules",
+	},
+	'members.enable': {
+		riskLevel: 'write',
+		description: 'Reactivate a deactivated member',
+	},
+	'jobs.list': { riskLevel: 'read', description: 'List jobs' },
+	'candidates.list': {
+		riskLevel: 'read',
+		description: 'List candidates across all jobs',
+	},
+	'stages.list': {
+		riskLevel: 'read',
+		description: 'List recruitment pipeline stages',
+	},
+	'requisitions.list': { riskLevel: 'read', description: 'List requisitions' },
+	'recruiters.list': {
+		riskLevel: 'read',
+		description: 'List external recruiters',
+	},
+	'legalEntities.list': {
+		riskLevel: 'read',
+		description: 'List account legal entities',
+	},
+	'customAttributes.list': {
+		riskLevel: 'read',
+		description: 'List custom attributes configured on the account',
+	},
+	'disqualificationReasons.list': {
+		riskLevel: 'read',
+		description: 'List disqualification reasons',
+	},
+	'permissionSets.list': {
+		riskLevel: 'read',
+		description: 'List permission sets',
+	},
+	'timeoffCategories.list': {
+		riskLevel: 'read',
+		description: 'List time-off categories',
+	},
+	'timeoffBalances.list': {
+		riskLevel: 'read',
+		description: 'List employee time-off balances',
+	},
+	'workSchedules.list': {
+		riskLevel: 'read',
+		description: 'List work schedules',
+	},
+	'events.list': { riskLevel: 'read', description: 'List scheduled events' },
+	'subscriptions.list': {
+		riskLevel: 'read',
+		description: 'List webhook subscriptions',
+	},
+	'subscriptions.create': {
+		riskLevel: 'write',
+		description: 'Subscribe to a candidate or employee webhook event',
+	},
+	'subscriptions.delete': {
+		riskLevel: 'destructive',
+		description: 'Delete a webhook subscription',
+	},
+	'publicJobs.list': {
+		riskLevel: 'read',
+		description:
+			"List an account's public job postings (no authentication required)",
+	},
+} as const satisfies RequiredPluginEndpointMeta<typeof workableEndpointsNested>;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+export type BaseWorkablePlugin<T extends WorkablePluginOptions> = CorsairPlugin<
+	'workable',
+	typeof WorkableSchema,
+	typeof workableEndpointsNested,
+	Record<string, never>,
+	T,
+	typeof defaultAuthType,
+	typeof workableAuthConfig
+>;
+
+export type InternalWorkablePlugin = BaseWorkablePlugin<WorkablePluginOptions>;
+export type ExternalWorkablePlugin<T extends WorkablePluginOptions> =
+	BaseWorkablePlugin<T>;
+
+export function workable<const T extends WorkablePluginOptions>(
+	incomingOptions: WorkablePluginOptions & T = {} as WorkablePluginOptions & T,
+): ExternalWorkablePlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+
+	return {
+		id: 'workable',
+		authConfig: workableAuthConfig,
+		schema: WorkableSchema,
+		options,
+		hooks: options.hooks,
+		webhookHooks: undefined,
+		endpoints: workableEndpointsNested,
+		webhooks: {},
+		endpointMeta: workableEndpointMeta,
+		endpointSchemas: workableEndpointSchemas,
+		webhookSchemas: {},
+		pluginWebhookMatcher: undefined,
+		pluginTenantWebhookMatcher: undefined,
+		oauthWebhookTenantLinkResolver: undefined,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: WorkableKeyBuilderContext, source) => {
+			if (source === 'endpoint' && options.key) return options.key;
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const key = (await ctx.keys.get_api_key()) ?? '';
+				if (!key) throw new AuthMissingError('workable', 'api_key');
+				return key;
+			}
+			throw new AuthMissingError('workable', 'api_key');
+		},
+	} satisfies InternalWorkablePlugin;
+}
+
+export type {
+	WorkableEndpointInputs,
+	WorkableEndpointOutputs,
+} from './endpoints/types';

--- a/packages/workable/jest.config.cjs
+++ b/packages/workable/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/workable/package.json
+++ b/packages/workable/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/workable",
+  "version": "0.1.0",
+  "description": "Workable plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "workable",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/workable/schema.test.ts
+++ b/packages/workable/schema.test.ts
@@ -1,0 +1,20 @@
+import { WorkableSchema } from './schema';
+
+describe('Workable schema', () => {
+	it('declares a semver version', () => {
+		expect(WorkableSchema.version).toBeDefined();
+		expect(WorkableSchema.version).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it('declares an entities map', () => {
+		expect(typeof WorkableSchema.entities).toBe('object');
+		expect(WorkableSchema.entities).not.toBeNull();
+		expect(Array.isArray(Object.keys(WorkableSchema.entities))).toBe(true);
+		for (const entity of Object.values(WorkableSchema.entities)) {
+			expect(entity).toBeDefined();
+		}
+	});
+});
+
+// Per .github/PLUGIN_PR_RULES.md (R2), every implemented endpoint
+// needs a corresponding test.

--- a/packages/workable/schema/database.ts
+++ b/packages/workable/schema/database.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod';
+
+/**
+ * Workable SPI v3 entity shapes for Corsair DB cache (`ctx.db.*`).
+ * Loose + catchall - Workable's account-configured custom fields mean
+ * responses carry tenant-specific extras beyond what's documented.
+ */
+
+/** GET /departments, POST /departments, PUT /departments. */
+export const WorkableDepartment = z
+	.object({
+		id: z.string().optional(),
+		name: z.string().optional(),
+		parent_id: z.string().nullable().optional(),
+	})
+	.catchall(z.unknown());
+export type WorkableDepartment = z.infer<typeof WorkableDepartment>;
+
+/** GET /employees, GET /employees/:id, POST /employees, PATCH /employees/:id. */
+export const WorkableEmployee = z
+	.object({
+		id: z.string().optional(),
+		firstname: z.string().optional(),
+		lastname: z.string().optional(),
+		email: z.string().optional(),
+		state: z.enum(['draft', 'published']).optional(),
+		job_title: z.string().optional(),
+		department_id: z.string().nullable().optional(),
+		manager_id: z.string().nullable().optional(),
+	})
+	.catchall(z.unknown());
+export type WorkableEmployee = z.infer<typeof WorkableEmployee>;
+
+/** GET /members, PUT /members, POST /members/invite. */
+export const WorkableMember = z
+	.object({
+		id: z.string().optional(),
+		name: z.string().optional(),
+		headline: z.string().optional(),
+		email: z.string().optional(),
+		roles: z.array(z.string()).optional(),
+		active: z.boolean().optional(),
+		collaboration_rules: z.array(z.unknown()).optional(),
+	})
+	.catchall(z.unknown());
+export type WorkableMember = z.infer<typeof WorkableMember>;
+
+/** GET /jobs. */
+export const WorkableJob = z
+	.object({
+		id: z.string().optional(),
+		title: z.string().optional(),
+		shortcode: z.string().optional(),
+		state: z.enum(['draft', 'published', 'closed', 'archived']).optional(),
+		department: z.string().nullable().optional(),
+		url: z.string().optional(),
+		created_at: z.coerce.date().optional(),
+		updated_at: z.coerce.date().optional(),
+	})
+	.catchall(z.unknown());
+export type WorkableJob = z.infer<typeof WorkableJob>;
+
+/** GET /candidates. */
+export const WorkableCandidate = z
+	.object({
+		id: z.string().optional(),
+		name: z.string().optional(),
+		firstname: z.string().optional(),
+		lastname: z.string().optional(),
+		email: z.string().optional(),
+		job: z
+			.object({
+				shortcode: z.string().optional(),
+				title: z.string().optional(),
+			})
+			.catchall(z.unknown())
+			.optional(),
+		stage: z.string().optional(),
+		disqualified: z.boolean().optional(),
+		created_at: z.coerce.date().optional(),
+		updated_at: z.coerce.date().optional(),
+	})
+	.catchall(z.unknown());
+export type WorkableCandidate = z.infer<typeof WorkableCandidate>;

--- a/packages/workable/schema/index.ts
+++ b/packages/workable/schema/index.ts
@@ -1,0 +1,26 @@
+import {
+	WorkableCandidate,
+	WorkableDepartment,
+	WorkableEmployee,
+	WorkableJob,
+	WorkableMember,
+} from './database';
+
+export const WorkableSchema = {
+	version: '1.0.0',
+	entities: {
+		departments: WorkableDepartment,
+		employees: WorkableEmployee,
+		members: WorkableMember,
+		jobs: WorkableJob,
+		candidates: WorkableCandidate,
+	},
+} as const;
+
+export {
+	WorkableCandidate,
+	WorkableDepartment,
+	WorkableEmployee,
+	WorkableJob,
+	WorkableMember,
+} from './database';

--- a/packages/workable/tsconfig.json
+++ b/packages/workable/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/workable/tsup.config.ts
+++ b/packages/workable/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,9 +228,6 @@ importers:
       '@corsair-dev/vapi':
         specifier: workspace:*
         version: link:../../packages/vapi
-      '@corsair-dev/workable':
-        specifier: workspace:*
-        version: link:../../packages/workable
       '@corsair-dev/xquik':
         specifier: workspace:*
         version: link:../../packages/xquik

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       '@corsair-dev/vapi':
         specifier: workspace:*
         version: link:../../packages/vapi
+      '@corsair-dev/workable':
+        specifier: workspace:*
+        version: link:../../packages/workable
       '@corsair-dev/xquik':
         specifier: workspace:*
         version: link:../../packages/xquik
@@ -7059,6 +7062,30 @@ importers:
         version: 4.4.3
 
   packages/wiza:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
+  packages/workable:
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14


### PR DESCRIPTION
<!-- Opened as a DRAFT per CONTRIBUTING.md - see the "Still needed before ready for review" note below. -->

## Description

Adds the Workable plugin (`packages/workable`), an HR/recruiting integration. Implements:

- **accounts**: list, get
- **departments**: list, create, update, merge, delete
- **employees**: list, get, create, update, uploadDocuments
- **employeeFields**: list
- **members**: list, invite, update, enable
- **jobs**: list
- **candidates**: list
- **stages**, **requisitions**, **recruiters**, **legalEntities**, **customAttributes**, **disqualificationReasons**, **permissionSets**, **timeoffCategories**, **timeoffBalances**, **workSchedules**, **events**: list
- **subscriptions**: list, create, delete (webhook subscription management)
- **publicJobs**: list (unauthenticated job-board listing)

Every route, method, scope and field name was checked against Workable's current public API docs (workable.readme.io) rather than assumed from the original corsair.dev/oss operation list - see the auth and scope notes below for what that check changed.

**Auth - correction to the corsair.dev/oss listing**: that page lists "API Key and OAuth 2.0" for Workable, but Workable's actual docs describe no OAuth 2.0 authorize/token flow - only static bearer tokens ("account tokens"/"user tokens") generated manually under Settings > Integrations, scoped to a subdomain (`https://<subdomain>.workable.com/spi/v3`). This plugin ships **`api_key`-only**, modeling the subdomain the same way `packages/activecampaign` models its subdomain-scoped credential (`account: ['account']` in `authConfig`, `ctx.keys.get_account()`).

**Webhooks**: contrary to what I assumed when opening #1660, Workable's API *does* document a full create/list/delete subscription flow (`POST/GET/DELETE /subscriptions`), so all three are implemented as regular endpoints. What's *not* implemented is Corsair's incoming-webhook receiver (signature verification, tenant routing, payload parsing) - Workable's subscription docs don't document a signing scheme, so that's flagged here rather than guessed at; happy to add it in a follow-up if a maintainer can point me at how it's meant to work.

**Local storage vs. live-fetch**: `departments`, `employees`, `members`, `jobs` and `candidates` are cached as DB entities (`schema/database.ts`) since they're created/updated through this plugin. Everything else (stages, legal entities, custom attributes, disqualification reasons, permission sets, work schedules, timeoff categories/balances, events, requisitions, recruiters, public jobs) is read-only reference/config data and is left live-fetch-only, matching the split `packages/workday` uses.

**Background checks**: the original op list in #1660 included background-check packages/providers endpoints, but I could not find them anywhere in Workable's current public API docs (`workable.readme.io/llms.txt` has no `background_check` reference at all) - dropped from this PR rather than guessed.

## Testing

- `packages/workable/client.test.ts` - credential/subdomain validation, request shape (Bearer header, base URL), unauthenticated public request shape.
- `packages/workable/endpoints.test.ts` - one test per endpoint group covering all 33 operations against mocked `fetch`, including DB-cache round-tripping for departments/employees/members/jobs/candidates.
- `packages/workable/schema.test.ts` - schema version/entity map shape.
- Registered in `demo/testing` locally (`corsair.ts` + `test-script.ts`) and confirmed the plugin typechecks and resolves correctly against the real `corsair` runtime types (`corsair.workable.api.<group>.<op>`) - **not included in this diff**, since `demo/testing/**` is outside a plugin PR's scope per `PLUGIN_PR_RULES.md` R1.

## Still needed before ready for review

- **Demo video (R4)**: I don't have a Workable account/access token, so I can't record a live call against the real API myself. Marking this **draft** until that's available - happy to record it once I (or a reviewer) can test against a real account, or if someone can share sandbox credentials.

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [ ] I have added or updated necessary documentation (docs generation pending - will run `pnpm generate:docs` once scope is confirmed)

## Screenshots / Demos (if applicable)

Pending - see "Still needed before ready for review" above.

## Additional Notes

- Fixes #1660.
- No breaking changes; this only adds a new plugin and one entry to `packages/corsair/core/constants.ts`.
