### PR TITLE
docs(resend): pin list/send on the overview

### DIFF
--- a/docs/plugins/resend/overview.mdx
+++ b/docs/plugins/resend/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: "Resend plugin for Corsair — transactional email send, list, and delivery events."
+description: "Developer email API for sending transactional messages, broadcasts, and deliverability tools."
 ---
 
 Use **Resend** through Corsair: one client, typed API calls, local DB sync, and incoming webhooks.

--- a/docs/plugins/resend/overview.mdx
+++ b/docs/plugins/resend/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: "Developer email API for sending transactional messages, broadcasts, and deliverability tools."
+description: "Resend plugin for Corsair — transactional email send, list, and delivery events."
 ---
 
 Use **Resend** through Corsair: one client, typed API calls, local DB sync, and incoming webhooks.
@@ -92,19 +92,24 @@ const { connectUrl } = await corsair.manage.connect.createLink({
 
 ## Example API calls
 
-**`contacts.get`**
+**List emails**
 
 ```ts
 const tenant = corsair.withTenant('acme');
-await tenant.resend.api.contacts.get({});
+await tenant.resend.api.emails.list({});
 ```
 
 
-**`contacts.create`**
+**Send an email**
 
 ```ts
 const tenant = corsair.withTenant('acme');
-await tenant.resend.api.contacts.create({});
+await tenant.resend.api.emails.send({
+	from: 'corsair@example.com',
+	to: 'you@example.com',
+	subject: 'Hello from Corsair',
+	text: 'Hello from Corsair',
+});
 ```
 
 
@@ -112,15 +117,37 @@ See the full list on the [API](/plugins/resend/api) page.
 
 ## Query synced data
 
-Synced entities support `tenant.resend.db.<entity>.search()` and `.list()`: `contacts`, `domains`, `emails`.
+Search synced emails without hitting Resend.
 
-See [Database](/plugins/resend/database) for filters and operators.
+```ts
+const tenant = corsair.withTenant('acme');
+const rows = await tenant.resend.db.emails.search({
+	data: {},
+	limit: 50,
+});
+```
+
+Synced entities: `contacts`, `domains`, `emails`. See [Database](/plugins/resend/database) for filters and operators.
 
 ## Webhooks
 
-This plugin registers **16** webhook event types. Configure the provider to POST to your Corsair HTTP handler, then use `webhookHooks` on the plugin factory.
+Fires when Resend accepts an outbound email.
 
-See [Webhooks](/plugins/resend/webhooks) for every event path and payload shape, and [Webhooks concept](/concepts/webhooks) for routing.
+```ts
+resend({
+    webhookHooks: {
+        emails: {
+            sent: {
+                after: async (ctx, result) => {
+                    console.log('Email sent:', result.data);
+                }
+            },
+        },
+    },
+})
+```
+
+Mount your framework handler once (see [Frameworks](/frameworks/next)), then point the provider at that URL. Full event list: [Webhooks](/plugins/resend/webhooks). Concepts: [Webhooks](/concepts/webhooks), [Hooks](/concepts/hooks).
 
 ## What's next
 

--- a/docs/plugins/resend/overview.mdx
+++ b/docs/plugins/resend/overview.mdx
@@ -52,7 +52,7 @@ export const corsair = createCorsair({
 });
 ```
 
-Multi-tenancy is the default — scope calls with `corsair.withTenant(id)`. See [Quick start](/quick-start) for KEK + Hub keys, and [Multi-tenancy](/concepts/multi-tenancy) for account isolation.
+Multi-tenancy is the default. Scope calls with `corsair.withTenant(id)`. See [Quick start](/quick-start) for KEK + Hub keys, and [Multi-tenancy](/concepts/multi-tenancy) for account isolation.
 
 </Step>
 
@@ -76,7 +76,7 @@ More: [API Key](/concepts/api-key)
 </Step>
 
 <Step title="Connect a tenant">
-Mint a connect link and send the tenant to it. Hub hosts the page and delivers the result to your app — see [Connect / OAuth](/management/connect).
+Mint a connect link and send the tenant to it. Hub hosts the page and delivers the result to your app. See [Connect / OAuth](/management/connect).
 
 ```ts
 const { connectUrl } = await corsair.manage.connect.createLink({

--- a/packages/resend/plugin-docs.yaml
+++ b/packages/resend/plugin-docs.yaml
@@ -1,5 +1,5 @@
 displayName: Resend
-description: "Resend plugin for Corsair — transactional email send, list, and delivery events."
+description: Developer email API for sending transactional messages, broadcasts, and deliverability tools.
 examples:
   read:
     path: emails.list
@@ -14,10 +14,10 @@ examples:
       text: Hello from Corsair
 dbExample:
   entity: emails
-  note: "Search synced emails without hitting Resend."
+  note: 'Search synced emails without hitting Resend.'
   limit: 50
 exampleWebhook:
   path: emails.sent
-  note: "Fires when Resend accepts an outbound email."
+  note: 'Fires when Resend accepts an outbound email.'
   after: |
     console.log('Email sent:', result.data);

--- a/packages/resend/plugin-docs.yaml
+++ b/packages/resend/plugin-docs.yaml
@@ -1,2 +1,23 @@
 displayName: Resend
-description: Developer email API for sending transactional messages, broadcasts, and deliverability tools.
+description: "Resend plugin for Corsair — transactional email send, list, and delivery events."
+examples:
+  read:
+    path: emails.list
+    title: List emails
+  write:
+    path: emails.send
+    title: Send an email
+    args:
+      from: corsair@example.com
+      to: you@example.com
+      subject: Hello from Corsair
+      text: Hello from Corsair
+dbExample:
+  entity: emails
+  note: "Search synced emails without hitting Resend."
+  limit: 50
+exampleWebhook:
+  path: emails.sent
+  note: "Fires when Resend accepts an outbound email."
+  after: |
+    console.log('Email sent:', result.data);


### PR DESCRIPTION
<!-- Please open this PR as a DRAFT until the checklist below is complete. -->

## Description

Adds Resend-specific documentation metadata so the generated Resend overview uses `emails.list` and `emails.send` as the primary API examples instead of the generator defaults.

Also configures the generated database and webhook examples for Resend.

Closes #1253

## Checklist

- [x] I have run `pnpm validate:docs`
- [x] I have run `pnpm typecheck`
- [x] I have run the Resend package tests
- [x] I have run `pnpm generate:docs -- --plugin=resend` successfully

## Screenshots / Demos

Not applicable: documentation-only change.

## Additional Notes

- Added `packages/resend/plugin-docs.yaml`.
- Regenerated `docs/plugins/resend/overview.mdx`.
- No Resend plugin source code was changed.
- The generator completed successfully twice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Resend integration guidance with clearer punctuation and revised API examples.
  * Added examples for listing and sending emails.
  * Added guidance for searching synced emails and configuring webhook handlers for sent-email events.
  * Expanded plugin configuration examples with sample arguments and handler behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->