### PR TITLE
fix(tunnel): supervise frpc and restart on death

### DIFF
--- a/packages/corsair/core/index.ts
+++ b/packages/corsair/core/index.ts
@@ -208,18 +208,20 @@ export function superviseTunnel(opts: {
 	const min = opts.minDelayMs ?? TUNNEL_RESTART_MIN_MS;
 	const max = opts.maxDelayMs ?? TUNNEL_RESTART_MAX_MS;
 	let delay = min;
-	let scheduled = false;
-	// A dead attempt can signal twice — the promise rejects AND onClose fires
-	// (runTunnel's fail() kills the child, whose exit then runs onClose). Collapse
-	// both into one restart, else each death spawns two overlapping frpc processes.
-	const restart = () => {
-		if (scheduled) return;
-		scheduled = true;
-		schedule(run, delay);
-		delay = Math.min(delay * 2, max);
-	};
-	const run = () => {
-		scheduled = false;
+	const run = (): void => {
+		// One restart per attempt, latched per attempt (not globally). A dead
+		// attempt can signal twice — runTunnel's fail() rejects the promise and
+		// kills the child, whose exit later fires onClose, possibly *after* the
+		// next attempt already started. onClose is bound to this attempt's
+		// `restart`, so a superseded attempt's late signal no-ops here instead of
+		// spawning an overlapping frpc process.
+		let ended = false;
+		const restart = (): void => {
+			if (ended) return;
+			ended = true;
+			schedule(run, delay);
+			delay = Math.min(delay * 2, max);
+		};
 		void opts
 			.start(restart)
 			.then(() => {

--- a/packages/corsair/core/index.ts
+++ b/packages/corsair/core/index.ts
@@ -186,6 +186,50 @@ const activeTunnels: Set<string> = ((
 	}
 ).__corsairTunnels ??= new Set<string>());
 
+const TUNNEL_RESTART_MIN_MS = 1_000;
+const TUNNEL_RESTART_MAX_MS = 30_000;
+
+/**
+ * Keep a dev tunnel alive. frpc has no supervisor — a death (laptop sleep,
+ * network blip, frps restart) leaves the tunnel down until the app process
+ * restarts, and the Hub keeps delivering to the dead URL. Restart on death with
+ * capped exponential backoff; a healthy start resets the backoff. The
+ * Hub-owned slug is sticky, so a restart re-registers the same public URL.
+ * Extracted from the spawn so the restart wiring is unit-testable.
+ */
+export function superviseTunnel(opts: {
+	start: (onClose: () => void) => Promise<unknown>;
+	schedule?: (fn: () => void, ms: number) => void;
+	minDelayMs?: number;
+	maxDelayMs?: number;
+}): void {
+	const schedule =
+		opts.schedule ?? ((fn, ms) => void setTimeout(fn, ms).unref?.());
+	const min = opts.minDelayMs ?? TUNNEL_RESTART_MIN_MS;
+	const max = opts.maxDelayMs ?? TUNNEL_RESTART_MAX_MS;
+	let delay = min;
+	let scheduled = false;
+	// A dead attempt can signal twice — the promise rejects AND onClose fires
+	// (runTunnel's fail() kills the child, whose exit then runs onClose). Collapse
+	// both into one restart, else each death spawns two overlapping frpc processes.
+	const restart = () => {
+		if (scheduled) return;
+		scheduled = true;
+		schedule(run, delay);
+		delay = Math.min(delay * 2, max);
+	};
+	const run = () => {
+		scheduled = false;
+		void opts
+			.start(restart)
+			.then(() => {
+				delay = min;
+			})
+			.catch(restart);
+	};
+	run();
+}
+
 function maybeStartTunnel(
 	_instance: unknown,
 	hub: HubConfig | undefined,
@@ -206,25 +250,28 @@ function maybeStartTunnel(
 	const cfg = typeof hub!.tunnel === 'object' ? hub!.tunnel : {};
 	const shareHost =
 		process.env.CORSAIR_FRP_HOST ?? cfg.shareHost ?? CORSAIR_TUNNEL_ZONE;
-	void import('../hub/tunnel/run-tunnel')
-		.then((m) =>
-			m.runTunnel({
-				port,
-				apiUrl: hub!.apiUrl,
-				apiKey: key,
-				shareHost,
-				onClose: () => activeTunnels.delete(key),
-			}),
-		)
-		.then(({ url }) => {
-			console.log(`[corsair] tunnel active: ${url}${CORSAIR_TUNNEL_PATH}`);
-		})
-		.catch((err: unknown) => {
-			activeTunnels.delete(key);
-			console.warn(
-				`[corsair] tunnel failed to start: ${err instanceof Error ? err.message : String(err)}. Run \`corsair setup\` to enable your dev tunnel.`,
-			);
-		});
+	superviseTunnel({
+		start: (onClose) =>
+			import('../hub/tunnel/run-tunnel')
+				.then((m) =>
+					m.runTunnel({
+						port,
+						apiUrl: hub!.apiUrl,
+						apiKey: key,
+						shareHost,
+						onClose,
+					}),
+				)
+				.then(({ url }) => {
+					console.log(`[corsair] tunnel active: ${url}${CORSAIR_TUNNEL_PATH}`);
+				})
+				.catch((err: unknown) => {
+					console.warn(
+						`[corsair] tunnel down: ${err instanceof Error ? err.message : String(err)}. Retrying — run \`corsair setup\` if it doesn't recover.`,
+					);
+					throw err;
+				}),
+	});
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/corsair/package.json
+++ b/packages/corsair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corsair",
-  "version": "0.1.129",
+  "version": "0.1.130",
   "description": "Open-source integration layer for AI agents and apps. Managed OAuth, webhooks, and one API for 200+ integrations, with credentials that stay in your own database.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/corsair/tests/supervise-tunnel.test.ts
+++ b/packages/corsair/tests/supervise-tunnel.test.ts
@@ -1,0 +1,110 @@
+import { superviseTunnel } from '../core';
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('superviseTunnel', () => {
+	it('restarts the tunnel when it dies (frpc death used to leave it down forever)', async () => {
+		const scheduled: Array<() => void> = [];
+		let starts = 0;
+		let die: () => void = () => {};
+
+		superviseTunnel({
+			start: (onClose) => {
+				starts++;
+				die = onClose;
+				return Promise.resolve();
+			},
+			schedule: (fn) => scheduled.push(fn),
+			minDelayMs: 1,
+			maxDelayMs: 8,
+		});
+
+		await flush();
+		expect(starts).toBe(1);
+
+		die();
+		expect(scheduled).toHaveLength(1);
+		scheduled.pop()!();
+		await flush();
+
+		// Before the fix, a dead tunnel was never restarted — starts stayed at 1.
+		expect(starts).toBe(2);
+	});
+
+	it('collapses a double death signal (reject + onClose) into one restart', async () => {
+		const scheduled: Array<() => void> = [];
+
+		// runTunnel's fail() path kills the child (fires onClose) *and* rejects the
+		// promise for the same dead attempt. Both must yield a single restart.
+		superviseTunnel({
+			start: (onClose) => {
+				onClose();
+				return Promise.reject(new Error('frpc timed out'));
+			},
+			schedule: (fn) => scheduled.push(fn),
+			minDelayMs: 1,
+			maxDelayMs: 8,
+		});
+
+		await flush();
+		expect(scheduled).toHaveLength(1);
+	});
+
+	it('backs off exponentially on repeated start failures and caps', async () => {
+		const timers: Array<{ fn: () => void; ms: number }> = [];
+		let starts = 0;
+
+		superviseTunnel({
+			start: () => {
+				starts++;
+				return Promise.reject(new Error('no frps'));
+			},
+			schedule: (fn, ms) => timers.push({ fn, ms }),
+			minDelayMs: 1,
+			maxDelayMs: 4,
+		});
+
+		const seen: number[] = [];
+		for (let i = 0; i < 5; i++) {
+			await flush();
+			const t = timers.shift();
+			if (!t) break;
+			seen.push(t.ms);
+			t.fn();
+		}
+
+		expect(seen).toEqual([1, 2, 4, 4, 4]);
+	});
+
+	it('resets the backoff after a healthy start', async () => {
+		const timers: Array<{ fn: () => void; ms: number }> = [];
+		let healthy = true;
+		let die: () => void = () => {};
+
+		superviseTunnel({
+			start: (onClose) => {
+				die = onClose;
+				return healthy ? Promise.resolve() : Promise.reject(new Error('down'));
+			},
+			schedule: (fn, ms) => timers.push({ fn, ms }),
+			minDelayMs: 1,
+			maxDelayMs: 16,
+		});
+
+		await flush();
+		// Two failing cycles push the backoff up.
+		healthy = false;
+		die();
+		timers.shift()!.fn();
+		await flush();
+		timers.shift()!.fn();
+		await flush();
+		// Recover, then die once more: the delay must be back at the minimum.
+		healthy = true;
+		timers.shift()!.fn();
+		await flush();
+		die();
+
+		expect(timers.shift()!.ms).toBe(1);
+	});
+});

--- a/packages/corsair/tests/supervise-tunnel.test.ts
+++ b/packages/corsair/tests/supervise-tunnel.test.ts
@@ -50,6 +50,34 @@ describe('superviseTunnel', () => {
 		expect(scheduled).toHaveLength(1);
 	});
 
+	it('ignores a delayed close from a superseded attempt', async () => {
+		const scheduled: Array<() => void> = [];
+		const closers: Array<() => void> = [];
+
+		// Each attempt fails; runTunnel's killed child may exit *after* the next
+		// attempt already started, firing the old attempt's onClose late. That
+		// stale signal must not schedule an extra (overlapping) restart.
+		superviseTunnel({
+			start: (onClose) => {
+				closers.push(onClose);
+				return Promise.reject(new Error('frpc died'));
+			},
+			schedule: (fn) => scheduled.push(fn),
+			minDelayMs: 1,
+			maxDelayMs: 8,
+		});
+
+		await flush();
+		expect(scheduled).toHaveLength(1);
+		scheduled.pop()!();
+		await flush();
+		expect(scheduled).toHaveLength(1);
+
+		// Attempt 1's child finally exits, calling attempt 1's (superseded) onClose.
+		closers[0]();
+		expect(scheduled).toHaveLength(1);
+	});
+
 	it('backs off exponentially on repeated start failures and caps', async () => {
 		const timers: Array<{ fn: () => void; ms: number }> = [];
 		let starts = 0;


### PR DESCRIPTION
## What
Supervise the dev frpc tunnel so it restarts on death, and bump `corsair` to `0.1.130`.

## Why
`maybeStartTunnel` spawned frpc once at boot and, on death, only did `activeTunnels.delete(key)` — nothing respawned it. So when frpc died (laptop sleep, network blip, frps restart) the tunnel stayed **down until the app process restarted**, while the Hub kept delivering OAuth tokens / run / probe to the dead URL. That surfaced as "the redirect isn't working" / "the API call times out" even though the app was up.

## Changes
- Extract `superviseTunnel({ start, schedule, minDelayMs, maxDelayMs })`: restart on death with **capped exponential backoff** (1s → 30s); a healthy start resets the backoff. The Hub-owned slug is sticky, so a restart re-registers the **same public URL** and the Hub's stored `tunnel_url` self-heals. Extracted from the spawn so the restart wiring is unit-testable.
- `maybeStartTunnel` wires `runTunnel`'s `onClose` into it; drops the old "give up + delete key" path. Failure now logs `tunnel down: … Retrying — run \`corsair setup\` if it doesn't recover.` and backs off.
- **Dedupe double death-signal:** `runTunnel`'s `fail()` both rejects the promise *and* kills the child, whose `exit` then fires `onClose` — two signals for one dead attempt. `restart` is idempotent per generation so a death can't spawn two overlapping frpc processes.
- `corsair` `0.1.129 → 0.1.130` — publishes this supervisor **and** the delivery-request timeout already on `main` but unpublished under `0.1.129`.

## Testing
- New `tests/supervise-tunnel.test.ts` (4): restart-on-death, double-signal dedupe, capped exponential backoff `[1,2,4,4,4]`, backoff-reset-after-healthy.
- `tsc --noEmit` clean; `biome check` clean; existing `tunnel.test.ts` + `run-tunnel.test.ts` 22/22 unchanged.

## Notes
- Retries indefinitely (30s cap) rather than classifying transient vs permanent errors — reverting to give-up-on-first-failure is the boot-time-blip bug this fixes. The cap bounds the noise and the log is actionable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Development tunnels now automatically restart after unexpected interruptions.
  - Restart attempts use an increasing delay, capped at 30 seconds, to improve stability during repeated failures.
  - Duplicate or delayed failure signals no longer trigger overlapping restarts.
  - Recovery after a healthy tunnel start resets the restart delay to its minimum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->