### PR TITLE
fix(tunnel): reap orphaned frpc so a dev tunnel can't wedge itself

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corsair-dev/cli",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Command-line tool for Corsair, the open-source integration layer. Scaffold a project, add integrations, and run your app.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/src/commands/http.command.ts
+++ b/packages/cli/src/commands/http.command.ts
@@ -54,22 +54,32 @@ export default class HttpCommand extends BaseCommand {
 
 		console.log(`[corsair]: Opening dev tunnel → localhost:${port} ...`);
 
+		// runTunnel reaps any orphan holding the slug, but frps frees the proxy a
+		// beat after the orphan's socket drops — so the first spawn can still race
+		// it and get "proxy already exists". The SDK path rides its supervisor's
+		// retry; this one-shot has none, so retry the transient here.
 		let stop: () => void;
-		try {
-			const result = await runTunnel({
-				port,
-				apiUrl: hub.apiUrl,
-				apiKey: hub.projectApiKey,
-				shareHost: process.env.CORSAIR_FRP_HOST,
-			});
-			stop = result.stop;
-			console.log(corsairBanner(`${result.url}${CORSAIR_TUNNEL_PATH}`));
-			console.log('  Press Ctrl+C to stop.\n');
-		} catch (err) {
-			console.error(
-				`[corsair]: Tunnel failed — ${err instanceof Error ? err.message : String(err)}`,
-			);
-			process.exit(1);
+		for (let attempt = 1; ; attempt++) {
+			try {
+				const result = await runTunnel({
+					port,
+					apiUrl: hub.apiUrl,
+					apiKey: hub.projectApiKey,
+					shareHost: process.env.CORSAIR_FRP_HOST,
+				});
+				stop = result.stop;
+				console.log(corsairBanner(`${result.url}${CORSAIR_TUNNEL_PATH}`));
+				console.log('  Press Ctrl+C to stop.\n');
+				break;
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				if (/already exists|still held/i.test(message) && attempt < 3) {
+					await new Promise((r) => setTimeout(r, 1_000));
+					continue;
+				}
+				console.error(`[corsair]: Tunnel failed — ${message}`);
+				process.exit(1);
+			}
 		}
 
 		await new Promise<void>((resolve) => {

--- a/packages/corsair/hub/tunnel/run-tunnel.ts
+++ b/packages/corsair/hub/tunnel/run-tunnel.ts
@@ -7,6 +7,13 @@ import { CORSAIR_TUNNEL_PATH, CORSAIR_TUNNEL_ZONE } from './constants';
 import { resolveFrpcBinary } from './frpc-binary';
 import { buildFrpcConfig } from './frpc-config';
 import { startPathGuard } from './path-guard';
+import type { LockRecord } from './tunnel-lock';
+import {
+	reapStaleTunnel,
+	releaseTunnelLock,
+	tunnelLockPath,
+	writeTunnelLock,
+} from './tunnel-lock';
 
 // Bound every Hub request so a hung/silent Hub can't wedge startup with an
 // open frpc child + path guard (and, on the auto path, a stuck activeTunnels key).
@@ -108,6 +115,22 @@ export async function runTunnel(opts: {
 			apiUrl,
 			apiKey,
 		});
+
+	// Reap a frpc orphaned by a prior run (abrupt death — SIGKILL, `next dev` HMR —
+	// skips our signal cleanup) that's still holding this slug. frps serves one
+	// owner per subdomain, so without this the spawn below is rejected with "proxy
+	// already exists" and the supervisor retries forever against a live orphan.
+	// Done before the guard/cfg are allocated so a reap failure can't leak them.
+	// If a prior holder is still up and can't be safely reaped, don't spawn — that
+	// would overwrite its lock and leave it untracked. Throw so the supervisor
+	// (and the CLI retry) back off and try again once it's gone.
+	const lockPath = tunnelLockPath(slug);
+	if (!(await reapStaleTunnel(lockPath))) {
+		throw new Error(
+			`frpc: slug ${slug} is still held by another process and could not be reaped`,
+		);
+	}
+
 	const bin = resolveFrpcBinary();
 
 	// The dev's delivery path (default /api/corsair). The path-guard and the Hub
@@ -159,6 +182,7 @@ export async function runTunnel(opts: {
 		let settled = false;
 		let ready = false;
 		let outputBuffer = '';
+		let lockRecord: LockRecord | null = null;
 
 		const child = spawn(bin, ['-c', cfgPath], {
 			stdio: ['ignore', 'pipe', 'pipe'],
@@ -249,6 +273,9 @@ export async function runTunnel(opts: {
 		});
 
 		child.on('exit', (code) => {
+			// frpc is confirmed dead here — safe to release, and only if the lock
+			// still holds our exact record (a newest-wins successor keeps its own).
+			if (lockRecord) releaseTunnelLock(lockPath, lockRecord);
 			if (!settled) {
 				const tail = lastLine(outputBuffer);
 				const detail = tail ? ` — ${tail}` : '';
@@ -272,6 +299,15 @@ export async function runTunnel(opts: {
 				),
 			);
 		}, timeoutMs);
+
+		// Record our PID last, once every handler + timer is wired: if the lock write
+		// throws (unwritable cache, disk full), fail() reaps the child, guard, and
+		// cfg instead of leaking an frpc that no later reap could find.
+		try {
+			if (child.pid) lockRecord = writeTunnelLock(lockPath, child.pid);
+		} catch (err) {
+			fail(err instanceof Error ? err : new Error(String(err)));
+		}
 	});
 }
 

--- a/packages/corsair/hub/tunnel/tunnel-lock.ts
+++ b/packages/corsair/hub/tunnel/tunnel-lock.ts
@@ -1,0 +1,240 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+/**
+ * frps serves one owner per `corsair-<slug>` subdomain, so a frpc orphaned by an
+ * abrupt parent death (SIGKILL, `next dev` HMR) keeps holding the slug and every
+ * new frpc is rejected with "proxy already exists". A per-slug lockfile lets the
+ * next start reap that orphan (newest-wins) instead of retrying forever.
+ *
+ * The record pins identity to the process start time, not just the PID: a dead
+ * frpc's PID can be reused by an unrelated process — or another dev tunnel — so
+ * we only ever signal a PID whose start time still matches what we recorded.
+ */
+export interface LockRecord {
+	pid: number;
+	/** OS process start time; '' when the platform couldn't report it. */
+	start: string;
+}
+
+export interface ProcessInfo {
+	/** False ONLY on confirmed absence (ESRCH); a query we couldn't run stays alive. */
+	alive: boolean;
+	frpc: boolean;
+	/** OS start time, or null when unavailable. */
+	start: string | null;
+	/** Whether the name/start-time probe actually succeeded (vs an unknown state). */
+	identified: boolean;
+}
+
+export interface LockIo {
+	read(path: string): LockRecord | null;
+	write(path: string, record: LockRecord): void;
+	remove(path: string): void;
+	inspect(pid: number): ProcessInfo;
+	kill(pid: number, signal: NodeJS.Signals): void;
+	sleep(ms: number): Promise<void>;
+}
+
+// Static PowerShell probe (Windows). A constant literal — not generated code:
+// the PID is supplied via $env:CORSAIR_REAP_PID, never interpolated in.
+const WIN_PROBE =
+	'$p=Get-CimInstance Win32_Process -Filter "ProcessId=$($env:CORSAIR_REAP_PID)"; if($p){"$($p.Name)|$($p.CreationDate.ToFileTimeUtc())"}';
+
+/** Lockfile keyed by the (non-secret) tunnel slug — the exact identity frps
+ *  collides on. The slug is validated `^[a-z0-9-]+$` upstream, so it's a safe
+ *  filename and no secret ever lands on disk. */
+export function tunnelLockPath(slug: string): string {
+	return join(homedir(), '.cache', 'corsair', 'tunnel', `${slug}.pid`);
+}
+
+/** One process is "ours" only if it's alive, looks like frpc, and — when we
+ *  captured a start time — started at the same instant we recorded. Without a
+ *  recorded start time (older lock / platform gap) we fall back to name-only. */
+function isOwnedBy(info: ProcessInfo, record: LockRecord): boolean {
+	if (!info.alive || !info.frpc) return false;
+	return record.start ? info.start === record.start : true;
+}
+
+export const defaultLockIo: LockIo = {
+	read: (path) => {
+		try {
+			const [pidLine = '', start = ''] = readFileSync(path, 'utf8').split('\n');
+			const pid = Number.parseInt(pidLine.trim(), 10);
+			return Number.isInteger(pid) && pid > 0
+				? { pid, start: start.trim() }
+				: null;
+		} catch {
+			return null;
+		}
+	},
+	write: (path, record) => {
+		mkdirSync(dirname(path), { recursive: true });
+		writeFileSync(path, `${record.pid}\n${record.start}`, { mode: 0o600 });
+	},
+	remove: (path) => {
+		// Best-effort: a lock is advisory, so a failed removal must never break the
+		// tunnel lifecycle (rmSync with force already ignores a missing file).
+		try {
+			rmSync(path, { force: true });
+		} catch {}
+	},
+	inspect: (pid) => {
+		// Existence first, via signal 0: ESRCH is the only *confirmed* absence.
+		// EPERM (another user's process) or any other error means it's still there —
+		// we just can't manage it, which is an unknown state, not a dead one.
+		try {
+			process.kill(pid, 0);
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code === 'ESRCH') {
+				return { alive: false, frpc: false, start: null, identified: true };
+			}
+		}
+		// Alive — probe identity (name + start time). A probe failure leaves the
+		// state unknown (identified: false), never silently "dead".
+		try {
+			if (process.platform === 'win32') {
+				// Win32_Process gives the image name and a stable creation time, so
+				// Windows gets the same PID-reuse-proof identity as posix. The command
+				// is a fixed literal (no generated code); the PID is passed through the
+				// environment and read via $env, never interpolated into the script.
+				const out = execFileSync(
+					'powershell',
+					['-NoProfile', '-Command', WIN_PROBE],
+					{
+						encoding: 'utf8',
+						env: { ...process.env, CORSAIR_REAP_PID: String(pid) },
+					},
+				).trim();
+				if (!out)
+					return { alive: true, frpc: false, start: null, identified: false };
+				const [name = '', start = ''] = out.split('|');
+				return {
+					alive: true,
+					frpc: /frpc/i.test(name),
+					start: start || null,
+					identified: true,
+				};
+			}
+			const comm = execFileSync('ps', ['-p', String(pid), '-o', 'comm='], {
+				encoding: 'utf8',
+			}).trim();
+			if (!comm)
+				return { alive: true, frpc: false, start: null, identified: false };
+			const start = execFileSync('ps', ['-p', String(pid), '-o', 'lstart='], {
+				encoding: 'utf8',
+			}).trim();
+			return {
+				alive: true,
+				frpc: /frpc/i.test(comm),
+				start: start || null,
+				identified: true,
+			};
+		} catch {
+			// Probe tool failed — alive (kill 0 didn't say ESRCH) but identity unknown.
+			return { alive: true, frpc: false, start: null, identified: false };
+		}
+	},
+	kill: (pid, signal) => {
+		try {
+			process.kill(pid, signal);
+		} catch {
+			// Already gone between inspect and here — nothing to do.
+		}
+	},
+	sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+};
+
+/**
+ * Try to free this slug's slot by reaping the frpc recorded in the lockfile
+ * (SIGTERM, then SIGKILL after a grace). Returns `true` when the slot is free to
+ * take — no prior lock, the recorded process is confirmed gone, we killed it, or
+ * the PID now demonstrably belongs to something else. Returns `false` when a
+ * process that might still hold the slug is alive and could not be safely reaped
+ * (couldn't signal it, or its identity is unknown): the caller must NOT spawn a
+ * replacement, or it would overwrite the holder's lock and orphan it untracked.
+ * Never signals a PID whose identity no longer matches the record.
+ */
+export async function reapStaleTunnel(
+	path: string,
+	io: LockIo = defaultLockIo,
+	opts: { pollMs?: number; polls?: number } = {},
+): Promise<boolean> {
+	const record = io.read(path);
+	if (record === null) return true;
+
+	let info = io.inspect(record.pid);
+
+	// If it's our live orphan, try to kill it (SIGTERM, then SIGKILL after a grace).
+	if (isOwnedBy(info, record)) {
+		io.kill(record.pid, 'SIGTERM');
+		const pollMs = opts.pollMs ?? 100;
+		const polls = opts.polls ?? 30;
+		for (let i = 0; i < polls && isOwnedBy(info, record); i++) {
+			await io.sleep(pollMs);
+			info = io.inspect(record.pid);
+		}
+		if (isOwnedBy(info, record)) {
+			io.kill(record.pid, 'SIGKILL');
+			info = io.inspect(record.pid);
+		}
+	}
+
+	// The slot is free when the recorded holder is confirmed gone or the PID now
+	// demonstrably belongs to a different process — evaluated the same way whether
+	// or not we just killed it, so a PID reused mid-termination isn't mistaken for
+	// a still-live holder. An alive-but-unidentified process stays blocked.
+	if (isSlotFree(info, record)) {
+		clearIfOurs(io, path, record);
+		return true;
+	}
+	return false;
+}
+
+/** Whether the recorded holder no longer occupies the slot: confirmed absent, or
+ *  positively a different process (identified as not-frpc, or a different start). */
+function isSlotFree(info: ProcessInfo, record: LockRecord): boolean {
+	if (!info.alive) return true;
+	return (
+		info.identified &&
+		(!info.frpc || (record.start !== '' && info.start !== record.start))
+	);
+}
+
+/** Compare-and-delete: remove the lock only if it still names the exact record we
+ *  reaped — a concurrent start may have written a newer owner while we polled. */
+function clearIfOurs(io: LockIo, path: string, record: LockRecord): void {
+	const current = io.read(path);
+	if (current && current.pid === record.pid && current.start === record.start) {
+		io.remove(path);
+	}
+}
+
+/** Record the frpc child we spawned (with its start-time identity) so the next
+ *  start can reap it if we die abruptly. Returns the record for release to match. */
+export function writeTunnelLock(
+	path: string,
+	pid: number,
+	io: LockIo = defaultLockIo,
+): LockRecord {
+	const record: LockRecord = { pid, start: io.inspect(pid).start ?? '' };
+	io.write(path, record);
+	return record;
+}
+
+/** Release our lock — but only if it still holds the exact record we wrote (pid
+ *  AND start). Matching on PID alone would let us delete a successor that reused
+ *  our PID; the process is dead by now, so we compare the recorded start, not a
+ *  fresh inspect. */
+export function releaseTunnelLock(
+	path: string,
+	record: LockRecord,
+	io: LockIo = defaultLockIo,
+): void {
+	const current = io.read(path);
+	if (current && current.pid === record.pid && current.start === record.start) {
+		io.remove(path);
+	}
+}

--- a/packages/corsair/package.json
+++ b/packages/corsair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corsair",
-  "version": "0.1.132",
+  "version": "0.1.133",
   "description": "Open-source integration layer for AI agents and apps. Managed OAuth, webhooks, and one API for 200+ integrations, with credentials that stay in your own database.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/corsair/tests/tunnel-lock.test.ts
+++ b/packages/corsair/tests/tunnel-lock.test.ts
@@ -1,0 +1,225 @@
+import type { LockIo, LockRecord } from '../hub/tunnel/tunnel-lock';
+import {
+	reapStaleTunnel,
+	releaseTunnelLock,
+	tunnelLockPath,
+	writeTunnelLock,
+} from '../hub/tunnel/tunnel-lock';
+
+/** In-memory LockIo so the reap logic is tested without real files or processes. */
+function fakeIo(overrides: Partial<LockIo> = {}): LockIo & {
+	files: Map<string, LockRecord>;
+	procs: Map<number, { frpc: boolean; start: string }>;
+	killed: Array<[number, NodeJS.Signals]>;
+} {
+	const files = new Map<string, LockRecord>();
+	const procs = new Map<number, { frpc: boolean; start: string }>();
+	const killed: Array<[number, NodeJS.Signals]> = [];
+	return {
+		files,
+		procs,
+		killed,
+		read: (p) => files.get(p) ?? null,
+		write: (p, rec) => {
+			files.set(p, { ...rec });
+		},
+		remove: (p) => {
+			files.delete(p);
+		},
+		inspect: (pid) => {
+			const pr = procs.get(pid);
+			return pr
+				? { alive: true, frpc: pr.frpc, start: pr.start, identified: true }
+				: { alive: false, frpc: false, start: null, identified: true };
+		},
+		kill: (pid, sig) => killed.push([pid, sig]),
+		sleep: () => Promise.resolve(),
+		...overrides,
+	};
+}
+
+describe('tunnelLockPath', () => {
+	it('is stable per slug and differs across slugs', () => {
+		expect(tunnelLockPath('drunken-mutiny-2980')).toBe(
+			tunnelLockPath('drunken-mutiny-2980'),
+		);
+		expect(tunnelLockPath('drunken-mutiny-2980')).not.toBe(
+			tunnelLockPath('crimson-cove-6408'),
+		);
+	});
+});
+
+describe('reapStaleTunnel', () => {
+	it('reports the slot free when there is no lockfile', async () => {
+		const io = fakeIo();
+		expect(await reapStaleTunnel('/lock', io)).toBe(true);
+		expect(io.killed).toHaveLength(0);
+	});
+
+	it('clears a stale lock whose process is already dead, and reports free', async () => {
+		const io = fakeIo();
+		io.files.set('/lock', { pid: 4242, start: 'S1' }); // no matching proc
+		expect(await reapStaleTunnel('/lock', io)).toBe(true);
+		expect(io.killed).toHaveLength(0);
+		expect(io.files.has('/lock')).toBe(false);
+	});
+
+	it('SIGTERMs a live orphan whose identity matches, then releases the lock', async () => {
+		const io = fakeIo({
+			kill: (pid, sig) => {
+				(io.killed as Array<[number, NodeJS.Signals]>).push([pid, sig]);
+				io.procs.delete(pid); // dies on SIGTERM
+			},
+		});
+		io.files.set('/lock', { pid: 100, start: 'S1' });
+		io.procs.set(100, { frpc: true, start: 'S1' });
+		expect(await reapStaleTunnel('/lock', io)).toBe(true);
+		expect(io.killed).toEqual([[100, 'SIGTERM']]);
+		expect(io.files.has('/lock')).toBe(false);
+	});
+
+	it('escalates to SIGKILL when the orphan survives SIGTERM, then releases once dead', async () => {
+		let sigkilled = false;
+		const io = fakeIo({
+			kill: (pid, sig) => {
+				(io.killed as Array<[number, NodeJS.Signals]>).push([pid, sig]);
+				if (sig === 'SIGKILL') {
+					sigkilled = true;
+					io.procs.delete(pid);
+				}
+			},
+		});
+		io.files.set('/lock', { pid: 100, start: 'S1' });
+		io.procs.set(100, { frpc: true, start: 'S1' });
+		expect(await reapStaleTunnel('/lock', io, { pollMs: 1, polls: 2 })).toBe(
+			true,
+		);
+		expect(io.killed).toEqual([
+			[100, 'SIGTERM'],
+			[100, 'SIGKILL'],
+		]);
+		expect(sigkilled).toBe(true);
+		expect(io.files.has('/lock')).toBe(false); // cleared once confirmed dead
+	});
+
+	it('blocks (keeps the lock) when the orphan cannot be killed (stays alive)', async () => {
+		const io = fakeIo(); // default kill never removes the proc → survives both signals
+		io.files.set('/lock', { pid: 100, start: 'S1' });
+		io.procs.set(100, { frpc: true, start: 'S1' });
+		expect(await reapStaleTunnel('/lock', io, { pollMs: 1, polls: 2 })).toBe(
+			false,
+		);
+		expect(io.killed).toEqual([
+			[100, 'SIGTERM'],
+			[100, 'SIGKILL'],
+		]);
+		expect(io.files.get('/lock')).toEqual({ pid: 100, start: 'S1' }); // still tracked
+	});
+
+	it('blocks (keeps the lock) when the process state is unknown', async () => {
+		const io = fakeIo({
+			// Alive (kill 0 didn't say ESRCH) but the identity probe failed.
+			inspect: () => ({
+				alive: true,
+				frpc: false,
+				start: null,
+				identified: false,
+			}),
+		});
+		io.files.set('/lock', { pid: 100, start: 'S1' });
+		expect(await reapStaleTunnel('/lock', io)).toBe(false);
+		expect(io.killed).toHaveLength(0);
+		expect(io.files.get('/lock')).toEqual({ pid: 100, start: 'S1' }); // not dropped
+	});
+
+	it('reports free without killing when a reused PID has a different start time', async () => {
+		const io = fakeIo();
+		io.files.set('/lock', { pid: 100, start: 'OLD' });
+		io.procs.set(100, { frpc: true, start: 'NEW' }); // reused by a different frpc
+		expect(await reapStaleTunnel('/lock', io)).toBe(true);
+		expect(io.killed).toHaveLength(0);
+		expect(io.files.has('/lock')).toBe(false); // stale entry cleared
+	});
+
+	it('reports free without killing when the reused PID is not frpc', async () => {
+		const io = fakeIo();
+		io.files.set('/lock', { pid: 100, start: 'S1' });
+		io.procs.set(100, { frpc: false, start: 'S1' });
+		expect(await reapStaleTunnel('/lock', io)).toBe(true);
+		expect(io.killed).toHaveLength(0);
+		expect(io.files.has('/lock')).toBe(false);
+	});
+
+	it('reports free when our PID is reused by a different process mid-termination', async () => {
+		let slept = false;
+		const io = fakeIo({
+			sleep: () => {
+				if (!slept) {
+					slept = true;
+					// Our frpc dies during the poll; its PID is reused by a different
+					// live process (frpc-named but a new start time).
+					io.procs.set(100, { frpc: true, start: 'DIFFERENT' });
+				}
+				return Promise.resolve();
+			},
+		});
+		io.files.set('/lock', { pid: 100, start: 'S1' });
+		io.procs.set(100, { frpc: true, start: 'S1' });
+		// Free (our holder is gone) — must not block startup on the unrelated process.
+		expect(await reapStaleTunnel('/lock', io, { pollMs: 1, polls: 5 })).toBe(
+			true,
+		);
+		expect(io.files.has('/lock')).toBe(false);
+	});
+
+	it('preserves a newer owner written while the reaper polls', async () => {
+		let slept = false;
+		const io = fakeIo({
+			sleep: () => {
+				if (!slept) {
+					slept = true;
+					io.files.set('/lock', { pid: 200, start: 'S2' }); // newest-wins takeover
+					io.procs.delete(100); // our old orphan finally dies
+				}
+				return Promise.resolve();
+			},
+		});
+		io.files.set('/lock', { pid: 100, start: 'S1' });
+		io.procs.set(100, { frpc: true, start: 'S1' });
+		await reapStaleTunnel('/lock', io, { pollMs: 1, polls: 5 });
+		expect(io.files.get('/lock')).toEqual({ pid: 200, start: 'S2' });
+	});
+});
+
+describe('releaseTunnelLock', () => {
+	it('removes the lock only when it holds our exact record', () => {
+		const io = fakeIo();
+		io.files.set('/lock', { pid: 100, start: 'S1' });
+		releaseTunnelLock('/lock', { pid: 100, start: 'S1' }, io);
+		expect(io.files.has('/lock')).toBe(false);
+	});
+
+	it('leaves a handed-over lock (different PID) intact', () => {
+		const io = fakeIo();
+		io.files.set('/lock', { pid: 200, start: 'S2' });
+		releaseTunnelLock('/lock', { pid: 100, start: 'S1' }, io);
+		expect(io.files.get('/lock')).toEqual({ pid: 200, start: 'S2' });
+	});
+
+	it('leaves a successor that reused our PID (start differs) intact', () => {
+		const io = fakeIo();
+		io.files.set('/lock', { pid: 100, start: 'NEW' }); // successor reused PID 100
+		releaseTunnelLock('/lock', { pid: 100, start: 'OLD' }, io);
+		expect(io.files.get('/lock')).toEqual({ pid: 100, start: 'NEW' });
+	});
+});
+
+describe('writeTunnelLock', () => {
+	it('records our PID and its start-time identity, and returns the record', () => {
+		const io = fakeIo();
+		io.procs.set(100, { frpc: true, start: 'S1' });
+		const record = writeTunnelLock('/lock', 100, io);
+		expect(record).toEqual({ pid: 100, start: 'S1' });
+		expect(io.files.get('/lock')).toEqual({ pid: 100, start: 'S1' });
+	});
+});


### PR DESCRIPTION
## Problem

frps serves **one owner per `corsair-<slug>` subdomain**. When an frpc dies abruptly (`next dev`/Turbopack HMR restart, Ctrl-C timing, SIGKILL, crash), the SDK's in-process signal handlers don't fire, so frpc is **orphaned but still connected to frps** — it keeps holding the slug. Every new frpc is then rejected with `start error: proxy already exists`, and `superviseTunnel` retries that forever against a live orphan. The dev tunnel never recovers, and because Hub can't deliver over a down tunnel, OAuth "connecting" screens hang.

Reproduced live: an orphaned frpc held the slug across app restarts; `pkill` missed it because the process path is `@corsair-dev+frpc-*/frpc` (never the substring `corsair-frpc`).

## Fix

`runTunnel` now keeps a **per-key PID lockfile** and reaps a stale/orphan holder before spawning:

- **Reap:** if the lock names a live frpc PID, SIGTERM → poll → SIGKILL. Dropping its control connection makes frps free the slug. Guarded by an `isFrpc` check so a reused PID is never killed (never kill on uncertainty).
- **Record + release:** write our frpc child PID after spawn; release the lock only if it still holds our PID, so a newest-wins handover isn't clobbered.
- **Both starters covered:** the SDK auto-tunnel and `corsair http` both call `runTunnel`, so one change fixes both.
- **CLI one-shot:** retries the brief post-reap `already exists` window (frps frees the slug a beat after the orphan's socket drops); the SDK path already rides its supervisor's retry.

Lockfile is keyed by `sha256(apiKey)` — same key → same lock (single-flight), and the raw key never lands in a filename.

## Tests

`tunnel-lock.test.ts` (10 cases, injected IO — no real files/processes): stable-per-key path, no-lock/dead-PID no-ops, SIGTERM→SIGKILL escalation, reused-PID safety, newest-wins release. Full tunnel suite green (44 tests), typecheck + build clean.

## Deferred (not needed for the common case)

- **Cross-machine same-key takeover** — if two machines share one `ck_dev_` key, the local reap can't reach the other machine's frpc. Distinct per-member keys get distinct slugs, so this doesn't arise in normal use; the Hub-side `KickProxy` option is the upgrade path if ever needed.
- **Concurrent double-start** (`pnpm dev` and `corsair http` at once, same key) can ping-pong briefly — run one, not both. An atomic O_EXCL lock would harden this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tunnel reliability by retrying transient tunnel-creation failures up to two times.
  * Prevented orphaned tunnel processes from interfering with subsequent connections.
  * Added safeguards to avoid terminating unrelated or newly reassigned processes during tunnel recovery.
  * Improved tunnel cleanup when setup fails unexpectedly.

* **Tests**
  * Added coverage for tunnel recovery, cleanup, process handling, and lock behavior.

* **Chores**
  * Updated CLI and Corsair package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->