### PR TITLE
fix(oss): block unclaim after a PR is linked

### DIFF
--- a/www/src/app/oss/[slug]/integration-detail-sidebar.tsx
+++ b/www/src/app/oss/[slug]/integration-detail-sidebar.tsx
@@ -107,7 +107,9 @@ export function IntegrationDetailSidebar({
 						</div>
 					) : null}
 
-					{session && integration.claimedByCurrentUser ? (
+					{session &&
+					integration.claimedByCurrentUser &&
+					!integration.urls.prUrl ? (
 						<div className="flex flex-wrap items-center gap-2 pt-1">
 							<UnclaimIntegrationButton integrationId={integration.id} />
 						</div>

--- a/www/src/app/oss/integration-card.tsx
+++ b/www/src/app/oss/integration-card.tsx
@@ -153,7 +153,9 @@ export function IntegrationCard({
 						integration.isClaimed ? 'text-[#1c1c1c33]' : 'text-[#1c1c1c66]'
 					}
 				/>
-				{session && integration.claimedByCurrentUser ? (
+				{session &&
+				integration.claimedByCurrentUser &&
+				!integration.urls.prUrl ? (
 					<UnclaimIntegrationButton integrationId={integration.id} />
 				) : null}
 				{session && !integration.isClaimed ? (

--- a/www/src/server/api/routers/integrations.ts
+++ b/www/src/server/api/routers/integrations.ts
@@ -1114,6 +1114,14 @@ export const integrationsRouter = createTRPCRouter({
 				});
 			}
 
+			const urls = await fetchIntegrationUrls(ctx.db, input.integrationId);
+			if (urls.prUrl) {
+				throw new TRPCError({
+					code: 'BAD_REQUEST',
+					message: 'You cannot unclaim an integration after linking a PR',
+				});
+			}
+
 			await releaseIntegrationClaim(ctx.db, {
 				integrationId: input.integrationId,
 				userId: ctx.user.id,

--- a/www/src/server/api/routers/integrations.ts
+++ b/www/src/server/api/routers/integrations.ts
@@ -1082,55 +1082,63 @@ export const integrationsRouter = createTRPCRouter({
 	unclaim: protectedProcedure
 		.input(z.object({ integrationId: z.string().min(1) }))
 		.mutation(async ({ ctx, input }) => {
-			const [integration] = await ctx.db
-				.select({ slug: integrations.slug })
-				.from(integrations)
-				.where(eq(integrations.id, input.integrationId))
-				.limit(1);
+			return ctx.db.transaction(async (tx) => {
+				const db = tx as unknown as DB;
 
-			if (!integration) {
-				throw new TRPCError({
-					code: 'NOT_FOUND',
-					message: 'Integration not found',
+				const [integration] = await tx
+					.select({ slug: integrations.slug })
+					.from(integrations)
+					.where(eq(integrations.id, input.integrationId))
+					.for('update')
+					.limit(1);
+
+				if (!integration) {
+					throw new TRPCError({
+						code: 'NOT_FOUND',
+						message: 'Integration not found',
+					});
+				}
+
+				const latestStatus = await getLatestStatusForIntegration(
+					db,
+					input.integrationId,
+				);
+
+				if (
+					!latestStatus ||
+					!isIntegrationActivelyClaimed(latestStatus.phase)
+				) {
+					throw new TRPCError({
+						code: 'NOT_FOUND',
+						message: 'This integration is not claimed',
+					});
+				}
+
+				if (latestStatus.userId !== ctx.user.id) {
+					throw new TRPCError({
+						code: 'FORBIDDEN',
+						message: 'You can only unclaim integrations you have claimed',
+					});
+				}
+
+				const urls = await fetchIntegrationUrls(db, input.integrationId);
+				if (urls.prUrl) {
+					throw new TRPCError({
+						code: 'BAD_REQUEST',
+						message: 'You cannot unclaim an integration after linking a PR',
+					});
+				}
+
+				await releaseIntegrationClaim(db, {
+					integrationId: input.integrationId,
+					userId: ctx.user.id,
+					reason: 'manual',
 				});
-			}
 
-			const latestStatus = await getLatestStatusForIntegration(
-				ctx.db,
-				input.integrationId,
-			);
+				await clearContributorIntegrationUrls(db, input.integrationId);
 
-			if (!latestStatus || !isIntegrationActivelyClaimed(latestStatus.phase)) {
-				throw new TRPCError({
-					code: 'NOT_FOUND',
-					message: 'This integration is not claimed',
-				});
-			}
-
-			if (latestStatus.userId !== ctx.user.id) {
-				throw new TRPCError({
-					code: 'FORBIDDEN',
-					message: 'You can only unclaim integrations you have claimed',
-				});
-			}
-
-			const urls = await fetchIntegrationUrls(ctx.db, input.integrationId);
-			if (urls.prUrl) {
-				throw new TRPCError({
-					code: 'BAD_REQUEST',
-					message: 'You cannot unclaim an integration after linking a PR',
-				});
-			}
-
-			await releaseIntegrationClaim(ctx.db, {
-				integrationId: input.integrationId,
-				userId: ctx.user.id,
-				reason: 'manual',
+				return { integrationId: input.integrationId, slug: integration.slug };
 			});
-
-			await clearContributorIntegrationUrls(ctx.db, input.integrationId);
-
-			return { integrationId: input.integrationId, slug: integration.slug };
 		}),
 
 	updateUrls: protectedProcedure
@@ -1141,63 +1149,68 @@ export const integrationsRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
-			const [integration] = await ctx.db
-				.select({ id: integrations.id, slug: integrations.slug })
-				.from(integrations)
-				.where(eq(integrations.id, input.integrationId))
-				.limit(1);
+			return ctx.db.transaction(async (tx) => {
+				const db = tx as unknown as DB;
 
-			if (!integration) {
-				throw new TRPCError({
-					code: 'NOT_FOUND',
-					message: 'Integration not found',
+				const [integration] = await tx
+					.select({ id: integrations.id, slug: integrations.slug })
+					.from(integrations)
+					.where(eq(integrations.id, input.integrationId))
+					.for('update')
+					.limit(1);
+
+				if (!integration) {
+					throw new TRPCError({
+						code: 'NOT_FOUND',
+						message: 'Integration not found',
+					});
+				}
+
+				const latestStatus = await getLatestStatusForIntegration(
+					db,
+					input.integrationId,
+				);
+
+				if (
+					!latestStatus ||
+					latestStatus.userId !== ctx.user.id ||
+					!isIntegrationActivelyClaimed(latestStatus.phase)
+				) {
+					throw new TRPCError({
+						code: 'FORBIDDEN',
+						message: 'Only the integration owner can update URLs',
+					});
+				}
+
+				const previousUrls = normalizeIntegrationUrls(
+					await fetchIntegrationUrls(db, input.integrationId),
+				);
+				const urls = normalizeIntegrationUrls(input.urls);
+
+				await upsertIntegrationUrls(db, input.integrationId, urls);
+
+				await maybeAdvancePhaseAfterUrlUpdate(db, {
+					integrationId: input.integrationId,
+					userId: ctx.user.id,
+					slug: integration.slug,
+					previousUrls,
+					nextUrls: urls,
 				});
-			}
 
-			const latestStatus = await getLatestStatusForIntegration(
-				ctx.db,
-				input.integrationId,
-			);
+				const updatedStatus = await getLatestStatusForIntegration(
+					db,
+					input.integrationId,
+				);
 
-			if (
-				!latestStatus ||
-				latestStatus.userId !== ctx.user.id ||
-				!isIntegrationActivelyClaimed(latestStatus.phase)
-			) {
-				throw new TRPCError({
-					code: 'FORBIDDEN',
-					message: 'Only the integration owner can update URLs',
-				});
-			}
-
-			const previousUrls = normalizeIntegrationUrls(
-				await fetchIntegrationUrls(ctx.db, input.integrationId),
-			);
-			const urls = normalizeIntegrationUrls(input.urls);
-
-			await upsertIntegrationUrls(ctx.db, input.integrationId, urls);
-
-			await maybeAdvancePhaseAfterUrlUpdate(ctx.db, {
-				integrationId: input.integrationId,
-				userId: ctx.user.id,
-				slug: integration.slug,
-				previousUrls,
-				nextUrls: urls,
+				return {
+					integrationId: input.integrationId,
+					slug: integration.slug,
+					urls,
+					phase: updatedStatus?.phase ?? latestStatus.phase,
+					issueDeadlineAt: updatedStatus?.issueDeadlineAt ?? null,
+					prDeadlineAt: updatedStatus?.prDeadlineAt ?? null,
+				};
 			});
-
-			const updatedStatus = await getLatestStatusForIntegration(
-				ctx.db,
-				input.integrationId,
-			);
-
-			return {
-				integrationId: input.integrationId,
-				slug: integration.slug,
-				urls,
-				phase: updatedStatus?.phase ?? latestStatus.phase,
-				issueDeadlineAt: updatedStatus?.issueDeadlineAt ?? null,
-				prDeadlineAt: updatedStatus?.prDeadlineAt ?? null,
-			};
 		}),
 
 	markReadyToReview: protectedProcedure


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

Stop contributors from unclaiming an OSS integration after they attach a PR. People were linking a PR, getting it merged, then unclaiming so the integration went back into the pool.

Hide the Unclaim button on `/oss` (list + detail) once a PR URL exists, and reject `integrations.unclaim` on the server with the same rule.

## Checklist

Before submitting your PR, please verify the following:

- [ ] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [ ] I have run `pnpm build` and all packages build successfully
- [ ] I have run `pnpm test` and all tests pass
- [ ] I have added or updated tests where applicable
- [ ] I have added or updated necessary documentation

## Screenshots / Demos (if applicable)

N/A — Unclaim disappears after a PR URL is saved.

## Additional Notes

Unclaim still works before a PR is linked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented integrations from being unclaimed after a pull request has been linked.
  * Hid the unclaim option once a pull request exists.
  * Added server-side validation to consistently block invalid unclaim attempts.
  * Improved consistency when updating integration links and releasing claimed integrations during simultaneous actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->