### PR TITLE
chore(tunnel): default tunnel zone to corsair.run

### DIFF
--- a/docs/hub/delivery-urls.mdx
+++ b/docs/hub/delivery-urls.mdx
@@ -45,7 +45,7 @@ CORSAIR_SIGNING_SECRET=...
 CORSAIR_DELIVERY_URL=http://localhost:3001/api/corsair
 ```
 
-On startup the SDK asks Hub for the tunnel connection details, then opens the tunnel. The `ck_dev_` key is the credential: the tunnel server validates it live on connect, and Hub vends a Corsair-owned public URL (`https://<slug>.corsair.cloud/api/corsair`) scoped to your app's delivery path. No account, ngrok, or manual URL is needed. `CORSAIR_DELIVERY_URL` only sets which local path your app serves.
+On startup the SDK asks Hub for the tunnel connection details, then opens the tunnel. The `ck_dev_` key is the credential: the tunnel server validates it live on connect, and Hub vends a Corsair-owned public URL (`https://<slug>.corsair.run/api/corsair`) scoped to your app's delivery path. No account, ngrok, or manual URL is needed. `CORSAIR_DELIVERY_URL` only sets which local path your app serves.
 
 Hub delivers signed JSON envelopes to that tunnel URL, the same signed-POST contract as production (see below); your handler verifies each one. No dashboard registration is required for development. While the tunnel is live the dashboard's **App sync** indicator turns green.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/cli",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Command-line tool for Corsair, the open-source integration layer. Scaffold a project, add integrations, and run your app.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/corsair/hub/tunnel/constants.ts
+++ b/packages/corsair/hub/tunnel/constants.ts
@@ -1,5 +1,5 @@
-/** Corsair's tunnel DNS zone; dev shares are served at `<slug>.corsair.cloud`. */
-export const CORSAIR_TUNNEL_ZONE = 'corsair.cloud';
+/** Corsair's tunnel DNS zone; dev shares are served at `<slug>.corsair.run`. */
+export const CORSAIR_TUNNEL_ZONE = 'corsair.run';
 
 /** The only path the dev tunnel forwards to the app; everything else 404s. */
 export const CORSAIR_TUNNEL_PATH = '/api/corsair';

--- a/packages/corsair/hub/types.ts
+++ b/packages/corsair/hub/types.ts
@@ -31,7 +31,7 @@ export type HubConfigInput = {
  * with the SDK (override with `CORSAIR_FRP_BIN`); this only tunes the URL zone.
  */
 export type TunnelConfig = {
-	/** DNS zone of the tunnel URL, e.g. `'corsair.cloud'` (the default). */
+	/** DNS zone of the tunnel URL, e.g. `'corsair.run'` (the default). */
 	shareHost?: string;
 };
 

--- a/packages/corsair/package.json
+++ b/packages/corsair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corsair",
-  "version": "0.1.130",
+  "version": "0.1.131",
   "description": "Open-source integration layer for AI agents and apps. Managed OAuth, webhooks, and one API for 200+ integrations, with credentials that stay in your own database.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
The self-hosted frp tunnel server moved from `corsair.cloud` to `corsair.run` (frees `corsair.cloud` for the hosted-VM work).

Bumps the `CORSAIR_TUNNEL_ZONE` constant + its JSDoc. This value is only the dev-share banner/URL fallback — actual routing (`serverAddr`, slug, CA cert) comes from the Hub via `fetchTunnelConfig`, so this is cosmetic for connectivity but makes the printed `corsair setup`/tunnel-active URL correct.

- biome: clean
- tunnel tests: 34 pass
- typecheck: unchanged (pre-existing `tenant-provision.test.ts` failures on main, unrelated)

Hub side needed no code change (zone is env-driven via `CORSAIR_TUNNEL_ZONE`); prod env already set to `corsair.run` and tunnel is live E2E.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updated the tunnel public DNS zone from `corsair.cloud` to `corsair.run`.
  * Tunnel URLs now use the `https://<slug>.corsair.run/api/corsair` format.
  * Updated configuration examples and delivery documentation to reflect the new domain.
  * Existing tunnel functionality remains unchanged aside from the public domain used for access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->