### PR TITLE
feat(oss): add /assign flow for first-time issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.yml
@@ -1,0 +1,23 @@
+name: Good first issue
+description: An issue reserved for first-time contributors
+title: '[good first issue] '
+labels: ['good first issue']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **First-time contributors only.** If you have already had a pull request merged in this repository, do not take this issue — we will not merge it.
+
+        Comment `/assign` to claim this issue. Do not open a PR until you are assigned. You may have only one assigned issue at a time. Unassigned PRs will be closed.
+  - type: textarea
+    attributes:
+      label: Task
+      description: What should a first-time contributor change?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Acceptance
+      description: How will we know this is done?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/integration_request.yml
+++ b/.github/ISSUE_TEMPLATE/integration_request.yml
@@ -5,10 +5,12 @@ body:
   - type: markdown
     attributes:
       value: |
+        <!-- corsair-integration-request -->
         Interested in using a new API with Corsair? Let us know!
 
         **Before submitting:**
-        - If you plan to build this integration, check [corsair.dev/oss](https://corsair.dev/oss) first to see whether it is already claimed or in progress. Claim it there before you start so two people do not work on the same plugin.
+        - If you plan to build this integration, check [corsair.dev/oss](https://corsair.dev/oss) first to see whether it is already claimed or in progress. Claim it there before you start so two people do not work on the same plugin. Opening this issue assigns it to you. Do not open a PR until you are assigned. One issue per person at a time. If you only want to request the integration and not build it, unassign yourself after it opens.
+        - If this issue is labeled `good first issue`, it is reserved for first-time contributors. We will not merge a PR from someone who already has a merged contribution here.
         - Check if this integration has already been [requested](https://github.com/corsairdev/corsair/issues?q=is%3Aissue+label%3Aenhancement) or [implemented](https://github.com/corsairdev/corsair/issues?q=is%3Aissue+label%3Aenhancement+is%3Aclosed). If it has, please add a 👍 reaction instead of creating a duplicate.
         - For general feature requests, please use the [feature request template](https://github.com/corsairdev/corsair/issues/new?assignees=&labels=&projects=&template=feature_request.yml&title=) instead.
   - type: input

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 ## Description
 
 <!-- Briefly describe the changes you've made and why they're necessary. -->
-<!-- Link to any related issues (e.g. "Fixes #123"). -->
+<!-- Link to any related issues (e.g. "Fixes #123"). Comment /assign on that issue first. -->
 
 ## Checklist
 

--- a/.github/workflows/first-issue-assign.yml
+++ b/.github/workflows/first-issue-assign.yml
@@ -1,0 +1,45 @@
+name: First-issue assign
+
+on:
+  workflow_dispatch:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened, labeled, assigned]
+  pull_request_target:
+    types: [opened, reopened, edited, ready_for_review]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  first-issue:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request == null &&
+       startsWith(github.event.comment.body, '/assign')) ||
+      (github.event_name == 'issues' &&
+       (github.event.action == 'opened' ||
+        github.event.action == 'assigned' ||
+        github.event.label.name == 'good first issue')) ||
+      github.event_name == 'pull_request_target'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+
+      - name: Run first-issue policy
+        run: node --experimental-strip-types scripts/first-issue/main.ts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENTER_ASSOCIATION: ${{ github.event.comment.author_association }}
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association || github.event.issue.author_association }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,14 @@ Please create an issue before starting work on anything significant. This helps 
 
 If you want to contribute a new integration, check the [OSS Integrations page](https://corsair.dev/oss) first. It shows which integrations are available, which are already claimed, and who is working on them. Claim an integration there before you start so two people do not work on the same plugin.
 
+## Claiming an issue
+
+Opening an **integration request** assigns it to you. For any other issue, comment `/assign` to take it. Do not open a pull request until you are assigned.
+
+- One person may have only one assigned issue at a time. That cap is shared across integration requests, `good first issue`, bugs, and everything else. You cannot hold one of each.
+- Issues labeled `good first issue` are reserved for **first-time contributors**. If you have already had a PR merged in this repo, do not take those issues — we will not merge them.
+- A pull request that is not assigned, or that is opened by someone who is not a first-time contributor on a `good first issue`, is closed automatically.
+
 Before opening a new issue:
 
 - Check [corsair.dev/oss](https://corsair.dev/oss) for new integrations.
@@ -146,7 +154,7 @@ If you are adding a new plugin, follow the official guide:
 That guide covers the expected scaffold and generator flow. In practice, the normal path is:
 
 1. Check [corsair.dev/oss](https://corsair.dev/oss) to make sure the integration is not already claimed or in progress, then claim it if it is available.
-2. Open an issue first and align on the integration.
+2. Open an integration issue first (it assigns to you) and align on the integration.
 3. Generate the plugin scaffold from the repo root.
 4. Implement endpoints, auth, schemas, and webhooks.
 5. Register the plugin in `demo/testing/src/server/corsair.ts`.
@@ -236,7 +244,8 @@ Building plugin infrastructure that fits every API and webhook model is hard, an
 
 When you open a pull request:
 
-- link the issue it addresses
+- be assigned to the issue first (integration issues assign on open; otherwise comment `/assign`)
+- link the issue it addresses (`Fixes #…`)
 - describe the API surface or behavior you added or changed
 - explain how you tested it
 - call out any schema, webhook, or infrastructure decisions that reviewers should pay attention to

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Closed integration platforms keep your users' tokens and data on infrastructure 
 
 We welcome PRs for the core library, docs, tooling, and new integration plugins. Read [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
 
-For a new integration, claim it on the [OSS Integrations page](https://corsair.dev/oss) before you start, then open an issue with the API you want to add. Questions? Ask in [Discord](https://discord.gg/uNgCP3mSzU).
+For a new integration, claim it on the [OSS Integrations page](https://corsair.dev/oss) before you start, then open an integration issue (it assigns to you). Questions? Ask in [Discord](https://discord.gg/uNgCP3mSzU).
 
 ---
 ## License

--- a/scripts/first-issue/main.ts
+++ b/scripts/first-issue/main.ts
@@ -1,0 +1,385 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import type { LinkedIssue } from './policy.ts';
+import {
+	decideAssign,
+	decideOneIssueCap,
+	decidePrGate,
+	FIRST_ISSUE_LABEL,
+	GFI_NOTICE,
+	hasFirstIssueLabel,
+	isIntegrationIssue,
+	NOTICE_MARKER,
+	parseLinkedIssueNumbers,
+} from './policy.ts';
+
+function gh(args: string[]): string {
+	return execFileSync('gh', args, {
+		encoding: 'utf8',
+		maxBuffer: 8 * 1024 * 1024,
+	}).trim();
+}
+
+function labelNames(labels: unknown): string[] {
+	if (!Array.isArray(labels)) return [];
+	return labels
+		.map((label) => {
+			if (typeof label === 'string') return label;
+			if (label && typeof label === 'object' && 'name' in label) {
+				return String((label as { name: string }).name);
+			}
+			return '';
+		})
+		.filter(Boolean);
+}
+
+function assigneeLogins(assignees: unknown): string[] {
+	if (!Array.isArray(assignees)) return [];
+	return assignees
+		.map((assignee) => {
+			if (typeof assignee === 'string') return assignee;
+			if (assignee && typeof assignee === 'object' && 'login' in assignee) {
+				return String((assignee as { login: string }).login);
+			}
+			return '';
+		})
+		.filter(Boolean);
+}
+
+function commentOnIssue(repo: string, number: number, body: string): void {
+	gh(['issue', 'comment', String(number), '--repo', repo, '--body', body]);
+}
+
+function alreadyHasNotice(repo: string, number: number): boolean {
+	const comments = JSON.parse(
+		gh(['api', `repos/${repo}/issues/${number}/comments`, '--paginate']),
+	) as { body?: string }[];
+	return comments.some((comment) => comment.body?.includes(NOTICE_MARKER));
+}
+
+function mergedPrCount(repo: string, user: string): number {
+	const rows = JSON.parse(
+		gh([
+			'pr',
+			'list',
+			'--repo',
+			repo,
+			'--author',
+			user,
+			'--state',
+			'merged',
+			'--limit',
+			'1',
+			'--json',
+			'number',
+		]),
+	) as unknown[];
+	return rows.length;
+}
+
+function otherAssignedIssue(
+	repo: string,
+	user: string,
+	currentIssue: number,
+): number | null {
+	const rows = JSON.parse(
+		gh([
+			'issue',
+			'list',
+			'--repo',
+			repo,
+			'--assignee',
+			user,
+			'--state',
+			'open',
+			'--limit',
+			'20',
+			'--json',
+			'number',
+		]),
+	) as { number: number }[];
+	const other = rows.find((row) => row.number !== currentIssue);
+	return other?.number ?? null;
+}
+
+function assigneeHasWrite(repo: string, user: string): boolean {
+	try {
+		const data = JSON.parse(
+			gh(['api', `repos/${repo}/collaborators/${user}/permission`]),
+		) as { permission?: string };
+		return (
+			data.permission === 'admin' ||
+			data.permission === 'maintain' ||
+			data.permission === 'write'
+		);
+	} catch {
+		return false;
+	}
+}
+
+function loadIssue(repo: string, number: number): LinkedIssue {
+	const issue = JSON.parse(
+		gh([
+			'issue',
+			'view',
+			String(number),
+			'--repo',
+			repo,
+			'--json',
+			'number,state,labels,assignees',
+		]),
+	) as {
+		number: number;
+		state: string;
+		labels: { name: string }[];
+		assignees: { login: string }[];
+	};
+	return {
+		number: issue.number,
+		open: issue.state.toLowerCase() === 'open',
+		labels: labelNames(issue.labels),
+		assignees: assigneeLogins(issue.assignees),
+	};
+}
+
+type IssuePayload = {
+	number: number;
+	state: string;
+	labels?: unknown;
+	assignees?: unknown;
+	pull_request?: unknown;
+	body?: string | null;
+	user?: { login?: string };
+};
+
+function applyAssign(
+	repo: string,
+	issue: IssuePayload,
+	commenter: string,
+	association: string,
+	auto: boolean,
+	commentBody: string,
+): void {
+	const decision = decideAssign({
+		isPullRequest: issue.pull_request != null,
+		commentBody,
+		issueOpen: issue.state === 'open',
+		issueLabels: labelNames(issue.labels),
+		assignees: assigneeLogins(issue.assignees),
+		commenter,
+		commenterAssociation: association,
+		commenterMergedPrs: mergedPrCount(repo, commenter),
+		otherAssignedIssue: otherAssignedIssue(repo, commenter, issue.number),
+		auto,
+	});
+
+	if (decision.action === 'ignore') return;
+
+	const alreadyAssigned = assigneeLogins(issue.assignees)
+		.map((login) => login.toLowerCase())
+		.includes(commenter.toLowerCase());
+	if (decision.action === 'assign' && !alreadyAssigned) {
+		try {
+			gh([
+				'issue',
+				'edit',
+				String(issue.number),
+				'--repo',
+				repo,
+				'--add-assignee',
+				commenter,
+			]);
+		} catch (error) {
+			commentOnIssue(
+				repo,
+				issue.number,
+				`@${commenter} I could not assign you automatically (${
+					error instanceof Error ? error.message.split('\n')[0] : error
+				}). A maintainer may need to assign you.`,
+			);
+			return;
+		}
+	}
+
+	commentOnIssue(repo, issue.number, decision.reply);
+}
+
+function handleAssign(
+	repo: string,
+	event: {
+		issue?: IssuePayload;
+		comment?: { body?: string; user?: { login?: string } };
+	},
+	association: string,
+): void {
+	const issue = event.issue;
+	const commenter = event.comment?.user?.login;
+	if (!issue || !commenter) return;
+	applyAssign(
+		repo,
+		issue,
+		commenter,
+		association,
+		false,
+		event.comment?.body ?? '',
+	);
+}
+
+function postNoticeIfNeeded(repo: string, number: number): void {
+	if (alreadyHasNotice(repo, number)) return;
+	commentOnIssue(repo, number, GFI_NOTICE);
+}
+
+function handleIssueEvent(
+	repo: string,
+	event: {
+		action?: string;
+		label?: { name?: string };
+		assignee?: { login?: string };
+		issue?: IssuePayload;
+	},
+	association: string,
+): void {
+	const issue = event.issue;
+	if (!issue || issue.pull_request) return;
+
+	const labels =
+		event.action === 'opened'
+			? labelNames(issue.labels)
+			: [event.label?.name ?? ''];
+	if (hasFirstIssueLabel(labels)) {
+		postNoticeIfNeeded(repo, issue.number);
+	}
+
+	if (event.action === 'assigned') {
+		const assignee = event.assignee?.login;
+		if (!assignee) return;
+		const cap = decideOneIssueCap({
+			login: assignee,
+			maintainer: assigneeHasWrite(repo, assignee),
+			otherAssignedIssue: otherAssignedIssue(repo, assignee, issue.number),
+		});
+		if (cap.action !== 'revert') return;
+		gh([
+			'issue',
+			'edit',
+			String(issue.number),
+			'--repo',
+			repo,
+			'--remove-assignee',
+			assignee,
+		]);
+		commentOnIssue(repo, issue.number, cap.reply);
+		return;
+	}
+
+	if (event.action !== 'opened') return;
+	const author = issue.user?.login;
+	if (!author || !isIntegrationIssue(issue.body ?? '')) return;
+	applyAssign(repo, issue, author, association, true, '/assign');
+}
+
+function handleBackfill(repo: string): void {
+	const rows = JSON.parse(
+		gh([
+			'issue',
+			'list',
+			'--repo',
+			repo,
+			'--label',
+			FIRST_ISSUE_LABEL,
+			'--state',
+			'open',
+			'--limit',
+			'100',
+			'--json',
+			'number',
+		]),
+	) as { number: number }[];
+	for (const row of rows) {
+		postNoticeIfNeeded(repo, row.number);
+	}
+}
+
+function handlePullRequest(
+	repo: string,
+	event: {
+		pull_request?: {
+			number: number;
+			draft?: boolean;
+			body?: string | null;
+			title?: string;
+			user?: { login?: string };
+			labels?: unknown;
+		};
+	},
+	association: string,
+): void {
+	const pr = event.pull_request;
+	const author = pr?.user?.login;
+	if (!pr || !author) return;
+
+	const linkedNumbers = parseLinkedIssueNumbers(
+		`${pr.title ?? ''}\n${pr.body ?? ''}`,
+	);
+	const linkedIssues = linkedNumbers.map((number) => loadIssue(repo, number));
+
+	const decision = decidePrGate({
+		isDraft: Boolean(pr.draft),
+		author,
+		authorAssociation: association,
+		authorMergedPrs: mergedPrCount(repo, author),
+		prLabels: labelNames(pr.labels),
+		linkedIssues,
+	});
+
+	if (decision.action === 'ok') return;
+
+	gh([
+		'pr',
+		'close',
+		String(pr.number),
+		'--repo',
+		repo,
+		'--comment',
+		decision.reason,
+	]);
+}
+
+const event = JSON.parse(
+	fs.readFileSync(process.env.GITHUB_EVENT_PATH ?? '', 'utf8'),
+) as {
+	action?: string;
+	label?: { name?: string };
+	assignee?: { login?: string };
+	issue?: IssuePayload;
+	comment?: { body?: string; user?: { login?: string } };
+	pull_request?: {
+		number: number;
+		draft?: boolean;
+		body?: string | null;
+		title?: string;
+		user?: { login?: string };
+		labels?: unknown;
+	};
+};
+
+const repo = process.env.GITHUB_REPOSITORY ?? '';
+const eventName = process.env.GITHUB_EVENT_NAME ?? '';
+const association =
+	process.env.COMMENTER_ASSOCIATION || process.env.AUTHOR_ASSOCIATION || '';
+
+if (eventName === 'workflow_dispatch') {
+	handleBackfill(repo);
+} else if (eventName === 'issue_comment') {
+	handleAssign(repo, event, association);
+} else if (eventName === 'issues') {
+	handleIssueEvent(repo, event, association);
+} else if (
+	eventName === 'pull_request' ||
+	eventName === 'pull_request_target'
+) {
+	handlePullRequest(repo, event, association);
+} else {
+	console.log(`Nothing to do for ${eventName}`);
+}

--- a/scripts/first-issue/policy.test.ts
+++ b/scripts/first-issue/policy.test.ts
@@ -1,0 +1,292 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+	decideAssign,
+	decideOneIssueCap,
+	decidePrGate,
+	INTEGRATION_MARKER,
+	isAssignCommand,
+	isFirstTimeContributor,
+	isIntegrationIssue,
+	parseLinkedIssueNumbers,
+} from './policy.ts';
+
+test('isAssignCommand accepts /assign and /assign me', () => {
+	assert.equal(isAssignCommand('/assign'), true);
+	assert.equal(isAssignCommand('  /assign me  '), true);
+	assert.equal(isAssignCommand('/assign please'), false);
+	assert.equal(isAssignCommand('please /assign'), false);
+});
+
+test('parseLinkedIssueNumbers finds Fixes/Closes/Resolves', () => {
+	assert.deepEqual(
+		parseLinkedIssueNumbers('Fixes #12 and closes #4. Resolves: #12.'),
+		[4, 12],
+	);
+	assert.deepEqual(parseLinkedIssueNumbers('See #9'), []);
+});
+
+test('merged PR count beats GitHub association', () => {
+	assert.equal(isFirstTimeContributor('FIRST_TIME_CONTRIBUTOR', 1), false);
+	assert.equal(isFirstTimeContributor('NONE', 0), true);
+	assert.equal(isFirstTimeContributor('CONTRIBUTOR', 0), false);
+});
+
+const assignBase = {
+	isPullRequest: false,
+	commentBody: '/assign',
+	issueOpen: true,
+	issueLabels: ['good first issue'],
+	assignees: [] as string[],
+	commenter: 'newbie',
+	commenterAssociation: 'FIRST_TIME_CONTRIBUTOR',
+	commenterMergedPrs: 0,
+	otherAssignedIssue: null as number | null,
+};
+
+test('isIntegrationIssue only matches the integration template marker', () => {
+	assert.equal(isIntegrationIssue(INTEGRATION_MARKER), true);
+	assert.equal(
+		isIntegrationIssue(
+			'### What API or service would you like integrated?\n\nStripe',
+		),
+		true,
+	);
+	assert.equal(isIntegrationIssue('Just a bug'), false);
+});
+
+test('auto-assign grants an integration issue to the opener', () => {
+	const d = decideAssign({
+		...assignBase,
+		issueLabels: ['enhancement'],
+		commentBody: '',
+		auto: true,
+	});
+	assert.equal(d.action, 'assign');
+});
+
+test('auto-assign still enforces one issue at a time', () => {
+	const d = decideAssign({
+		...assignBase,
+		issueLabels: ['enhancement'],
+		commentBody: '',
+		auto: true,
+		otherAssignedIssue: 88,
+	});
+	assert.equal(d.action, 'reject');
+});
+
+test('auto-assign ignores non-command comments without auto', () => {
+	assert.equal(
+		decideAssign({ ...assignBase, commentBody: '', auto: false }).action,
+		'ignore',
+	);
+});
+
+test('assign grants a free first-issue to a first-timer', () => {
+	const d = decideAssign(assignBase);
+	assert.equal(d.action, 'assign');
+});
+
+test('assign rejects a regular who already merged here', () => {
+	const d = decideAssign({
+		...assignBase,
+		commenter: 'regular',
+		commenterAssociation: 'CONTRIBUTOR',
+		commenterMergedPrs: 2,
+	});
+	assert.equal(d.action, 'reject');
+	assert.match((d as { reply: string }).reply, /first-time contributors/);
+});
+
+test('assign rejects a second open issue of any type', () => {
+	const d = decideAssign({
+		...assignBase,
+		issueLabels: ['enhancement'],
+		otherAssignedIssue: 88,
+	});
+	assert.equal(d.action, 'reject');
+	assert.match((d as { reply: string }).reply, /#88/);
+	assert.match((d as { reply: string }).reply, /anything else/);
+});
+
+test('one-issue cap is shared across issue types', () => {
+	assert.equal(
+		decideOneIssueCap({
+			login: 'dev',
+			maintainer: false,
+			otherAssignedIssue: 12,
+		}).action,
+		'revert',
+	);
+	assert.equal(
+		decideOneIssueCap({
+			login: 'dev',
+			maintainer: false,
+			otherAssignedIssue: null,
+		}).action,
+		'ok',
+	);
+	assert.equal(
+		decideOneIssueCap({
+			login: 'maintainer',
+			maintainer: true,
+			otherAssignedIssue: 12,
+		}).action,
+		'ok',
+	);
+});
+
+test('assign rejects an already claimed issue', () => {
+	const d = decideAssign({ ...assignBase, assignees: ['other'] });
+	assert.equal(d.action, 'reject');
+	assert.match((d as { reply: string }).reply, /@other/);
+});
+
+test('assign is idempotent for the current assignee', () => {
+	const d = decideAssign({ ...assignBase, assignees: ['newbie'] });
+	assert.equal(d.action, 'assign');
+});
+
+test('assign ignores PR review comments and non-commands', () => {
+	assert.equal(
+		decideAssign({ ...assignBase, isPullRequest: true }).action,
+		'ignore',
+	);
+	assert.equal(
+		decideAssign({ ...assignBase, commentBody: 'I can take this' }).action,
+		'ignore',
+	);
+});
+
+test('assign allows maintainers on first-issues and past the one-issue cap', () => {
+	const d = decideAssign({
+		...assignBase,
+		commenter: 'maintainer',
+		commenterAssociation: 'MEMBER',
+		commenterMergedPrs: 40,
+		otherAssignedIssue: 3,
+	});
+	assert.equal(d.action, 'assign');
+});
+
+const prBase = {
+	isDraft: false,
+	author: 'newbie',
+	authorAssociation: 'FIRST_TIME_CONTRIBUTOR',
+	authorMergedPrs: 0,
+	prLabels: [] as string[],
+	linkedIssues: [
+		{
+			number: 10,
+			open: true,
+			labels: ['good first issue'],
+			assignees: ['newbie'],
+		},
+	],
+};
+
+test('PR gate allows an assigned first-timer', () => {
+	assert.equal(decidePrGate(prBase).action, 'ok');
+});
+
+test('PR gate allows an assigned regular enhancement', () => {
+	assert.equal(
+		decidePrGate({
+			...prBase,
+			author: 'regular',
+			authorAssociation: 'CONTRIBUTOR',
+			authorMergedPrs: 3,
+			linkedIssues: [
+				{
+					number: 40,
+					open: true,
+					labels: ['enhancement'],
+					assignees: ['regular'],
+				},
+			],
+		}).action,
+		'ok',
+	);
+});
+
+test('PR gate closes an unassigned first-issue PR', () => {
+	const d = decidePrGate({
+		...prBase,
+		linkedIssues: [
+			{
+				number: 10,
+				open: true,
+				labels: ['good first issue'],
+				assignees: [],
+			},
+		],
+	});
+	assert.equal(d.action, 'close');
+	assert.match((d as { reason: string }).reason, /\/assign/);
+});
+
+test('PR gate closes a first-issue PR from a returning contributor', () => {
+	const d = decidePrGate({
+		...prBase,
+		author: 'regular',
+		authorAssociation: 'CONTRIBUTOR',
+		authorMergedPrs: 1,
+	});
+	assert.equal(d.action, 'close');
+	assert.match((d as { reason: string }).reason, /first-time/);
+});
+
+test('PR gate closes an unassigned linked issue', () => {
+	const d = decidePrGate({
+		...prBase,
+		linkedIssues: [
+			{
+				number: 22,
+				open: true,
+				labels: ['enhancement'],
+				assignees: [],
+			},
+		],
+	});
+	assert.equal(d.action, 'close');
+	assert.match((d as { reason: string }).reason, /\/assign/);
+});
+
+test('PR gate closes a sniped assigned issue', () => {
+	const d = decidePrGate({
+		...prBase,
+		author: 'sniper',
+		linkedIssues: [
+			{
+				number: 10,
+				open: true,
+				labels: ['enhancement'],
+				assignees: ['newbie'],
+			},
+		],
+	});
+	assert.equal(d.action, 'close');
+	assert.match((d as { reason: string }).reason, /already assigned/);
+});
+
+test('PR gate skips drafts and maintainers', () => {
+	assert.equal(decidePrGate({ ...prBase, isDraft: true }).action, 'ok');
+	assert.equal(
+		decidePrGate({
+			...prBase,
+			author: 'djain',
+			authorAssociation: 'MEMBER',
+			authorMergedPrs: 50,
+			linkedIssues: [
+				{
+					number: 10,
+					open: true,
+					labels: ['good first issue'],
+					assignees: [],
+				},
+			],
+		}).action,
+		'ok',
+	);
+});

--- a/scripts/first-issue/policy.ts
+++ b/scripts/first-issue/policy.ts
@@ -1,0 +1,247 @@
+export const FIRST_ISSUE_LABEL = 'good first issue';
+export const NOTICE_MARKER = '<!-- corsair-gfi-notice -->';
+export const INTEGRATION_MARKER = '<!-- corsair-integration-request -->';
+
+export const GFI_NOTICE = `${NOTICE_MARKER}
+## First-time contributors only
+
+This issue is reserved for **first-time contributors** to Corsair. If you have already had a pull request merged here, do not take this issue — we will not merge it.
+
+**How to claim**
+1. Comment \`/assign\` on this issue.
+2. Wait until GitHub shows you as the assignee. Do not open a PR before that.
+3. You may have only **one** assigned issue at a time, across integration requests, \`good first issue\`, and every other issue.
+
+Pull requests that are not assigned, or that are opened by someone who is not a first-time contributor, will be closed and will not be merged.
+`;
+
+const FTC_ASSOCIATIONS = new Set([
+	'FIRST_TIMER',
+	'FIRST_TIME_CONTRIBUTOR',
+	'NONE',
+	'',
+]);
+
+const MAINTAINER_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+
+export function isAssignCommand(body: string): boolean {
+	return /^\s*\/assign(?:\s+me)?\s*$/i.test(body.trim());
+}
+
+export function isIntegrationIssue(body: string): boolean {
+	return (
+		body.includes(INTEGRATION_MARKER) ||
+		body.includes('### What API or service would you like integrated?')
+	);
+}
+
+export function parseLinkedIssueNumbers(text: string): number[] {
+	const found = new Set<number>();
+	const re = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?):?\s+#(\d+)/gi;
+	for (const match of text.matchAll(re)) {
+		found.add(Number(match[1]));
+	}
+	return [...found].sort((a, b) => a - b);
+}
+
+export function isMaintainer(association: string): boolean {
+	return MAINTAINER_ASSOCIATIONS.has(association);
+}
+
+export function isFirstTimeContributor(
+	association: string,
+	mergedPrCount: number,
+): boolean {
+	if (mergedPrCount > 0) return false;
+	return FTC_ASSOCIATIONS.has(association);
+}
+
+export function hasFirstIssueLabel(labels: string[]): boolean {
+	return labels.some((label) => label.toLowerCase() === FIRST_ISSUE_LABEL);
+}
+
+export function oneIssueCapReply(login: string, otherIssue: number): string {
+	return `@${login} you already have #${otherIssue} assigned. Finish or unassign that one first — one issue at a time, whether it is an integration, a \`good first issue\`, or anything else.`;
+}
+
+export type CapDecision =
+	| { action: 'ok' }
+	| { action: 'revert'; reply: string };
+
+export function decideOneIssueCap(input: {
+	login: string;
+	maintainer: boolean;
+	otherAssignedIssue: number | null;
+}): CapDecision {
+	if (input.maintainer || input.otherAssignedIssue == null) {
+		return { action: 'ok' };
+	}
+	return {
+		action: 'revert',
+		reply: oneIssueCapReply(input.login, input.otherAssignedIssue),
+	};
+}
+
+export type AssignDecision =
+	| { action: 'ignore' }
+	| { action: 'assign'; reply: string }
+	| { action: 'reject'; reply: string };
+
+export function decideAssign(input: {
+	isPullRequest: boolean;
+	commentBody: string;
+	issueOpen: boolean;
+	issueLabels: string[];
+	assignees: string[];
+	commenter: string;
+	commenterAssociation: string;
+	commenterMergedPrs: number;
+	otherAssignedIssue: number | null;
+	auto?: boolean;
+}): AssignDecision {
+	if (input.isPullRequest) {
+		return { action: 'ignore' };
+	}
+	if (!input.auto && !isAssignCommand(input.commentBody)) {
+		return { action: 'ignore' };
+	}
+
+	const commenter = input.commenter.toLowerCase();
+	const assignees = input.assignees.map((login) => login.toLowerCase());
+	const maintainer = isMaintainer(input.commenterAssociation);
+	const firstIssue = hasFirstIssueLabel(input.issueLabels);
+
+	if (!input.issueOpen) {
+		return {
+			action: 'reject',
+			reply: 'This issue is closed, so it cannot be assigned.',
+		};
+	}
+
+	if (assignees.includes(commenter)) {
+		return {
+			action: 'assign',
+			reply: `@${input.commenter} you are already assigned to this issue.`,
+		};
+	}
+
+	if (assignees.length > 0) {
+		return {
+			action: 'reject',
+			reply: `This issue is already assigned to ${assignees.map((login) => `@${login}`).join(', ')}.`,
+		};
+	}
+
+	const cap = decideOneIssueCap({
+		login: input.commenter,
+		maintainer,
+		otherAssignedIssue: input.otherAssignedIssue,
+	});
+	if (cap.action === 'revert') {
+		return { action: 'reject', reply: cap.reply };
+	}
+
+	if (
+		firstIssue &&
+		!maintainer &&
+		!isFirstTimeContributor(
+			input.commenterAssociation,
+			input.commenterMergedPrs,
+		)
+	) {
+		return {
+			action: 'reject',
+			reply: `@${input.commenter} this issue is marked \`${FIRST_ISSUE_LABEL}\` and is reserved for first-time contributors. We will not merge a PR from someone who already has a merged contribution here.`,
+		};
+	}
+
+	return {
+		action: 'assign',
+		reply: `@${input.commenter} you are assigned. You can open a PR that links this issue (\`Fixes #…\`). Remember: one issue at a time.`,
+	};
+}
+
+export type LinkedIssue = {
+	number: number;
+	open: boolean;
+	labels: string[];
+	assignees: string[];
+};
+
+export type PrGateDecision =
+	| { action: 'ok' }
+	| { action: 'close'; reason: string };
+
+export function decidePrGate(input: {
+	isDraft: boolean;
+	author: string;
+	authorAssociation: string;
+	authorMergedPrs: number;
+	prLabels: string[];
+	linkedIssues: LinkedIssue[];
+}): PrGateDecision {
+	if (input.isDraft || isMaintainer(input.authorAssociation)) {
+		return { action: 'ok' };
+	}
+
+	const author = input.author.toLowerCase();
+	const firstTime = isFirstTimeContributor(
+		input.authorAssociation,
+		input.authorMergedPrs,
+	);
+	const prIsFirstIssue = hasFirstIssueLabel(input.prLabels);
+	const firstIssues = input.linkedIssues.filter((issue) =>
+		hasFirstIssueLabel(issue.labels),
+	);
+
+	if (prIsFirstIssue && firstIssues.length === 0) {
+		if (!firstTime) {
+			return {
+				action: 'close',
+				reason: `This pull request is marked \`${FIRST_ISSUE_LABEL}\`, which is reserved for first-time contributors. It will not be merged.`,
+			};
+		}
+		return {
+			action: 'close',
+			reason: `This pull request is marked \`${FIRST_ISSUE_LABEL}\`. Link the issue with \`Fixes #…\` and comment \`/assign\` on that issue before opening a PR.`,
+		};
+	}
+
+	for (const issue of firstIssues) {
+		if (!firstTime) {
+			return {
+				action: 'close',
+				reason: `#${issue.number} is marked \`${FIRST_ISSUE_LABEL}\` and is reserved for first-time contributors. This PR will not be merged.`,
+			};
+		}
+		if (issue.assignees.length === 0) {
+			return {
+				action: 'close',
+				reason: `#${issue.number} is a \`${FIRST_ISSUE_LABEL}\` and is not assigned. Comment \`/assign\` on the issue first, then reopen your PR.`,
+			};
+		}
+		if (!issue.assignees.map((login) => login.toLowerCase()).includes(author)) {
+			return {
+				action: 'close',
+				reason: `#${issue.number} is assigned to ${issue.assignees.map((login) => `@${login}`).join(', ')}, not @${input.author}.`,
+			};
+		}
+	}
+
+	for (const issue of input.linkedIssues) {
+		if (issue.assignees.length === 0) {
+			return {
+				action: 'close',
+				reason: `#${issue.number} is not assigned. Comment \`/assign\` on the issue first, then reopen your PR.`,
+			};
+		}
+		if (!issue.assignees.map((login) => login.toLowerCase()).includes(author)) {
+			return {
+				action: 'close',
+				reason: `#${issue.number} is already assigned to ${issue.assignees.map((login) => `@${login}`).join(', ')}.`,
+			};
+		}
+	}
+
+	return { action: 'ok' };
+}

--- a/scripts/pr-review/pr-scope.test.ts
+++ b/scripts/pr-review/pr-scope.test.ts
@@ -97,6 +97,29 @@ test('uses the www lane when www changes include root docs', () => {
 	});
 });
 
+test('uses the www lane when www changes include github and scripts', () => {
+	assert.deepEqual(
+		classifyPrScope([
+			'www/src/app/oss/how-it-works.tsx',
+			'.github/workflows/first-issue-assign.yml',
+			'scripts/first-issue/policy.ts',
+			'CONTRIBUTING.md',
+		]),
+		{ lane: 'www' },
+	);
+});
+
+test('skips heavy checks for github and script-only changes', () => {
+	assert.deepEqual(
+		classifyPrScope([
+			'.github/workflows/first-issue-assign.yml',
+			'scripts/first-issue/policy.ts',
+			'README.md',
+		]),
+		{ lane: 'skip-heavy' },
+	);
+});
+
 test('uses the full lane and includes www when www and packages both change', () => {
 	assert.deepEqual(
 		classifyPrScope(['www/src/app/page.tsx', 'packages/slack/index.ts']),

--- a/scripts/pr-review/pr-scope.ts
+++ b/scripts/pr-review/pr-scope.ts
@@ -36,6 +36,10 @@ function isWwwFile(file: string): boolean {
 	return file === 'www' || file.startsWith('www/');
 }
 
+function isRepoMetaFile(file: string): boolean {
+	return file.startsWith('.github/') || file.startsWith('scripts/');
+}
+
 export function isGitZeroOid(oid: string): boolean {
 	return oid.length > 0 && /^0+$/.test(oid);
 }
@@ -106,7 +110,12 @@ export function classifyPrScope(changedFiles: string[]): PrScope {
 		return { lane: 'plugin', plugin };
 	}
 
-	if (changedFiles.length > 0 && changedFiles.every(isDocumentationOnlyFile)) {
+	if (
+		changedFiles.length > 0 &&
+		changedFiles.every(
+			(file) => isDocumentationOnlyFile(file) || isRepoMetaFile(file),
+		)
+	) {
 		return { lane: 'skip-heavy' };
 	}
 
@@ -114,7 +123,10 @@ export function classifyPrScope(changedFiles: string[]): PrScope {
 	if (
 		hasWww &&
 		changedFiles.every(
-			(file) => isWwwFile(file) || isDocumentationOnlyFile(file),
+			(file) =>
+				isWwwFile(file) ||
+				isDocumentationOnlyFile(file) ||
+				isRepoMetaFile(file),
 		)
 	) {
 		return { lane: 'www' };

--- a/www/src/app/oss/[slug]/contributor-workflow-steps.tsx
+++ b/www/src/app/oss/[slug]/contributor-workflow-steps.tsx
@@ -238,7 +238,17 @@ pnpm test`;
 								existing issues
 							</a>{' '}
 							and file an integration request if needed. Include API docs,
-							endpoints, webhook needs, and auth constraints.
+							endpoints, webhook needs, and auth constraints. Opening an
+							integration issue assigns it to you. For any other issue, comment{' '}
+							<code className="rounded-md bg-[#1c1c1c]/5 px-1.5 py-0.5 font-mono text-xs">
+								/assign
+							</code>{' '}
+							to get it assigned. Do not open a PR until you are assigned. One
+							assigned issue at a time across every issue type. Issues marked{' '}
+							<code className="rounded-md bg-[#1c1c1c]/5 px-1.5 py-0.5 font-mono text-xs">
+								good first issue
+							</code>{' '}
+							are first-time contributors only and will not be merged otherwise.
 						</p>
 						<IntegrationUrlFieldForm
 							integrationId={integrationId}

--- a/www/src/app/oss/how-it-works.tsx
+++ b/www/src/app/oss/how-it-works.tsx
@@ -7,7 +7,8 @@ const steps = [
 	},
 	{
 		title: 'Build',
-		description: 'Open an issue, ship the plugin PR following the guide.',
+		description:
+			'Open an integration issue (you are assigned), then ship the plugin PR following the guide.',
 	},
 	{
 		title: 'Earn',


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->
<!-- Automated review (Greptile + gate) starts when you mark it ready. -->

## Description

Experienced contributors were taking `good first issue` PRs. This adds a GitHub `/assign` flow so those issues stay with first-timers.

- Opening an integration request assigns it to you.
- Other issues need a `/assign` comment.
- One open assigned issue per person, across every issue type. Assigning a second one via the UI gets reverted.
- `good first issue` is first-timers only. Unassigned PRs, or GFI PRs from someone who already merged here, get closed.
- CONTRIBUTING, issue templates, and `/oss` say how to get assigned.

After merge, run the **First-issue assign** workflow once (`workflow_dispatch`) so existing open GFI issues get the notice.

## Checklist

Before submitting your PR, please verify the following:

- [x] I have run `pnpm lint` and all checks pass
- [ ] I have run `pnpm typecheck` and there are no TypeScript errors
- [ ] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

`node --test --experimental-strip-types scripts/first-issue/policy.test.ts` (22 tests). Lint-staged/biome on commit. Full `pnpm typecheck` / `pnpm build` not run in this worktree.

## Screenshots / Demos (if applicable)

n/a

## Additional Notes

`GITHUB_TOKEN` often cannot assign people who are not collaborators. The bot comments when that happens. If it shows up a lot, swap the workflow token for a PAT with issues write.