### PR TITLE
fix(ci): skip uninstalled plugins in readmes check

### DIFF
--- a/scripts/generate-plugin-readmes.test.ts
+++ b/scripts/generate-plugin-readmes.test.ts
@@ -157,14 +157,8 @@ test('isWorkspaceNotInstalledError detects lane-scoped missing installs', () => 
 		),
 		false,
 	);
-	assert.equal(
-		isWorkspaceNotInstalledError('factory() threw: boom'),
-		false,
-	);
-	assert.equal(
-		isWorkspaceNotInstalledError('no factory export "acme"'),
-		false,
-	);
+	assert.equal(isWorkspaceNotInstalledError('factory() threw: boom'), false);
+	assert.equal(isWorkspaceNotInstalledError('no factory export "acme"'), false);
 });
 
 test('summarizeCheckResults skips uninstalled plugins but fails on gaps', () => {

--- a/scripts/generate-plugin-readmes.test.ts
+++ b/scripts/generate-plugin-readmes.test.ts
@@ -4,9 +4,11 @@ import type { PluginDocsIntrospection } from '../packages/corsair/core/inspect/i
 import {
 	buildChangesetContent,
 	fillPackageMetadata,
+	isWorkspaceNotInstalledError,
 	MISSING_METADATA_FIELDS,
 	missingMetadataFields,
 	renderPluginReadme,
+	summarizeCheckResults,
 } from './generate-plugin-readmes.ts';
 
 const sampleIntrospection: PluginDocsIntrospection = {
@@ -140,6 +142,78 @@ test('missingMetadataFields detects gaps for --check', () => {
 	for (const f of MISSING_METADATA_FIELDS) {
 		assert.ok(gaps.includes(f), `expected ${f} to be reported missing`);
 	}
+});
+
+test('isWorkspaceNotInstalledError detects lane-scoped missing installs', () => {
+	assert.equal(
+		isWorkspaceNotInstalledError(
+			"import failed: Cannot find package 'corsair' imported from '/repo/packages/acme/index.ts'",
+		),
+		true,
+	);
+	assert.equal(
+		isWorkspaceNotInstalledError(
+			"import failed: Cannot find package 'zod' imported from '/repo/packages/acme/index.ts'",
+		),
+		false,
+	);
+	assert.equal(
+		isWorkspaceNotInstalledError('factory() threw: boom'),
+		false,
+	);
+	assert.equal(
+		isWorkspaceNotInstalledError('no factory export "acme"'),
+		false,
+	);
+});
+
+test('summarizeCheckResults skips uninstalled plugins but fails on gaps', () => {
+	const results = [
+		{ dir: 'acme', gaps: [], error: undefined },
+		{
+			dir: 'beta',
+			gaps: [],
+			error:
+				"import failed: Cannot find package 'corsair' imported from '/repo/packages/beta/index.ts'",
+		},
+	];
+	const summary = summarizeCheckResults(results);
+	assert.equal(summary.ok, true);
+	assert.deepEqual(summary.skipped, ['beta']);
+	assert.deepEqual(summary.offenders, []);
+	assert.deepEqual(summary.errored, []);
+});
+
+test('summarizeCheckResults still fails on real gaps and other errors', () => {
+	const results = [
+		{ dir: 'acme', gaps: ['README.md'], error: undefined },
+		{ dir: 'beta', gaps: [], error: 'factory() threw: boom' },
+		{
+			dir: 'gamma',
+			gaps: [],
+			error:
+				"import failed: Cannot find package 'corsair' imported from '/repo/packages/gamma/index.ts'",
+		},
+	];
+	const summary = summarizeCheckResults(results);
+	assert.equal(summary.ok, false);
+	assert.deepEqual(summary.offenders, ['acme']);
+	assert.deepEqual(summary.errored, ['beta']);
+	assert.deepEqual(summary.skipped, ['gamma']);
+});
+
+test('summarizeCheckResults fails when nothing introspected at all', () => {
+	const results = [
+		{
+			dir: 'beta',
+			gaps: [],
+			error:
+				"import failed: Cannot find package 'corsair' imported from '/repo/packages/beta/index.ts'",
+		},
+	];
+	const summary = summarizeCheckResults(results);
+	assert.equal(summary.ok, false);
+	assert.deepEqual(summary.skipped, ['beta']);
 });
 
 test('buildChangesetContent lists exactly the touched packages at patch', () => {

--- a/scripts/generate-plugin-readmes.ts
+++ b/scripts/generate-plugin-readmes.ts
@@ -310,6 +310,49 @@ const FACTORY_OPTIONS: Record<string, Record<string, unknown>> = {
 	workday: { tenant: 'acme', host: 'wd2-impl-services1.workday.com' },
 };
 
+/**
+ * True when a plugin failed to load only because the `corsair` workspace
+ * dependency is not installed — the signature of a lane-scoped CI install
+ * (the plugin lane installs just the PR's plugin), not a broken plugin.
+ */
+export function isWorkspaceNotInstalledError(error: string): boolean {
+	return error.startsWith("import failed: Cannot find package 'corsair'");
+}
+
+export type CheckResultSummary = {
+	ok: boolean;
+	offenders: string[];
+	errored: string[];
+	skipped: string[];
+};
+
+/**
+ * Decide a `--check` run: gaps and real load errors fail, uninstalled
+ * plugins are skipped, and a run that introspected nothing fails so a
+ * broken install can never pass vacuously.
+ */
+export function summarizeCheckResults(
+	results: { dir: string; gaps: string[]; error?: string }[],
+): CheckResultSummary {
+	const skipped = results
+		.filter((r) => r.error && isWorkspaceNotInstalledError(r.error))
+		.map((r) => r.dir);
+	const errored = results
+		.filter((r) => r.error && !isWorkspaceNotInstalledError(r.error))
+		.map((r) => r.dir);
+	const offenders = results
+		.filter((r) => !r.error && r.gaps.length > 0)
+		.map((r) => r.dir);
+	const introspected = results.length - skipped.length;
+	return {
+		ok:
+			offenders.length === 0 && errored.length === 0 && introspected > 0,
+		offenders,
+		errored,
+		skipped,
+	};
+}
+
 async function loadPlugin(
 	entryPath: string,
 ): Promise<{ ok: true; plugin: CorsairPlugin } | { ok: false; error: string }> {
@@ -495,20 +538,32 @@ async function main() {
 	}
 
 	const errored = results.filter((r) => r.error);
-	for (const r of errored) {
-		console.error(`[${r.dir}] ${r.error}`);
-	}
 
 	if (check) {
-		const offenders = results.filter((r) => !r.error && r.gaps.length > 0);
-		for (const r of offenders) {
-			console.error(`[${r.dir}] missing: ${r.gaps.join(', ')}`);
+		const summary = summarizeCheckResults(results);
+		for (const dir of summary.skipped) {
+			console.warn(
+				`[${dir}] skipped: 'corsair' workspace dependency not installed`,
+			);
 		}
-		const ok = offenders.length === 0 && errored.length === 0;
+		for (const dir of summary.errored) {
+			console.error(
+				`[${dir}] ${results.find((r) => r.dir === dir)?.error}`,
+			);
+		}
+		for (const dir of summary.offenders) {
+			console.error(
+				`[${dir}] missing: ${results.find((r) => r.dir === dir)?.gaps.join(', ')}`,
+			);
+		}
 		console.log(
-			`--check: ${results.length} plugins, ${offenders.length} with gaps, ${errored.length} failed to introspect.`,
+			`--check: ${results.length} plugins, ${summary.offenders.length} with gaps, ${summary.errored.length} failed to introspect, ${summary.skipped.length} skipped (not installed).`,
 		);
-		process.exit(ok ? 0 : 1);
+		process.exit(summary.ok ? 0 : 1);
+	}
+
+	for (const r of errored) {
+		console.error(`[${r.dir}] ${r.error}`);
 	}
 
 	const readmesWritten = results.filter((r) => r.readmeWritten);

--- a/scripts/generate-plugin-readmes.ts
+++ b/scripts/generate-plugin-readmes.ts
@@ -345,8 +345,7 @@ export function summarizeCheckResults(
 		.map((r) => r.dir);
 	const introspected = results.length - skipped.length;
 	return {
-		ok:
-			offenders.length === 0 && errored.length === 0 && introspected > 0,
+		ok: offenders.length === 0 && errored.length === 0 && introspected > 0,
 		offenders,
 		errored,
 		skipped,
@@ -547,9 +546,7 @@ async function main() {
 			);
 		}
 		for (const dir of summary.errored) {
-			console.error(
-				`[${dir}] ${results.find((r) => r.dir === dir)?.error}`,
-			);
+			console.error(`[${dir}] ${results.find((r) => r.dir === dir)?.error}`);
 		}
 		for (const dir of summary.offenders) {
 			console.error(


### PR DESCRIPTION
## Description

`pnpm generate:readmes:all --check` imports every plugin, but plugin-lane CI only installs the PR's plugin. The other ~280 fail with `Cannot find package 'corsair'` and fail the Build job on every plugin PR (first seen on #1506).

`--check` now skips plugins with no `corsair` install (warns instead), still fails on real gaps and other import errors, and fails if nothing introspected at all. Full-install runs behave as before.

## Checklist

- [x] I have run `pnpm typecheck` and there are no TypeScript errors
- [x] I have added or updated tests where applicable
- [ ] I have run `pnpm lint` and all checks pass
- [ ] I have run `pnpm build` and all packages build successfully
- [ ] I have run `pnpm test` and all tests pass
- [ ] I have added or updated necessary documentation

## Additional Notes

Script tests 11/11 pass. Lane simulation (30 installs hidden) exits 0 with 30 skipped; full-install `--check` still reports the 30 pre-existing gaps and exits 1. Full `pnpm lint` is red repo-wide on unrelated files, pre-existing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Plugin documentation checks now distinguish unavailable workspace dependencies from genuine errors.
  - Checks continue past plugins that cannot be loaded because dependencies are unavailable, while still failing for documentation gaps and other errors.
  - Checks no longer pass when no plugins were successfully inspected.

- **Improvements**
  - Check output now includes skipped-plugin warnings, per-plugin issues, and a summary of skipped results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->