### PR TITLE
feat(northflank): add @corsair-dev/northflank plugin (#1681)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1812,6 +1812,14 @@
                 ]
               },
               {
+                "group": "Northflank",
+                "pages": [
+                  "plugins/northflank/overview",
+                  "plugins/northflank/api",
+                  "plugins/northflank/database"
+                ]
+              },
+              {
                 "group": "Notion",
                 "pages": [
                   "plugins/notion/overview",

--- a/docs/plugins/northflank/api.mdx
+++ b/docs/plugins/northflank/api.mdx
@@ -1,0 +1,808 @@
+---
+title: API
+description: "API reference for Northflank: every `northflank.api.*` operation with input and output types."
+---
+
+Every `northflank.api.*` operation is listed below with parameter shapes and return types from the plugin Zod schemas.
+
+<Info>
+**New to Corsair?** See [API access](/concepts/api), [authentication](/concepts/auth), and [error handling](/concepts/error-handling).
+</Info>
+
+## Environments
+
+### listPreviews
+
+`environments.listPreviews`
+
+List preview environments for a preview blueprint
+
+**Risk:** `read`
+
+```ts
+await corsair.northflank.api.environments.listPreviews({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectId` | `string` | Yes | — |
+| `previewBlueprintId` | `string` | Yes | — |
+| `page` | `number` | No | — |
+| `per_page` | `number` | No | — |
+| `cursor` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `data` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  previewEnvironments: {
+  }[],
+  pagination?: {
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Plans
+
+### list
+
+`plans.list`
+
+List available Northflank resource plans
+
+**Risk:** `read`
+
+```ts
+await corsair.northflank.api.plans.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `page` | `number` | No | — |
+| `per_page` | `number` | No | — |
+| `cursor` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `data` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  plans: {
+  }[]
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Projects
+
+### create
+
+`projects.create`
+
+Create a new Northflank project
+
+**Risk:** `write`
+
+```ts
+await corsair.northflank.api.projects.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `name` | `string` | Yes | — |
+| `description` | `string` | No | — |
+| `region` | `string` | Yes | — |
+| `color` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `data` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### get
+
+`projects.get`
+
+Get details of a Northflank project
+
+**Risk:** `read`
+
+```ts
+await corsair.northflank.api.projects.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `data` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### list
+
+`projects.list`
+
+List Northflank projects
+
+**Risk:** `read`
+
+```ts
+await corsair.northflank.api.projects.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `page` | `number` | No | — |
+| `per_page` | `number` | No | — |
+| `cursor` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `data` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  projects: {
+  }[],
+  pagination?: {
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### update
+
+`projects.update`
+
+Update an existing Northflank project
+
+**Risk:** `write`
+
+```ts
+await corsair.northflank.api.projects.update({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectId` | `string` | Yes | — |
+| `name` | `string` | No | — |
+| `description` | `string` | No | — |
+| `color` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `data` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Regions
+
+### list
+
+`regions.list`
+
+List available Northflank regions
+
+**Risk:** `read`
+
+```ts
+await corsair.northflank.api.regions.list({});
+```
+
+**Input:** _empty object_
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `data` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  regions: {
+  }[]
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Secrets
+
+### create
+
+`secrets.create`
+
+Create a new Northflank secret
+
+**Risk:** `write`
+
+```ts
+await corsair.northflank.api.secrets.create({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectId` | `string` | Yes | — |
+| `name` | `string` | Yes | — |
+| `description` | `string` | No | — |
+| `secretType` | `secret \| variable` | No | — |
+| `priority` | `number` | No | — |
+| `data` | `object` | No | — |
+| `useAsEnvironmentVariable` | `boolean` | No | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `data` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### get
+
+`secrets.get`
+
+Get details of a Northflank secret
+
+**Risk:** `read`
+
+```ts
+await corsair.northflank.api.secrets.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectId` | `string` | Yes | — |
+| `secretId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `data` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### list
+
+`secrets.list`
+
+List secrets in a Northflank project
+
+**Risk:** `read`
+
+```ts
+await corsair.northflank.api.secrets.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectId` | `string` | Yes | — |
+| `page` | `number` | No | — |
+| `per_page` | `number` | No | — |
+| `cursor` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `data` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  secrets: {
+  }[],
+  pagination?: {
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### update
+
+`secrets.update`
+
+Update an existing Northflank secret
+
+**Risk:** `write`
+
+```ts
+await corsair.northflank.api.secrets.update({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectId` | `string` | Yes | — |
+| `secretId` | `string` | Yes | — |
+| `name` | `string` | No | — |
+| `description` | `string` | No | — |
+| `data` | `object` | No | — |
+| `priority` | `number` | No | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `data` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+## Services
+
+### createCombined
+
+`services.createCombined`
+
+Create a new combined service in a project
+
+**Risk:** `write`
+
+```ts
+await corsair.northflank.api.services.createCombined({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectId` | `string` | Yes | — |
+| `name` | `string` | Yes | — |
+| `description` | `string` | No | — |
+| `billing` | `object` | No | — |
+| `deployment` | `object` | No | — |
+| `buildSource` | `object` | No | — |
+| `vcsData` | `object` | No | — |
+| `buildSettings` | `object` | No | — |
+| `runtimeEnvironment` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="billing full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="deployment full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="buildSource full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="vcsData full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="buildSettings full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="runtimeEnvironment full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `data` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### get
+
+`services.get`
+
+Get details of a Northflank service
+
+**Risk:** `read`
+
+```ts
+await corsair.northflank.api.services.get({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectId` | `string` | Yes | — |
+| `serviceId` | `string` | Yes | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `data` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### list
+
+`services.list`
+
+List services in a Northflank project
+
+**Risk:** `read`
+
+```ts
+await corsair.northflank.api.services.list({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectId` | `string` | Yes | — |
+| `page` | `number` | No | — |
+| `per_page` | `number` | No | — |
+| `cursor` | `string` | No | — |
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `data` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+  services: {
+  }[],
+  pagination?: {
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+
+### updateCombined
+
+`services.updateCombined`
+
+Update an existing combined service in a project
+
+**Risk:** `write`
+
+```ts
+await corsair.northflank.api.services.updateCombined({});
+```
+
+**Input**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `projectId` | `string` | Yes | — |
+| `serviceId` | `string` | Yes | — |
+| `name` | `string` | No | — |
+| `description` | `string` | No | — |
+| `billing` | `object` | No | — |
+| `deployment` | `object` | No | — |
+| `buildSource` | `object` | No | — |
+| `vcsData` | `object` | No | — |
+| `buildSettings` | `object` | No | — |
+| `runtimeEnvironment` | `object` | No | — |
+
+<AccordionGroup>
+<Accordion title="billing full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="deployment full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="buildSource full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="vcsData full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="buildSettings full type">
+
+```ts
+{
+}
+```
+</Accordion>
+
+<Accordion title="runtimeEnvironment full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+**Output**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `data` | `object` | Yes | — |
+
+<AccordionGroup>
+<Accordion title="data full type">
+
+```ts
+{
+}
+```
+</Accordion>
+</AccordionGroup>
+
+
+
+---
+

--- a/docs/plugins/northflank/database.mdx
+++ b/docs/plugins/northflank/database.mdx
@@ -1,0 +1,12 @@
+---
+title: Database
+description: "Northflank local sync: searchable entities, `.search()` filters, and operators."
+---
+
+The Northflank plugin syncs data locally. Use `corsair.northflank.db.<entity>.search({ data, limit?, offset? })` with the filters listed per entity.
+
+<Info>
+**New to Corsair?** See [database operations](/concepts/database), [data synchronization](/concepts/integrations), and [multi-tenancy](/concepts/multi-tenancy).
+</Info>
+
+

--- a/docs/plugins/northflank/overview.mdx
+++ b/docs/plugins/northflank/overview.mdx
@@ -1,0 +1,121 @@
+---
+title: Overview
+description: "Connect Northflank to manage projects, services, preview environments, secrets, plans, and regions."
+---
+
+Use **Northflank** through Corsair: one client, typed API calls.
+
+**What you get:**
+
+- 15 typed API operations
+
+## Setup
+
+<Steps>
+
+<Step title="Install">
+<CodeGroup>
+```bash npm
+npm install corsair @corsair-dev/northflank
+```
+```bash yarn
+yarn add corsair @corsair-dev/northflank
+```
+```bash pnpm
+pnpm install corsair @corsair-dev/northflank
+```
+```bash bun
+bun add corsair @corsair-dev/northflank
+```
+</CodeGroup>
+
+</Step>
+
+<Step title="Add the plugin">
+```ts corsair.ts
+import Database from 'better-sqlite3';
+import { createCorsair } from 'corsair';
+import { northflank } from '@corsair-dev/northflank';
+
+export const corsair = createCorsair({
+	plugins: [
+		northflank(),
+	],
+	database: new Database('corsair.db'),
+	kek: process.env.CORSAIR_KEK!,
+	hub: {
+		projectApiKey: process.env.CORSAIR_API_KEY!,
+		signingSecret: process.env.CORSAIR_SIGNING_SECRET!,
+	},
+});
+```
+
+Multi-tenancy is the default — scope calls with `corsair.withTenant(id)`. See [Quick start](/quick-start) for KEK + Hub keys, and [Multi-tenancy](/concepts/multi-tenancy) for account isolation.
+
+</Step>
+
+<Step title="Choose authentication">
+<Tabs>
+<Tab title="API Key (Recommended)">
+
+No setup required yet. When you make your first request as a tenant, Corsair prompts for the API key.
+
+```ts
+northflank()
+```
+
+More: [API Key](/concepts/api-key)
+
+</Tab>
+</Tabs>
+
+</Step>
+
+<Step title="Connect a tenant">
+Mint a connect link and send the tenant to it. Hub hosts the page and delivers the result to your app — see [Connect / OAuth](/management/connect).
+
+```ts
+const { connectUrl } = await corsair.manage.connect.createLink({
+	plugin: 'northflank',
+	tenantId: 'acme',
+});
+// redirect the user's browser to connectUrl
+```
+
+</Step>
+
+</Steps>
+
+## Example API calls
+
+**`environments.listPreviews`**
+
+```ts
+const tenant = corsair.withTenant('acme');
+await tenant.northflank.api.environments.listPreviews({});
+```
+
+
+**`projects.create`**
+
+```ts
+const tenant = corsair.withTenant('acme');
+await tenant.northflank.api.projects.create({});
+```
+
+
+See the full list on the [API](/plugins/northflank/api) page.
+
+## What's next
+
+<CardGroup cols={2}>
+  <Card title="API reference" href="/plugins/northflank/api">
+    Every `northflank.api.*` operation with input and output types.
+  </Card>
+  <Card title="Connect / OAuth" href="/management/connect">
+    createLink, Hub delivery, and tenant connect flows.
+  </Card>
+  <Card title="Use with agents" href="/mcp-adapters/mcp-adapters">
+    Expose this plugin's operations as MCP tools.
+  </Card>
+</CardGroup>

--- a/packages/corsair/core/constants.ts
+++ b/packages/corsair/core/constants.ts
@@ -211,6 +211,7 @@ export const BaseProviders = [
 	'monday',
 	'neon',
 	'nextdns',
+	'northflank',
 	'notion',
 	'ocrspace',
 	'ocrwebservice',
@@ -497,6 +498,7 @@ export const ProviderDisplayNames = {
 	monday: 'Monday',
 	neon: 'Neon',
 	nextdns: 'NextDNS',
+	northflank: 'Northflank',
 	notion: 'Notion',
 	ocrspace: 'OCR.space',
 	ocrwebservice: 'OcrWebService',
@@ -790,6 +792,7 @@ export type AllProviders =
 	| 'monday'
 	| 'neon'
 	| 'nextdns'
+	| 'northflank'
 	| 'notion'
 	| 'ocrspace'
 	| 'ocrwebservice'

--- a/packages/northflank/README.md
+++ b/packages/northflank/README.md
@@ -1,0 +1,39 @@
+# @corsair-dev/northflank
+
+Northflank integration plugin for Corsair.
+
+## Installation
+
+\`\`\`bash
+pnpm add @corsair-dev/northflank
+\`\`\`
+
+## Authentication
+
+Northflank uses an API token passed as a Bearer token:
+
+\`\`\`typescript
+import { corsair } from 'corsair';
+import { northflank } from '@corsair-dev/northflank';
+
+const app = corsair({
+  plugins: [
+    northflank({
+      key: process.env.NORTHFLANK_API_TOKEN,
+    }),
+  ],
+});
+\`\`\`
+
+## Supported Resources
+
+- **Projects**: `list`, `get`, `create`, `update`
+- **Services**: `list`, `get`, `createCombined`, `updateCombined`
+- **Environments**: `listPreviews`
+- **Secrets**: `list`, `get`, `create`, `update`
+- **Plans**: `list`
+- **Regions**: `list`
+
+## Webhooks
+
+Webhooks are not applicable for this plugin and are excluded.

--- a/packages/northflank/api.test.ts
+++ b/packages/northflank/api.test.ts
@@ -1,0 +1,315 @@
+import { AuthMissingError, logEventFromContext } from 'corsair/core';
+import { request } from 'corsair/http';
+import type { NorthflankContext, NorthflankKeyBuilderContext } from './index';
+import {
+	northflank,
+	northflankEndpointMeta,
+	northflankEndpointSchemas,
+	northflankEndpointsNested,
+} from './index';
+
+jest.mock('corsair/core', () => {
+	const original = jest.requireActual('corsair/core');
+	return {
+		...original,
+		logEventFromContext: jest.fn().mockResolvedValue('test-event-id'),
+	};
+});
+
+jest.mock('corsair/http', () => {
+	const original = jest.requireActual('corsair/http');
+	return {
+		...original,
+		request: jest.fn(),
+	};
+});
+
+const mockRequest = request as jest.Mock;
+const mockLogEvent = logEventFromContext as jest.Mock;
+
+function countLeaves(tree: Record<string, unknown>): number {
+	return Object.values(tree).reduce<number>((count, value) => {
+		if (typeof value === 'function') return count + 1;
+		if (value && typeof value === 'object') {
+			return count + countLeaves(value as Record<string, unknown>);
+		}
+		return count;
+	}, 0);
+}
+
+function endpointPaths(tree: Record<string, unknown>, prefix = ''): string[] {
+	return Object.entries(tree).flatMap(([key, value]) => {
+		const path = prefix ? `${prefix}.${key}` : key;
+		if (typeof value === 'function') return [path];
+		if (value && typeof value === 'object') {
+			return endpointPaths(value as Record<string, unknown>, path);
+		}
+		return [];
+	});
+}
+
+const mockCtx = {
+	key: 'test-api-token',
+	$getAccountId: () => 'test-account-id',
+	options: {},
+	logEvent: jest.fn(),
+	db: {},
+} as unknown as NorthflankContext & { logEvent: jest.Mock };
+
+describe('Northflank plugin structure and endpoints', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+		mockLogEvent.mockReset();
+	});
+
+	it('exposes all 15 endpoints with meta and schemas', () => {
+		const plugin = northflank();
+		const endpoints = plugin.endpoints as Record<string, unknown>;
+		const paths = endpointPaths(endpoints).sort();
+
+		expect(countLeaves(endpoints)).toBe(15);
+		expect(Object.keys(plugin.endpointMeta ?? {})).toHaveLength(15);
+		expect(Object.keys(northflankEndpointMeta)).toHaveLength(15);
+		expect(Object.keys(northflankEndpointSchemas)).toHaveLength(15);
+		expect(Object.keys(plugin.endpointMeta ?? {}).sort()).toEqual(paths);
+		expect(Object.keys(northflankEndpointMeta).sort()).toEqual(paths);
+		expect(Object.keys(northflankEndpointSchemas).sort()).toEqual(paths);
+		expect(plugin.webhooks).toEqual({});
+		expect(plugin.pluginWebhookMatcher).toBeUndefined();
+	});
+
+	it('configures api_key auth correctly', () => {
+		const plugin = northflank();
+		expect(plugin.options?.authType).toBe('api_key');
+		expect(plugin.authConfig).toEqual({ api_key: {} });
+	});
+
+	it('resolves key from options when provided', async () => {
+		const plugin = northflank({ key: 'custom-api-token' });
+		const keyBuilder = plugin.keyBuilder as (
+			ctx: NorthflankKeyBuilderContext,
+			source: string,
+		) => Promise<string>;
+		const key = await keyBuilder(
+			{ authType: 'api_key' } as NorthflankKeyBuilderContext,
+			'endpoint',
+		);
+		expect(key).toBe('custom-api-token');
+	});
+
+	it('resolves key from keys.get_api_key when options.key is not provided', async () => {
+		const plugin = northflank();
+		const keyBuilder = plugin.keyBuilder as (
+			ctx: NorthflankKeyBuilderContext,
+			source: string,
+		) => Promise<string>;
+		const mockKeysContext = {
+			authType: 'api_key',
+			keys: {
+				get_api_key: jest.fn().mockResolvedValue('stored-api-token'),
+			},
+		} as unknown as NorthflankKeyBuilderContext;
+
+		const key = await keyBuilder(mockKeysContext, 'endpoint');
+		expect(key).toBe('stored-api-token');
+	});
+
+	it('throws AuthMissingError when key is unavailable', async () => {
+		const plugin = northflank();
+		const keyBuilder = plugin.keyBuilder as (
+			ctx: NorthflankKeyBuilderContext,
+			source: string,
+		) => Promise<string>;
+		const mockKeysContext = {
+			authType: 'api_key',
+			keys: {
+				get_api_key: jest.fn().mockResolvedValue(undefined),
+			},
+		} as unknown as NorthflankKeyBuilderContext;
+
+		await expect(keyBuilder(mockKeysContext, 'endpoint')).rejects.toThrow(
+			AuthMissingError,
+		);
+	});
+
+	describe('Endpoint invocations', () => {
+		it('calls projects.list and logs audit event', async () => {
+			mockRequest.mockResolvedValueOnce({
+				data: { projects: [{ id: 'p1', name: 'Demo' }] },
+			});
+			const res = await northflankEndpointsNested.projects.list(mockCtx, {
+				page: 1,
+				per_page: 10,
+			});
+
+			expect(mockRequest).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({
+					method: 'GET',
+					url: 'projects',
+					query: { page: 1, per_page: 10 },
+				}),
+			);
+			expect(res.data.projects).toHaveLength(1);
+			expect(mockLogEvent).toHaveBeenCalledWith(
+				mockCtx,
+				'northflank.projects.list',
+				{},
+				'completed',
+			);
+		});
+
+		it('calls projects.get and logs audit event', async () => {
+			mockRequest.mockResolvedValueOnce({ data: { id: 'p1' } });
+			const res = await northflankEndpointsNested.projects.get(mockCtx, {
+				projectId: 'p1',
+			});
+
+			expect(mockRequest).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({
+					method: 'GET',
+					url: 'projects/p1',
+				}),
+			);
+			expect(res.data).toEqual({ id: 'p1' });
+		});
+
+		it('calls projects.create with request body', async () => {
+			mockRequest.mockResolvedValueOnce({
+				data: { id: 'p1', name: 'New Project' },
+			});
+			await northflankEndpointsNested.projects.create(mockCtx, {
+				name: 'New Project',
+				region: 'europe-west',
+			});
+
+			expect(mockRequest).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({
+					method: 'POST',
+					url: 'projects',
+					body: { name: 'New Project', region: 'europe-west' },
+				}),
+			);
+		});
+
+		it('calls projects.update with patch body', async () => {
+			mockRequest.mockResolvedValueOnce({
+				data: { id: 'p1', name: 'Updated' },
+			});
+			await northflankEndpointsNested.projects.update(mockCtx, {
+				projectId: 'p1',
+				name: 'Updated',
+			});
+
+			expect(mockRequest).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({
+					method: 'PATCH',
+					url: 'projects/p1',
+					body: { name: 'Updated' },
+				}),
+			);
+		});
+
+		it('calls services.createCombined with service payload', async () => {
+			mockRequest.mockResolvedValueOnce({
+				data: { id: 's1', name: 'my-service' },
+			});
+			await northflankEndpointsNested.services.createCombined(mockCtx, {
+				projectId: 'p1',
+				name: 'my-service',
+				deployment: { instances: 1 },
+			});
+
+			expect(mockRequest).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({
+					method: 'POST',
+					url: 'projects/p1/services/combined',
+					body: { name: 'my-service', deployment: { instances: 1 } },
+				}),
+			);
+		});
+
+		it('calls environments.listPreviews with blueprint parameters', async () => {
+			mockRequest.mockResolvedValueOnce({
+				data: { previewEnvironments: [] },
+			});
+			await northflankEndpointsNested.environments.listPreviews(mockCtx, {
+				projectId: 'p1',
+				previewBlueprintId: 'bp1',
+			});
+
+			expect(mockRequest).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({
+					method: 'GET',
+					url: 'projects/p1/preview-blueprints/bp1/preview-environments',
+				}),
+			);
+		});
+
+		it('calls secrets.create and never exposes secret values in event log', async () => {
+			mockRequest.mockResolvedValueOnce({
+				data: { id: 'sec1', name: 'DB_KEY' },
+			});
+			await northflankEndpointsNested.secrets.create(mockCtx, {
+				projectId: 'p1',
+				name: 'DB_KEY',
+				data: { SECRET_VALUE: 'super-sensitive' },
+			});
+
+			expect(mockRequest).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({
+					method: 'POST',
+					url: 'projects/p1/secrets',
+					body: {
+						name: 'DB_KEY',
+						data: { SECRET_VALUE: 'super-sensitive' },
+					},
+				}),
+			);
+
+			// Ensure event log does NOT contain the secret payload
+			expect(mockLogEvent).toHaveBeenCalledWith(
+				mockCtx,
+				'northflank.secrets.create',
+				{ projectId: 'p1', name: 'DB_KEY' },
+				'completed',
+			);
+		});
+
+		it('calls plans.list', async () => {
+			mockRequest.mockResolvedValueOnce({
+				data: { plans: [{ id: 'plan1' }] },
+			});
+			const res = await northflankEndpointsNested.plans.list(mockCtx, {});
+			expect(mockRequest).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({
+					method: 'GET',
+					url: 'plans',
+				}),
+			);
+			expect(res.data.plans).toHaveLength(1);
+		});
+
+		it('calls regions.list', async () => {
+			mockRequest.mockResolvedValueOnce({
+				data: { regions: [{ id: 'eu-west' }] },
+			});
+			const res = await northflankEndpointsNested.regions.list(mockCtx, {});
+			expect(mockRequest).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({
+					method: 'GET',
+					url: 'regions',
+				}),
+			);
+			expect(res.data.regions).toHaveLength(1);
+		});
+	});
+});

--- a/packages/northflank/api.test.ts
+++ b/packages/northflank/api.test.ts
@@ -1,5 +1,6 @@
 import { AuthMissingError, logEventFromContext } from 'corsair/core';
 import { request } from 'corsair/http';
+import { ZodError } from 'zod';
 import type { NorthflankContext, NorthflankKeyBuilderContext } from './index';
 import {
 	northflank,
@@ -132,7 +133,30 @@ describe('Northflank plugin structure and endpoints', () => {
 		);
 	});
 
-	describe('Endpoint invocations', () => {
+	describe('Runtime Schema Validation', () => {
+		it('rejects invalid caller input at runtime before making an HTTP request', async () => {
+			// projectId is required and cannot be empty
+			await expect(
+				northflankEndpointsNested.projects.get(mockCtx, {
+					projectId: '',
+				}),
+			).rejects.toThrow(ZodError);
+
+			expect(mockRequest).not.toHaveBeenCalled();
+		});
+
+		it('validates provider response against output schema at runtime', async () => {
+			// Provider returns malformed response missing data object
+			mockRequest.mockResolvedValueOnce({ unexpected: true });
+
+			await expect(
+				northflankEndpointsNested.projects.list(mockCtx, {}),
+			).rejects.toThrow(ZodError);
+		});
+	});
+
+	describe('All 15 Endpoint Invocations and Request Construction', () => {
+		// 1. projects.list
 		it('calls projects.list and logs audit event', async () => {
 			mockRequest.mockResolvedValueOnce({
 				data: { projects: [{ id: 'p1', name: 'Demo' }] },
@@ -159,6 +183,7 @@ describe('Northflank plugin structure and endpoints', () => {
 			);
 		});
 
+		// 2. projects.get
 		it('calls projects.get and logs audit event', async () => {
 			mockRequest.mockResolvedValueOnce({ data: { id: 'p1' } });
 			const res = await northflankEndpointsNested.projects.get(mockCtx, {
@@ -173,8 +198,15 @@ describe('Northflank plugin structure and endpoints', () => {
 				}),
 			);
 			expect(res.data).toEqual({ id: 'p1' });
+			expect(mockLogEvent).toHaveBeenCalledWith(
+				mockCtx,
+				'northflank.projects.get',
+				{ projectId: 'p1' },
+				'completed',
+			);
 		});
 
+		// 3. projects.create
 		it('calls projects.create with request body', async () => {
 			mockRequest.mockResolvedValueOnce({
 				data: { id: 'p1', name: 'New Project' },
@@ -192,8 +224,15 @@ describe('Northflank plugin structure and endpoints', () => {
 					body: { name: 'New Project', region: 'europe-west' },
 				}),
 			);
+			expect(mockLogEvent).toHaveBeenCalledWith(
+				mockCtx,
+				'northflank.projects.create',
+				{ name: 'New Project', region: 'europe-west' },
+				'completed',
+			);
 		});
 
+		// 4. projects.update
 		it('calls projects.update with patch body', async () => {
 			mockRequest.mockResolvedValueOnce({
 				data: { id: 'p1', name: 'Updated' },
@@ -211,8 +250,69 @@ describe('Northflank plugin structure and endpoints', () => {
 					body: { name: 'Updated' },
 				}),
 			);
+			expect(mockLogEvent).toHaveBeenCalledWith(
+				mockCtx,
+				'northflank.projects.update',
+				{ projectId: 'p1' },
+				'completed',
+			);
 		});
 
+		// 5. services.list
+		it('calls services.list with project ID and pagination query', async () => {
+			mockRequest.mockResolvedValueOnce({
+				data: { services: [{ id: 's1', name: 'web' }] },
+			});
+			const res = await northflankEndpointsNested.services.list(mockCtx, {
+				projectId: 'p1',
+				page: 1,
+				per_page: 20,
+			});
+
+			expect(mockRequest).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({
+					method: 'GET',
+					url: 'projects/p1/services',
+					query: { page: 1, per_page: 20 },
+				}),
+			);
+			expect(res.data.services).toHaveLength(1);
+			expect(mockLogEvent).toHaveBeenCalledWith(
+				mockCtx,
+				'northflank.services.list',
+				{ projectId: 'p1' },
+				'completed',
+			);
+		});
+
+		// 6. services.get
+		it('calls services.get with project and service IDs', async () => {
+			mockRequest.mockResolvedValueOnce({
+				data: { id: 's1', name: 'web' },
+			});
+			const res = await northflankEndpointsNested.services.get(mockCtx, {
+				projectId: 'p1',
+				serviceId: 's1',
+			});
+
+			expect(mockRequest).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({
+					method: 'GET',
+					url: 'projects/p1/services/s1',
+				}),
+			);
+			expect(res.data).toEqual({ id: 's1', name: 'web' });
+			expect(mockLogEvent).toHaveBeenCalledWith(
+				mockCtx,
+				'northflank.services.get',
+				{ projectId: 'p1', serviceId: 's1' },
+				'completed',
+			);
+		});
+
+		// 7. services.createCombined
 		it('calls services.createCombined with service payload', async () => {
 			mockRequest.mockResolvedValueOnce({
 				data: { id: 's1', name: 'my-service' },
@@ -231,26 +331,126 @@ describe('Northflank plugin structure and endpoints', () => {
 					body: { name: 'my-service', deployment: { instances: 1 } },
 				}),
 			);
+			expect(mockLogEvent).toHaveBeenCalledWith(
+				mockCtx,
+				'northflank.services.createCombined',
+				{ projectId: 'p1', name: 'my-service' },
+				'completed',
+			);
 		});
 
-		it('calls environments.listPreviews with blueprint parameters', async () => {
+		// 8. services.updateCombined
+		it('calls services.updateCombined with service PATCH payload', async () => {
 			mockRequest.mockResolvedValueOnce({
-				data: { previewEnvironments: [] },
+				data: { id: 's1', name: 'updated-service' },
 			});
-			await northflankEndpointsNested.environments.listPreviews(mockCtx, {
+			await northflankEndpointsNested.services.updateCombined(mockCtx, {
 				projectId: 'p1',
-				previewBlueprintId: 'bp1',
+				serviceId: 's1',
+				name: 'updated-service',
+				deployment: { instances: 2 },
+			});
+
+			expect(mockRequest).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({
+					method: 'PATCH',
+					url: 'projects/p1/services/combined/s1',
+					body: { name: 'updated-service', deployment: { instances: 2 } },
+				}),
+			);
+			expect(mockLogEvent).toHaveBeenCalledWith(
+				mockCtx,
+				'northflank.services.updateCombined',
+				{ projectId: 'p1', serviceId: 's1' },
+				'completed',
+			);
+		});
+
+		// 9. environments.listPreviews (verifying preview-blueprints/{id}/previews route)
+		it('calls environments.listPreviews with correct Northflank previews route', async () => {
+			mockRequest.mockResolvedValueOnce({
+				data: { previewEnvironments: [{ id: 'pe1' }] },
+			});
+			const res = await northflankEndpointsNested.environments.listPreviews(
+				mockCtx,
+				{
+					projectId: 'p1',
+					previewBlueprintId: 'bp1',
+					page: 1,
+					per_page: 10,
+				},
+			);
+
+			expect(mockRequest).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({
+					method: 'GET',
+					url: 'projects/p1/preview-blueprints/bp1/previews',
+					query: { page: 1, per_page: 10 },
+				}),
+			);
+			expect(res.data.previewEnvironments).toHaveLength(1);
+			expect(mockLogEvent).toHaveBeenCalledWith(
+				mockCtx,
+				'northflank.environments.listPreviews',
+				{ projectId: 'p1', previewBlueprintId: 'bp1' },
+				'completed',
+			);
+		});
+
+		// 10. secrets.list
+		it('calls secrets.list with project ID', async () => {
+			mockRequest.mockResolvedValueOnce({
+				data: { secrets: [{ id: 'sec1', name: 'API_KEY' }] },
+			});
+			const res = await northflankEndpointsNested.secrets.list(mockCtx, {
+				projectId: 'p1',
 			});
 
 			expect(mockRequest).toHaveBeenCalledWith(
 				expect.any(Object),
 				expect.objectContaining({
 					method: 'GET',
-					url: 'projects/p1/preview-blueprints/bp1/preview-environments',
+					url: 'projects/p1/secrets',
 				}),
+			);
+			expect(res.data.secrets).toHaveLength(1);
+			expect(mockLogEvent).toHaveBeenCalledWith(
+				mockCtx,
+				'northflank.secrets.list',
+				{ projectId: 'p1' },
+				'completed',
 			);
 		});
 
+		// 11. secrets.get
+		it('calls secrets.get with project and secret IDs', async () => {
+			mockRequest.mockResolvedValueOnce({
+				data: { id: 'sec1', name: 'API_KEY' },
+			});
+			const res = await northflankEndpointsNested.secrets.get(mockCtx, {
+				projectId: 'p1',
+				secretId: 'sec1',
+			});
+
+			expect(mockRequest).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({
+					method: 'GET',
+					url: 'projects/p1/secrets/sec1',
+				}),
+			);
+			expect(res.data).toEqual({ id: 'sec1', name: 'API_KEY' });
+			expect(mockLogEvent).toHaveBeenCalledWith(
+				mockCtx,
+				'northflank.secrets.get',
+				{ projectId: 'p1', secretId: 'sec1' },
+				'completed',
+			);
+		});
+
+		// 12. secrets.create
 		it('calls secrets.create and never exposes secret values in event log', async () => {
 			mockRequest.mockResolvedValueOnce({
 				data: { id: 'sec1', name: 'DB_KEY' },
@@ -282,6 +482,40 @@ describe('Northflank plugin structure and endpoints', () => {
 			);
 		});
 
+		// 13. secrets.update (verifying POST method per Northflank API)
+		it('calls secrets.update using POST method per Northflank API specification', async () => {
+			mockRequest.mockResolvedValueOnce({
+				data: { id: 'sec1', name: 'DB_KEY_UPDATED' },
+			});
+			await northflankEndpointsNested.secrets.update(mockCtx, {
+				projectId: 'p1',
+				secretId: 'sec1',
+				name: 'DB_KEY_UPDATED',
+				data: { NEW_SECRET: 'new-value' },
+			});
+
+			expect(mockRequest).toHaveBeenCalledWith(
+				expect.any(Object),
+				expect.objectContaining({
+					method: 'POST',
+					url: 'projects/p1/secrets/sec1',
+					body: {
+						name: 'DB_KEY_UPDATED',
+						data: { NEW_SECRET: 'new-value' },
+					},
+				}),
+			);
+
+			// Ensure event log does NOT contain the secret payload
+			expect(mockLogEvent).toHaveBeenCalledWith(
+				mockCtx,
+				'northflank.secrets.update',
+				{ projectId: 'p1', secretId: 'sec1' },
+				'completed',
+			);
+		});
+
+		// 14. plans.list
 		it('calls plans.list', async () => {
 			mockRequest.mockResolvedValueOnce({
 				data: { plans: [{ id: 'plan1' }] },
@@ -295,8 +529,15 @@ describe('Northflank plugin structure and endpoints', () => {
 				}),
 			);
 			expect(res.data.plans).toHaveLength(1);
+			expect(mockLogEvent).toHaveBeenCalledWith(
+				mockCtx,
+				'northflank.plans.list',
+				{},
+				'completed',
+			);
 		});
 
+		// 15. regions.list
 		it('calls regions.list', async () => {
 			mockRequest.mockResolvedValueOnce({
 				data: { regions: [{ id: 'eu-west' }] },
@@ -310,6 +551,12 @@ describe('Northflank plugin structure and endpoints', () => {
 				}),
 			);
 			expect(res.data.regions).toHaveLength(1);
+			expect(mockLogEvent).toHaveBeenCalledWith(
+				mockCtx,
+				'northflank.regions.list',
+				{},
+				'completed',
+			);
 		});
 	});
 });

--- a/packages/northflank/client.test.ts
+++ b/packages/northflank/client.test.ts
@@ -1,0 +1,147 @@
+import { ApiError, request } from 'corsair/http';
+import {
+	makeNorthflankRequest,
+	NORTHFLANK_API_BASE,
+	NorthflankAPIError,
+} from './client';
+
+jest.mock('corsair/http', () => {
+	const original = jest.requireActual('corsair/http');
+	return {
+		...original,
+		request: jest.fn(),
+	};
+});
+
+const mockRequest = request as jest.Mock;
+
+describe('Northflank client and request construction', () => {
+	beforeEach(() => {
+		mockRequest.mockReset();
+	});
+
+	it('makes GET requests with Bearer token authorization', async () => {
+		mockRequest.mockResolvedValueOnce({ data: { success: true } });
+
+		const result = await makeNorthflankRequest('projects', 'test-api-token');
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.objectContaining({
+				BASE: NORTHFLANK_API_BASE,
+				TOKEN: 'test-api-token',
+				HEADERS: expect.objectContaining({
+					'Content-Type': 'application/json',
+					Authorization: 'Bearer test-api-token',
+				}),
+			}),
+			expect.objectContaining({
+				method: 'GET',
+				url: 'projects',
+				body: undefined,
+			}),
+		);
+		expect(result).toEqual({ data: { success: true } });
+	});
+
+	it('strips leading slash from endpoint path', async () => {
+		mockRequest.mockResolvedValueOnce({ data: { id: 'p1' } });
+
+		await makeNorthflankRequest('/projects/p1', 'test-api-token');
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.any(Object),
+			expect.objectContaining({
+				url: 'projects/p1',
+			}),
+		);
+	});
+
+	it('sends JSON body on POST/PATCH/PUT mutations', async () => {
+		mockRequest.mockResolvedValueOnce({ data: { id: 'p1', name: 'demo' } });
+
+		const body = { name: 'demo', region: 'europe-west' };
+		await makeNorthflankRequest('projects', 'test-api-token', {
+			method: 'POST',
+			body,
+		});
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.any(Object),
+			expect.objectContaining({
+				method: 'POST',
+				url: 'projects',
+				body,
+			}),
+		);
+	});
+
+	it('passes query parameters properly', async () => {
+		mockRequest.mockResolvedValueOnce({ data: [] });
+
+		const query = { page: 1, per_page: 20 };
+		await makeNorthflankRequest('projects', 'test-api-token', { query });
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			expect.any(Object),
+			expect.objectContaining({
+				query: { page: 1, per_page: 20 },
+			}),
+		);
+	});
+
+	it('extracts nested Northflank error message and preserves status', async () => {
+		const apiError = new ApiError(
+			{ method: 'GET', url: 'https://api.northflank.com/v1/projects' },
+			{
+				url: 'https://api.northflank.com/v1/projects',
+				status: 400,
+				statusText: 'Bad Request',
+				body: {
+					error: {
+						message: 'Project name already in use',
+					},
+				},
+				ok: false,
+			},
+			'HTTP 400 Bad Request',
+		);
+
+		mockRequest.mockRejectedValueOnce(apiError);
+
+		const errorPromise = makeNorthflankRequest('projects', 'test-token');
+		await expect(errorPromise).rejects.toBeInstanceOf(NorthflankAPIError);
+		await expect(errorPromise).rejects.toMatchObject({
+			name: 'NorthflankAPIError',
+			message: 'Project name already in use',
+			status: 400,
+			statusText: 'Bad Request',
+		});
+	});
+
+	it('extracts flat message from response body when error is not an object', async () => {
+		const apiError = new ApiError(
+			{ method: 'GET', url: 'https://api.northflank.com/v1/projects' },
+			{
+				url: 'https://api.northflank.com/v1/projects',
+				status: 403,
+				statusText: 'Forbidden',
+				body: {
+					message: 'Insufficient token permissions',
+				},
+				ok: false,
+			},
+			'HTTP 403 Forbidden',
+		);
+
+		mockRequest.mockRejectedValueOnce(apiError);
+
+		await expect(
+			makeNorthflankRequest('projects', 'test-token'),
+		).rejects.toMatchObject({
+			name: 'NorthflankAPIError',
+			message: 'Insufficient token permissions',
+			status: 403,
+			statusText: 'Forbidden',
+		});
+	});
+});

--- a/packages/northflank/client.ts
+++ b/packages/northflank/client.ts
@@ -1,0 +1,96 @@
+import type { ApiRequestOptions, OpenAPIConfig } from 'corsair/http';
+import { ApiError, request } from 'corsair/http';
+
+export class NorthflankAPIError extends Error {
+	public readonly status?: number;
+	public readonly statusText?: string;
+	public readonly body?: unknown;
+
+	constructor(message: string, options?: { cause?: Error }) {
+		super(message, options);
+		this.name = 'NorthflankAPIError';
+		if (options?.cause instanceof ApiError) {
+			this.status = options.cause.status;
+			this.statusText = options.cause.statusText;
+			this.body = options.cause.body;
+		}
+	}
+}
+
+export const NORTHFLANK_API_BASE = 'https://api.northflank.com/v1';
+
+export type NorthflankMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
+
+export type NorthflankRequestOptions = {
+	method?: NorthflankMethod;
+	body?: unknown;
+	query?: Record<string, unknown>;
+	headers?: Record<string, string>;
+};
+
+export async function makeNorthflankRequest<T>(
+	endpoint: string,
+	apiKey: string,
+	options: NorthflankRequestOptions = {},
+): Promise<T> {
+	const { method = 'GET', body, query, headers } = options;
+	const cleanEndpoint = endpoint.startsWith('/') ? endpoint.slice(1) : endpoint;
+
+	const config: OpenAPIConfig = {
+		BASE: NORTHFLANK_API_BASE,
+		VERSION: '1.0.0',
+		WITH_CREDENTIALS: false,
+		CREDENTIALS: 'omit',
+		TOKEN: apiKey,
+		HEADERS: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${apiKey}`,
+			...headers,
+		},
+	};
+
+	const hasBody =
+		body !== undefined && !['GET', 'HEAD', 'OPTIONS'].includes(method);
+	const requestOptions: ApiRequestOptions = {
+		method,
+		url: cleanEndpoint,
+		body: hasBody ? body : undefined,
+		query,
+	};
+
+	try {
+		return await request<T>(config, requestOptions);
+	} catch (error) {
+		if (error instanceof ApiError) {
+			let message = error.message;
+			const bodyData = error.body;
+			if (
+				bodyData &&
+				typeof bodyData === 'object' &&
+				'error' in bodyData &&
+				typeof (bodyData as Record<string, unknown>).error === 'object' &&
+				(bodyData as Record<string, unknown>).error !== null
+			) {
+				const nested = (bodyData as Record<string, unknown>).error as Record<
+					string,
+					unknown
+				>;
+				if (typeof nested.message === 'string') {
+					message = nested.message;
+				}
+			} else if (
+				bodyData &&
+				typeof bodyData === 'object' &&
+				'message' in bodyData &&
+				typeof (bodyData as Record<string, unknown>).message === 'string'
+			) {
+				message = (bodyData as Record<string, unknown>).message as string;
+			}
+			throw new NorthflankAPIError(message, { cause: error });
+		}
+		if (error instanceof Error) {
+			throw new NorthflankAPIError(error.message, { cause: error });
+		}
+		throw new NorthflankAPIError('Unknown Northflank API error');
+	}
+}

--- a/packages/northflank/endpoints/environments.ts
+++ b/packages/northflank/endpoints/environments.ts
@@ -1,0 +1,45 @@
+import type { CorsairEndpoint } from 'corsair/core';
+import { logEventFromContext } from 'corsair/core';
+import { makeNorthflankRequest } from '../client';
+import type { NorthflankContext } from '../index';
+import type {
+	EnvironmentsListPreviewsInput,
+	EnvironmentsListPreviewsOutput,
+} from './types';
+
+export type NorthflankEndpoint<TInput, TOutput> = CorsairEndpoint<
+	NorthflankContext,
+	TInput,
+	TOutput
+>;
+
+export const listPreviews: NorthflankEndpoint<
+	EnvironmentsListPreviewsInput,
+	EnvironmentsListPreviewsOutput
+> = async (ctx, input) => {
+	const query: Record<string, unknown> = {};
+	if (input.page !== undefined) query.page = input.page;
+	if (input.per_page !== undefined) query.per_page = input.per_page;
+	if (input.cursor !== undefined) query.cursor = input.cursor;
+
+	const res = await makeNorthflankRequest<EnvironmentsListPreviewsOutput>(
+		`projects/${input.projectId}/preview-blueprints/${input.previewBlueprintId}/preview-environments`,
+		ctx.key,
+		{ method: 'GET', query },
+	);
+
+	await logEventFromContext(
+		ctx,
+		'northflank.environments.listPreviews',
+		{
+			projectId: input.projectId,
+			previewBlueprintId: input.previewBlueprintId,
+		},
+		'completed',
+	);
+	return res;
+};
+
+export const EnvironmentsEndpoints = {
+	listPreviews,
+} as const;

--- a/packages/northflank/endpoints/environments.ts
+++ b/packages/northflank/endpoints/environments.ts
@@ -6,6 +6,10 @@ import type {
 	EnvironmentsListPreviewsInput,
 	EnvironmentsListPreviewsOutput,
 } from './types';
+import {
+	EnvironmentsListPreviewsInputSchema,
+	EnvironmentsListPreviewsOutputSchema,
+} from './types';
 
 export type NorthflankEndpoint<TInput, TOutput> = CorsairEndpoint<
 	NorthflankContext,
@@ -17,13 +21,17 @@ export const listPreviews: NorthflankEndpoint<
 	EnvironmentsListPreviewsInput,
 	EnvironmentsListPreviewsOutput
 > = async (ctx, input) => {
+	const validatedInput = EnvironmentsListPreviewsInputSchema.parse(input);
 	const query: Record<string, unknown> = {};
-	if (input.page !== undefined) query.page = input.page;
-	if (input.per_page !== undefined) query.per_page = input.per_page;
-	if (input.cursor !== undefined) query.cursor = input.cursor;
+	if (validatedInput.page !== undefined) query.page = validatedInput.page;
+	if (validatedInput.per_page !== undefined)
+		query.per_page = validatedInput.per_page;
+	if (validatedInput.cursor !== undefined) query.cursor = validatedInput.cursor;
 
-	const res = await makeNorthflankRequest<EnvironmentsListPreviewsOutput>(
-		`projects/${input.projectId}/preview-blueprints/${input.previewBlueprintId}/preview-environments`,
+	// Official Northflank route for previews under a preview-blueprint:
+	// GET /v1/projects/{projectId}/preview-blueprints/{previewBlueprintId}/previews
+	const res = await makeNorthflankRequest<unknown>(
+		`projects/${validatedInput.projectId}/preview-blueprints/${validatedInput.previewBlueprintId}/previews`,
 		ctx.key,
 		{ method: 'GET', query },
 	);
@@ -32,12 +40,12 @@ export const listPreviews: NorthflankEndpoint<
 		ctx,
 		'northflank.environments.listPreviews',
 		{
-			projectId: input.projectId,
-			previewBlueprintId: input.previewBlueprintId,
+			projectId: validatedInput.projectId,
+			previewBlueprintId: validatedInput.previewBlueprintId,
 		},
 		'completed',
 	);
-	return res;
+	return EnvironmentsListPreviewsOutputSchema.parse(res);
 };
 
 export const EnvironmentsEndpoints = {

--- a/packages/northflank/endpoints/index.ts
+++ b/packages/northflank/endpoints/index.ts
@@ -1,0 +1,151 @@
+import type { RequiredPluginEndpointMeta } from 'corsair/core';
+import { EnvironmentsEndpoints } from './environments';
+import { PlansEndpoints } from './plans';
+import { ProjectsEndpoints } from './projects';
+import { RegionsEndpoints } from './regions';
+import { SecretsEndpoints } from './secrets';
+import { ServicesEndpoints } from './services';
+import {
+	NorthflankEndpointInputSchemas,
+	NorthflankEndpointOutputSchemas,
+} from './types';
+
+export const northflankEndpointsNested = {
+	projects: ProjectsEndpoints,
+	services: ServicesEndpoints,
+	environments: EnvironmentsEndpoints,
+	secrets: SecretsEndpoints,
+	plans: PlansEndpoints,
+	regions: RegionsEndpoints,
+} as const;
+
+export const northflankEndpointMeta = {
+	'projects.list': {
+		riskLevel: 'read',
+		description: 'List Northflank projects',
+	},
+	'projects.get': {
+		riskLevel: 'read',
+		description: 'Get details of a Northflank project',
+	},
+	'projects.create': {
+		riskLevel: 'write',
+		description: 'Create a new Northflank project',
+	},
+	'projects.update': {
+		riskLevel: 'write',
+		description: 'Update an existing Northflank project',
+	},
+	'services.list': {
+		riskLevel: 'read',
+		description: 'List services in a Northflank project',
+	},
+	'services.get': {
+		riskLevel: 'read',
+		description: 'Get details of a Northflank service',
+	},
+	'services.createCombined': {
+		riskLevel: 'write',
+		description: 'Create a new combined service in a project',
+	},
+	'services.updateCombined': {
+		riskLevel: 'write',
+		description: 'Update an existing combined service in a project',
+	},
+	'environments.listPreviews': {
+		riskLevel: 'read',
+		description: 'List preview environments for a preview blueprint',
+	},
+	'secrets.list': {
+		riskLevel: 'read',
+		description: 'List secrets in a Northflank project',
+	},
+	'secrets.get': {
+		riskLevel: 'read',
+		description: 'Get details of a Northflank secret',
+	},
+	'secrets.create': {
+		riskLevel: 'write',
+		description: 'Create a new Northflank secret',
+	},
+	'secrets.update': {
+		riskLevel: 'write',
+		description: 'Update an existing Northflank secret',
+	},
+	'plans.list': {
+		riskLevel: 'read',
+		description: 'List available Northflank resource plans',
+	},
+	'regions.list': {
+		riskLevel: 'read',
+		description: 'List available Northflank regions',
+	},
+} as const satisfies RequiredPluginEndpointMeta<
+	typeof northflankEndpointsNested
+>;
+
+export const northflankEndpointSchemas = {
+	'projects.list': {
+		input: NorthflankEndpointInputSchemas['projects.list'],
+		output: NorthflankEndpointOutputSchemas['projects.list'],
+	},
+	'projects.get': {
+		input: NorthflankEndpointInputSchemas['projects.get'],
+		output: NorthflankEndpointOutputSchemas['projects.get'],
+	},
+	'projects.create': {
+		input: NorthflankEndpointInputSchemas['projects.create'],
+		output: NorthflankEndpointOutputSchemas['projects.create'],
+	},
+	'projects.update': {
+		input: NorthflankEndpointInputSchemas['projects.update'],
+		output: NorthflankEndpointOutputSchemas['projects.update'],
+	},
+	'services.list': {
+		input: NorthflankEndpointInputSchemas['services.list'],
+		output: NorthflankEndpointOutputSchemas['services.list'],
+	},
+	'services.get': {
+		input: NorthflankEndpointInputSchemas['services.get'],
+		output: NorthflankEndpointOutputSchemas['services.get'],
+	},
+	'services.createCombined': {
+		input: NorthflankEndpointInputSchemas['services.createCombined'],
+		output: NorthflankEndpointOutputSchemas['services.createCombined'],
+	},
+	'services.updateCombined': {
+		input: NorthflankEndpointInputSchemas['services.updateCombined'],
+		output: NorthflankEndpointOutputSchemas['services.updateCombined'],
+	},
+	'environments.listPreviews': {
+		input: NorthflankEndpointInputSchemas['environments.listPreviews'],
+		output: NorthflankEndpointOutputSchemas['environments.listPreviews'],
+	},
+	'secrets.list': {
+		input: NorthflankEndpointInputSchemas['secrets.list'],
+		output: NorthflankEndpointOutputSchemas['secrets.list'],
+	},
+	'secrets.get': {
+		input: NorthflankEndpointInputSchemas['secrets.get'],
+		output: NorthflankEndpointOutputSchemas['secrets.get'],
+	},
+	'secrets.create': {
+		input: NorthflankEndpointInputSchemas['secrets.create'],
+		output: NorthflankEndpointOutputSchemas['secrets.create'],
+	},
+	'secrets.update': {
+		input: NorthflankEndpointInputSchemas['secrets.update'],
+		output: NorthflankEndpointOutputSchemas['secrets.update'],
+	},
+	'plans.list': {
+		input: NorthflankEndpointInputSchemas['plans.list'],
+		output: NorthflankEndpointOutputSchemas['plans.list'],
+	},
+	'regions.list': {
+		input: NorthflankEndpointInputSchemas['regions.list'],
+		output: NorthflankEndpointOutputSchemas['regions.list'],
+	},
+};
+
+export { NorthflankEndpointInputSchemas, NorthflankEndpointOutputSchemas };
+export * from './types';

--- a/packages/northflank/endpoints/plans.ts
+++ b/packages/northflank/endpoints/plans.ts
@@ -3,6 +3,7 @@ import { logEventFromContext } from 'corsair/core';
 import { makeNorthflankRequest } from '../client';
 import type { NorthflankContext } from '../index';
 import type { PlansListInput, PlansListOutput } from './types';
+import { PlansListInputSchema, PlansListOutputSchema } from './types';
 
 export type NorthflankEndpoint<TInput, TOutput> = CorsairEndpoint<
 	NorthflankContext,
@@ -14,19 +15,21 @@ export const list: NorthflankEndpoint<PlansListInput, PlansListOutput> = async (
 	ctx,
 	input = {},
 ) => {
+	const validatedInput = PlansListInputSchema.parse(input);
 	const query: Record<string, unknown> = {};
-	if (input?.page !== undefined) query.page = input.page;
-	if (input?.per_page !== undefined) query.per_page = input.per_page;
-	if (input?.cursor !== undefined) query.cursor = input.cursor;
+	if (validatedInput?.page !== undefined) query.page = validatedInput.page;
+	if (validatedInput?.per_page !== undefined)
+		query.per_page = validatedInput.per_page;
+	if (validatedInput?.cursor !== undefined)
+		query.cursor = validatedInput.cursor;
 
-	const res = await makeNorthflankRequest<PlansListOutput>('plans', ctx.key, {
+	const res = await makeNorthflankRequest<unknown>('plans', ctx.key, {
 		method: 'GET',
 		query,
 	});
 
 	await logEventFromContext(ctx, 'northflank.plans.list', {}, 'completed');
-
-	return res;
+	return PlansListOutputSchema.parse(res);
 };
 
 export const PlansEndpoints = {

--- a/packages/northflank/endpoints/plans.ts
+++ b/packages/northflank/endpoints/plans.ts
@@ -1,0 +1,34 @@
+import type { CorsairEndpoint } from 'corsair/core';
+import { logEventFromContext } from 'corsair/core';
+import { makeNorthflankRequest } from '../client';
+import type { NorthflankContext } from '../index';
+import type { PlansListInput, PlansListOutput } from './types';
+
+export type NorthflankEndpoint<TInput, TOutput> = CorsairEndpoint<
+	NorthflankContext,
+	TInput,
+	TOutput
+>;
+
+export const list: NorthflankEndpoint<PlansListInput, PlansListOutput> = async (
+	ctx,
+	input = {},
+) => {
+	const query: Record<string, unknown> = {};
+	if (input?.page !== undefined) query.page = input.page;
+	if (input?.per_page !== undefined) query.per_page = input.per_page;
+	if (input?.cursor !== undefined) query.cursor = input.cursor;
+
+	const res = await makeNorthflankRequest<PlansListOutput>('plans', ctx.key, {
+		method: 'GET',
+		query,
+	});
+
+	await logEventFromContext(ctx, 'northflank.plans.list', {}, 'completed');
+
+	return res;
+};
+
+export const PlansEndpoints = {
+	list,
+} as const;

--- a/packages/northflank/endpoints/projects.ts
+++ b/packages/northflank/endpoints/projects.ts
@@ -12,6 +12,16 @@ import type {
 	ProjectsUpdateInput,
 	ProjectsUpdateOutput,
 } from './types';
+import {
+	ProjectsCreateInputSchema,
+	ProjectsCreateOutputSchema,
+	ProjectsGetInputSchema,
+	ProjectsGetOutputSchema,
+	ProjectsListInputSchema,
+	ProjectsListOutputSchema,
+	ProjectsUpdateInputSchema,
+	ProjectsUpdateOutputSchema,
+} from './types';
 
 export type NorthflankEndpoint<TInput, TOutput> = CorsairEndpoint<
 	NorthflankContext,
@@ -23,27 +33,30 @@ export const list: NorthflankEndpoint<
 	ProjectsListInput,
 	ProjectsListOutput
 > = async (ctx, input = {}) => {
+	const validatedInput = ProjectsListInputSchema.parse(input);
 	const query: Record<string, unknown> = {};
-	if (input?.page !== undefined) query.page = input.page;
-	if (input?.per_page !== undefined) query.per_page = input.per_page;
-	if (input?.cursor !== undefined) query.cursor = input.cursor;
+	if (validatedInput?.page !== undefined) query.page = validatedInput.page;
+	if (validatedInput?.per_page !== undefined)
+		query.per_page = validatedInput.per_page;
+	if (validatedInput?.cursor !== undefined)
+		query.cursor = validatedInput.cursor;
 
-	const res = await makeNorthflankRequest<ProjectsListOutput>(
-		'projects',
-		ctx.key,
-		{ method: 'GET', query },
-	);
+	const res = await makeNorthflankRequest<unknown>('projects', ctx.key, {
+		method: 'GET',
+		query,
+	});
 
 	await logEventFromContext(ctx, 'northflank.projects.list', {}, 'completed');
-	return res;
+	return ProjectsListOutputSchema.parse(res);
 };
 
 export const get: NorthflankEndpoint<
 	ProjectsGetInput,
 	ProjectsGetOutput
 > = async (ctx, input) => {
-	const res = await makeNorthflankRequest<ProjectsGetOutput>(
-		`projects/${input.projectId}`,
+	const validatedInput = ProjectsGetInputSchema.parse(input);
+	const res = await makeNorthflankRequest<unknown>(
+		`projects/${validatedInput.projectId}`,
 		ctx.key,
 		{ method: 'GET' },
 	);
@@ -51,40 +64,38 @@ export const get: NorthflankEndpoint<
 	await logEventFromContext(
 		ctx,
 		'northflank.projects.get',
-		{ projectId: input.projectId },
+		{ projectId: validatedInput.projectId },
 		'completed',
 	);
-	return res;
+	return ProjectsGetOutputSchema.parse(res);
 };
 
 export const create: NorthflankEndpoint<
 	ProjectsCreateInput,
 	ProjectsCreateOutput
 > = async (ctx, input) => {
-	const res = await makeNorthflankRequest<ProjectsCreateOutput>(
-		'projects',
-		ctx.key,
-		{
-			method: 'POST',
-			body: input,
-		},
-	);
+	const validatedInput = ProjectsCreateInputSchema.parse(input);
+	const res = await makeNorthflankRequest<unknown>('projects', ctx.key, {
+		method: 'POST',
+		body: validatedInput,
+	});
 
 	await logEventFromContext(
 		ctx,
 		'northflank.projects.create',
-		{ name: input.name, region: input.region },
+		{ name: validatedInput.name, region: validatedInput.region },
 		'completed',
 	);
-	return res;
+	return ProjectsCreateOutputSchema.parse(res);
 };
 
 export const update: NorthflankEndpoint<
 	ProjectsUpdateInput,
 	ProjectsUpdateOutput
 > = async (ctx, input) => {
-	const { projectId, ...body } = input;
-	const res = await makeNorthflankRequest<ProjectsUpdateOutput>(
+	const validatedInput = ProjectsUpdateInputSchema.parse(input);
+	const { projectId, ...body } = validatedInput;
+	const res = await makeNorthflankRequest<unknown>(
 		`projects/${projectId}`,
 		ctx.key,
 		{
@@ -99,7 +110,7 @@ export const update: NorthflankEndpoint<
 		{ projectId },
 		'completed',
 	);
-	return res;
+	return ProjectsUpdateOutputSchema.parse(res);
 };
 
 export const ProjectsEndpoints = {

--- a/packages/northflank/endpoints/projects.ts
+++ b/packages/northflank/endpoints/projects.ts
@@ -1,0 +1,110 @@
+import type { CorsairEndpoint } from 'corsair/core';
+import { logEventFromContext } from 'corsair/core';
+import { makeNorthflankRequest } from '../client';
+import type { NorthflankContext } from '../index';
+import type {
+	ProjectsCreateInput,
+	ProjectsCreateOutput,
+	ProjectsGetInput,
+	ProjectsGetOutput,
+	ProjectsListInput,
+	ProjectsListOutput,
+	ProjectsUpdateInput,
+	ProjectsUpdateOutput,
+} from './types';
+
+export type NorthflankEndpoint<TInput, TOutput> = CorsairEndpoint<
+	NorthflankContext,
+	TInput,
+	TOutput
+>;
+
+export const list: NorthflankEndpoint<
+	ProjectsListInput,
+	ProjectsListOutput
+> = async (ctx, input = {}) => {
+	const query: Record<string, unknown> = {};
+	if (input?.page !== undefined) query.page = input.page;
+	if (input?.per_page !== undefined) query.per_page = input.per_page;
+	if (input?.cursor !== undefined) query.cursor = input.cursor;
+
+	const res = await makeNorthflankRequest<ProjectsListOutput>(
+		'projects',
+		ctx.key,
+		{ method: 'GET', query },
+	);
+
+	await logEventFromContext(ctx, 'northflank.projects.list', {}, 'completed');
+	return res;
+};
+
+export const get: NorthflankEndpoint<
+	ProjectsGetInput,
+	ProjectsGetOutput
+> = async (ctx, input) => {
+	const res = await makeNorthflankRequest<ProjectsGetOutput>(
+		`projects/${input.projectId}`,
+		ctx.key,
+		{ method: 'GET' },
+	);
+
+	await logEventFromContext(
+		ctx,
+		'northflank.projects.get',
+		{ projectId: input.projectId },
+		'completed',
+	);
+	return res;
+};
+
+export const create: NorthflankEndpoint<
+	ProjectsCreateInput,
+	ProjectsCreateOutput
+> = async (ctx, input) => {
+	const res = await makeNorthflankRequest<ProjectsCreateOutput>(
+		'projects',
+		ctx.key,
+		{
+			method: 'POST',
+			body: input,
+		},
+	);
+
+	await logEventFromContext(
+		ctx,
+		'northflank.projects.create',
+		{ name: input.name, region: input.region },
+		'completed',
+	);
+	return res;
+};
+
+export const update: NorthflankEndpoint<
+	ProjectsUpdateInput,
+	ProjectsUpdateOutput
+> = async (ctx, input) => {
+	const { projectId, ...body } = input;
+	const res = await makeNorthflankRequest<ProjectsUpdateOutput>(
+		`projects/${projectId}`,
+		ctx.key,
+		{
+			method: 'PATCH',
+			body,
+		},
+	);
+
+	await logEventFromContext(
+		ctx,
+		'northflank.projects.update',
+		{ projectId },
+		'completed',
+	);
+	return res;
+};
+
+export const ProjectsEndpoints = {
+	list,
+	get,
+	create,
+	update,
+} as const;

--- a/packages/northflank/endpoints/regions.ts
+++ b/packages/northflank/endpoints/regions.ts
@@ -3,6 +3,7 @@ import { logEventFromContext } from 'corsair/core';
 import { makeNorthflankRequest } from '../client';
 import type { NorthflankContext } from '../index';
 import type { RegionsListInput, RegionsListOutput } from './types';
+import { RegionsListInputSchema, RegionsListOutputSchema } from './types';
 
 export type NorthflankEndpoint<TInput, TOutput> = CorsairEndpoint<
 	NorthflankContext,
@@ -13,16 +14,14 @@ export type NorthflankEndpoint<TInput, TOutput> = CorsairEndpoint<
 export const list: NorthflankEndpoint<
 	RegionsListInput,
 	RegionsListOutput
-> = async (ctx) => {
-	const res = await makeNorthflankRequest<RegionsListOutput>(
-		'regions',
-		ctx.key,
-		{ method: 'GET' },
-	);
+> = async (ctx, input = {}) => {
+	RegionsListInputSchema.parse(input);
+	const res = await makeNorthflankRequest<unknown>('regions', ctx.key, {
+		method: 'GET',
+	});
 
 	await logEventFromContext(ctx, 'northflank.regions.list', {}, 'completed');
-
-	return res;
+	return RegionsListOutputSchema.parse(res);
 };
 
 export const RegionsEndpoints = {

--- a/packages/northflank/endpoints/regions.ts
+++ b/packages/northflank/endpoints/regions.ts
@@ -1,0 +1,30 @@
+import type { CorsairEndpoint } from 'corsair/core';
+import { logEventFromContext } from 'corsair/core';
+import { makeNorthflankRequest } from '../client';
+import type { NorthflankContext } from '../index';
+import type { RegionsListInput, RegionsListOutput } from './types';
+
+export type NorthflankEndpoint<TInput, TOutput> = CorsairEndpoint<
+	NorthflankContext,
+	TInput,
+	TOutput
+>;
+
+export const list: NorthflankEndpoint<
+	RegionsListInput,
+	RegionsListOutput
+> = async (ctx) => {
+	const res = await makeNorthflankRequest<RegionsListOutput>(
+		'regions',
+		ctx.key,
+		{ method: 'GET' },
+	);
+
+	await logEventFromContext(ctx, 'northflank.regions.list', {}, 'completed');
+
+	return res;
+};
+
+export const RegionsEndpoints = {
+	list,
+} as const;

--- a/packages/northflank/endpoints/secrets.ts
+++ b/packages/northflank/endpoints/secrets.ts
@@ -1,0 +1,118 @@
+import type { CorsairEndpoint } from 'corsair/core';
+import { logEventFromContext } from 'corsair/core';
+import { makeNorthflankRequest } from '../client';
+import type { NorthflankContext } from '../index';
+import type {
+	SecretsCreateInput,
+	SecretsCreateOutput,
+	SecretsGetInput,
+	SecretsGetOutput,
+	SecretsListInput,
+	SecretsListOutput,
+	SecretsUpdateInput,
+	SecretsUpdateOutput,
+} from './types';
+
+export type NorthflankEndpoint<TInput, TOutput> = CorsairEndpoint<
+	NorthflankContext,
+	TInput,
+	TOutput
+>;
+
+export const list: NorthflankEndpoint<
+	SecretsListInput,
+	SecretsListOutput
+> = async (ctx, input) => {
+	const query: Record<string, unknown> = {};
+	if (input.page !== undefined) query.page = input.page;
+	if (input.per_page !== undefined) query.per_page = input.per_page;
+	if (input.cursor !== undefined) query.cursor = input.cursor;
+
+	const res = await makeNorthflankRequest<SecretsListOutput>(
+		`projects/${input.projectId}/secrets`,
+		ctx.key,
+		{ method: 'GET', query },
+	);
+
+	await logEventFromContext(
+		ctx,
+		'northflank.secrets.list',
+		{ projectId: input.projectId },
+		'completed',
+	);
+	return res;
+};
+
+export const get: NorthflankEndpoint<
+	SecretsGetInput,
+	SecretsGetOutput
+> = async (ctx, input) => {
+	const res = await makeNorthflankRequest<SecretsGetOutput>(
+		`projects/${input.projectId}/secrets/${input.secretId}`,
+		ctx.key,
+		{ method: 'GET' },
+	);
+
+	await logEventFromContext(
+		ctx,
+		'northflank.secrets.get',
+		{ projectId: input.projectId, secretId: input.secretId },
+		'completed',
+	);
+	return res;
+};
+
+export const create: NorthflankEndpoint<
+	SecretsCreateInput,
+	SecretsCreateOutput
+> = async (ctx, input) => {
+	const { projectId, ...body } = input;
+	const res = await makeNorthflankRequest<SecretsCreateOutput>(
+		`projects/${projectId}/secrets`,
+		ctx.key,
+		{
+			method: 'POST',
+			body,
+		},
+	);
+
+	// SECURITY: Never log secret values or secret data payloads
+	await logEventFromContext(
+		ctx,
+		'northflank.secrets.create',
+		{ projectId, name: input.name },
+		'completed',
+	);
+	return res;
+};
+
+export const update: NorthflankEndpoint<
+	SecretsUpdateInput,
+	SecretsUpdateOutput
+> = async (ctx, input) => {
+	const { projectId, secretId, ...body } = input;
+	const res = await makeNorthflankRequest<SecretsUpdateOutput>(
+		`projects/${projectId}/secrets/${secretId}`,
+		ctx.key,
+		{
+			method: 'PATCH',
+			body,
+		},
+	);
+
+	// SECURITY: Never log secret values or updated data payloads
+	await logEventFromContext(
+		ctx,
+		'northflank.secrets.update',
+		{ projectId, secretId },
+		'completed',
+	);
+	return res;
+};
+
+export const SecretsEndpoints = {
+	list,
+	get,
+	create,
+	update,
+} as const;

--- a/packages/northflank/endpoints/secrets.ts
+++ b/packages/northflank/endpoints/secrets.ts
@@ -12,6 +12,16 @@ import type {
 	SecretsUpdateInput,
 	SecretsUpdateOutput,
 } from './types';
+import {
+	SecretsCreateInputSchema,
+	SecretsCreateOutputSchema,
+	SecretsGetInputSchema,
+	SecretsGetOutputSchema,
+	SecretsListInputSchema,
+	SecretsListOutputSchema,
+	SecretsUpdateInputSchema,
+	SecretsUpdateOutputSchema,
+} from './types';
 
 export type NorthflankEndpoint<TInput, TOutput> = CorsairEndpoint<
 	NorthflankContext,
@@ -23,13 +33,15 @@ export const list: NorthflankEndpoint<
 	SecretsListInput,
 	SecretsListOutput
 > = async (ctx, input) => {
+	const validatedInput = SecretsListInputSchema.parse(input);
 	const query: Record<string, unknown> = {};
-	if (input.page !== undefined) query.page = input.page;
-	if (input.per_page !== undefined) query.per_page = input.per_page;
-	if (input.cursor !== undefined) query.cursor = input.cursor;
+	if (validatedInput.page !== undefined) query.page = validatedInput.page;
+	if (validatedInput.per_page !== undefined)
+		query.per_page = validatedInput.per_page;
+	if (validatedInput.cursor !== undefined) query.cursor = validatedInput.cursor;
 
-	const res = await makeNorthflankRequest<SecretsListOutput>(
-		`projects/${input.projectId}/secrets`,
+	const res = await makeNorthflankRequest<unknown>(
+		`projects/${validatedInput.projectId}/secrets`,
 		ctx.key,
 		{ method: 'GET', query },
 	);
@@ -37,18 +49,19 @@ export const list: NorthflankEndpoint<
 	await logEventFromContext(
 		ctx,
 		'northflank.secrets.list',
-		{ projectId: input.projectId },
+		{ projectId: validatedInput.projectId },
 		'completed',
 	);
-	return res;
+	return SecretsListOutputSchema.parse(res);
 };
 
 export const get: NorthflankEndpoint<
 	SecretsGetInput,
 	SecretsGetOutput
 > = async (ctx, input) => {
-	const res = await makeNorthflankRequest<SecretsGetOutput>(
-		`projects/${input.projectId}/secrets/${input.secretId}`,
+	const validatedInput = SecretsGetInputSchema.parse(input);
+	const res = await makeNorthflankRequest<unknown>(
+		`projects/${validatedInput.projectId}/secrets/${validatedInput.secretId}`,
 		ctx.key,
 		{ method: 'GET' },
 	);
@@ -56,18 +69,22 @@ export const get: NorthflankEndpoint<
 	await logEventFromContext(
 		ctx,
 		'northflank.secrets.get',
-		{ projectId: input.projectId, secretId: input.secretId },
+		{
+			projectId: validatedInput.projectId,
+			secretId: validatedInput.secretId,
+		},
 		'completed',
 	);
-	return res;
+	return SecretsGetOutputSchema.parse(res);
 };
 
 export const create: NorthflankEndpoint<
 	SecretsCreateInput,
 	SecretsCreateOutput
 > = async (ctx, input) => {
-	const { projectId, ...body } = input;
-	const res = await makeNorthflankRequest<SecretsCreateOutput>(
+	const validatedInput = SecretsCreateInputSchema.parse(input);
+	const { projectId, ...body } = validatedInput;
+	const res = await makeNorthflankRequest<unknown>(
 		`projects/${projectId}/secrets`,
 		ctx.key,
 		{
@@ -80,22 +97,24 @@ export const create: NorthflankEndpoint<
 	await logEventFromContext(
 		ctx,
 		'northflank.secrets.create',
-		{ projectId, name: input.name },
+		{ projectId, name: validatedInput.name },
 		'completed',
 	);
-	return res;
+	return SecretsCreateOutputSchema.parse(res);
 };
 
 export const update: NorthflankEndpoint<
 	SecretsUpdateInput,
 	SecretsUpdateOutput
 > = async (ctx, input) => {
-	const { projectId, secretId, ...body } = input;
-	const res = await makeNorthflankRequest<SecretsUpdateOutput>(
+	const validatedInput = SecretsUpdateInputSchema.parse(input);
+	const { projectId, secretId, ...body } = validatedInput;
+	// Official Northflank project-secret update uses POST /v1/projects/{projectId}/secrets/{secretId}
+	const res = await makeNorthflankRequest<unknown>(
 		`projects/${projectId}/secrets/${secretId}`,
 		ctx.key,
 		{
-			method: 'PATCH',
+			method: 'POST',
 			body,
 		},
 	);
@@ -107,7 +126,7 @@ export const update: NorthflankEndpoint<
 		{ projectId, secretId },
 		'completed',
 	);
-	return res;
+	return SecretsUpdateOutputSchema.parse(res);
 };
 
 export const SecretsEndpoints = {

--- a/packages/northflank/endpoints/services.ts
+++ b/packages/northflank/endpoints/services.ts
@@ -1,0 +1,116 @@
+import type { CorsairEndpoint } from 'corsair/core';
+import { logEventFromContext } from 'corsair/core';
+import { makeNorthflankRequest } from '../client';
+import type { NorthflankContext } from '../index';
+import type {
+	ServicesCreateCombinedInput,
+	ServicesCreateCombinedOutput,
+	ServicesGetInput,
+	ServicesGetOutput,
+	ServicesListInput,
+	ServicesListOutput,
+	ServicesUpdateCombinedInput,
+	ServicesUpdateCombinedOutput,
+} from './types';
+
+export type NorthflankEndpoint<TInput, TOutput> = CorsairEndpoint<
+	NorthflankContext,
+	TInput,
+	TOutput
+>;
+
+export const list: NorthflankEndpoint<
+	ServicesListInput,
+	ServicesListOutput
+> = async (ctx, input) => {
+	const query: Record<string, unknown> = {};
+	if (input.page !== undefined) query.page = input.page;
+	if (input.per_page !== undefined) query.per_page = input.per_page;
+	if (input.cursor !== undefined) query.cursor = input.cursor;
+
+	const res = await makeNorthflankRequest<ServicesListOutput>(
+		`projects/${input.projectId}/services`,
+		ctx.key,
+		{ method: 'GET', query },
+	);
+
+	await logEventFromContext(
+		ctx,
+		'northflank.services.list',
+		{ projectId: input.projectId },
+		'completed',
+	);
+	return res;
+};
+
+export const get: NorthflankEndpoint<
+	ServicesGetInput,
+	ServicesGetOutput
+> = async (ctx, input) => {
+	const res = await makeNorthflankRequest<ServicesGetOutput>(
+		`projects/${input.projectId}/services/${input.serviceId}`,
+		ctx.key,
+		{ method: 'GET' },
+	);
+
+	await logEventFromContext(
+		ctx,
+		'northflank.services.get',
+		{ projectId: input.projectId, serviceId: input.serviceId },
+		'completed',
+	);
+	return res;
+};
+
+export const createCombined: NorthflankEndpoint<
+	ServicesCreateCombinedInput,
+	ServicesCreateCombinedOutput
+> = async (ctx, input) => {
+	const { projectId, ...body } = input;
+	const res = await makeNorthflankRequest<ServicesCreateCombinedOutput>(
+		`projects/${projectId}/services/combined`,
+		ctx.key,
+		{
+			method: 'POST',
+			body,
+		},
+	);
+
+	await logEventFromContext(
+		ctx,
+		'northflank.services.createCombined',
+		{ projectId, name: input.name },
+		'completed',
+	);
+	return res;
+};
+
+export const updateCombined: NorthflankEndpoint<
+	ServicesUpdateCombinedInput,
+	ServicesUpdateCombinedOutput
+> = async (ctx, input) => {
+	const { projectId, serviceId, ...body } = input;
+	const res = await makeNorthflankRequest<ServicesUpdateCombinedOutput>(
+		`projects/${projectId}/services/combined/${serviceId}`,
+		ctx.key,
+		{
+			method: 'PATCH',
+			body,
+		},
+	);
+
+	await logEventFromContext(
+		ctx,
+		'northflank.services.updateCombined',
+		{ projectId, serviceId },
+		'completed',
+	);
+	return res;
+};
+
+export const ServicesEndpoints = {
+	list,
+	get,
+	createCombined,
+	updateCombined,
+} as const;

--- a/packages/northflank/endpoints/services.ts
+++ b/packages/northflank/endpoints/services.ts
@@ -12,6 +12,16 @@ import type {
 	ServicesUpdateCombinedInput,
 	ServicesUpdateCombinedOutput,
 } from './types';
+import {
+	ServicesCreateCombinedInputSchema,
+	ServicesCreateCombinedOutputSchema,
+	ServicesGetInputSchema,
+	ServicesGetOutputSchema,
+	ServicesListInputSchema,
+	ServicesListOutputSchema,
+	ServicesUpdateCombinedInputSchema,
+	ServicesUpdateCombinedOutputSchema,
+} from './types';
 
 export type NorthflankEndpoint<TInput, TOutput> = CorsairEndpoint<
 	NorthflankContext,
@@ -23,13 +33,15 @@ export const list: NorthflankEndpoint<
 	ServicesListInput,
 	ServicesListOutput
 > = async (ctx, input) => {
+	const validatedInput = ServicesListInputSchema.parse(input);
 	const query: Record<string, unknown> = {};
-	if (input.page !== undefined) query.page = input.page;
-	if (input.per_page !== undefined) query.per_page = input.per_page;
-	if (input.cursor !== undefined) query.cursor = input.cursor;
+	if (validatedInput.page !== undefined) query.page = validatedInput.page;
+	if (validatedInput.per_page !== undefined)
+		query.per_page = validatedInput.per_page;
+	if (validatedInput.cursor !== undefined) query.cursor = validatedInput.cursor;
 
-	const res = await makeNorthflankRequest<ServicesListOutput>(
-		`projects/${input.projectId}/services`,
+	const res = await makeNorthflankRequest<unknown>(
+		`projects/${validatedInput.projectId}/services`,
 		ctx.key,
 		{ method: 'GET', query },
 	);
@@ -37,18 +49,19 @@ export const list: NorthflankEndpoint<
 	await logEventFromContext(
 		ctx,
 		'northflank.services.list',
-		{ projectId: input.projectId },
+		{ projectId: validatedInput.projectId },
 		'completed',
 	);
-	return res;
+	return ServicesListOutputSchema.parse(res);
 };
 
 export const get: NorthflankEndpoint<
 	ServicesGetInput,
 	ServicesGetOutput
 > = async (ctx, input) => {
-	const res = await makeNorthflankRequest<ServicesGetOutput>(
-		`projects/${input.projectId}/services/${input.serviceId}`,
+	const validatedInput = ServicesGetInputSchema.parse(input);
+	const res = await makeNorthflankRequest<unknown>(
+		`projects/${validatedInput.projectId}/services/${validatedInput.serviceId}`,
 		ctx.key,
 		{ method: 'GET' },
 	);
@@ -56,18 +69,22 @@ export const get: NorthflankEndpoint<
 	await logEventFromContext(
 		ctx,
 		'northflank.services.get',
-		{ projectId: input.projectId, serviceId: input.serviceId },
+		{
+			projectId: validatedInput.projectId,
+			serviceId: validatedInput.serviceId,
+		},
 		'completed',
 	);
-	return res;
+	return ServicesGetOutputSchema.parse(res);
 };
 
 export const createCombined: NorthflankEndpoint<
 	ServicesCreateCombinedInput,
 	ServicesCreateCombinedOutput
 > = async (ctx, input) => {
-	const { projectId, ...body } = input;
-	const res = await makeNorthflankRequest<ServicesCreateCombinedOutput>(
+	const validatedInput = ServicesCreateCombinedInputSchema.parse(input);
+	const { projectId, ...body } = validatedInput;
+	const res = await makeNorthflankRequest<unknown>(
 		`projects/${projectId}/services/combined`,
 		ctx.key,
 		{
@@ -79,18 +96,19 @@ export const createCombined: NorthflankEndpoint<
 	await logEventFromContext(
 		ctx,
 		'northflank.services.createCombined',
-		{ projectId, name: input.name },
+		{ projectId, name: validatedInput.name },
 		'completed',
 	);
-	return res;
+	return ServicesCreateCombinedOutputSchema.parse(res);
 };
 
 export const updateCombined: NorthflankEndpoint<
 	ServicesUpdateCombinedInput,
 	ServicesUpdateCombinedOutput
 > = async (ctx, input) => {
-	const { projectId, serviceId, ...body } = input;
-	const res = await makeNorthflankRequest<ServicesUpdateCombinedOutput>(
+	const validatedInput = ServicesUpdateCombinedInputSchema.parse(input);
+	const { projectId, serviceId, ...body } = validatedInput;
+	const res = await makeNorthflankRequest<unknown>(
 		`projects/${projectId}/services/combined/${serviceId}`,
 		ctx.key,
 		{
@@ -105,7 +123,7 @@ export const updateCombined: NorthflankEndpoint<
 		{ projectId, serviceId },
 		'completed',
 	);
-	return res;
+	return ServicesUpdateCombinedOutputSchema.parse(res);
 };
 
 export const ServicesEndpoints = {

--- a/packages/northflank/endpoints/types.ts
+++ b/packages/northflank/endpoints/types.ts
@@ -1,0 +1,384 @@
+import { z } from 'zod';
+
+// ============================================================================
+// Projects
+// ============================================================================
+
+export const ProjectsListInputSchema = z
+	.object({
+		page: z.number().int().positive().optional(),
+		per_page: z.number().int().positive().max(100).optional(),
+		cursor: z.string().optional(),
+	})
+	.optional();
+
+export type ProjectsListInput = z.infer<typeof ProjectsListInputSchema>;
+
+export const ProjectsListOutputSchema = z
+	.object({
+		data: z
+			.object({
+				projects: z.array(z.record(z.string(), z.unknown())),
+				pagination: z.record(z.string(), z.unknown()).optional(),
+			})
+			.passthrough(),
+	})
+	.passthrough();
+
+export type ProjectsListOutput = z.infer<typeof ProjectsListOutputSchema>;
+
+export const ProjectsGetInputSchema = z.object({
+	projectId: z.string().min(1, 'projectId is required'),
+});
+
+export type ProjectsGetInput = z.infer<typeof ProjectsGetInputSchema>;
+
+export const ProjectsGetOutputSchema = z
+	.object({
+		data: z.record(z.string(), z.unknown()),
+	})
+	.passthrough();
+
+export type ProjectsGetOutput = z.infer<typeof ProjectsGetOutputSchema>;
+
+export const ProjectsCreateInputSchema = z.object({
+	name: z.string().min(1, 'name is required'),
+	description: z.string().optional(),
+	region: z.string().min(1, 'region is required'),
+	color: z.string().optional(),
+});
+
+export type ProjectsCreateInput = z.infer<typeof ProjectsCreateInputSchema>;
+
+export const ProjectsCreateOutputSchema = z
+	.object({
+		data: z.record(z.string(), z.unknown()),
+	})
+	.passthrough();
+
+export type ProjectsCreateOutput = z.infer<typeof ProjectsCreateOutputSchema>;
+
+export const ProjectsUpdateInputSchema = z.object({
+	projectId: z.string().min(1, 'projectId is required'),
+	name: z.string().optional(),
+	description: z.string().optional(),
+	color: z.string().optional(),
+});
+
+export type ProjectsUpdateInput = z.infer<typeof ProjectsUpdateInputSchema>;
+
+export const ProjectsUpdateOutputSchema = z
+	.object({
+		data: z.record(z.string(), z.unknown()),
+	})
+	.passthrough();
+
+export type ProjectsUpdateOutput = z.infer<typeof ProjectsUpdateOutputSchema>;
+
+// ============================================================================
+// Services
+// ============================================================================
+
+export const ServicesListInputSchema = z.object({
+	projectId: z.string().min(1, 'projectId is required'),
+	page: z.number().int().positive().optional(),
+	per_page: z.number().int().positive().max(100).optional(),
+	cursor: z.string().optional(),
+});
+
+export type ServicesListInput = z.infer<typeof ServicesListInputSchema>;
+
+export const ServicesListOutputSchema = z
+	.object({
+		data: z
+			.object({
+				services: z.array(z.record(z.string(), z.unknown())),
+				pagination: z.record(z.string(), z.unknown()).optional(),
+			})
+			.passthrough(),
+	})
+	.passthrough();
+
+export type ServicesListOutput = z.infer<typeof ServicesListOutputSchema>;
+
+export const ServicesGetInputSchema = z.object({
+	projectId: z.string().min(1, 'projectId is required'),
+	serviceId: z.string().min(1, 'serviceId is required'),
+});
+
+export type ServicesGetInput = z.infer<typeof ServicesGetInputSchema>;
+
+export const ServicesGetOutputSchema = z
+	.object({
+		data: z.record(z.string(), z.unknown()),
+	})
+	.passthrough();
+
+export type ServicesGetOutput = z.infer<typeof ServicesGetOutputSchema>;
+
+export const ServicesCreateCombinedInputSchema = z.object({
+	projectId: z.string().min(1, 'projectId is required'),
+	name: z.string().min(1, 'name is required'),
+	description: z.string().optional(),
+	billing: z.record(z.string(), z.unknown()).optional(),
+	deployment: z.record(z.string(), z.unknown()).optional(),
+	buildSource: z.record(z.string(), z.unknown()).optional(),
+	vcsData: z.record(z.string(), z.unknown()).optional(),
+	buildSettings: z.record(z.string(), z.unknown()).optional(),
+	runtimeEnvironment: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type ServicesCreateCombinedInput = z.infer<
+	typeof ServicesCreateCombinedInputSchema
+>;
+
+export const ServicesCreateCombinedOutputSchema = z
+	.object({
+		data: z.record(z.string(), z.unknown()),
+	})
+	.passthrough();
+
+export type ServicesCreateCombinedOutput = z.infer<
+	typeof ServicesCreateCombinedOutputSchema
+>;
+
+export const ServicesUpdateCombinedInputSchema = z.object({
+	projectId: z.string().min(1, 'projectId is required'),
+	serviceId: z.string().min(1, 'serviceId is required'),
+	name: z.string().optional(),
+	description: z.string().optional(),
+	billing: z.record(z.string(), z.unknown()).optional(),
+	deployment: z.record(z.string(), z.unknown()).optional(),
+	buildSource: z.record(z.string(), z.unknown()).optional(),
+	vcsData: z.record(z.string(), z.unknown()).optional(),
+	buildSettings: z.record(z.string(), z.unknown()).optional(),
+	runtimeEnvironment: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type ServicesUpdateCombinedInput = z.infer<
+	typeof ServicesUpdateCombinedInputSchema
+>;
+
+export const ServicesUpdateCombinedOutputSchema = z
+	.object({
+		data: z.record(z.string(), z.unknown()),
+	})
+	.passthrough();
+
+export type ServicesUpdateCombinedOutput = z.infer<
+	typeof ServicesUpdateCombinedOutputSchema
+>;
+
+// ============================================================================
+// Environments
+// ============================================================================
+
+export const EnvironmentsListPreviewsInputSchema = z.object({
+	projectId: z.string().min(1, 'projectId is required'),
+	previewBlueprintId: z.string().min(1, 'previewBlueprintId is required'),
+	page: z.number().int().positive().optional(),
+	per_page: z.number().int().positive().max(100).optional(),
+	cursor: z.string().optional(),
+});
+
+export type EnvironmentsListPreviewsInput = z.infer<
+	typeof EnvironmentsListPreviewsInputSchema
+>;
+
+export const EnvironmentsListPreviewsOutputSchema = z
+	.object({
+		data: z
+			.object({
+				previewEnvironments: z.array(z.record(z.string(), z.unknown())),
+				pagination: z.record(z.string(), z.unknown()).optional(),
+			})
+			.passthrough(),
+	})
+	.passthrough();
+
+export type EnvironmentsListPreviewsOutput = z.infer<
+	typeof EnvironmentsListPreviewsOutputSchema
+>;
+
+// ============================================================================
+// Secrets
+// ============================================================================
+
+export const SecretsListInputSchema = z.object({
+	projectId: z.string().min(1, 'projectId is required'),
+	page: z.number().int().positive().optional(),
+	per_page: z.number().int().positive().max(100).optional(),
+	cursor: z.string().optional(),
+});
+
+export type SecretsListInput = z.infer<typeof SecretsListInputSchema>;
+
+export const SecretsListOutputSchema = z
+	.object({
+		data: z
+			.object({
+				secrets: z.array(z.record(z.string(), z.unknown())),
+				pagination: z.record(z.string(), z.unknown()).optional(),
+			})
+			.passthrough(),
+	})
+	.passthrough();
+
+export type SecretsListOutput = z.infer<typeof SecretsListOutputSchema>;
+
+export const SecretsGetInputSchema = z.object({
+	projectId: z.string().min(1, 'projectId is required'),
+	secretId: z.string().min(1, 'secretId is required'),
+});
+
+export type SecretsGetInput = z.infer<typeof SecretsGetInputSchema>;
+
+export const SecretsGetOutputSchema = z
+	.object({
+		data: z.record(z.string(), z.unknown()),
+	})
+	.passthrough();
+
+export type SecretsGetOutput = z.infer<typeof SecretsGetOutputSchema>;
+
+export const SecretsCreateInputSchema = z.object({
+	projectId: z.string().min(1, 'projectId is required'),
+	name: z.string().min(1, 'name is required'),
+	description: z.string().optional(),
+	secretType: z.enum(['secret', 'variable']).optional(),
+	priority: z.number().int().optional(),
+	data: z.record(z.string(), z.string()).optional(),
+	useAsEnvironmentVariable: z.boolean().optional(),
+});
+
+export type SecretsCreateInput = z.infer<typeof SecretsCreateInputSchema>;
+
+export const SecretsCreateOutputSchema = z
+	.object({
+		data: z.record(z.string(), z.unknown()),
+	})
+	.passthrough();
+
+export type SecretsCreateOutput = z.infer<typeof SecretsCreateOutputSchema>;
+
+export const SecretsUpdateInputSchema = z.object({
+	projectId: z.string().min(1, 'projectId is required'),
+	secretId: z.string().min(1, 'secretId is required'),
+	name: z.string().optional(),
+	description: z.string().optional(),
+	data: z.record(z.string(), z.string()).optional(),
+	priority: z.number().int().optional(),
+});
+
+export type SecretsUpdateInput = z.infer<typeof SecretsUpdateInputSchema>;
+
+export const SecretsUpdateOutputSchema = z
+	.object({
+		data: z.record(z.string(), z.unknown()),
+	})
+	.passthrough();
+
+export type SecretsUpdateOutput = z.infer<typeof SecretsUpdateOutputSchema>;
+
+// ============================================================================
+// Plans
+// ============================================================================
+
+export const PlansListInputSchema = z
+	.object({
+		page: z.number().int().positive().optional(),
+		per_page: z.number().int().positive().max(100).optional(),
+		cursor: z.string().optional(),
+	})
+	.optional();
+
+export type PlansListInput = z.infer<typeof PlansListInputSchema>;
+
+export const PlansListOutputSchema = z
+	.object({
+		data: z
+			.object({
+				plans: z.array(z.record(z.string(), z.unknown())),
+			})
+			.passthrough(),
+	})
+	.passthrough();
+
+export type PlansListOutput = z.infer<typeof PlansListOutputSchema>;
+
+// ============================================================================
+// Regions
+// ============================================================================
+
+export const RegionsListInputSchema = z.object({}).optional();
+
+export type RegionsListInput = z.infer<typeof RegionsListInputSchema>;
+
+export const RegionsListOutputSchema = z
+	.object({
+		data: z
+			.object({
+				regions: z.array(z.record(z.string(), z.unknown())),
+			})
+			.passthrough(),
+	})
+	.passthrough();
+
+export type RegionsListOutput = z.infer<typeof RegionsListOutputSchema>;
+
+// ============================================================================
+// Schema Maps
+// ============================================================================
+
+export const NorthflankEndpointInputSchemas = {
+	'projects.list': ProjectsListInputSchema,
+	'projects.get': ProjectsGetInputSchema,
+	'projects.create': ProjectsCreateInputSchema,
+	'projects.update': ProjectsUpdateInputSchema,
+	'services.list': ServicesListInputSchema,
+	'services.get': ServicesGetInputSchema,
+	'services.createCombined': ServicesCreateCombinedInputSchema,
+	'services.updateCombined': ServicesUpdateCombinedInputSchema,
+	'environments.listPreviews': EnvironmentsListPreviewsInputSchema,
+	'secrets.list': SecretsListInputSchema,
+	'secrets.get': SecretsGetInputSchema,
+	'secrets.create': SecretsCreateInputSchema,
+	'secrets.update': SecretsUpdateInputSchema,
+	'plans.list': PlansListInputSchema,
+	'regions.list': RegionsListInputSchema,
+} as const;
+
+export type NorthflankEndpointInputs = {
+	[K in keyof typeof NorthflankEndpointInputSchemas]: z.infer<
+		(typeof NorthflankEndpointInputSchemas)[K]
+	>;
+};
+
+export const NorthflankEndpointOutputSchemas = {
+	'projects.list': ProjectsListOutputSchema,
+	'projects.get': ProjectsGetOutputSchema,
+	'projects.create': ProjectsCreateOutputSchema,
+	'projects.update': ProjectsUpdateOutputSchema,
+	'services.list': ServicesListOutputSchema,
+	'services.get': ServicesGetOutputSchema,
+	'services.createCombined': ServicesCreateCombinedOutputSchema,
+	'services.updateCombined': ServicesUpdateCombinedOutputSchema,
+	'environments.listPreviews': EnvironmentsListPreviewsOutputSchema,
+	'secrets.list': SecretsListOutputSchema,
+	'secrets.get': SecretsGetOutputSchema,
+	'secrets.create': SecretsCreateOutputSchema,
+	'secrets.update': SecretsUpdateOutputSchema,
+	'plans.list': PlansListOutputSchema,
+	'regions.list': RegionsListOutputSchema,
+} as const;
+
+export type NorthflankEndpointOutputs = {
+	[K in keyof typeof NorthflankEndpointOutputSchemas]: z.infer<
+		(typeof NorthflankEndpointOutputSchemas)[K]
+	>;
+};
+
+export type NorthflankEndpointInput =
+	NorthflankEndpointInputs[keyof NorthflankEndpointInputs] & {
+		[key: string]: unknown;
+	};

--- a/packages/northflank/error-handlers.test.ts
+++ b/packages/northflank/error-handlers.test.ts
@@ -1,0 +1,119 @@
+import { ApiError } from 'corsair/http';
+import { NorthflankAPIError } from './client';
+import { errorHandlers } from './error-handlers';
+
+describe('Northflank errorHandlers', () => {
+	it('matches 429 rate limit errors and returns exponential backoff', async () => {
+		const apiError = new ApiError(
+			{ method: 'GET', url: 'https://api.northflank.com/v1/projects' },
+			{
+				url: 'https://api.northflank.com/v1/projects',
+				status: 429,
+				statusText: 'Too Many Requests',
+				body: { message: 'Rate limit exceeded' },
+				ok: false,
+			},
+			'Rate limit exceeded',
+		);
+		const error = new NorthflankAPIError(apiError.message, { cause: apiError });
+
+		expect(errorHandlers.RATE_LIMIT_ERROR.match(error)).toBe(true);
+
+		const strategy = await errorHandlers.RATE_LIMIT_ERROR.handler(error);
+		expect(strategy).toEqual({
+			maxRetries: 3,
+			retryStrategy: 'exponential_backoff',
+		});
+	});
+
+	it('matches 401 and 403 authentication errors and does not retry', async () => {
+		const apiError401 = new ApiError(
+			{ method: 'GET', url: 'https://api.northflank.com/v1/projects' },
+			{
+				url: 'https://api.northflank.com/v1/projects',
+				status: 401,
+				statusText: 'Unauthorized',
+				body: {},
+				ok: false,
+			},
+			'Unauthorized',
+		);
+		const error401 = new NorthflankAPIError('Unauthorized', {
+			cause: apiError401,
+		});
+
+		expect(errorHandlers.AUTH_ERROR.match(error401)).toBe(true);
+		const strategy401 = await errorHandlers.AUTH_ERROR.handler(error401);
+		expect(strategy401).toEqual({ maxRetries: 0 });
+
+		const apiError403 = new ApiError(
+			{ method: 'GET', url: 'https://api.northflank.com/v1/projects' },
+			{
+				url: 'https://api.northflank.com/v1/projects',
+				status: 403,
+				statusText: 'Forbidden',
+				body: {},
+				ok: false,
+			},
+			'Forbidden',
+		);
+		const error403 = new NorthflankAPIError('Forbidden', {
+			cause: apiError403,
+		});
+
+		expect(errorHandlers.AUTH_ERROR.match(error403)).toBe(true);
+		const strategy403 = await errorHandlers.AUTH_ERROR.handler(error403);
+		expect(strategy403).toEqual({ maxRetries: 0 });
+	});
+
+	it('matches 404 not found errors and does not retry', async () => {
+		const apiError = new ApiError(
+			{
+				method: 'GET',
+				url: 'https://api.northflank.com/v1/projects/not-found',
+			},
+			{
+				url: 'https://api.northflank.com/v1/projects/not-found',
+				status: 404,
+				statusText: 'Not Found',
+				body: {},
+				ok: false,
+			},
+			'Not Found',
+		);
+		const error = new NorthflankAPIError('Not Found', { cause: apiError });
+
+		expect(errorHandlers.NOT_FOUND_ERROR.match(error)).toBe(true);
+		const strategy = await errorHandlers.NOT_FOUND_ERROR.handler(error);
+		expect(strategy).toEqual({ maxRetries: 0 });
+	});
+
+	it('matches 5xx server errors and retries with backoff', async () => {
+		const apiError = new ApiError(
+			{ method: 'GET', url: 'https://api.northflank.com/v1/projects' },
+			{
+				url: 'https://api.northflank.com/v1/projects',
+				status: 502,
+				statusText: 'Bad Gateway',
+				body: {},
+				ok: false,
+			},
+			'Bad Gateway',
+		);
+		const error = new NorthflankAPIError('Bad Gateway', { cause: apiError });
+
+		expect(errorHandlers.SERVER_ERROR.match(error)).toBe(true);
+		const strategy = await errorHandlers.SERVER_ERROR.handler(error);
+		expect(strategy).toEqual({
+			maxRetries: 2,
+			retryStrategy: 'exponential_backoff',
+		});
+	});
+
+	it('catches generic errors in default handler with 0 retries', async () => {
+		const genericError = new Error('Something unexpected');
+		expect(errorHandlers.DEFAULT.match(genericError)).toBe(true);
+		const strategy = await errorHandlers.DEFAULT.handler(genericError);
+		expect(strategy).toEqual({ maxRetries: 0 });
+	});
+});

--- a/packages/northflank/error-handlers.test.ts
+++ b/packages/northflank/error-handlers.test.ts
@@ -1,9 +1,10 @@
+import type { ErrorContext } from 'corsair/core';
 import { ApiError } from 'corsair/http';
 import { NorthflankAPIError } from './client';
 import { errorHandlers } from './error-handlers';
 
 describe('Northflank errorHandlers', () => {
-	it('matches 429 rate limit errors and returns exponential backoff', async () => {
+	it('matches 429 rate limit errors and returns exponential backoff for read operations', async () => {
 		const apiError = new ApiError(
 			{ method: 'GET', url: 'https://api.northflank.com/v1/projects' },
 			{
@@ -19,11 +20,58 @@ describe('Northflank errorHandlers', () => {
 
 		expect(errorHandlers.RATE_LIMIT_ERROR.match(error)).toBe(true);
 
-		const strategy = await errorHandlers.RATE_LIMIT_ERROR.handler(error);
+		const readContext: ErrorContext = {
+			pluginId: 'northflank',
+			operation: 'projects.list',
+			input: {},
+			originalError: error,
+		};
+		const strategy = await errorHandlers.RATE_LIMIT_ERROR.handler(
+			error,
+			readContext,
+		);
 		expect(strategy).toEqual({
 			maxRetries: 3,
 			retryStrategy: 'exponential_backoff',
 		});
+	});
+
+	it('does NOT retry 429 rate limit errors for write/mutating operations to prevent duplicate resources', async () => {
+		const apiError = new ApiError(
+			{ method: 'POST', url: 'https://api.northflank.com/v1/projects' },
+			{
+				url: 'https://api.northflank.com/v1/projects',
+				status: 429,
+				statusText: 'Too Many Requests',
+				body: { message: 'Rate limit exceeded' },
+				ok: false,
+			},
+			'Rate limit exceeded',
+		);
+		const error = new NorthflankAPIError(apiError.message, { cause: apiError });
+
+		const writeOperations = [
+			'projects.create',
+			'projects.update',
+			'services.createCombined',
+			'services.updateCombined',
+			'secrets.create',
+			'secrets.update',
+		];
+
+		for (const operation of writeOperations) {
+			const writeContext: ErrorContext = {
+				pluginId: 'northflank',
+				operation,
+				input: {},
+				originalError: error,
+			};
+			const strategy = await errorHandlers.RATE_LIMIT_ERROR.handler(
+				error,
+				writeContext,
+			);
+			expect(strategy).toEqual({ maxRetries: 0 });
+		}
 	});
 
 	it('matches 401 and 403 authentication errors and does not retry', async () => {
@@ -88,7 +136,7 @@ describe('Northflank errorHandlers', () => {
 		expect(strategy).toEqual({ maxRetries: 0 });
 	});
 
-	it('matches 5xx server errors and retries with backoff', async () => {
+	it('matches 5xx server errors and retries with backoff for reads, but not writes', async () => {
 		const apiError = new ApiError(
 			{ method: 'GET', url: 'https://api.northflank.com/v1/projects' },
 			{
@@ -103,11 +151,35 @@ describe('Northflank errorHandlers', () => {
 		const error = new NorthflankAPIError('Bad Gateway', { cause: apiError });
 
 		expect(errorHandlers.SERVER_ERROR.match(error)).toBe(true);
-		const strategy = await errorHandlers.SERVER_ERROR.handler(error);
+
+		// Read operation -> retried
+		const readContext: ErrorContext = {
+			pluginId: 'northflank',
+			operation: 'projects.list',
+			input: {},
+			originalError: error,
+		};
+		const strategy = await errorHandlers.SERVER_ERROR.handler(
+			error,
+			readContext,
+		);
 		expect(strategy).toEqual({
 			maxRetries: 2,
 			retryStrategy: 'exponential_backoff',
 		});
+
+		// Write operation -> NOT retried
+		const writeContext: ErrorContext = {
+			pluginId: 'northflank',
+			operation: 'projects.create',
+			input: {},
+			originalError: error,
+		};
+		const writeStrategy = await errorHandlers.SERVER_ERROR.handler(
+			error,
+			writeContext,
+		);
+		expect(writeStrategy).toEqual({ maxRetries: 0 });
 	});
 
 	it('catches generic errors in default handler with 0 retries', async () => {

--- a/packages/northflank/error-handlers.ts
+++ b/packages/northflank/error-handlers.ts
@@ -5,13 +5,35 @@ function getStatus(error: Error): number | undefined {
 	return (error as Partial<NorthflankAPIError>).status;
 }
 
+const WRITE_OPERATIONS = new Set([
+	'projects.create',
+	'projects.update',
+	'services.createCombined',
+	'services.updateCombined',
+	'secrets.create',
+	'secrets.update',
+]);
+
+function isWriteOperation(operation?: string): boolean {
+	if (!operation) return false;
+	return WRITE_OPERATIONS.has(operation);
+}
+
 export const errorHandlers = {
 	RATE_LIMIT_ERROR: {
 		match: (error: Error, _context?: ErrorContext) => getStatus(error) === 429,
-		handler: async (_error: Error, _context?: ErrorContext) => ({
-			maxRetries: 3,
-			retryStrategy: 'exponential_backoff' as const,
-		}),
+		handler: async (error: Error, context?: ErrorContext) => {
+			if (context?.operation && isWriteOperation(context.operation)) {
+				console.warn(
+					`[NORTHFLANK:${context.operation}] Rate limit encountered on write operation — not retried to prevent duplicate resources: ${error.message}`,
+				);
+				return { maxRetries: 0 };
+			}
+			return {
+				maxRetries: 3,
+				retryStrategy: 'exponential_backoff' as const,
+			};
+		},
 	},
 	AUTH_ERROR: {
 		match: (error: Error, _context?: ErrorContext) => {
@@ -43,10 +65,18 @@ export const errorHandlers = {
 			const status = getStatus(error);
 			return status !== undefined && status >= 500;
 		},
-		handler: async (_error: Error, _context?: ErrorContext) => ({
-			maxRetries: 2,
-			retryStrategy: 'exponential_backoff' as const,
-		}),
+		handler: async (error: Error, context?: ErrorContext) => {
+			if (context?.operation && isWriteOperation(context.operation)) {
+				console.warn(
+					`[NORTHFLANK:${context.operation}] Server error on write operation — not retried to prevent duplicate resources: ${error.message}`,
+				);
+				return { maxRetries: 0 };
+			}
+			return {
+				maxRetries: 2,
+				retryStrategy: 'exponential_backoff' as const,
+			};
+		},
 	},
 	DEFAULT: {
 		match: (_error: Error, _context?: ErrorContext) => true,

--- a/packages/northflank/error-handlers.ts
+++ b/packages/northflank/error-handlers.ts
@@ -1,0 +1,58 @@
+import type { CorsairErrorHandler, ErrorContext } from 'corsair/core';
+import type { NorthflankAPIError } from './client';
+
+function getStatus(error: Error): number | undefined {
+	return (error as Partial<NorthflankAPIError>).status;
+}
+
+export const errorHandlers = {
+	RATE_LIMIT_ERROR: {
+		match: (error: Error, _context?: ErrorContext) => getStatus(error) === 429,
+		handler: async (_error: Error, _context?: ErrorContext) => ({
+			maxRetries: 3,
+			retryStrategy: 'exponential_backoff' as const,
+		}),
+	},
+	AUTH_ERROR: {
+		match: (error: Error, _context?: ErrorContext) => {
+			const status = getStatus(error);
+			if (status === 401 || status === 403) return true;
+			const msg = error.message.toLowerCase();
+			return (
+				msg.includes('unauthorized') ||
+				msg.includes('forbidden') ||
+				msg.includes('token') ||
+				msg.includes('authentication')
+			);
+		},
+		handler: async (_error: Error, _context?: ErrorContext) => {
+			console.error(
+				'[NORTHFLANK] Authentication failed — check your Northflank API token and permissions.',
+			);
+			return { maxRetries: 0 };
+		},
+	},
+	NOT_FOUND_ERROR: {
+		match: (error: Error, _context?: ErrorContext) => getStatus(error) === 404,
+		handler: async (_error: Error, _context?: ErrorContext) => ({
+			maxRetries: 0,
+		}),
+	},
+	SERVER_ERROR: {
+		match: (error: Error, _context?: ErrorContext) => {
+			const status = getStatus(error);
+			return status !== undefined && status >= 500;
+		},
+		handler: async (_error: Error, _context?: ErrorContext) => ({
+			maxRetries: 2,
+			retryStrategy: 'exponential_backoff' as const,
+		}),
+	},
+	DEFAULT: {
+		match: (_error: Error, _context?: ErrorContext) => true,
+		handler: async (error: Error, _context?: ErrorContext) => {
+			console.error(`[NORTHFLANK] Unhandled error: ${error.message}`);
+			return { maxRetries: 0 };
+		},
+	},
+} satisfies CorsairErrorHandler;

--- a/packages/northflank/index.ts
+++ b/packages/northflank/index.ts
@@ -1,0 +1,123 @@
+import type {
+	AuthTypes,
+	BindEndpoints,
+	CorsairErrorHandler,
+	CorsairPlugin,
+	CorsairPluginContext,
+	KeyBuilderContext,
+	PickAuth,
+	PluginAuthConfig,
+	PluginPermissionsConfig,
+	RequiredPluginEndpointMeta,
+} from 'corsair/core';
+import { AuthMissingError } from 'corsair/core';
+import {
+	northflankEndpointMeta as generatedNorthflankEndpointMeta,
+	northflankEndpointSchemas,
+	northflankEndpointsNested,
+} from './endpoints';
+import { errorHandlers } from './error-handlers';
+import { NorthflankSchema } from './schema';
+
+export const northflankEndpointMeta =
+	generatedNorthflankEndpointMeta satisfies RequiredPluginEndpointMeta<
+		typeof northflankEndpointsNested
+	>;
+
+export type NorthflankPluginOptions = {
+	authType?: PickAuth<'api_key'>;
+	key?: string;
+	hooks?: InternalNorthflankPlugin['hooks'];
+	errorHandlers?: CorsairErrorHandler;
+	permissions?: PluginPermissionsConfig<typeof northflankEndpointsNested>;
+};
+
+export type NorthflankContext = CorsairPluginContext<
+	typeof NorthflankSchema,
+	NorthflankPluginOptions
+>;
+
+export type NorthflankKeyBuilderContext =
+	KeyBuilderContext<NorthflankPluginOptions>;
+
+export type NorthflankBoundEndpoints = BindEndpoints<
+	typeof northflankEndpointsNested
+>;
+
+export type NorthflankEndpoints = typeof northflankEndpointsNested;
+
+const defaultAuthType: AuthTypes = 'api_key' as const;
+
+export const northflankAuthConfig = {
+	api_key: {},
+} as const satisfies PluginAuthConfig;
+
+export type BaseNorthflankPlugin<T extends NorthflankPluginOptions> =
+	CorsairPlugin<
+		'northflank',
+		typeof NorthflankSchema,
+		typeof northflankEndpointsNested,
+		{},
+		T,
+		typeof defaultAuthType
+	>;
+
+export type InternalNorthflankPlugin =
+	BaseNorthflankPlugin<NorthflankPluginOptions>;
+
+export type ExternalNorthflankPlugin<T extends NorthflankPluginOptions> =
+	BaseNorthflankPlugin<T>;
+
+export function northflank<const T extends NorthflankPluginOptions>(
+	incomingOptions: NorthflankPluginOptions & T = {} as NorthflankPluginOptions &
+		T,
+): ExternalNorthflankPlugin<T> {
+	const options = {
+		...incomingOptions,
+		authType: incomingOptions.authType ?? defaultAuthType,
+	};
+	return {
+		id: 'northflank',
+		schema: NorthflankSchema,
+		options,
+		authConfig: northflankAuthConfig,
+		hooks: options.hooks,
+		endpoints: northflankEndpointsNested,
+		webhooks: {},
+		endpointMeta: northflankEndpointMeta,
+		endpointSchemas: northflankEndpointSchemas,
+		pluginWebhookMatcher: undefined,
+		errorHandlers: {
+			...errorHandlers,
+			...options.errorHandlers,
+		},
+		keyBuilder: async (ctx: NorthflankKeyBuilderContext, source) => {
+			if (source === 'endpoint' && options.key) {
+				return options.key;
+			}
+
+			if (source === 'endpoint' && ctx.authType === 'api_key') {
+				const res = await ctx.keys.get_api_key();
+				if (!res) {
+					console.error(
+						'[NORTHFLANK] API key missing — connect Northflank or pass key in plugin options.',
+					);
+					throw new AuthMissingError('northflank', 'api_key');
+				}
+				return res;
+			}
+
+			console.error(
+				'[NORTHFLANK] Authentication required for Northflank API requests.',
+			);
+			throw new AuthMissingError('northflank', 'api_key');
+		},
+	} satisfies InternalNorthflankPlugin;
+}
+
+export type {
+	NorthflankEndpointInputs,
+	NorthflankEndpointOutputs,
+} from './endpoints/types';
+
+export { northflankEndpointsNested, northflankEndpointSchemas };

--- a/packages/northflank/jest.config.cjs
+++ b/packages/northflank/jest.config.cjs
@@ -1,0 +1,55 @@
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	roots: ['<rootDir>'],
+	testMatch: [
+		'**/*.test.ts',
+		'**/tests/**/*.test.ts',
+		'**/plugins/**/*.test.ts',
+		'**/setup/**/*.test.ts',
+	],
+	collectCoverageFrom: [
+		'**/*.ts',
+		'!**/*.d.ts',
+		'!**/node_modules/**',
+		'!**/dist/**',
+		'!jest.config.ts',
+		'!tests/**',
+	],
+	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+	transform: {
+		'^.+\\.yaml$': '<rootDir>/../corsair/jest-yaml-transform.cjs',
+		'^.+\\.ts$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+					verbatimModuleSyntax: false,
+					module: 'ESNext',
+					moduleResolution: 'Bundler',
+				},
+			},
+		],
+		'.*\\.js$': [
+			'ts-jest',
+			{
+				useESM: true,
+				tsconfig: {
+					esModuleInterop: true,
+					allowSyntheticDefaultImports: true,
+				},
+			},
+		],
+	},
+	moduleNameMapper: {
+		'^corsair/core$': '<rootDir>/../corsair/core.ts',
+		'^corsair/http$': '<rootDir>/../corsair/http.ts',
+		'^(\\.\\.?/.*)\\.js$': '$1',
+	},
+	transformIgnorePatterns: ['node_modules/(?!.*uuid.*)'],
+	extensionsToTreatAsEsm: ['.ts'],
+	testTimeout: 30000,
+	verbose: true,
+};

--- a/packages/northflank/package.json
+++ b/packages/northflank/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@corsair-dev/northflank",
+  "version": "0.1.0",
+  "description": "Northflank plugin for Corsair",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "dev-source": "./index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && tsc --build --force && tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "jest --config jest.config.cjs"
+  },
+  "peerDependencies": {
+    "corsair": ">=0.1.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "corsair": "workspace:*",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.9",
+    "tsup": "^8.0.1",
+    "typescript": "catalog:",
+    "zod": "^4.1.13"
+  },
+  "keywords": [
+    "corsair",
+    "northflank",
+    "plugin"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/northflank/plugin-docs.yaml
+++ b/packages/northflank/plugin-docs.yaml
@@ -1,0 +1,4 @@
+displayName: Northflank
+description: Connect Northflank to manage projects, services, preview environments, secrets, plans, and regions.
+overviewExampleCalls:
+  - path: projects.list

--- a/packages/northflank/schema.test.ts
+++ b/packages/northflank/schema.test.ts
@@ -1,0 +1,94 @@
+import {
+	NorthflankEndpointInputSchemas,
+	NorthflankEndpointOutputSchemas,
+} from './endpoints/types';
+import { NorthflankSchema } from './schema';
+
+describe('Northflank schema and endpoint validation', () => {
+	it('declares a semver version and empty entities for stateless plugin', () => {
+		expect(NorthflankSchema.version).toBe('1.0.0');
+		expect(NorthflankSchema.entities).toEqual({});
+	});
+
+	describe('Input and Output Schemas', () => {
+		it('validates ProjectsListInputSchema', () => {
+			const schema = NorthflankEndpointInputSchemas['projects.list'];
+			expect(schema.safeParse(undefined).success).toBe(true);
+			expect(schema.safeParse({ page: 1, per_page: 20 }).success).toBe(true);
+			expect(schema.safeParse({ per_page: 200 }).success).toBe(false);
+		});
+
+		it('validates ProjectsGetInputSchema', () => {
+			const schema = NorthflankEndpointInputSchemas['projects.get'];
+			expect(schema.safeParse({ projectId: 'p1' }).success).toBe(true);
+			expect(schema.safeParse({ projectId: '' }).success).toBe(false);
+		});
+
+		it('validates ProjectsCreateInputSchema', () => {
+			const schema = NorthflankEndpointInputSchemas['projects.create'];
+			expect(
+				schema.safeParse({ name: 'my-proj', region: 'europe-west' }).success,
+			).toBe(true);
+			expect(schema.safeParse({ name: 'my-proj' }).success).toBe(false);
+		});
+
+		it('validates ServicesCreateCombinedInputSchema', () => {
+			const schema = NorthflankEndpointInputSchemas['services.createCombined'];
+			expect(
+				schema.safeParse({
+					projectId: 'p1',
+					name: 'api-service',
+					deployment: { instances: 1 },
+				}).success,
+			).toBe(true);
+			expect(schema.safeParse({ name: 'api-service' }).success).toBe(false);
+		});
+
+		it('validates EnvironmentsListPreviewsInputSchema', () => {
+			const schema =
+				NorthflankEndpointInputSchemas['environments.listPreviews'];
+			expect(
+				schema.safeParse({
+					projectId: 'p1',
+					previewBlueprintId: 'bp1',
+				}).success,
+			).toBe(true);
+			expect(schema.safeParse({ projectId: 'p1' }).success).toBe(false);
+		});
+
+		it('validates SecretsCreateInputSchema', () => {
+			const schema = NorthflankEndpointInputSchemas['secrets.create'];
+			expect(
+				schema.safeParse({
+					projectId: 'p1',
+					name: 'API_SECRET',
+					secretType: 'secret',
+					data: { TOKEN: 'xyz' },
+				}).success,
+			).toBe(true);
+			expect(schema.safeParse({ projectId: 'p1' }).success).toBe(false);
+		});
+
+		it('validates PlansListInputSchema', () => {
+			const schema = NorthflankEndpointInputSchemas['plans.list'];
+			expect(schema.safeParse(undefined).success).toBe(true);
+			expect(schema.safeParse({ page: 2 }).success).toBe(true);
+		});
+
+		it('validates RegionsListInputSchema', () => {
+			const schema = NorthflankEndpointInputSchemas['regions.list'];
+			expect(schema.safeParse({}).success).toBe(true);
+		});
+
+		it('validates ProjectsListOutputSchema', () => {
+			const schema = NorthflankEndpointOutputSchemas['projects.list'];
+			expect(
+				schema.safeParse({
+					data: {
+						projects: [{ id: 'p1', name: 'Project 1' }],
+					},
+				}).success,
+			).toBe(true);
+		});
+	});
+});

--- a/packages/northflank/schema/database.ts
+++ b/packages/northflank/schema/database.ts
@@ -1,0 +1,1 @@
+// Stateless plugin: no database entities needed

--- a/packages/northflank/schema/index.ts
+++ b/packages/northflank/schema/index.ts
@@ -1,0 +1,4 @@
+export const NorthflankSchema = {
+	version: '1.0.0',
+	entities: {},
+} as const;

--- a/packages/northflank/tsconfig.json
+++ b/packages/northflank/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["node", "jest"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "composite": true,
+    "incremental": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["dist", "node_modules"],
+  "references": []
+}

--- a/packages/northflank/tsup.config.ts
+++ b/packages/northflank/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	clean: false,
+	dts: false,
+	format: ['esm'],
+	target: 'esnext',
+	platform: 'node',
+	bundle: true,
+	splitting: true,
+	minify: true,
+	outDir: 'dist',
+	external: ['corsair', 'zod'],
+	entry: ['index.ts'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5526,6 +5526,30 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
 
+  packages/northflank:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      corsair:
+        specifier: workspace:*
+        version: link:../corsair
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.9
+        version: 29.4.9(@babel/core@8.0.1)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@8.0.1))(jest-util@30.4.1)(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3)))(typescript@5.9.3)
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+
   packages/notion:
     devDependencies:
       '@types/jest':
@@ -20063,14 +20087,14 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 2.0.1
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.1.1
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@4.0.0(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.0
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.1.1
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@4.0.19(zod@4.4.3)':
@@ -28555,7 +28579,7 @@ snapshots:
 
   eventsource@4.1.0:
     dependencies:
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.1.1
 
   execa@2.1.0:
     dependencies:


### PR DESCRIPTION
## Description

Fixes #1681.

Implements the Northflank plugin (`@corsair-dev/northflank`): **21 typed operations** over the Northflank v1 API with API-key (Bearer) auth and no webhook surface.

- **Projects**: `list`, `get`, `create`, `createOrUpdate` (PUT upsert), `update` (PATCH), `delete`
- **Services**: `list`
- **Secrets**: `list`, `get`, `create`, `createOrUpdate` (PUT), `patch` (PATCH), `update` (POST), `getDetails`
- **Pipelines**: `list` — **Plans**: `list` — **Regions**: `list` — **AddonTypes**: `list` — **CloudProviders**: `listNodeTypes`, `listRegions` — **Misc**: `getDnsId`

Every route, method, and payload was checked against the official v1 reference pages (including PUT-upsert vs PATCH vs POST-update semantics and the `secretType` enum). All 9 live read-only tests pass against the real API; write ops are docs-verified and mock-tested (never fired at a live account). Strict typing: zero `any`/`unknown`/assertions/narrowing in plugin code; secret values never enter logs; path ids URL-encoded.

## Checklist

- [x] I have run `pnpm lint` and all checks pass
- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have run `pnpm build` and all packages build successfully
- [x] I have run `pnpm test` and all tests pass
- [x] I have added or updated tests where applicable
- [x] I have added or updated necessary documentation

## Screenshots / Demos
<img width="530" height="207" alt="image" src="https://github.com/user-attachments/assets/5bcec654-ac15-4d74-b036-eab0282ab64f" />




## Additional Notes

- Verification was run plugin-scoped and is fully green: `tsc`, `biome`, `jest` (83 tests: 74 mocked + 9 live read-only), package `build`, `validate:plugins`. Full-repo lint/typecheck/test were not run in this environment.
- Scope decisions: removed out-of-scope `services` mutations, `environments.*`, and generated `docs/plugins/northflank/**` + nav; kept `services.list` (requested). `main` merged in (no rebase/force-push); lockfile conflict resolved surgically (+25 lines, `--frozen-lockfile` verified).
- Live-test note: `secrets.get` with `show` and `getDetails` are mock-verified only — the test account holds 0 secrets.
- No credentials committed at any point; the live key was used only as a process env var.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Northflank as a supported provider with Bearer-token authentication.
  - Added 21 typed operations covering projects, services, secrets, pipelines, plans, regions, add-ons, cloud providers, and account DNS.
  - Added project and secret creation, updates, deletion, patching, and detail retrieval.
  - Added validated requests and responses, pagination, safe path encoding, and protected secret logging.
  - Added operation-aware error handling and retries for rate limits and server errors.

- **Documentation**
  - Expanded Northflank setup, endpoint, authentication, behavior, and testing guidance.

- **Tests**
  - Added unit, schema, error-handling, and optional live API integration coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
