### PR TITLE
ci: parallelize build/test, shard test run, cancel stale CodeQL runs

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -1,0 +1,39 @@
+name: Prepare workspace
+description: Install pnpm/node and the lane-scoped workspace dependencies. Assumes the repo is already checked out.
+inputs:
+  lane:
+    description: Scope lane (plugin | full | www) from the scope job.
+    required: true
+  turbo_filter:
+    description: Turbo/pnpm filter for the lane's package(s).
+    required: true
+  www_install_filter:
+    description: Extra pnpm filter that pulls in www on a full-lane PR that also touches www.
+    required: false
+    default: ''
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v4
+      with:
+        version: 10.20.0
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '24.x'
+        cache: 'pnpm'
+
+    - name: Install plugin dependencies
+      if: inputs.lane == 'plugin'
+      shell: bash
+      run: pnpm install --frozen-lockfile --filter . --filter corsair... --filter="${{ inputs.turbo_filter }}"
+
+    - name: Install package dependencies
+      if: inputs.lane == 'full'
+      shell: bash
+      run: pnpm install --frozen-lockfile --filter . --filter "./packages/**" ${{ inputs.www_install_filter }}
+
+    - name: Install www dependencies
+      if: inputs.lane == 'www'
+      shell: bash
+      run: pnpm install --frozen-lockfile --filter . --filter "@corsair/www..."

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '30 2 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -35,25 +35,26 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  ci:
-    name: CI Checks
+  scope:
+    name: Classify scope
     needs: plugin-gate
     if: always() && (github.event_name == 'push' || needs.plugin-gate.result == 'success')
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 5
+    outputs:
+      lane: ${{ steps.scope.outputs.lane }}
+      turbo_filter: ${{ steps.scope.outputs.turbo_filter }}
+      skip_heavy: ${{ steps.scope.outputs.skip_heavy }}
+      www_install_filter: ${{ steps.scope.outputs.www_install_filter }}
+      www_test_filter: ${{ steps.scope.outputs.www_test_filter }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.20.0
-
       - uses: actions/setup-node@v4
         with:
           node-version: '24.x'
-          cache: 'pnpm'
 
       - name: Classify PR scope
         id: scope
@@ -61,65 +62,117 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install plugin dependencies
-        if: steps.scope.outputs.lane == 'plugin'
-        run: pnpm install --frozen-lockfile --filter . --filter corsair... --filter="${{ steps.scope.outputs.turbo_filter }}"
+  build:
+    name: Build & static checks
+    needs: scope
+    if: needs.scope.outputs.skip_heavy != 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
-      - name: Install package dependencies
-        if: steps.scope.outputs.lane == 'full'
-        run: pnpm install --frozen-lockfile --filter . --filter "./packages/**" ${{ steps.scope.outputs.www_install_filter }}
+      - uses: ./.github/actions/prepare
+        with:
+          lane: ${{ needs.scope.outputs.lane }}
+          turbo_filter: ${{ needs.scope.outputs.turbo_filter }}
+          www_install_filter: ${{ needs.scope.outputs.www_install_filter }}
 
-      - name: Install www dependencies
-        if: steps.scope.outputs.lane == 'www'
-        run: pnpm install --frozen-lockfile --filter . --filter "@corsair/www..."
-
-      - name: Turbo cache for main
-        if: github.event_name == 'push' && steps.scope.outputs.lane == 'full'
+      - name: Turbo cache
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: turbo-${{ runner.os }}-${{ github.sha }}
-          restore-keys: turbo-${{ runner.os }}-
-
-      - name: Turbo cache for pull request
-        if: github.event_name == 'pull_request' && steps.scope.outputs.skip_heavy != 'true'
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-pr-${{ github.event.pull_request.number }}-${{ github.sha }}
-          restore-keys: turbo-${{ runner.os }}-
+          key: turbo-build-${{ runner.os }}-${{ github.event_name == 'pull_request' && format('pr-{0}-', github.event.pull_request.number) || '' }}${{ github.sha }}
+          restore-keys: turbo-build-${{ runner.os }}-
 
       - name: Lint
-        if: steps.scope.outputs.skip_heavy != 'true'
         run: pnpm lint
 
       - name: Validate Plugins
-        if: steps.scope.outputs.skip_heavy != 'true'
         run: pnpm run validate:plugins
 
       - name: Validate Docs
-        if: steps.scope.outputs.skip_heavy != 'true'
         run: pnpm run validate:docs
 
       - name: Typecheck
-        if: steps.scope.outputs.skip_heavy != 'true'
         run: pnpm typecheck
 
       - name: Typecheck review scripts
-        if: steps.scope.outputs.skip_heavy != 'true'
         run: pnpm exec tsc -p scripts/pr-review
 
       - name: Build
-        if: steps.scope.outputs.skip_heavy != 'true' && steps.scope.outputs.lane != 'www'
-        run: pnpm exec turbo build --filter="${{ steps.scope.outputs.turbo_filter }}"
+        if: needs.scope.outputs.lane != 'www'
+        run: pnpm exec turbo build --filter="${{ needs.scope.outputs.turbo_filter }}"
 
+  test:
+    name: Test
+    needs: scope
+    if: needs.scope.outputs.skip_heavy != 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.scope.outputs.lane == 'full' && '["1","2","3","4"]' || '["1"]') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - uses: ./.github/actions/prepare
+        with:
+          lane: ${{ needs.scope.outputs.lane }}
+          turbo_filter: ${{ needs.scope.outputs.turbo_filter }}
+          www_install_filter: ${{ needs.scope.outputs.www_install_filter }}
+
+      - name: Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-test-${{ runner.os }}-${{ github.event_name == 'pull_request' && format('pr-{0}-', github.event.pull_request.number) || '' }}${{ github.sha }}-${{ matrix.shard }}
+          restore-keys: turbo-test-${{ runner.os }}-
+
+      # Only the full lane's filter is pure jest packages, so --shard applies
+      # there; www runs its node:test suite separately below, never sharded.
       - name: Run tests
-        if: steps.scope.outputs.skip_heavy != 'true'
-        run: pnpm exec turbo test --filter="${{ steps.scope.outputs.turbo_filter }}" ${{ steps.scope.outputs.www_test_filter }} -- --passWithNoTests --ci --testPathIgnorePatterns="api\.test\.ts$|(^|/)integration\.test\.ts$"
+        run: >-
+          pnpm exec turbo test --filter="${{ needs.scope.outputs.turbo_filter }}"
+          -- --passWithNoTests --ci
+          ${{ needs.scope.outputs.lane == 'full' && format('--shard={0}/4', matrix.shard) || '' }}
+          --testPathIgnorePatterns="api\.test\.ts$|(^|/)integration\.test\.ts$"
         env:
           CI: true
           SKIP_PG_TESTS: 1
 
-      - name: Skip package checks
-        if: steps.scope.outputs.skip_heavy == 'true'
-        run: echo "Package checks skipped for documentation or explorer-only changes."
+      - name: Run www tests
+        if: needs.scope.outputs.www_test_filter != '' && matrix.shard == '1'
+        run: >-
+          pnpm exec turbo test ${{ needs.scope.outputs.www_test_filter }}
+          -- --passWithNoTests --ci
+          --testPathIgnorePatterns="api\.test\.ts$|(^|/)integration\.test\.ts$"
+        env:
+          CI: true
+          SKIP_PG_TESTS: 1
+
+  ci:
+    name: CI Checks
+    needs: [scope, build, test]
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      # scope must succeed (a skipped scope means the plugin gate failed);
+      # build/test may be skipped only on the docs-only skip-heavy lane.
+      - name: Verify required jobs passed
+        run: |
+          if [ "${{ needs.scope.result }}" != "success" ]; then
+            echo "scope did not pass (result: ${{ needs.scope.result }})"
+            exit 1
+          fi
+          for r in "${{ needs.build.result }}" "${{ needs.test.result }}"; do
+            case "$r" in
+              success|skipped) ;;
+              *) echo "A required job did not pass: $r"; exit 1 ;;
+            esac
+          done


### PR DESCRIPTION
## What
- Split the PR Checks `ci` job into `scope` → parallel `build` + sharded `test` → `CI Checks` aggregator.
- Full lane shards jest across 4 runners; `plugin`/`www`/`skip-heavy` lanes stay a single unsharded job, byte-identical to before.
- Extract the pnpm/node + lane install into `.github/actions/prepare`.
- Add `concurrency` to `codeql.yml` so a new commit cancels the in-progress run.

## Why
Full-lane runs were serial: build ~14m then tests ~26m ≈ 42m. Running build and test in parallel and sharding the tests takes it to ~14m. CodeQL had no `concurrency`, so every commit ran a full analysis to completion (and a manual cancel on PR Checks never touched it).

Public repo + standard runners → **$0 extra**.

## Notes
- `CI Checks` name preserved for branch protection; it now goes **red** on a plugin-gate failure (previously it could report green when scope/build/test were skipped).
- `www` uses `node:test`, so it never receives jest `--shard` — its invocation is unchanged.
- Scope-classification (`scripts/pr-review`) untouched; the shard matrix is derived in YAML from the existing `lane` output.
- Real proof is the first full-lane PR run — it should fan out to 4 `Test` shards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated workspace preparation for consistent dependency installation across validation workflows.
  - Improved pull request checks with scope-aware validation, separate build and test stages, and parallelized testing.
  - Added lane-specific checks so changes run only the relevant validation tasks.
  - Improved workflow efficiency by canceling outdated pull request runs and reusing shared setup steps.
  - Updated checks to clearly report whether required validation stages completed successfully or were appropriately skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->